### PR TITLE
Migrate API pipeline script from closed source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "jest": "^29.7.0",
         "lodash": "^4.17.21",
         "mdast": "^3.0.0",
+        "mkdirp": "^3.0.1",
+        "p-map": "^6.0.0",
+        "p-queue": "^7.4.1",
         "rehype-parse": "^8.0.0",
         "rehype-remark": "^9.1.2",
         "remark-gfm": "^3.0.1",
@@ -34,7 +37,8 @@
         "remark-stringify": "^10.0.3",
         "typescript": "^5.2.2",
         "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
+        "unist-util-visit": "^4.0.0",
+        "zx": "^7.2.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2607,6 +2611,16 @@
       "integrity": "sha512-CqDQhn7jxaN9zw7zAu926zIx51ZzMaX8U8Wa4jGpKI6jeBr9ejFE68AQ+h+ztfrNJD+leo7K1cLbvMjpHfZSRg==",
       "dev": true
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.2.tgz",
+      "integrity": "sha512-c0hrgAOVYr21EX8J0jBMXGLMgJqVf/v6yxi0dLaJboW9aQPh16Id+z6w2Tx1hm+piJOLv8xPfVKZCLfjPw/IMQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
@@ -2659,6 +2673,15 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.2.tgz",
+      "integrity": "sha512-8t92P+oeW4d/CRQfJaSqEwXujrhH4OEeHRjGU3v1Q8mUS8GPF3yiX26sw4svv6faL2HfBtGTe2xWIoVgN3dy9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/katex": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.3.tgz",
@@ -2680,6 +2703,12 @@
         "@types/unist": "^2"
       }
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+      "integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==",
+      "dev": true
+    },
     "node_modules/@types/ms": {
       "version": "0.7.32",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
@@ -2692,6 +2721,12 @@
       "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
       "dev": true
     },
+    "node_modules/@types/ps-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.3.tgz",
+      "integrity": "sha512-J8IrehehphLtxpABSekURTw9jthrlLcM4llH1I2fZ0zKaxq8jI/O1+Q/tabAJgBY/ffoqDxPRNYBM1lFUXm0lw==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -2702,6 +2737,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==",
+      "dev": true
+    },
+    "node_modules/@types/which": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -3766,6 +3807,15 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3937,6 +3987,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.535",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.535.tgz",
@@ -4090,6 +4146,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4205,6 +4282,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.0.tgz",
@@ -4265,6 +4365,38 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4290,6 +4422,15 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/fx": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/fx/-/fx-30.2.0.tgz",
+      "integrity": "sha512-rIYQBmx85Jfhd3pkSw06YPgvSvfTi022ZXTeFDkcCZGCs5nt3sjqFBGtcMFe1TR2S00RDz63be0ab5mhCiOLBw==",
+      "dev": true,
+      "bin": {
+        "fx": "index.js"
+      }
     },
     "node_modules/gensequence": {
       "version": "6.0.0",
@@ -6134,6 +6275,18 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.8.tgz",
@@ -6264,6 +6417,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+      "dev": true
     },
     "node_modules/markdown-table": {
       "version": "3.0.3",
@@ -7338,6 +7497,30 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -7358,6 +7541,25 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -7473,6 +7675,46 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7602,6 +7844,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3"
       }
     },
     "node_modules/picocolors": {
@@ -7742,6 +7993,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/pure-rand": {
@@ -8163,6 +8429,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8188,6 +8466,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.1.1"
       }
     },
     "node_modules/string-length": {
@@ -8364,6 +8651,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8591,6 +8884,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -8743,11 +9045,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
+    },
+    "node_modules/webpod": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/webpod/-/webpod-0.0.2.tgz",
+      "integrity": "sha512-cSwwQIeg8v4i3p4ajHhwgR7N6VyxAf+KYSSsY6Pd3aETE+xEU4vbitz7qQkB0I321xnhDdgtxuiSfk5r/FVtjg==",
+      "dev": true,
+      "bin": {
+        "webpod": "dist/index.js"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -8857,6 +9177,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -8904,6 +9233,86 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/zx": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.2.3.tgz",
+      "integrity": "sha512-QODu38nLlYXg/B/Gw7ZKiZrvPkEsjPN3LQ5JFXM7h0JvwhEdPNNl+4Ao1y4+o3CLNiDUNcwzQYZ4/Ko7kKzCMA==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^11.0.1",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^18.16.3",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^3.0.0",
+        "chalk": "^5.2.0",
+        "fs-extra": "^11.1.1",
+        "fx": "*",
+        "globby": "^13.1.4",
+        "minimist": "^1.2.8",
+        "node-fetch": "3.3.1",
+        "ps-tree": "^1.2.0",
+        "webpod": "^0",
+        "which": "^3.0.0",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/zx/node_modules/@types/node": {
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
+      "dev": true
+    },
+    "node_modules/zx/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/zx/node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/zx/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "jest": "^29.7.0",
     "lodash": "^4.17.21",
     "mdast": "^3.0.0",
+    "mkdirp": "^3.0.1",
+    "p-map": "^6.0.0",
+    "p-queue": "^7.4.1",
     "rehype-parse": "^8.0.0",
     "rehype-remark": "^9.1.2",
     "remark-gfm": "^3.0.1",
@@ -37,6 +40,7 @@
     "remark-stringify": "^10.0.3",
     "typescript": "^5.2.2",
     "unified": "^10.0.0",
-    "unist-util-visit": "^4.0.0"
+    "unist-util-visit": "^4.0.0",
+    "zx": "^7.2.3"
   }
 }

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -1,0 +1,292 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// To run the script, first generate an access token in GitHub. Click on your profile, then "Settings",
+// then "Developer settings" at the bottom. Go to "Personal access tokens" and generate a new "classic"
+// token. These classic tokens can be dangerous because they are so permissive, so set a short expiration
+// timeline and be careful to not share the token.
+//
+// Once you have a token generated, run:
+//
+//   PUBLIC_GITHUB_TOKEN=ghp_... node -r esbuild-register scripts/commands/updateApiDocs.ts
+
+import { $ } from 'zx';
+import { zxMain } from '../lib/zx';
+import { getRequiredEnv } from '../lib/env';
+import { GithubApiClient } from '../lib/GithubApiClient';
+import { pathExists, getRoot } from '../lib/fs';
+import { readFile, writeFile } from 'fs/promises';
+import { globby } from 'globby';
+import { join, parse, relative } from 'path';
+import { sphinxHtmlToMarkdown } from '../lib/sphinx/sphinxHtmlToMarkdown';
+import { first, last, uniq, uniqBy } from 'lodash';
+import { mkdirp } from 'mkdirp';
+import { WebCrawler } from '../lib/WebCrawler';
+import { downloadImages } from '../lib/downloadImages';
+import { generateToc } from '../lib/sphinx/generateToc';
+import { SphinxToMdResult } from '../lib/sphinx/SphinxToMdResult';
+import { mergeClassMembers } from '../lib/sphinx/mergeClassMembers';
+import { flatFolders } from '../lib/sphinx/flatFolders';
+import { updateLinks } from '../lib/sphinx/updateLinks';
+import { addFrontMatter } from '../lib/sphinx/addFrontMatter';
+import { dedupeResultIds } from '../lib/sphinx/dedupeIds';
+import { removePrefix, removeSuffix } from '../lib/stringUtils';
+
+type Pkg = {
+  name: string;
+  githubSlug: string;
+  baseUrl: string;
+  initialUrls: string[];
+  title: string;
+  ignore?(id: string): boolean;
+  tocOptions?: {
+    collapsed?: boolean;
+    nestModule?(id: string): boolean;
+  };
+  transformLink?: (url: string, text?: string) => { url: string; text?: string } | undefined;
+};
+
+type PkgHtml = { pkg: Pkg; version: string; path: string };
+
+const packages: Pkg[] = [
+  {
+    title: 'Qiskit Runtime IBM Client',
+    name: 'qiskit-ibm-runtime',
+    githubSlug: 'qiskit/qiskit-ibm-runtime',
+    baseUrl: `https://qiskit.org/documentation/partners/qiskit_ibm_runtime`,
+    initialUrls: [
+      `https://qiskit.org/documentation/partners/qiskit_ibm_runtime/apidocs/ibm-runtime.html`,
+    ],
+    transformLink(url, text) {
+      const prefixes = [
+        'https://qiskit.org/documentation/apidoc/',
+        'https://qiskit.org/documentation/stubs/',
+      ];
+      let updateText = url === text;
+      const prefix = prefixes.find((prefix) => url.startsWith(prefix));
+      if (prefix) {
+        url = removePrefix(url, prefix);
+        url = removeSuffix(url, '.html');
+        const newText = updateText ? url : undefined;
+        return { url: `/api/qiskit/${url}`, text: newText };
+      }
+    },
+  },
+  {
+    title: 'Qiskit IBM Provider',
+    name: 'qiskit-ibm-provider',
+    githubSlug: 'qiskit/qiskit-ibm-provider',
+    baseUrl: `https://qiskit.org/ecosystem/ibm-provider`,
+    initialUrls: [`https://qiskit.org/ecosystem/ibm-provider/apidocs/ibm-provider.html`],
+    transformLink(url, text) {
+      const prefixes = [
+        'https://qiskit.org/documentation/apidoc/',
+        'https://qiskit.org/documentation/stubs/',
+      ];
+      let updateText = url === text;
+      const prefix = prefixes.find((prefix) => url.startsWith(prefix));
+      if (prefix) {
+        url = removePrefix(url, prefix);
+        url = removeSuffix(url, '.html');
+        const newText = updateText ? url : undefined;
+        return { url: `/api/qiskit/${url}`, text: newText };
+      }
+    },
+  },
+  {
+    title: 'Qiskit',
+    name: 'qiskit',
+    githubSlug: 'qiskit/qiskit-terra',
+    baseUrl: `https://qiskit.org/documentation`,
+    initialUrls: [`https://qiskit.org/documentation/apidoc/index.html`],
+    ignore(id: string): boolean {
+      return id.startsWith('qiskit.opflow') || id.startsWith('qiskit.algorithms');
+    },
+    tocOptions: {
+      collapsed: true,
+      nestModule(id: string) {
+        return id.split('.').length > 2;
+      },
+    },
+    transformLink(url) {
+      // Transform links from ignored modules
+      let path = last(url.split('/'))!;
+      if (path.includes('#')) {
+        path = path.split('#').join('.html#');
+      } else {
+        path += '.html';
+      }
+
+      if (path?.startsWith('algorithms') || path?.startsWith('opflow')) {
+        return { url: `http://qiskit.org/documentation/apidoc/${path}` };
+      }
+      if (path?.startsWith('qiskit.algorithms.') || path?.startsWith('qiskit.opflow.')) {
+        return { url: `http://qiskit.org/documentation/stubs/${path}` };
+      }
+    },
+  },
+];
+
+zxMain(async () => {
+  const sourcesPath = `${getRoot()}/.out/python/sources`;
+
+  const pkgHtmls: PkgHtml[] = [];
+
+  for (const pkg of packages) {
+    const version = await getLatestVersion(pkg.githubSlug);
+    const destination = `${sourcesPath}/${pkg.name}/${version}`;
+    pkgHtmls.push({ pkg, version, path: destination });
+
+    if (await pathExists(destination)) {
+      console.log(`Skip downloading sources for ${pkg.name}:${version}`);
+      continue;
+    }
+
+    await downloadHtml({ baseUrl: pkg.baseUrl, initialUrls: pkg.initialUrls, destination });
+  }
+
+  // Sphinx html to markdown
+  console.log('Deleting existing markdowns');
+  await $`rm -rf ${getRoot()}/docs/api/`;
+
+  //console.log('Deleting existing api images');
+  //await $`rm -rf ${getRoot()}/public/images/api/`;
+
+  for (const src of pkgHtmls) {
+    console.log(`Convert sphinx html to markdown for ${src.pkg.name}:${src.version}`);
+
+    const htmlBase = src.path;
+    const output = `${getRoot()}/docs/api/${src.pkg.name}`;
+    const baseSourceUrl = `https://github.com/${src.pkg.githubSlug}/tree/${src.version}/`;
+
+    // Convert html to markdown
+    await convertHtmlToMarkdown(htmlBase, output, baseSourceUrl, src);
+  }
+});
+
+async function getLatestVersion(githubSlug: string): Promise<string> {
+  const githubToken = getRequiredEnv(`PUBLIC_GITHUB_TOKEN`);
+  const github = new GithubApiClient({ domain: 'public', token: githubToken });
+
+  const releases = await github.getReleases({ slug: githubSlug });
+
+  const latestVersion = first(releases)?.tag_name;
+  if (!latestVersion) throw new Error('Cannot fetch latest version');
+
+  return latestVersion;
+}
+
+async function downloadHtml(options: {
+  baseUrl: string;
+  initialUrls: string[];
+  destination: string;
+}): Promise<void> {
+  const { baseUrl, destination, initialUrls } = options;
+  let successCount = 0;
+  let errorCount = 0;
+  const crawler = new WebCrawler({
+    initialUrls: initialUrls,
+    followUrl(url) {
+      return (
+        url.startsWith(`${baseUrl}/apidocs`) ||
+        url.startsWith(`${baseUrl}/apidoc`) ||
+        url.startsWith(`${baseUrl}/stubs`)
+      );
+    },
+    async onSuccess(url: string, content: string) {
+      successCount++;
+      const relativePath = url.substring(`${baseUrl}/`.length);
+      const destinationPath = `${destination}/${relativePath}`;
+      const { dir } = parse(destinationPath);
+      await mkdirp(dir); // TODO track the folders already created
+      await writeFile(destinationPath, content);
+    },
+    async onError(url: string, error: unknown) {
+      errorCount++;
+      console.error(`Error ${url}`, error);
+    },
+  });
+  await crawler.run();
+  console.log(`Download summary from ${baseUrl}`, { success: successCount, error: errorCount });
+}
+
+async function convertHtmlToMarkdown(
+  htmlPath: string,
+  markdownPath: string,
+  baseSourceUrl: string,
+  pkg: PkgHtml
+) {
+  const files = await globby(['apidocs/**.html', 'apidoc/**.html', 'stubs/**.html'], {
+    cwd: htmlPath,
+  });
+
+  const ignore = pkg.pkg.ignore ?? (() => false);
+
+  let results: Array<SphinxToMdResult & { url: string }> = [];
+  for (const file of files) {
+    const html = await readFile(join(htmlPath, file), 'utf-8');
+    const result = await sphinxHtmlToMarkdown({
+      html,
+      url: `${pkg.pkg.baseUrl}/${file}`,
+      baseSourceUrl,
+      imageDestination: `/images/api/${pkg.pkg.name}`,
+    });
+    const { dir, name } = parse(`${markdownPath}/${file}`);
+    let url = `/${relative(`${getRoot()}/docs`, dir)}/${name}`;
+
+    if (!result.meta.python_api_name || !ignore(result.meta.python_api_name)) {
+      results.push({ ...result, url });
+    }
+  }
+
+  const allImages = uniqBy(
+    results.flatMap((result) => result.images),
+    (image) => image.src
+  );
+
+  const dirsNeeded = uniq(results.map((result) => parse(urlToPath(result.url)).dir));
+  for (const dir of dirsNeeded) {
+    await mkdirp(dir);
+  }
+
+  results = await mergeClassMembers(results);
+  results = flatFolders(results);
+  results = await updateLinks(results, pkg.pkg.transformLink);
+  results = await dedupeResultIds(results);
+  results = addFrontMatter(results);
+
+  for (const result of results) {
+    await writeFile(urlToPath(result.url), result.markdown);
+  }
+
+  console.log('Generating toc');
+  const toc = generateToc({
+    pkg: {
+      title: pkg.pkg.title,
+      name: pkg.pkg.name,
+      version: pkg.version,
+      changelogUrl: `https://github.com/${pkg.pkg.githubSlug}/releases`,
+      tocOptions: pkg.pkg.tocOptions,
+    },
+    results,
+  });
+  await writeFile(`${markdownPath}/_toc.json`, JSON.stringify(toc, null, 2) + '\n');
+
+  console.log('Downloading images');
+  await downloadImages(
+    allImages.map((img) => ({ src: img.src, dest: `${getRoot()}/packages/web/public${img.dest}` }))
+  );
+}
+
+function urlToPath(url: string) {
+  return `${getRoot()}/docs${url}.md`;
+}

--- a/scripts/lib/GithubApiClient.ts
+++ b/scripts/lib/GithubApiClient.ts
@@ -1,0 +1,127 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { merge } from 'lodash';
+
+export class GithubApiClient {
+  token: string;
+  baseUrl: string;
+
+  constructor(options: { token: string; domain: 'public' | 'ibm' }) {
+    this.token = options.token;
+    this.baseUrl = options.domain === 'public' ? 'api.github.com' : 'github.ibm.com/api/v3';
+  }
+
+  getReleases(options: { slug: string }) {
+    const { slug } = options;
+    return this.fetch<GithubRelease[]>(`repos/${slug}/releases`);
+  }
+
+
+  private getUrl(url: string) {
+    if (url.startsWith('https:')) return url;
+    return `https://${this.baseUrl}/${url}`;
+  }
+
+  private async fetch<Response>(url: string, options?: RequestInit) {
+    const response = await fetch(
+      this.getUrl(url),
+      merge(
+        {
+          headers: {
+            Authorization: `token ${this.token}`,
+            Accept: 'application/vnd.github.v3+json',
+          },
+        },
+        options
+      )
+    );
+    if (!response.ok) {
+      console.error(response);
+      throw new Error(`Failed to fetch: ${response.statusText}`);
+    }
+    return (await response.json()) as Promise<Response>;
+  }
+}
+
+type GithubRelease = {
+  url: string;
+  html_url: string;
+  assets_url: string;
+  upload_url: string;
+  tarball_url: string;
+  zipball_url: string;
+  id: number;
+  node_id: string;
+  tag_name: string;
+  target_commitish: string;
+  name: string;
+  body: string;
+  draft: boolean;
+  prerelease: boolean;
+  created_at: string;
+  published_at: string;
+  author: {
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    site_admin: boolean;
+  };
+  assets: Array<{
+    url: string;
+    browser_download_url: string;
+    id: number;
+    node_id: string;
+    name: string;
+    label: string;
+    state: string;
+    content_type: string;
+    size: number;
+    download_count: number;
+    created_at: string;
+    updated_at: string;
+    uploader: {
+      login: string;
+      id: number;
+      node_id: string;
+      avatar_url: string;
+      gravatar_id: string;
+      url: string;
+      html_url: string;
+      followers_url: string;
+      following_url: string;
+      gists_url: string;
+      starred_url: string;
+      subscriptions_url: string;
+      organizations_url: string;
+      repos_url: string;
+      events_url: string;
+      received_events_url: string;
+      type: string;
+      site_admin: boolean;
+    };
+  }>;
+};

--- a/scripts/lib/WebCrawler.ts
+++ b/scripts/lib/WebCrawler.ts
@@ -1,0 +1,117 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { load } from 'cheerio';
+import PQueue from 'p-queue';
+
+export class WebCrawler {
+  private initialUrls: string[];
+  private followUrl: (url: string, baseUrl: string) => boolean;
+  private retryUrl?: (url: string) => boolean;
+  private onSuccess: (url: string, content: string) => void;
+  private onError?: (url: string, error: unknown) => void;
+  private onSkip?: (url: string, reason: string) => void;
+
+  private queue: PQueue;
+  private parsedUrls = new Set<string>();
+  private pendingUrls = new Set<string>();
+  private linkSelector: string;
+
+  constructor(options: {
+    initialUrls: string[];
+    linkSelector?: string;
+    retryUrl?: (url: string) => boolean;
+    followUrl: (linkUrl: string, baseUrl: string) => boolean;
+    onSuccess: (url: string, content: string) => Promise<void>;
+    onSkip?: (url: string, reason: string) => void;
+    onError?: (url: string, error: unknown) => void;
+    concurrency?: number;
+  }) {
+    this.initialUrls = options.initialUrls;
+    this.followUrl = options.followUrl;
+    this.retryUrl = options.retryUrl;
+    this.onSuccess = options.onSuccess;
+    this.onError = options.onError;
+    this.onSkip = options.onSkip;
+    this.queue = new PQueue({ concurrency: 4 });
+    this.linkSelector = options.linkSelector ?? 'a';
+  }
+
+  async run() {
+    return new Promise((resolve) => {
+      this.queue.once('idle', resolve);
+      this.queueUrls(this.initialUrls);
+    });
+  }
+
+  private async queueUrl(url: string) {
+    if (this.pendingUrls.has(url) || this.parsedUrls.has(url)) return;
+
+    this.pendingUrls.add(url);
+    this.queue.add(() => this.processUrl(url));
+  }
+
+  private async queueUrls(urls: string[]) {
+    for (const url of urls) {
+      this.queueUrl(url);
+    }
+  }
+
+  private async processUrl(url: string) {
+    this.parsedUrls.add(url);
+    this.pendingUrls.delete(url);
+
+    try {
+      let response = await fetch(url);
+
+      if (!response.ok && this.retryUrl?.(url)) {
+        response = await fetch(url);
+      }
+
+      if (response.ok) {
+        if (!response.headers.get('content-type')?.includes('text/html')) {
+          this.onSkip?.(url, 'Not html');
+          return;
+        }
+
+        // download file
+        const html = await response.text();
+        await this.onSuccess(url, html);
+
+        // extract link and queue links that needs to be followed
+        const links = this.extractLinks(url, html);
+        const linksToParse = links.filter((link) => this.followUrl(link, url));
+        this.queueUrls(linksToParse);
+      } else {
+        this.onError?.(url, response);
+      }
+    } catch (e) {
+      this.onError?.(url, e);
+    }
+  }
+
+  private extractLinks(url: string, html: string): string[] {
+    const $ = load(html);
+    const links = $(this.linkSelector)
+      .toArray()
+      .flatMap((el) => {
+        const $el = $(el);
+        const href = $el.attr('href');
+        if (!href) return [];
+
+        const parsedUrl = new URL(href, url);
+        parsedUrl.hash = '';
+        return [parsedUrl.toString()];
+      });
+    return links;
+  }
+}

--- a/scripts/lib/downloadImages.ts
+++ b/scripts/lib/downloadImages.ts
@@ -1,0 +1,37 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { pathExists } from './fs';
+import { mkdirp } from 'mkdirp';
+import { dirname } from 'path';
+import { createWriteStream } from 'node:fs';
+import { finished } from 'stream/promises';
+import { Readable } from 'stream';
+import pMap from 'p-map';
+
+export async function downloadImages(images: Array<{ src: string; dest: string }>) {
+  await pMap(
+    images,
+    async (img) => {
+      if (await pathExists(img.dest)) return;
+      const response = await fetch(img.src);
+      if (response.ok) {
+        await mkdirp(dirname(img.dest));
+        const stream = createWriteStream(img.dest);
+        await finished(Readable.fromWeb(response.body as any).pipe(stream));
+      } else {
+        console.log(`Error downloading ${img.src} to ${img.dest}`);
+      }
+    },
+    { concurrency: 4 }
+  );
+}

--- a/scripts/lib/env.ts
+++ b/scripts/lib/env.ts
@@ -1,0 +1,18 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+export function getRequiredEnv(envVarName: string): string {
+  if (!process.env[envVarName]) {
+    throw new Error(`Environment variable ${envVarName} not defined`);
+  }
+  return process.env[envVarName]!;
+}

--- a/scripts/lib/fs.ts
+++ b/scripts/lib/fs.ts
@@ -1,0 +1,28 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { stat } from 'fs/promises';
+import { normalize } from 'path';
+
+export function getRoot() {
+  return normalize(`${__dirname}/../../`);
+}
+
+export async function pathExists(path: string) {
+  try {
+    await stat(path);
+    return true;
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return false;
+    throw err;
+  }
+}

--- a/scripts/lib/zx.ts
+++ b/scripts/lib/zx.ts
@@ -1,0 +1,31 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { ProcessOutput } from 'zx';
+
+export function zxMain(mainFn: () => Promise<void>) {
+  enableCliColors();
+  void mainFn().catch((e) => {
+    if (!(e instanceof ProcessOutput)) {
+      console.log(e);
+    }
+    return process.exit(1);
+  });
+}
+
+export function enableCliColors() {
+  process.env.FORCE_COLOR = '3';
+}
+
+export function disableCliColors() {
+  process.env.FORCE_COLOR = '0';
+}


### PR DESCRIPTION
Part 2 of https://github.com/Qiskit/documentation/issues/9.

The final part will run this script to generate the API docs. There are some things I want to tweak in the script like that the qiskit-ibm-runtime site has changed URLs, but I wanted to avoid making changes to the script in this PR so that it simply copies them over.

This PR simply copies over the API pipeline written by @axelhzf from closed source to open source. Its only modifications are adding copyright headers and removing unused code from utility files.

https://github.com/Qiskit/documentation/issues/63 tracks some ideas to simplify this pipeline in follow ups, such as not needing GitHub.