### PR TITLE
Migrate support page from closed source

### DIFF
--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,0 +1,33 @@
+---
+title: Getting help
+description: How to find answers to questions or problems you encounter while using IBM Quantum (Platform, or on IBM Cloud) or Qiskit Runtime
+
+---
+
+# Getting help
+
+
+## Qiskit
+
+For help with Qiskit, access our Slack community: [Qiskit Slack](https://qisk.it/join-slack).
+
+## Qiskit Runtime
+
+- Review the [Runtime FAQs](/start/runtime#runtime-faqs). {/*we should probably move this content into these docs*/}
+- Join the qiskit-runtime channel within the [Qiskit Slack workspace](https://qisk.it/join-slack).
+
+## Open-source governance
+
+The following pages are resources for anyone interested in contributing code to Qiskit.
+
+- [Code of conduct](https://github.com/Qiskit/qiskit-metapackage/blob/master/CODE_OF_CONDUCT.md)
+- [Contributing guide](https://qiskit.org/documentation/contributing_to_qiskit.html#contributing-links)
+- [Deprecation policy](https://qiskit.org/documentation/deprecation_policy.html)
+- [Maintainers guide](https://qiskit.org/documentation/maintainers_guide.html)
+
+## Other discussions
+
+Discuss quantum information science and development with the larger quantum computing field on the [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/) site. Be sure to read the ["How do I ask a good question?"](https://quantumcomputing.stackexchange.com/help/how-to-ask) guide, and make use of tags such as `qiskit`, `ibm-runtime`, and `ibm-quantum-services` for best results.
+
+For questions specific to programming, visit [Stack Overflow](https://stackoverflow.com/) and use the tag `qiskit`.
+


### PR DESCRIPTION
This was oversight. I didn't realize we needed to migrate this page too.

The page is simply copy-and-pasted.