### PR TITLE
Remove errors page link from run toc

### DIFF
--- a/docs/run/_toc.json
+++ b/docs/run/_toc.json
@@ -65,10 +65,6 @@
     {
       "title": "Retired systems",
       "url": "/run/retired-systems"
-    },
-    {
-      "title": "Error code registry",
-      "url": "/errors"
     }
   ]
 }


### PR DESCRIPTION
We have move the errors page link to the _Api reference_ header menu in https://docs.quantum-computing.ibm.com/ to facilitate the access, so it won't be under run section anymore.
