### PR TITLE
Edits to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: 🪲 Content bug or inaccuracy
-description: Report typos/bugs, out-of-date content, broken links
-labels: ["BUG 🪲"]
+description: Report typos, bugs, out-of-date content, broken links, etc.
+labels: ["bug 🐛"]
 assignees:
   - abbycross
   - beckykd
@@ -17,6 +17,19 @@ body:
       description: provide a URL and section name/paragraph if applicable
     validations:
       required: false
+
+  - type: checkboxes
+    attributes:
+      label: Select all that apply
+      description: Please select all that apply from the following.
+      options:
+        - label: typo
+        - label: code bug
+        - label: out-of-date content
+        - label: broken link
+        - label: other
+    validations:
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Qiskit API feedback
     url: https://github.com/Qiskit/qiskit/issues/new/choose
-    about: Open an issue in the Qiskit repository (https://github.com/Qiskit/qiskit/).
+    about: Open an issue in the Qiskit repository for the docs found at https://docs.quantum-computing.ibm.com/api/qiskit.
   - name: Qiskit Runtime Client API feedback
     url: https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose
-    about: Open an issue in the qiskit-ibm-runtime repository (https://github.com/Qiskit/qiskit-ibm-runtime/).
+    about: Open an issue in the qiskit-ibm-runtime repository for the docs found at https://docs.quantum-computing.ibm.com/api/qiskit-ibm-runtime/runtime_service.

--- a/.github/ISSUE_TEMPLATE/new-content.yaml
+++ b/.github/ISSUE_TEMPLATE/new-content.yaml
@@ -35,7 +35,7 @@ body:
         - I will write a draft of the proposed content
         - I can help the team by providing enough information to write the material
         - I only want to review the material when it's finished
-        - No
+        - "no"
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new-content.yaml
+++ b/.github/ISSUE_TEMPLATE/new-content.yaml
@@ -1,6 +1,6 @@
 name: ✨ Request new content
 description: Make a request to the Content Team to add a new section in the docs.
-labels: ["NEW CONTENT REQUEST ✨"]
+labels: ["content request", "new"]
 assignees:
   - abbycross
   - beckykd
@@ -28,13 +28,14 @@ body:
 
   - type: dropdown
     attributes:
-      label: If this new content request is accepted, will you write a draft the content, or help the team draft it?
+      label: If this new content request is accepted, do you want to write the content?
       description:
       multiple: false
       options:
         - I will write a draft of the proposed content
         - I can help the team by providing enough information to write the material
         - I only want to review the material when it's finished
+        - No
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new-content.yaml
+++ b/.github/ISSUE_TEMPLATE/new-content.yaml
@@ -1,6 +1,6 @@
 name: ✨ Request new content
 description: Make a request to the Content Team to add a new section in the docs.
-labels: ["content request", "new"]
+labels: ["content request", "new ✨"]
 assignees:
   - abbycross
   - beckykd

--- a/.github/ISSUE_TEMPLATE/ui.yml
+++ b/.github/ISSUE_TEMPLATE/ui.yml
@@ -23,6 +23,6 @@ body:
     attributes:
       label: Please describe the UI problem.
       description: >
-        Please be as specific as possible. Include steps to reproduce, the operating system and browser you're using, a screenshot if possible, etc.).    
+        Please be as specific as possible. Include steps to reproduce, the operating system and browser you're using, a screenshot if possible, etc.    
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/ui.yml
+++ b/.github/ISSUE_TEMPLATE/ui.yml
@@ -1,6 +1,6 @@
 name: 📱 UI issue
 description: Report a rendering or other visual problem with the user interface.
-labels: ["UI 📱"]
+labels: ["UI feedback"]
 assignees:
   - abbycross
   - beckykd


### PR DESCRIPTION
From @javabster -- improvements to issue templates:

### content bug or inaccuracy

- [x] can we add a checkbox selection like we had in the old one? something like this:

```
- [ ] typo
- [ ] code bug
- [ ] out-of-date content
- [ ] it's just wrong
- [ ] other
```

- [x] description formatting is a bit weird with the slash (/). Can you update to say "Report typos, bugs, out-of-date content, broken links etc."

- [x] can you have it automatically add the "bug" label when the issue is opened?

### UI issue

- [x] typo in the "please describe the UI problem" description, there is an extra ) at the end

- [x] also can you have it automatically add a label, might need to make a new one called "UI feedback" or something

### Request new content
- [x] could you rephrase the last question in the form to emphasise that it is optional? i imagine some people might just want to add a suggestion but dont want to be further involved at all, they just want to submit a request and leave. That currently doesn't have an option in the dropdown and the q is mandatory. You could rephrase the question to "if this new content request is accepted, do you want to write the content?" and then have all the dropdown options including a "no" option
- [x]  can you automatically add the "new" label and also a "content request" label (i think the second will need to be created
### API refs
add the links to the 1 line description of the issue
- [x] https://docs.quantum-computing.ibm.com/api/qiskit
- [x] https://docs.quantum-computing.ibm.com/api/qiskit-ibm-runtime/runtime_service