### PR TITLE
Fix broken links after toc reorganization

### DIFF
--- a/docs/run/run-sessions.mdx
+++ b/docs/run/run-sessions.mdx
@@ -10,7 +10,7 @@ There are several ways to set up and use [sessions](sessions). The following
 information should not be considered mandatory steps to follow. Instead,
 choose the configuration that best suits your needs. This
 information assumes that you are using Qiskit Runtime
-[primitives](../build/primitives).
+[primitives](./primitives-get-started).
 
 ## Prerequisites
 

--- a/docs/run/sessions.mdx
+++ b/docs/run/sessions.mdx
@@ -27,7 +27,7 @@ that you want returned as a result. After identifying the appropriate
 primitive for your program, you can use Qiskit to prepare inputs, such
 as circuits, observables (for Estimator), and customizable options to
 optimize your job. For more information, see the
-[Primitives](../build/primitives) topic.
+[Primitives](./primitives-get-started) topic.
 
 ## Benefits of using sessions
 
@@ -160,6 +160,6 @@ recommend that you set a realistic `max_time` value.
 ## Next steps
 
 <Admonition type="tip" title="Recommendation">
-    - [Run a primitive in a session.](../build/primitives-examples#leverage-sessions-and-advanced-options)
+    - [Run a primitive in a session.](./primitives-examples#leverage-sessions-and-advanced-options)
     - See sessions at work in the [VQE tutorial.](https://learning.quantum-computing.ibm.com/tutorial/variational-quantum-eigensolver-using-estimator-primitive-and-sessions).
 </Admonition>

--- a/docs/start/hello-world.ipynb
+++ b/docs/start/hello-world.ipynb
@@ -136,7 +136,7 @@
     "## Step 3. Execute using a quantum primitive function\n",
     "\n",
     "\n",
-    "Quantum computers can produce random results, so you'll often want to collect a sample of the outputs by running the circuit many times. You can estimate the value of the observable using the `Estimator` class. `Estimator` is one of our two [primitives](../build/primitives); the other is `Sampler`, which can be used to get data from a quantum computer. "
+    "Quantum computers can produce random results, so you'll often want to collect a sample of the outputs by running the circuit many times. You can estimate the value of the observable using the `Estimator` class. `Estimator` is one of our two [primitives](../run/primitives-get-started); the other is `Sampler`, which can be used to get data from a quantum computer. "
    ]
   },
   {

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -42,8 +42,8 @@ Join other users in our quantum community to share ideas and see what others are
 
 <Admonition type="tip" title="Recommendations">
     - [Install and set up for Qiskit](install).
-    - Read the [introduction to Qiskit](intro-to-qiskit).
-    - Read the iIntroduction to the Qiskit Runtime service](runtime).
+    - Read the [Introduction to Qiskit](intro-to-qiskit).
+    - Read the [Introduction to the Qiskit Runtime service](runtime).
     - Explore hand-on tutorials in IBM Quantum Learning, such as:
       - [Variational Quantum Eigensolver using Estimator primitive and sessions](https://learning.quantum-computing.ibm.com/tutorial/variational-quantum-eigensolver-using-estimator-primitive-and-sessions)
       - [Quantum Approximate Optimization Algorithm using Qiskit Runtime primitives and sessions](https://learning.quantum-computing.ibm.com/tutorial/quantum-approximate-optimization-algorithm-using-qiskit-runtime-primitives-and-sessions)

--- a/docs/start/migrate-examples.mdx
+++ b/docs/start/migrate-examples.mdx
@@ -222,7 +222,7 @@ to the following:
 -   [Error mitigation
     tutorial](https://learning.quantum-computing.ibm.com/tutorial/error-suppression-and-error-mitigation-with-qiskit-runtime)
 -   [Setting execution options
-    topic](../build/primitive-options)
+    topic](../run/primitive-options)
 -   [Primitive execution options API
     reference](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options)
 -   [How to run a session
@@ -537,7 +537,7 @@ help improve your performance and results. For more information, refer
 to the following:
 
 -   [Error mitigation tutorial](https://learning.quantum-computing.ibm.com/tutorial/error-suppression-and-error-mitigation-with-qiskit-runtime)
--   [Setting execution options topic](../build/primitive-options)
+-   [Setting execution options topic](../run/primitive-options)
 -   [How to run a session topic](../run/run-sessions)
 
 ### 3. Other execution alternatives (non-Runtime)

--- a/docs/start/migrate.mdx
+++ b/docs/start/migrate.mdx
@@ -458,8 +458,8 @@ an algorithm, you might want to tune certain primitive options. For details, see
 
 <Admonition type="tip" title="Recommendations">
     - Review some [migration examples](migrate-examples).
-    - [Get started with Estimator.](../build/primitives-get-started#start-estimator)
-    - [Get started with Sampler.](../build/primitives-get-started#start-sampler)
+    - [Get started with Estimator.](../run/primitives-get-started#start-estimator)
+    - [Get started with Sampler.](../run/primitives-get-started#start-sampler)
     - Explore [sessions.](../run/sessions)
     - [Run a primitive in a session.](../run/run-sessions)
     - Experiment with the [migration tutorial.](https://qiskit.org/documentation/partners/qiskit_ibm_provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html) 

--- a/docs/start/runtime.mdx
+++ b/docs/start/runtime.mdx
@@ -13,7 +13,7 @@ in_page_toc_max_heading_level: 2
   This documentation is based on Qiskit Runtime version 0.12.1.
 </Admonition>
 
-Qiskit Runtime is a cloud-based quantum computing service developed by IBM. It offers computational *primitives* to perform foundational quantum computing tasks that use built-in error suppression and mitigation techniques. Primitives can be executed inside of *sessions*, so that collections of circuits can jointly run on a quantum computer without being interrupted by other users’ jobs. The combination of primitives, error suppression / mitigation, and sessions paves the way to efficiently build and execute scalable quantum applications, as shown in the [code examples](../build/primitives-examples).
+Qiskit Runtime is a cloud-based quantum computing service developed by IBM. It offers computational *primitives* to perform foundational quantum computing tasks that use built-in error suppression and mitigation techniques. Primitives can be executed inside of *sessions*, so that collections of circuits can jointly run on a quantum computer without being interrupted by other users’ jobs. The combination of primitives, error suppression / mitigation, and sessions paves the way to efficiently build and execute scalable quantum applications, as shown in the [code examples](../run/primitives-examples).
 
 The following figure illustrates how one can use Qiskit Runtime sessions and primitives. The first session request (job) waits through the regular [fair-share queue](../run/queue). When it starts to run, the session is started. After the first session job is finished processing, the next job in the session is run. This process continues until the session is paused (due to a lack of queued session jobs) or closed.
 

--- a/docs/start/runtime.mdx
+++ b/docs/start/runtime.mdx
@@ -87,17 +87,17 @@ def _get_evaluate_energy_vqe_primitives(
 
 ## Primitives
 
-Primitives are base level operations that serve as building blocks for many quantum algorithms and applications. Through these primitives, users can obtain high-fidelity results without needing detailed hardware knowledge. This abstraction allows you to write code, using Qiskit algorithms or otherwise, that can run on various quantum hardware or simulators without having to explicitly manage aspects such as compilation, optimization, and error suppression / mitigation. The primitives offered by [qiskit_ibm_runtime](../api/qiskit-ibm-runtime/runtime_service) add additional options specific to IBM services. See [Introduction to primitives](../build/primitives) for further details.
+Primitives are base-level operations that serve as building blocks for many quantum algorithms and applications. Through these primitives, users can obtain high-fidelity results without needing detailed hardware knowledge. This abstraction allows you to write code, using Qiskit algorithms or otherwise, that can run on various quantum hardware or simulators without having to explicitly manage aspects such as compilation, optimization, and error suppression / mitigation. The primitives offered by [qiskit_ibm_runtime](../api/qiskit-ibm-runtime/runtime_service) add additional options specific to IBM services. See [Introduction to primitives](../run/primitives-get-started) for further details.
 There are currently two primitives defined in Qiskit: Estimator and Sampler.
 
 ### Estimator
 
-The Estimator primitive allows you to efficiently calculate and interpret expectation values of quantum operators, which are the values of interest for many near-term quantum algorithms. You specify circuits that prepare quantum states and then Pauli-basis observables to measure on those states. Estimator can use advanced error suppression and mitigation capabilities to improve the accuracy of the returned expectation values. [Get started with the Estimator primitive here.](../build/primitives-get-started#get-started-with-estimator)
+The Estimator primitive allows you to efficiently calculate and interpret expectation values of quantum operators, which are the values of interest for many near-term quantum algorithms. You specify circuits that prepare quantum states and then Pauli-basis observables to measure on those states. Estimator can use advanced error suppression and mitigation capabilities to improve the accuracy of the returned expectation values. [Get started with the Estimator primitive here.](../run/primitives-get-started#get-started-with-estimator)
 
 
 ### Sampler
 
-This primitive takes circuits as input and returns a quasi-probability distribution over the measurement outcomes. This generalizes histograms from quantum circuits, allowing for mitigation of readout errors. [Get started with the Sampler primitive tutorial here.](../build/primitives-get-started#get-started-with-sampler)
+This primitive takes circuits as input and returns a quasi-probability distribution over the measurement outcomes. This generalizes histograms from quantum circuits, allowing for mitigation of readout errors. [Get started with the Sampler primitive tutorial here.](../run/primitives-get-started#get-started-with-sampler)
 
 ## Sessions
 

--- a/docs/test/noise.mdx
+++ b/docs/test/noise.mdx
@@ -73,7 +73,7 @@ options.resilience_level = 0 # no error mitigation
 ```
 ### Run the circuits on Sampler
 
-Next, we use the Sampler primitive to sample the circuit and get the resultant quasi-probability distribution. Visit the [Get started with Sampler](../build/primitives-get-started#get-started-with-sampler) section for more information about the Sampler primitive.
+Next, we use the Sampler primitive to sample the circuit and get the resultant quasi-probability distribution. Visit the [Get started with Sampler](../run/primitives-get-started#get-started-with-sampler) section for more information about the Sampler primitive.
 
 ``` python
 sampler = Sampler(options=options, backend=backend)
@@ -105,7 +105,7 @@ plt.legend()
 
 ### Run the circuits on Estimator
 
-Visit the [Get started with Estimator](../build/primitives-get-started#get-started-with-estimator) section for more information on the Estimator primitive.
+Visit the [Get started with Estimator](../run/primitives-get-started#get-started-with-estimator) section for more information on the Estimator primitive.
 
 The Estimator binds single-qubit rotations to get Hamiltonians before it returns expectation values of quantum operators. Therefore, the circuit doesn’t require any measurements. Currently the circuit ``qc`` has measurements, so we will remove these with ``remove_final_measurements``.
 

--- a/docs/test/noise.mdx
+++ b/docs/test/noise.mdx
@@ -23,7 +23,7 @@ service = QiskitRuntimeService()
 
 ## Prepare the environment
 
-First, we run an example routine. One of the major benefits of using primitives is simplification of binding multiple parameters in parameterized circuits. To illustrate this, we start with is an example circuit with a controlled [P-gate](/api/qiskit/qiskit.circuit.library.PhaseGate) as implemented in the following code. Here, we parameterize the ``P-gate`` with a rotation parameter ``theta``. For instructions to create circuits and bind parameters to them by using Qiskit, see the [Circuit Basics](https://qiskit.org/documentation/tutorials/circuits/01_circuit_basics.html) and [Advanced Circuits](https://qiskit.org/documentation/tutorials/circuits_advanced/01_advanced_circuits.html#Parameterized-circuits) tutorials in Qiskit documentation. {/*Will these tutorials still live at those URLs?*/}
+First, we run an example routine. One of the major benefits of using primitives is simplification of binding multiple parameters in parameterized circuits. To illustrate this, we start with is an example circuit with a controlled [P-gate](/api/qiskit/qiskit.circuit.library.PhaseGate) as implemented in the following code. Here, we parameterize the ``P-gate`` with a rotation parameter ``theta``.
 
 ``` python
 from qiskit.circuit import Parameter


### PR DESCRIPTION
Check for any links pointing to files that have moved or been removed.

- [x] primitives-get-started
- [x] primitive-options
- [x] backend_reset
- [x] all of dynamic circuits
- [x] first-circuit
- [x] midcircuit_measurement
- [x] algorithm-tuning-options