### PR TITLE
Switch local preview to public Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@
 
 # This Dockerfile is used to preview the docs in pull requests via GitHub Actions.
 #
-# Keep it in sync with ./start. This Dockerfile essentially is the same,
-# only it sets the CLI args directly in the Dockerfile because the
-# GitHub Action expects that.
+# Keep it aligned with ./start. This Dockerfile is similar,
+# but it uses a private Docker image from IBM Cloud Registry rather
+# than a public image from Dockerhub. It also sets the CLI args
+# directly in the Dockerfile because the GitHub Action expects that.
 #
 # To test it out locally:
 #

--- a/README.md
+++ b/README.md
@@ -8,22 +8,13 @@ The documentation content home for https://docs.quantum-computing.ibm.com. Refer
 
 These tools will also run in CI. But, it can be convenient when iterating to run the tools locally.
 
-Currently, this workflow only works for IBM maintainers. We are prioritizing fixing this workflow so that anyone can run the tools locally, tracked by https://github.com/Qiskit/docs/issues/53.
-
 First, install the below software:
 
 1. [Node.js](https://nodejs.org/en). If you expect to use JavaScript in other projects, consider using [NVM](https://github.com/nvm-sh/nvm). Otherwise, consider using [Homebrew](https://formulae.brew.sh/formula/node) or installing [Node.js directly](https://nodejs.org/en).
-2. [IBM Cloud command line](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
-3. [Docker](https://www.docker.com). You must also ensure that it is running.
+2. [Docker](https://www.docker.com). You must also ensure that it is running.
    * You can use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
 
-Set up IBM Cloud to access the Docker image:
-
-1. `ibmcloud plugin install cr`
-2. `ibmcloud cr region-set global`
-3. Make sure Docker is running, then `ibmcloud cr login`
-
-Finally, install the dependencies with:
+Then, install the dependencies with:
 
 ```bash
 npm install
@@ -31,7 +22,15 @@ npm install
 
 ## Preview the docs locally
 
-Run `./start` in your terminal, then open http://localhost:3000 in your browser.
+Run `./start` in your terminal, then open http://localhost:3000/start in your browser.
+
+The local preview does not include the top nav bar from docs.quantum-computing.ibm.com due to security considerations. So, you must directly navigate in the URL to the folder that you want:
+
+* http://localhost:3000/build
+* http://localhost:3000/start
+* http://localhost:3000/run
+* http://localhost:3000/test
+* http://localhost:3000/transpile
 
 ## Preview the docs in PRs
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 
 Run `./start` in your terminal, then open http://localhost:3000/start in your browser.
 
-The local preview does not include the top nav bar from docs.quantum-computing.ibm.com due to security considerations. So, you must directly navigate in the URL to the folder that you want:
+The local preview does not include the initial index page and the top nav bar from docs.quantum-computing.ibm.com. So, you must directly navigate in the URL to the folder that you want:
 
 * http://localhost:3000/build
 * http://localhost:3000/start

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 
 Run `./start` in your terminal, then open http://localhost:3000/start in your browser.
 
-The local preview does not include the initial index page and the top nav bar from docs.quantum-computing.ibm.com. So, you must directly navigate in the URL to the folder that you want:
+The local preview does not include the initial index page and the top nav bar from docs.quantum-computing.ibm.com. Therefore, you must directly navigate in the URL to the folder that you want:
 
 * http://localhost:3000/build
 * http://localhost:3000/start

--- a/start
+++ b/start
@@ -11,10 +11,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Keep this in sync with the Dockerfile at the root of the repository.
+# Keep this aligned with the Dockerfile at the root of the repository.
 docker run \
   -v "$(pwd)"/docs:/home/node/app/docs \
-  -v "$(pwd)"/public/images:/home/node/app/public/images \
+  -v "$(pwd)"/public/images:/home/node/app/packages/preview/public/images \
   -p 3000:3000 \
   -p 5001:5001 \
-  icr.io/quantum-computing/iqp-channel-docs-dev
+  qiskit/documentation


### PR DESCRIPTION
We started publishing a new Docker image to public Dockerhub without password protection. So, we can now have live local preview for every contributor! Closes https://github.com/Qiskit/documentation/issues/53.

However, the live preview has a worse UI due to security constraints. It doesn't have the top nav bar, nor the index page.

<img width="1556" alt="Screenshot 2023-10-11 at 3 41 39 PM" src="https://github.com/Qiskit/documentation/assets/14852634/f433c550-f30b-42ce-967c-d74fe7de1d4b">

So, we will have _two_ Docker images: the public Docker image and the password-protected Docker image. We'll keep using the password-protected Docker image for PR previews and the staging website at https://qiskit-docs-preview-staging.1799mxdls7qz.us-south.codeengine.appdomain.cloud/, since it's a more useful preview. 
