### PR TITLE
Remove broken links on Start page

### DIFF
--- a/docs/start/hello-world.ipynb
+++ b/docs/start/hello-world.ipynb
@@ -270,7 +270,6 @@
     "<Admonition type=\"tip\" title=\"Recommendations\">\n",
     "    - Learn how to [build circuits](../build/) in more detail.\n",
     "    - Try out some [tutorials.](https://learning.quantum-computing.ibm.com/catalog?content=tutorials)\n",
-    "    - Learn more about [Qiskit](intro-to-qiskit) or [Qiskit Runtime](runtime).\n",
     "</Admonition>\n"
    ]
   }

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -46,8 +46,6 @@ Join other users in our quantum community to share ideas and see what others are
 
 <Admonition type="tip" title="Recommendations">
     - [Install and set up for Qiskit](install).
-    - Read the [Introduction to Qiskit](intro-to-qiskit).
-    - Read the [Introduction to the Qiskit Runtime service](runtime).
     - Explore hand-on tutorials in IBM Quantum Learning, such as:
       - [Variational Quantum Eigensolver using the Estimator primitive and sessions](https://learning.quantum-computing.ibm.com/tutorial/variational-quantum-eigensolver-using-estimator-primitive-and-sessions)
       - [Quantum Approximate Optimization Algorithm using Qiskit Runtime primitives and sessions](https://learning.quantum-computing.ibm.com/tutorial/quantum-approximate-optimization-algorithm-using-qiskit-runtime-primitives-and-sessions)

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -46,6 +46,7 @@ Join other users in our quantum community to share ideas and see what others are
 
 <Admonition type="tip" title="Recommendations">
     - [Install and set up for Qiskit](install).
+    - [Run the Hello world program](hello-world).
     - Explore hand-on tutorials in IBM Quantum Learning, such as:
       - [Variational Quantum Eigensolver using the Estimator primitive and sessions](https://learning.quantum-computing.ibm.com/tutorial/variational-quantum-eigensolver-using-estimator-primitive-and-sessions)
       - [Quantum Approximate Optimization Algorithm using Qiskit Runtime primitives and sessions](https://learning.quantum-computing.ibm.com/tutorial/quantum-approximate-optimization-algorithm-using-qiskit-runtime-primitives-and-sessions)


### PR DESCRIPTION
We've removed intro to Qiskit and intro to Qiskit Runtime temporarily, so need to remove links to these files on the Start/index page.