### PR TITLE
Fix permalinks with API generation for Sphinx 7.2+

### DIFF
--- a/scripts/lib/sphinx/sphinxHtmlToMarkdown.test.ts
+++ b/scripts/lib/sphinx/sphinxHtmlToMarkdown.test.ts
@@ -68,46 +68,17 @@ describe('sphinxHtmlToMarkdown', () => {
 
   test('remove permalink', async () => {
     expect(
-      await toMd(`<div
-  role='main'
-  class='main-content'
-  itemscope='itemscope'
-  itemtype='http://schema.org/Article'
->
-  <article itemprop='articleBody' id='pytorch-article' class='pytorch-article'>
-    <section id='qiskit-ibm-runtime-api-reference'>
-      <h1>
-        qiskit-ibm-runtime API reference<a
-        class='headerlink'
-        href='#qiskit-ibm-runtime-api-reference'
-        title='Permalink to this heading'
-      >¶</a
-      >
-      </h1>
-      <div class='toctree-wrapper compound'>
-        <ul>
-          <li class='toctree-l1'>
-            <a class='reference internal' href='runtime_service.html'
-            >Qiskit Runtime (<code
-              class='xref py py-mod docutils literal notranslate'
-            ><span class='pre'>qiskit_ibm_runtime</span></code
-            >)</a
-            >
-          </li>
-          <li class='toctree-l1'>
-            <a class='reference internal' href='options.html'
-            >Primitive options (<code
-              class='xref py py-mod docutils literal notranslate'
-            ><span class='pre'>qiskit_ibm_runtime.options</span></code
-            >)</a
-            >
-          </li>
-        </ul>
-      </div>
-    </section>
-  </article>
-</div>
-`)
+      await toMd(`<article role="main">
+        <section id="qiskit-ibm-runtime-api-reference">
+          <h1>qiskit-ibm-runtime API reference<a class="headerlink" href="#qiskit-ibm-runtime-api-reference" title="Link to this heading">#</a></h1>
+         <div class="toctree-wrapper compound">
+           <ul>
+             <li class="toctree-l1"><a class="reference internal" href="runtime_service.html">Qiskit Runtime (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime</span></code>)</a></li>
+             <li class="toctree-l1"><a class="reference internal" href="options.html">Primitive options (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.options</span></code>)</a></li>
+           </ul>
+         </div>
+       </section>
+    </article>`)
     ).toMatchInlineSnapshot(`
       "<span id="qiskit-ibm-runtime-api-reference" />
 

--- a/scripts/lib/sphinx/sphinxHtmlToMarkdown.ts
+++ b/scripts/lib/sphinx/sphinxHtmlToMarkdown.ts
@@ -73,6 +73,8 @@ export async function sphinxHtmlToMarkdown(options: {
   // remove permalink links
   $main.find('a[title="Permalink to this heading"]').remove();
   $main.find('a[title="Permalink to this definition"]').remove();
+  $main.find('a[title="Link to this heading"]').remove();
+  $main.find('a[title="Link to this definition"]').remove();
 
   // remove download source code
   $main.find('p > a.reference.download.internal').closest('p').remove();


### PR DESCRIPTION
Fixes one of the issues in https://github.com/Qiskit/documentation/issues/67, that we weren't removing the permalink in headers with qiskit-ibm-runtime:

![screenshot_2023-10-20_at_11 17 25___am_720](https://github.com/Qiskit/documentation/assets/14852634/4fde70dc-e8c5-424f-9d34-c71cba68501a)

This change is because of https://github.com/sphinx-doc/sphinx/commit/7e9a2066c2f31eda53d075f5a8b20a7430ca0c61. Sphinx 7.2 changed the title from "Permalink" to "Link".