### PR TITLE
Update Runtime API docs to 0.13

### DIFF
--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -1,6 +1,6 @@
 {
   "title": "Qiskit Runtime IBM Client",
-  "subtitle": "v0.11.3",
+  "subtitle": "v0.13.0",
   "children": [
     {
       "title": "qiskit_ibm_runtime",

--- a/docs/api/qiskit-ibm-runtime/options.md
+++ b/docs/api/qiskit-ibm-runtime/options.md
@@ -6,9 +6,9 @@ python_api_type: module
 python_api_name: qiskit_ibm_runtime.options
 ---
 
-<span id="module-qiskit_ibm_runtime.options" />
-
 <span id="primitive-options-qiskit-ibm-runtime-options" />
+
+<span id="module-qiskit_ibm_runtime.options" />
 
 # Primitive options
 
@@ -18,7 +18,7 @@ python_api_name: qiskit_ibm_runtime.options
 
 Options that can be passed to the primitives.
 
-The [`Options`](qiskit_ibm_runtime.options.Options "qiskit_ibm_runtime.options.Options") class encapsulates all the options you can specify when invoking a primitive. It includes frequestly used options, such as `optimization_level` and `resilience_level` as well as sub-categories, such as `transpilation` and `execution`. You can use auto-complete to easily find the options inside each sub-category, for example:
+The [`Options`](qiskit_ibm_runtime.options.Options "qiskit_ibm_runtime.options.Options") class encapsulates all the options you can specify when invoking a primitive. It includes frequently used options, such as `optimization_level` and `resilience_level` as well as sub-categories, such as `transpilation` and `execution`. You can use auto-complete to easily find the options inside each sub-category, for example:
 
 ```python
 from qiskit_ibm_runtime.options import Options
@@ -39,10 +39,10 @@ options = Options(transpilation={"initial_layout": [0, 1, 2, 3]})
 
 |                                                                                                                                                          |                                               |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| [`Options`](qiskit_ibm_runtime.options.Options "qiskit_ibm_runtime.options.Options")(\[optimization\_level, ...])                                        | Options for the primitives.                   |
-| [`TranspilationOptions`](qiskit_ibm_runtime.options.TranspilationOptions "qiskit_ibm_runtime.options.TranspilationOptions")(\[skip\_transpilation, ...]) | Transpilation options.                        |
-| [`ResilienceOptions`](qiskit_ibm_runtime.options.ResilienceOptions "qiskit_ibm_runtime.options.ResilienceOptions")(\[noise\_amplifier, ...])             | Resilience options.                           |
-| [`ExecutionOptions`](qiskit_ibm_runtime.options.ExecutionOptions "qiskit_ibm_runtime.options.ExecutionOptions")(\[shots, init\_qubits])                  | Execution options.                            |
-| [`EnvironmentOptions`](qiskit_ibm_runtime.options.EnvironmentOptions "qiskit_ibm_runtime.options.EnvironmentOptions")(\[log\_level, callback, ...])      | Options related to the execution environment. |
-| [`SimulatorOptions`](qiskit_ibm_runtime.options.SimulatorOptions "qiskit_ibm_runtime.options.SimulatorOptions")(\[noise\_model, ...])                    | Simulator options.                            |
+| [`Options`](qiskit_ibm_runtime.options.Options "qiskit_ibm_runtime.options.Options")(\[optimization\_level, ...])                                        | Options for the primitives.                   |
+| [`TranspilationOptions`](qiskit_ibm_runtime.options.TranspilationOptions "qiskit_ibm_runtime.options.TranspilationOptions")(\[skip\_transpilation, ...]) | Transpilation options.                        |
+| [`ResilienceOptions`](qiskit_ibm_runtime.options.ResilienceOptions "qiskit_ibm_runtime.options.ResilienceOptions")(\[noise\_amplifier, ...])             | Resilience options.                           |
+| [`ExecutionOptions`](qiskit_ibm_runtime.options.ExecutionOptions "qiskit_ibm_runtime.options.ExecutionOptions")(\[shots, init\_qubits])                  | Execution options.                            |
+| [`EnvironmentOptions`](qiskit_ibm_runtime.options.EnvironmentOptions "qiskit_ibm_runtime.options.EnvironmentOptions")(\[log\_level, callback, ...])      | Options related to the execution environment. |
+| [`SimulatorOptions`](qiskit_ibm_runtime.options.SimulatorOptions "qiskit_ibm_runtime.options.SimulatorOptions")(\[noise\_model, ...])                    | Simulator options.                            |
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator.md
@@ -16,7 +16,7 @@ Class for interacting with Qiskit Runtime Estimator primitive service.
 
 Qiskit Runtime Estimator primitive service estimates expectation values of quantum circuits and observables.
 
-The [`run()`](qiskit_ibm_runtime.Estimator#run "qiskit_ibm_runtime.Estimator.run") can be used to submit circuits, observables, and parameters to the Estimator primitive.
+The [`run()`](#qiskit_ibm_runtime.Estimator.run "qiskit_ibm_runtime.Estimator.run") can be used to submit circuits, observables, and parameters to the Estimator primitive.
 
 You are encouraged to use [`Session`](qiskit_ibm_runtime.Session "qiskit_ibm_runtime.Session") to open a session, during which you can invoke one or more primitives. Jobs submitted within a session are prioritized by the scheduler, and data is cached for efficiency.
 
@@ -52,9 +52,6 @@ with Session(service=service, backend="ibmq_qasm_simulator") as session:
         parameter_values=[theta1]*2
     )
     print(psi1_H23.result())
-    # Close the session only if all jobs are finished
-    # and you don't need to run more in the session
-    session.close()
 ```
 
 Initializes the Estimator primitive.
@@ -73,13 +70,9 @@ Initializes the Estimator primitive.
 
 ## Attributes
 
-<span id="estimator-circuits" />
-
-### circuits
-
 <span id="qiskit_ibm_runtime.Estimator.circuits" />
 
-`tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]`
+### circuits
 
 Quantum circuits that represents quantum states.
 
@@ -91,13 +84,9 @@ Quantum circuits that represents quantum states.
 
 The quantum circuits.
 
-<span id="estimator-observables" />
-
-### observables
-
 <span id="qiskit_ibm_runtime.Estimator.observables" />
 
-`tuple[qiskit.quantum_info.operators.symplectic.sparse_pauli_op.SparsePauliOp, ...]`
+### observables
 
 Observables to be estimated.
 
@@ -109,13 +98,9 @@ Observables to be estimated.
 
 The observables.
 
-<span id="estimator-options" />
-
-### options
-
 <span id="qiskit_ibm_runtime.Estimator.options" />
 
-`Options`
+### options
 
 Return options values for the sampler.
 
@@ -127,13 +112,9 @@ Return options values for the sampler.
 
 options
 
-<span id="estimator-parameters" />
-
-### parameters
-
 <span id="qiskit_ibm_runtime.Estimator.parameters" />
 
-`tuple[qiskit.circuit.parametertable.ParameterView, ...]`
+### parameters
 
 Parameters of the quantum circuits.
 
@@ -145,13 +126,9 @@ Parameters of the quantum circuits.
 
 Parameters, where `parameters[i][j]` is the j-th parameter of the i-th circuit.
 
-<span id="estimator-session" />
-
-### session
-
 <span id="qiskit_ibm_runtime.Estimator.session" />
 
-`Session | None`
+### session
 
 Return session used by this primitive.
 
@@ -165,13 +142,11 @@ Session used by this primitive, or `None` if session is not used.
 
 ## Methods
 
-<span id="estimator-run" />
-
 ### run
 
 <span id="qiskit_ibm_runtime.Estimator.run" />
 
-`Estimator.run(circuits, observables, parameter_values=None, **kwargs)`
+`run(circuits, observables, parameter_values=None, **kwargs)`
 
 Submit a request to the estimator primitive.
 
@@ -194,13 +169,11 @@ Submitted job. The result of the job is an instance of `qiskit.primitives.Estima
 
 **ValueError** – Invalid arguments are given.
 
-<span id="estimator-set-options" />
-
 ### set\_options
 
 <span id="qiskit_ibm_runtime.Estimator.set_options" />
 
-`Estimator.set_options(**fields)`
+`set_options(**fields)`
 
 Set options values for the sampler.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend.md
@@ -18,7 +18,7 @@ Backend class interfacing with an IBM Quantum backend.
   *   You should not instantiate the `IBMBackend` class directly. Instead, use the methods provided by an [`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance to retrieve and handle backends.
 </Admonition>
 
-This class represents an IBM Quantum backend. Its attributes and methods provide information about the backend. For example, the [`status()`](qiskit_ibm_runtime.IBMBackend#status "qiskit_ibm_runtime.IBMBackend.status") method returns a `BackendStatus` instance. The instance contains the `operational` and `pending_jobs` attributes, which state whether the backend is operational and also the number of jobs in the server queue for the backend, respectively:
+This class represents an IBM Quantum backend. Its attributes and methods provide information about the backend. For example, the [`status()`](#qiskit_ibm_runtime.IBMBackend.status "qiskit_ibm_runtime.IBMBackend.status") method returns a `BackendStatus` instance. The instance contains the `operational` and `pending_jobs` attributes, which state whether the backend is operational and also the number of jobs in the server queue for the backend, respectively:
 
 ```python
 status = backend.status()
@@ -134,19 +134,15 @@ IBMBackend constructor.
 
 ## Attributes
 
-<span id="ibmbackend-coupling-map" />
+<span id="qiskit_ibm_runtime.IBMBackend.coupling_map" />
 
 ### coupling\_map
 
 Return the `CouplingMap` object
 
-<span id="ibmbackend-dt" />
-
-### dt
-
 <span id="qiskit_ibm_runtime.IBMBackend.dt" />
 
-`float | None`
+### dt
 
 Return the system time resolution of input signals
 
@@ -160,13 +156,9 @@ The input signal timestep in seconds. If the backend doesn’t define `dt` `None
 
 dt
 
-<span id="ibmbackend-dtm" />
-
-### dtm
-
 <span id="qiskit_ibm_runtime.IBMBackend.dtm" />
 
-`float`
+### dtm
 
 Return the system time resolution of output signals
 
@@ -178,33 +170,27 @@ The output signal timestep in seconds.
 
 dtm
 
-<span id="ibmbackend-id-warning-issued" />
+<span id="qiskit_ibm_runtime.IBMBackend.id_warning_issued" />
 
 ### id\_warning\_issued
 
-<span id="qiskit_ibm_runtime.IBMBackend.id_warning_issued" />
-
 `= False`
 
-<span id="ibmbackend-instruction-durations" />
+<span id="qiskit_ibm_runtime.IBMBackend.instruction_durations" />
 
 ### instruction\_durations
 
 Return the `InstructionDurations` object.
 
-<span id="ibmbackend-instruction-schedule-map" />
+<span id="qiskit_ibm_runtime.IBMBackend.instruction_schedule_map" />
 
 ### instruction\_schedule\_map
 
 Return the `InstructionScheduleMap` for the instructions defined in this backend’s target.
 
-<span id="ibmbackend-instructions" />
-
-### instructions
-
 <span id="qiskit_ibm_runtime.IBMBackend.instructions" />
 
-`List[Tuple[Instruction, Tuple[int]]]`
+### instructions
 
 A list of Instruction tuples on the backend of the form `(instruction, (qubits)`
 
@@ -212,13 +198,9 @@ A list of Instruction tuples on the backend of the form `(instruction, (qubits)`
 
 `List`\[`Tuple`\[`Instruction`, `Tuple`\[`int`]]]
 
-<span id="ibmbackend-max-circuits" />
-
-### max\_circuits
-
 <span id="qiskit_ibm_runtime.IBMBackend.max_circuits" />
 
-`int`
+### max\_circuits
 
 The maximum number of circuits
 
@@ -228,13 +210,9 @@ The maximum number of circuits (or Pulse schedules) that can be run in a single 
 
 `int`
 
-<span id="ibmbackend-meas-map" />
-
-### meas\_map
-
 <span id="qiskit_ibm_runtime.IBMBackend.meas_map" />
 
-`List[List[int]]`
+### meas\_map
 
 Return the grouping of measurements which are multiplexed
 
@@ -248,13 +226,9 @@ The grouping of measurements which are multiplexed
 
 meas\_map
 
-<span id="ibmbackend-num-qubits" />
-
-### num\_qubits
-
 <span id="qiskit_ibm_runtime.IBMBackend.num_qubits" />
 
-`int`
+### num\_qubits
 
 Return the number of qubits the backend has.
 
@@ -262,13 +236,9 @@ Return the number of qubits the backend has.
 
 `int`
 
-<span id="ibmbackend-operation-names" />
-
-### operation\_names
-
 <span id="qiskit_ibm_runtime.IBMBackend.operation_names" />
 
-`List[str]`
+### operation\_names
 
 A list of instruction names that the backend supports.
 
@@ -276,13 +246,9 @@ A list of instruction names that the backend supports.
 
 `List`\[`str`]
 
-<span id="ibmbackend-operations" />
-
-### operations
-
 <span id="qiskit_ibm_runtime.IBMBackend.operations" />
 
-`List[Instruction]`
+### operations
 
 A list of `Instruction` instances that the backend supports.
 
@@ -290,15 +256,15 @@ A list of `Instruction` instances that the backend supports.
 
 `List`\[`Instruction`]
 
-<span id="ibmbackend-options" />
+<span id="qiskit_ibm_runtime.IBMBackend.options" />
 
 ### options
 
 Return the options for the backend
 
-The options of a backend are the dynamic parameters defining how the backend is used. These are used to control the [`run()`](qiskit_ibm_runtime.IBMBackend#run "qiskit_ibm_runtime.IBMBackend.run") method.
+The options of a backend are the dynamic parameters defining how the backend is used. These are used to control the [`run()`](#qiskit_ibm_runtime.IBMBackend.run "qiskit_ibm_runtime.IBMBackend.run") method.
 
-<span id="ibmbackend-provider" />
+<span id="qiskit_ibm_runtime.IBMBackend.provider" />
 
 ### provider
 
@@ -312,13 +278,9 @@ the Provider responsible for the backend.
 
 Provider
 
-<span id="ibmbackend-service" />
-
-### service
-
 <span id="qiskit_ibm_runtime.IBMBackend.service" />
 
-`QiskitRuntimeService`
+### service
 
 Return the `service` object
 
@@ -330,13 +292,9 @@ instance of QiskitRuntimeService
 
 service
 
-<span id="ibmbackend-target" />
-
-### target
-
 <span id="qiskit_ibm_runtime.IBMBackend.target" />
 
-`Target`
+### target
 
 A `qiskit.transpiler.Target` object for the backend.
 
@@ -348,37 +306,31 @@ A `qiskit.transpiler.Target` object for the backend.
 
 Target
 
-<span id="ibmbackend-version" />
+<span id="qiskit_ibm_runtime.IBMBackend.version" />
 
 ### version
-
-<span id="qiskit_ibm_runtime.IBMBackend.version" />
 
 `= 2`
 
 ## Methods
 
-<span id="ibmbackend-call" />
-
 ### \_\_call\_\_
 
 <span id="qiskit_ibm_runtime.IBMBackend.__call__" />
 
-`IBMBackend.__call__()`
+`__call__()`
 
 Call self as a function.
 
 **Return type**
 
-[`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend")
-
-<span id="ibmbackend-acquire-channel" />
+[`IBMBackend`](#qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend")
 
 ### acquire\_channel
 
 <span id="qiskit_ibm_runtime.IBMBackend.acquire_channel" />
 
-`IBMBackend.acquire_channel(qubit)`
+`acquire_channel(qubit)`
 
 Return the acquisition channel for the given qubit.
 
@@ -390,13 +342,11 @@ The Qubit measurement acquisition line.
 
 AcquireChannel
 
-<span id="ibmbackend-check-faulty" />
-
 ### check\_faulty
 
 <span id="qiskit_ibm_runtime.IBMBackend.check_faulty" />
 
-`IBMBackend.check_faulty(circuit)`
+`check_faulty(circuit)`
 
 Check if the input circuit uses faulty qubits or edges.
 
@@ -412,19 +362,17 @@ Check if the input circuit uses faulty qubits or edges.
 
 `None`
 
-<span id="ibmbackend-configuration" />
-
 ### configuration
 
 <span id="qiskit_ibm_runtime.IBMBackend.configuration" />
 
-`IBMBackend.configuration()`
+`configuration()`
 
 Return the backend configuration.
 
 Backend configuration contains fixed information about the backend, such as its name, number of qubits, basis gates, coupling map, quantum volume, etc.
 
-The schema for backend configuration can be found in [Qiskit/ibm-quantum-schemas](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json).
+The schema for backend configuration can be found in [Qiskit/ibm-quantum-schemas/backend\_configuration](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json).
 
 **Return type**
 
@@ -434,13 +382,11 @@ The schema for backend configuration can be found in [Qiskit/ibm-quantum-schemas
 
 The configuration for the backend.
 
-<span id="ibmbackend-control-channel" />
-
 ### control\_channel
 
 <span id="qiskit_ibm_runtime.IBMBackend.control_channel" />
 
-`IBMBackend.control_channel(qubits)`
+`control_channel(qubits)`
 
 Return the secondary drive channel for the given qubit
 
@@ -458,17 +404,15 @@ The Qubit measurement acquisition line.
 
 List\[ControlChannel]
 
-<span id="ibmbackend-defaults" />
-
 ### defaults
 
 <span id="qiskit_ibm_runtime.IBMBackend.defaults" />
 
-`IBMBackend.defaults(refresh=False)`
+`defaults(refresh=False)`
 
 Return the pulse defaults for the backend.
 
-The schema for default pulse configuration can be found in [Qiskit/ibm-quantum-schemas](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/default_pulse_configuration_schema.json).
+The schema for default pulse configuration can be found in [Qiskit/ibm-quantum-schemas/default\_pulse\_configuration](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/default_pulse_configuration_schema.json).
 
 **Parameters**
 
@@ -482,13 +426,11 @@ The schema for default pulse configuration can be found in [Qiskit/ibm-quantum-s
 
 The backend pulse defaults or `None` if the backend does not support pulse.
 
-<span id="ibmbackend-drive-channel" />
-
 ### drive\_channel
 
 <span id="qiskit_ibm_runtime.IBMBackend.drive_channel" />
 
-`IBMBackend.drive_channel(qubit)`
+`drive_channel(qubit)`
 
 Return the drive channel for the given qubit.
 
@@ -500,13 +442,11 @@ The Qubit drive channel
 
 DriveChannel
 
-<span id="ibmbackend-measure-channel" />
-
 ### measure\_channel
 
 <span id="qiskit_ibm_runtime.IBMBackend.measure_channel" />
 
-`IBMBackend.measure_channel(qubit)`
+`measure_channel(qubit)`
 
 Return the measure stimulus channel for the given qubit.
 
@@ -518,19 +458,17 @@ The Qubit measurement stimulus line
 
 MeasureChannel
 
-<span id="ibmbackend-properties" />
-
 ### properties
 
 <span id="qiskit_ibm_runtime.IBMBackend.properties" />
 
-`IBMBackend.properties(refresh=False, datetime=None)`
+`properties(refresh=False, datetime=None)`
 
 Return the backend properties, subject to optional filtering.
 
 This data describes qubits properties (such as T1 and T2), gates properties (such as gate length and error), and other general properties of the backend.
 
-The schema for backend properties can be found in [Qiskit/ibm-quantum-schemas](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_properties_schema.json).
+The schema for backend properties can be found in [Qiskit/ibm-quantum-schemas/backend\_properties](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_properties_schema.json).
 
 **Parameters**
 
@@ -548,15 +486,13 @@ The backend properties or `None` if the backend properties are not currently ava
 **Raises**
 
 *   **TypeError** – If an input argument is not of the correct type.
-*   **NotImplementedError** – If datetime is specified when cloud rutime is used.
-
-<span id="ibmbackend-qubit-properties" />
+*   **NotImplementedError** – If datetime is specified when cloud runtime is used.
 
 ### qubit\_properties
 
 <span id="qiskit_ibm_runtime.IBMBackend.qubit_properties" />
 
-`IBMBackend.qubit_properties(qubit)`
+`qubit_properties(qubit)`
 
 Return QubitProperties for a given qubit.
 
@@ -578,13 +514,11 @@ qubit\_properties
 
 **NotImplementedError** – if the backend doesn’t support querying the qubit properties
 
-<span id="ibmbackend-run" />
-
 ### run
 
 <span id="qiskit_ibm_runtime.IBMBackend.run" />
 
-`IBMBackend.run(*args, **kwargs)`
+`run(*args, **kwargs)`
 
 Not supported method
 
@@ -592,13 +526,11 @@ Not supported method
 
 `None`
 
-<span id="ibmbackend-set-options" />
-
 ### set\_options
 
 <span id="qiskit_ibm_runtime.IBMBackend.set_options" />
 
-`IBMBackend.set_options(**fields)`
+`set_options(**fields)`
 
 Set the options fields for the backend
 
@@ -612,13 +544,11 @@ This method is used to update the options of a backend. If you need to change an
 
 **AttributeError** – If the field passed in is not part of the options
 
-<span id="ibmbackend-status" />
-
 ### status
 
 <span id="qiskit_ibm_runtime.IBMBackend.status" />
 
-`IBMBackend.status()`
+`status()`
 
 Return the backend status.
 
@@ -638,13 +568,11 @@ The status of the backend.
 
 **IBMBackendApiProtocolError** – If the status for the backend cannot be formatted properly.
 
-<span id="ibmbackend-target-history" />
-
 ### target\_history
 
 <span id="qiskit_ibm_runtime.IBMBackend.target_history" />
 
-`IBMBackend.target_history(datetime=None)`
+`target_history(datetime=None)`
 
 A `qiskit.transpiler.Target` object for the backend. :rtype: `Target` :returns: Target with properties found on datetime
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.ParameterNamespace.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.ParameterNamespace.md
@@ -24,13 +24,9 @@ ParameterNamespace constructor.
 
 ## Attributes
 
-<span id="parameternamespace-metadata" />
-
-### metadata
-
 <span id="qiskit_ibm_runtime.ParameterNamespace.metadata" />
 
-`Dict`
+### metadata
 
 Returns the parameter metadata
 
@@ -40,13 +36,11 @@ Returns the parameter metadata
 
 ## Methods
 
-<span id="parameternamespace-to-dict" />
-
 ### to\_dict
 
 <span id="qiskit_ibm_runtime.ParameterNamespace.to_dict" />
 
-`ParameterNamespace.to_dict()`
+`to_dict()`
 
 Convert to dictionary.
 
@@ -54,13 +48,11 @@ Convert to dictionary.
 
 `Dict`
 
-<span id="parameternamespace-validate" />
-
 ### validate
 
 <span id="qiskit_ibm_runtime.ParameterNamespace.validate" />
 
-`ParameterNamespace.validate()`
+`validate()`
 
 Validate program input values.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.QiskitRuntimeService
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService" />
 
-`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None)`
+`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`
 
 Class for interacting with the Qiskit Runtime service.
 
@@ -48,16 +48,13 @@ with Session(service=service, backend="ibmq_qasm_simulator") as session:
         circuits=[psi], observables=[H1], parameter_values=[theta]
     )
     print(f"Estimator results: {job.result()}")
-    # Close the session only if all jobs are finished
-    # and you don't need to run more in the session.
-    session.close()
 ```
 
-The example above uses the dedicated [`Sampler`](qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler") and [`Estimator`](qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator") classes. You can also use the [`run()`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") method directly to invoke a Qiskit Runtime program.
+The example above uses the dedicated [`Sampler`](qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler") and [`Estimator`](qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator") classes. You can also use the [`run()`](#qiskit_ibm_runtime.QiskitRuntimeService.run "qiskit_ibm_runtime.QiskitRuntimeService.run") method directly to invoke a Qiskit Runtime program.
 
-If the program has any interim results, you can use the `callback` parameter of the [`run()`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") method to stream the interim results. Alternatively, you can use the [`RuntimeJob.stream_results()`](qiskit_ibm_runtime.RuntimeJob#stream_results "qiskit_ibm_runtime.RuntimeJob.stream_results") method to stream the results at a later time, but before the job finishes.
+If the program has any interim results, you can use the `callback` parameter of the [`run()`](#qiskit_ibm_runtime.QiskitRuntimeService.run "qiskit_ibm_runtime.QiskitRuntimeService.run") method to stream the interim results. Alternatively, you can use the [`RuntimeJob.stream_results()`](qiskit_ibm_runtime.RuntimeJob#stream_results "qiskit_ibm_runtime.RuntimeJob.stream_results") method to stream the results at a later time, but before the job finishes.
 
-The [`run()`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") method returns a [`RuntimeJob`](qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob") object. You can use its methods to perform tasks like checking job status, getting job result, and canceling job.
+The [`run()`](#qiskit_ibm_runtime.QiskitRuntimeService.run "qiskit_ibm_runtime.QiskitRuntimeService.run") method returns a [`RuntimeJob`](qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob") object. You can use its methods to perform tasks like checking job status, getting job result, and canceling job.
 
 QiskitRuntimeService constructor
 
@@ -66,6 +63,7 @@ An account is selected in the following order:
 > *   Account with the input name, if specified.
 > *   Default account for the channel type, if channel is specified but token is not.
 > *   Account defined by the input channel and token, if specified.
+> *   Account defined by the default\_channel if defined in filename
 > *   Account defined by the environment variables, if defined.
 > *   Default account for the `ibm_cloud` account, if one is available.
 > *   Default account for the `ibm_quantum` account, if one is available.
@@ -82,6 +80,7 @@ instance, proxies, and verify can be used to overwrite corresponding values in t
 *   **instance** (`Optional`\[`str`]) – The service instance to use. For `ibm_cloud` runtime, this is the Cloud Resource Name (CRN) or the service name. For `ibm_quantum` runtime, this is the hub/group/project in that format.
 *   **proxies** (`Optional`\[`dict`]) – Proxy configuration. Supported optional keys are `urls` (a dictionary mapping protocol or protocol and host to the URL of the proxy, documented at [https://docs.python-requests.org/en/latest/api/#requests.Session.proxies](https://docs.python-requests.org/en/latest/api/#requests.Session.proxies)), `username_ntlm`, `password_ntlm` (username and password to enable NTLM user authentication)
 *   **verify** (`Optional`\[`bool`]) – Whether to verify the server’s TLS certificate.
+*   **channel\_strategy** (`Optional`\[`str`]) – Error mitigation strategy.
 
 **Returns**
 
@@ -93,31 +92,9 @@ An instance of QiskitRuntimeService.
 
 ## Attributes
 
-<span id="qiskitruntimeservice-auth" />
-
-### auth
-
-<span id="qiskit_ibm_runtime.QiskitRuntimeService.auth" />
-
-`str`
-
-Return the authentication type used.
-
-**Return type**
-
-`str`
-
-**Returns**
-
-The authentication type used.
-
-<span id="qiskitruntimeservice-channel" />
-
-### channel
-
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.channel" />
 
-`str`
+### channel
 
 Return the channel type used.
 
@@ -129,7 +106,13 @@ Return the channel type used.
 
 The channel type used.
 
-<span id="qiskitruntimeservice-runtime" />
+<span id="qiskit_ibm_runtime.QiskitRuntimeService.global_service" />
+
+### global\_service
+
+`= None`
+
+<span id="qiskit_ibm_runtime.QiskitRuntimeService.runtime" />
 
 ### runtime
 
@@ -139,23 +122,19 @@ Return self for compatibility with IBMQ provider.
 
 self
 
-<span id="qiskitruntimeservice-version" />
+<span id="qiskit_ibm_runtime.QiskitRuntimeService.version" />
 
 ### version
-
-<span id="qiskit_ibm_runtime.QiskitRuntimeService.version" />
 
 `= 1`
 
 ## Methods
 
-<span id="qiskitruntimeservice-active-account" />
-
 ### active\_account
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.active_account" />
 
-`QiskitRuntimeService.active_account()`
+`active_account()`
 
 Return the IBM Quantum account currently in use for the session.
 
@@ -167,20 +146,18 @@ Return the IBM Quantum account currently in use for the session.
 
 A dictionary with information about the account currently in the session.
 
-<span id="qiskitruntimeservice-backend" />
-
 ### backend
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.backend" />
 
-`QiskitRuntimeService.backend(name=None, instance=None)`
+`backend(name=None, instance=None)`
 
 Return a single backend matching the specified filtering.
 
 **Parameters**
 
 *   **name** (`Optional`\[`str`]) – Name of the backend.
-*   **instance** (`Optional`\[`str`]) – This is only supported for `ibm_quantum` runtime and is in the hub/group/project format. If an instance is not given, among the providers with access to the backend, a premium provider will be priotized. For users without access to a premium provider, the default open provider will be used.
+*   **instance** (`Optional`\[`str`]) – This is only supported for `ibm_quantum` runtime and is in the hub/group/project format. If an instance is not given, among the providers with access to the backend, a premium provider will be prioritized. For users without access to a premium provider, the default open provider will be used.
 
 **Returns**
 
@@ -194,13 +171,11 @@ Backend
 
 **QiskitBackendNotFoundError** – if no backend could be found.
 
-<span id="qiskitruntimeservice-backends" />
-
 ### backends
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.backends" />
 
-`QiskitRuntimeService.backends(name=None, min_num_qubits=None, instance=None, filters=None, **kwargs)`
+`backends(name=None, min_num_qubits=None, instance=None, filters=None, **kwargs)`
 
 Return all backends accessible via this account, subject to optional filtering.
 
@@ -253,13 +228,11 @@ The list of available backends that match the filter.
 *   **IBMInputValueError** – If an input is invalid.
 *   **QiskitBackendNotFoundError** – If the backend is not in any instance.
 
-<span id="qiskitruntimeservice-delete-account" />
-
 ### delete\_account
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.delete_account" />
 
-`static QiskitRuntimeService.delete_account(filename=None, name=None, channel=None)`
+`static delete_account(filename=None, name=None, channel=None)`
 
 Delete a saved account from disk.
 
@@ -277,13 +250,11 @@ Delete a saved account from disk.
 
 True if the account was deleted. False if no account was found.
 
-<span id="qiskitruntimeservice-delete-job" />
-
 ### delete\_job
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.delete_job" />
 
-`QiskitRuntimeService.delete_job(job_id)`
+`delete_job(job_id)`
 
 Delete a runtime job.
 
@@ -302,13 +273,11 @@ Note that this operation cannot be reversed.
 
 `None`
 
-<span id="qiskitruntimeservice-delete-program" />
-
 ### delete\_program
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.delete_program" />
 
-`QiskitRuntimeService.delete_program(program_id)`
+`delete_program(program_id)`
 
 Delete a runtime program.
 
@@ -325,13 +294,11 @@ Delete a runtime program.
 
 `None`
 
-<span id="qiskitruntimeservice-get-backend" />
-
 ### get\_backend
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.get_backend" />
 
-`QiskitRuntimeService.get_backend(name=None, **kwargs)`
+`get_backend(name=None, **kwargs)`
 
 Return a single backend matching the specified filtering.
 
@@ -352,13 +319,27 @@ Backend
 
 **QiskitBackendNotFoundError** – if no backend could be found or more than one backend matches the filtering criteria.
 
-<span id="qiskitruntimeservice-job" />
+### instances
+
+<span id="qiskit_ibm_runtime.QiskitRuntimeService.instances" />
+
+`instances()`
+
+Return the IBM Quantum instances list currently in use for the session.
+
+**Return type**
+
+`List`\[`str`]
+
+**Returns**
+
+A list with instances currently in the session.
 
 ### job
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.job" />
 
-`QiskitRuntimeService.job(job_id)`
+`job(job_id)`
 
 Retrieve a runtime job.
 
@@ -379,13 +360,11 @@ Runtime job retrieved.
 *   **RuntimeJobNotFound** – If the job doesn’t exist.
 *   **IBMRuntimeError** – If the request failed.
 
-<span id="qiskitruntimeservice-jobs" />
-
 ### jobs
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.jobs" />
 
-`QiskitRuntimeService.jobs(limit=10, skip=0, backend_name=None, pending=None, program_id=None, instance=None, job_tags=None, session_id=None, created_after=None, created_before=None, descending=True)`
+`jobs(limit=10, skip=0, backend_name=None, pending=None, program_id=None, instance=None, job_tags=None, session_id=None, created_after=None, created_before=None, descending=True)`
 
 Retrieve all runtime jobs, subject to optional filtering.
 
@@ -415,13 +394,11 @@ A list of runtime jobs.
 
 **IBMInputValueError** – If an input value is invalid.
 
-<span id="qiskitruntimeservice-least-busy" />
-
 ### least\_busy
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.least_busy" />
 
-`QiskitRuntimeService.least_busy(min_num_qubits=None, instance=None, filters=None, **kwargs)`
+`least_busy(min_num_qubits=None, instance=None, filters=None, **kwargs)`
 
 Return the least busy available backend.
 
@@ -433,7 +410,7 @@ Return the least busy available backend.
 
 *   **filters** (`Optional`\[`Callable`\[\[`List`\[[`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend")]], `bool`]]) –
 
-    Filters can be defined as for the [`backends()`](qiskit_ibm_runtime.QiskitRuntimeService#backends "qiskit_ibm_runtime.QiskitRuntimeService.backends") method. An example to get the operational backends with 5 qubits:
+    Filters can be defined as for the [`backends()`](#qiskit_ibm_runtime.QiskitRuntimeService.backends "qiskit_ibm_runtime.QiskitRuntimeService.backends") method. An example to get the operational backends with 5 qubits:
 
     ```python
     QiskitRuntimeService.least_busy(n_qubits=5, operational=True)
@@ -451,13 +428,11 @@ The backend with the fewest number of pending jobs.
 
 **QiskitBackendNotFoundError** – If no backend matches the criteria.
 
-<span id="qiskitruntimeservice-pprint-programs" />
-
 ### pprint\_programs
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.pprint_programs" />
 
-`QiskitRuntimeService.pprint_programs(refresh=False, detailed=False, limit=20, skip=0)`
+`pprint_programs(refresh=False, detailed=False, limit=20, skip=0)`
 
 Pretty print information about available runtime programs.
 
@@ -472,13 +447,11 @@ Pretty print information about available runtime programs.
 
 `None`
 
-<span id="qiskitruntimeservice-program" />
-
 ### program
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.program" />
 
-`QiskitRuntimeService.program(program_id, refresh=False)`
+`program(program_id, refresh=False)`
 
 Retrieve a runtime program.
 
@@ -502,13 +475,11 @@ Runtime program.
 *   **RuntimeProgramNotFound** – If the program does not exist.
 *   **IBMRuntimeError** – If the request failed.
 
-<span id="qiskitruntimeservice-programs" />
-
 ### programs
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.programs" />
 
-`QiskitRuntimeService.programs(refresh=False, limit=20, skip=0)`
+`programs(refresh=False, limit=20, skip=0)`
 
 Return available runtime programs.
 
@@ -528,13 +499,11 @@ Currently only program metadata is returned.
 
 A list of runtime programs.
 
-<span id="qiskitruntimeservice-run" />
-
 ### run
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.run" />
 
-`QiskitRuntimeService.run(program_id, inputs, options=None, callback=None, result_decoder=None, session_id=None, start_session=False)`
+`run(program_id, inputs, options=None, callback=None, result_decoder=None, session_id=None, start_session=False)`
 
 Execute the runtime program.
 
@@ -573,13 +542,11 @@ A `RuntimeJob` instance representing the execution.
 *   **RuntimeProgramNotFound** – If the program cannot be found.
 *   **IBMRuntimeError** – An error occurred running the program.
 
-<span id="qiskitruntimeservice-save-account" />
-
 ### save\_account
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.save_account" />
 
-`static QiskitRuntimeService.save_account(token=None, url=None, instance=None, channel=None, filename=None, name=None, proxies=None, verify=None, overwrite=False)`
+`static save_account(token=None, url=None, instance=None, channel=None, filename=None, name=None, proxies=None, verify=None, overwrite=False, channel_strategy=None, set_as_default=None)`
 
 Save the account to disk for future use.
 
@@ -594,18 +561,18 @@ Save the account to disk for future use.
 *   **proxies** (`Optional`\[`dict`]) – Proxy configuration. Supported optional keys are `urls` (a dictionary mapping protocol or protocol and host to the URL of the proxy, documented at [https://docs.python-requests.org/en/latest/api/#requests.Session.proxies](https://docs.python-requests.org/en/latest/api/#requests.Session.proxies)), `username_ntlm`, `password_ntlm` (username and password to enable NTLM user authentication)
 *   **verify** (`Optional`\[`bool`]) – Verify the server’s TLS certificate.
 *   **overwrite** (`Optional`\[`bool`]) – `True` if the existing account is to be overwritten.
+*   **channel\_strategy** (`Optional`\[`str`]) – Error mitigation strategy.
+*   **set\_as\_default** (`Optional`\[`bool`]) – If `True`, the account is saved in filename, as the default account.
 
 **Return type**
 
 `None`
 
-<span id="qiskitruntimeservice-saved-accounts" />
-
 ### saved\_accounts
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.saved_accounts" />
 
-`static QiskitRuntimeService.saved_accounts(default=None, channel=None, filename=None, name=None)`
+`static saved_accounts(default=None, channel=None, filename=None, name=None)`
 
 List the accounts saved on disk.
 
@@ -628,13 +595,11 @@ A dictionary with information about the accounts saved on disk.
 
 **ValueError** – If an invalid account is found on disk.
 
-<span id="qiskitruntimeservice-set-program-visibility" />
-
 ### set\_program\_visibility
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.set_program_visibility" />
 
-`QiskitRuntimeService.set_program_visibility(program_id, public)`
+`set_program_visibility(program_id, public)`
 
 Sets a program’s visibility.
 
@@ -652,13 +617,11 @@ Sets a program’s visibility.
 
 `None`
 
-<span id="qiskitruntimeservice-update-program" />
-
 ### update\_program
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.update_program" />
 
-`QiskitRuntimeService.update_program(program_id, data=None, metadata=None, name=None, description=None, max_execution_time=None, spec=None)`
+`update_program(program_id, data=None, metadata=None, name=None, description=None, max_execution_time=None, spec=None)`
 
 Update a runtime program.
 
@@ -683,13 +646,11 @@ Program metadata can be specified using the metadata parameter or individual par
 
 `None`
 
-<span id="qiskitruntimeservice-upload-program" />
-
 ### upload\_program
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService.upload_program" />
 
-`QiskitRuntimeService.upload_program(data, metadata=None)`
+`upload_program(data, metadata=None)`
 
 Upload a runtime program.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeDecoder.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeDecoder.md
@@ -28,23 +28,19 @@ If `strict` is false (true is the default), then control characters will be allo
 
 ## Methods
 
-<span id="runtimedecoder-decode" />
-
 ### decode
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder.decode" />
 
-`RuntimeDecoder.decode(s, _w=<built-in method match of re.Pattern object>)`
+`decode(s, _w=<built-in method match of re.Pattern object>)`
 
 Return the Python representation of `s` (a `str` instance containing a JSON document).
-
-<span id="runtimedecoder-object-hook" />
 
 ### object\_hook
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder.object_hook" />
 
-`RuntimeDecoder.object_hook(obj)`
+`object_hook(obj)`
 
 Called to decode object.
 
@@ -52,13 +48,11 @@ Called to decode object.
 
 `Any`
 
-<span id="runtimedecoder-raw-decode" />
-
 ### raw\_decode
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder.raw_decode" />
 
-`RuntimeDecoder.raw_decode(s, idx=0)`
+`raw_decode(s, idx=0)`
 
 Decode a JSON document from `s` (a `str` beginning with a JSON document) and return a 2-tuple of the Python representation and the index in `s` where the document ended.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder.md
@@ -34,31 +34,27 @@ If specified, default is a function that gets called for objects that can’t ot
 
 ## Attributes
 
-<span id="runtimeencoder-item-separator" />
+<span id="qiskit_ibm_runtime.RuntimeEncoder.item_separator" />
 
 ### item\_separator
 
-<span id="qiskit_ibm_runtime.RuntimeEncoder.item_separator" />
-
 `= ', '`
 
-<span id="runtimeencoder-key-separator" />
-
-### key\_separator
-
 <span id="qiskit_ibm_runtime.RuntimeEncoder.key_separator" />
+
+### key\_separator = '
+
+`= ':`
 
 `= ': '`
 
 ## Methods
 
-<span id="runtimeencoder-default" />
-
 ### default
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder.default" />
 
-`RuntimeEncoder.default(obj)`
+`default(obj)`
 
 Implement this method in a subclass such that it returns a serializable object for `o`, or calls the base implementation (to raise a `TypeError`).
 
@@ -80,13 +76,11 @@ def default(self, o):
 
 `Any`
 
-<span id="runtimeencoder-encode" />
-
 ### encode
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder.encode" />
 
-`RuntimeEncoder.encode(o)`
+`encode(o)`
 
 Return a JSON string representation of a Python data structure.
 
@@ -95,15 +89,12 @@ Return a JSON string representation of a Python data structure.
 >>> JSONEncoder().encode({"foo": ["bar", "baz"]})
 '{"foo": ["bar", "baz"]}'
 ```
- {/* cspell:ignore iterencode */}
- 
-<span id="runtimeencoder-iterencode" />
 
 ### iterencode
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder.iterencode" />
 
-`RuntimeEncoder.iterencode(o, _one_shot=False)`
+`iterencode(o, _one_shot=False)`
 
 Encode the given object and yield each string representation as available.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeJob.md
@@ -16,9 +16,9 @@ Representation of a runtime program execution.
 
 A new `RuntimeJob` instance is returned when you call [`QiskitRuntimeService.run`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") to execute a runtime program, or [`QiskitRuntimeService.job`](qiskit_ibm_runtime.QiskitRuntimeService#job "qiskit_ibm_runtime.QiskitRuntimeService.job") to retrieve a previously executed job.
 
-If the program execution is successful, you can inspect the job’s status by calling [`status()`](qiskit_ibm_runtime.RuntimeJob#status "qiskit_ibm_runtime.RuntimeJob.status"). Job status can be one of the `JobStatus` members.
+If the program execution is successful, you can inspect the job’s status by calling [`status()`](#qiskit_ibm_runtime.RuntimeJob.status "qiskit_ibm_runtime.RuntimeJob.status"). Job status can be one of the `JobStatus` members.
 
-Some of the methods in this class are blocking, which means control may not be returned immediately. [`result()`](qiskit_ibm_runtime.RuntimeJob#result "qiskit_ibm_runtime.RuntimeJob.result") is an example of a blocking method:
+Some of the methods in this class are blocking, which means control may not be returned immediately. [`result()`](#qiskit_ibm_runtime.RuntimeJob.result "qiskit_ibm_runtime.RuntimeJob.result") is an example of a blocking method:
 
 ```python
 job = service.run(...)
@@ -30,7 +30,7 @@ except RuntimeJobFailureError as ex:
     print("Job failed!: {}".format(ex))
 ```
 
-If the program has any interim results, you can use the `callback` parameter of the [`run()`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") method to stream the interim results along with the final result. Alternatively, you can use the [`stream_results()`](qiskit_ibm_runtime.RuntimeJob#stream_results "qiskit_ibm_runtime.RuntimeJob.stream_results") method to stream the results at a later time, but before the job finishes.
+If the program has any interim results, you can use the `callback` parameter of the [`run()`](qiskit_ibm_runtime.QiskitRuntimeService#run "qiskit_ibm_runtime.QiskitRuntimeService.run") method to stream the interim results along with the final result. Alternatively, you can use the [`stream_results()`](#qiskit_ibm_runtime.RuntimeJob.stream_results "qiskit_ibm_runtime.RuntimeJob.stream_results") method to stream the results at a later time, but before the job finishes.
 
 RuntimeJob constructor.
 
@@ -52,13 +52,9 @@ RuntimeJob constructor.
 
 ## Attributes
 
-<span id="runtimejob-creation-date" />
-
-### creation\_date
-
 <span id="qiskit_ibm_runtime.RuntimeJob.creation_date" />
 
-`datetime | None`
+### creation\_date
 
 Job creation date in local time.
 
@@ -70,13 +66,9 @@ Job creation date in local time.
 
 The job creation date as a datetime object, in local time, or `None` if creation date is not available.
 
-<span id="runtimejob-image" />
-
-### image
-
 <span id="qiskit_ibm_runtime.RuntimeJob.image" />
 
-`str`
+### image
 
 Return the runtime image used for the job.
 
@@ -88,13 +80,9 @@ image\_name:tag or “” if the default image is used.
 
 Runtime image
 
-<span id="runtimejob-inputs" />
-
-### inputs
-
 <span id="qiskit_ibm_runtime.RuntimeJob.inputs" />
 
-`Dict`
+### inputs
 
 Job input parameters.
 
@@ -106,13 +94,9 @@ Job input parameters.
 
 Input parameters used in this job.
 
-<span id="runtimejob-program-id" />
-
-### program\_id
-
 <span id="qiskit_ibm_runtime.RuntimeJob.program_id" />
 
-`str`
+### program\_id
 
 Program ID.
 
@@ -124,13 +108,9 @@ Program ID.
 
 ID of the program this job is for.
 
-<span id="runtimejob-session-id" />
-
-### session\_id
-
 <span id="qiskit_ibm_runtime.RuntimeJob.session_id" />
 
-`str`
+### session\_id
 
 Session ID.
 
@@ -142,13 +122,9 @@ Session ID.
 
 Job ID of the first job in a runtime session.
 
-<span id="runtimejob-tags" />
-
-### tags
-
 <span id="qiskit_ibm_runtime.RuntimeJob.tags" />
 
-`List`
+### tags
 
 Job tags.
 
@@ -160,13 +136,9 @@ Job tags.
 
 Tags assigned to the job that can be used for filtering.
 
-<span id="runtimejob-usage-estimation" />
-
-### usage\_estimation
-
 <span id="qiskit_ibm_runtime.RuntimeJob.usage_estimation" />
 
-`Dict[str, Any]`
+### usage\_estimation
 
 Return the usage estimation infromation for this job.
 
@@ -176,25 +148,21 @@ Return the usage estimation infromation for this job.
 
 **Returns**
 
-`quantum_seconds` which is the estimated quantum time of the job in seconds. Quantum time represents the time that the QPU complex is occupied exclusively by the job.
-
-<span id="runtimejob-version" />
-
-### version
+`quantum_seconds` which is the estimated system execution time of the job in seconds. Quantum time represents the time that the system is dedicated to processing your job.
 
 <span id="qiskit_ibm_runtime.RuntimeJob.version" />
+
+### version
 
 `= 1`
 
 ## Methods
 
-<span id="runtimejob-backend" />
-
 ### backend
 
 <span id="qiskit_ibm_runtime.RuntimeJob.backend" />
 
-`RuntimeJob.backend()`
+`backend(timeout=None)`
 
 Return the backend where this job was executed. Retrieve data again if backend is None.
 
@@ -206,13 +174,11 @@ Return the backend where this job was executed. Retrieve data again if backend i
 
 `Optional`\[`Backend`]
 
-<span id="runtimejob-cancel" />
-
 ### cancel
 
 <span id="qiskit_ibm_runtime.RuntimeJob.cancel" />
 
-`RuntimeJob.cancel()`
+`cancel()`
 
 Cancel the job.
 
@@ -225,13 +191,11 @@ Cancel the job.
 
 `None`
 
-<span id="runtimejob-cancel-result-streaming" />
-
 ### cancel\_result\_streaming
 
 <span id="qiskit_ibm_runtime.RuntimeJob.cancel_result_streaming" />
 
-`RuntimeJob.cancel_result_streaming()`
+`cancel_result_streaming()`
 
 Cancel result streaming.
 
@@ -239,13 +203,11 @@ Cancel result streaming.
 
 `None`
 
-<span id="runtimejob-cancelled" />
-
 ### cancelled
 
 <span id="qiskit_ibm_runtime.RuntimeJob.cancelled" />
 
-`RuntimeJob.cancelled()`
+`cancelled()`
 
 Return whether the job has been cancelled.
 
@@ -253,13 +215,11 @@ Return whether the job has been cancelled.
 
 `bool`
 
-<span id="runtimejob-done" />
-
 ### done
 
 <span id="qiskit_ibm_runtime.RuntimeJob.done" />
 
-`RuntimeJob.done()`
+`done()`
 
 Return whether the job has successfully run.
 
@@ -267,13 +227,11 @@ Return whether the job has successfully run.
 
 `bool`
 
-<span id="runtimejob-error-message" />
-
 ### error\_message
 
 <span id="qiskit_ibm_runtime.RuntimeJob.error_message" />
 
-`RuntimeJob.error_message()`
+`error_message()`
 
 Returns the reason if the job failed.
 
@@ -285,13 +243,11 @@ Returns the reason if the job failed.
 
 Error message string or `None`.
 
-<span id="runtimejob-in-final-state" />
-
 ### in\_final\_state
 
 <span id="qiskit_ibm_runtime.RuntimeJob.in_final_state" />
 
-`RuntimeJob.in_final_state()`
+`in_final_state()`
 
 Return whether the job is in a final job state such as `DONE` or `ERROR`.
 
@@ -299,13 +255,11 @@ Return whether the job is in a final job state such as `DONE` or `ERROR`.
 
 `bool`
 
-<span id="runtimejob-interim-results" />
-
 ### interim\_results
 
 <span id="qiskit_ibm_runtime.RuntimeJob.interim_results" />
 
-`RuntimeJob.interim_results(decoder=None)`
+`interim_results(decoder=None)`
 
 Return the interim results of the job.
 
@@ -325,13 +279,11 @@ Runtime job interim results.
 
 **RuntimeJobFailureError** – If the job failed.
 
-<span id="runtimejob-job-id" />
-
 ### job\_id
 
 <span id="qiskit_ibm_runtime.RuntimeJob.job_id" />
 
-`RuntimeJob.job_id()`
+`job_id()`
 
 Return a unique id identifying the job.
 
@@ -339,13 +291,11 @@ Return a unique id identifying the job.
 
 `str`
 
-<span id="runtimejob-logs" />
-
 ### logs
 
 <span id="qiskit_ibm_runtime.RuntimeJob.logs" />
 
-`RuntimeJob.logs()`
+`logs()`
 
 Return job logs.
 
@@ -365,13 +315,11 @@ Job logs, including standard output and error.
 
 **IBMRuntimeError** – If a network error occurred.
 
-<span id="runtimejob-metrics" />
-
 ### metrics
 
 <span id="qiskit_ibm_runtime.RuntimeJob.metrics" />
 
-`RuntimeJob.metrics()`
+`metrics()`
 
 Return job metrics.
 
@@ -387,13 +335,11 @@ Job metrics, which includes timestamp information.
 
 **IBMRuntimeError** – If a network error occurred.
 
-<span id="runtimejob-result" />
-
 ### result
 
 <span id="qiskit_ibm_runtime.RuntimeJob.result" />
 
-`RuntimeJob.result(timeout=None, decoder=None)`
+`result(timeout=None, decoder=None)`
 
 Return the results of the job.
 
@@ -416,13 +362,11 @@ Runtime job result.
 *   **RuntimeJobMaxTimeoutError** – If the job does not complete within given timeout.
 *   **RuntimeInvalidStateError** – If the job was cancelled, and attempting to retrieve result.
 
-<span id="runtimejob-running" />
-
 ### running
 
 <span id="qiskit_ibm_runtime.RuntimeJob.running" />
 
-`RuntimeJob.running()`
+`running()`
 
 Return whether the job is actively running.
 
@@ -430,13 +374,11 @@ Return whether the job is actively running.
 
 `bool`
 
-<span id="runtimejob-status" />
-
 ### status
 
 <span id="qiskit_ibm_runtime.RuntimeJob.status" />
 
-`RuntimeJob.status()`
+`status()`
 
 Return the status of the job.
 
@@ -448,13 +390,11 @@ Return the status of the job.
 
 Status of this job.
 
-<span id="runtimejob-stream-results" />
-
 ### stream\_results
 
 <span id="qiskit_ibm_runtime.RuntimeJob.stream_results" />
 
-`RuntimeJob.stream_results(callback, decoder=None)`
+`stream_results(callback, decoder=None)`
 
 Start streaming job results.
 
@@ -477,13 +417,11 @@ Start streaming job results.
 
 `None`
 
-<span id="runtimejob-submit" />
-
 ### submit
 
 <span id="qiskit_ibm_runtime.RuntimeJob.submit" />
 
-`RuntimeJob.submit()`
+`submit()`
 
 Unsupported method. .. note:
 
@@ -501,13 +439,11 @@ to submit a job.
 
 `None`
 
-<span id="runtimejob-update-tags" />
-
 ### update\_tags
 
 <span id="qiskit_ibm_runtime.RuntimeJob.update_tags" />
 
-`RuntimeJob.update_tags(new_tags)`
+`update_tags(new_tags)`
 
 Update the tags associated with this job.
 
@@ -527,13 +463,11 @@ The new tags associated with this job.
 
 **IBMApiError** – If an unexpected error occurred when communicating with the server or updating the job tags.
 
-<span id="runtimejob-wait-for-final-state" />
-
 ### wait\_for\_final\_state
 
 <span id="qiskit_ibm_runtime.RuntimeJob.wait_for_final_state" />
 
-`RuntimeJob.wait_for_final_state(timeout=None)`
+`wait_for_final_state(timeout=None)`
 
 Use the websocket server to wait for the final the state of a job.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeOptions.md
@@ -23,76 +23,74 @@ RuntimeOptions constructor.
 *   **log\_level** (`Optional`\[`str`]) – logging level to set in the execution environment. The valid log levels are: `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`. The default level is `WARNING`.
 *   **instance** (`Optional`\[`str`]) – The hub/group/project to use, in that format. This is only supported for `ibm_quantum` channel. If `None`, a hub/group/project that provides access to the target backend is randomly selected.
 *   **job\_tags** (`Optional`\[`List`\[`str`]]) – Tags to be assigned to the job. The tags can subsequently be used as a filter in the `jobs()` function call.
-*   **max\_execution\_time** (`Optional`\[`int`]) – Maximum execution time in seconds. If a job exceeds this time limit, it is forcibly cancelled.
+*   **max\_execution\_time** (`Optional`\[`int`]) – Maximum execution time in seconds, which is based on system execution time (not wall clock time). System execution time is the amount of time that the system is dedicated to processing your job. If a job exceeds this time limit, it is forcibly cancelled. Simulator jobs continue to use wall clock time.
 *   **session\_time** (`Optional`\[`int`]) – Length of session in seconds.
 
 ## Attributes
 
-<span id="runtimeoptions-backend" />
+<span id="qiskit_ibm_runtime.RuntimeOptions.backend" />
 
 ### backend
 
-<span id="qiskit_ibm_runtime.RuntimeOptions.backend" />
+`str | None`
 
-`str | None = None`
-
-<span id="runtimeoptions-image" />
-
-### image
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.image" />
 
-`str | None = None`
+### image
 
-<span id="runtimeoptions-instance" />
+`str | None`
 
-### instance
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.instance" />
 
-`str | None = None`
+### instance
 
-<span id="runtimeoptions-job-tags" />
+`str | None`
 
-### job\_tags
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.job_tags" />
 
-`List[str] | None = None`
+### job\_tags
 
-<span id="runtimeoptions-log-level" />
+`List[str] | None`
 
-### log\_level
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.log_level" />
 
-`str | None = None`
+### log\_level
 
-<span id="runtimeoptions-max-execution-time" />
+`str | None`
 
-### max\_execution\_time
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.max_execution_time" />
 
-`int | None = None`
+### max\_execution\_time
 
-<span id="runtimeoptions-session-time" />
+`int | None`
 
-### session\_time
+`= None`
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.session_time" />
 
-`int | None = None`
+### session\_time
+
+`int | None`
+
+`= None`
 
 ## Methods
-
-<span id="runtimeoptions-validate" />
 
 ### validate
 
 <span id="qiskit_ibm_runtime.RuntimeOptions.validate" />
 
-`RuntimeOptions.validate(channel)`
+`validate(channel)`
 
 Validate options.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeProgram.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeProgram.md
@@ -51,13 +51,9 @@ RuntimeProgram constructor.
 
 ## Attributes
 
-<span id="runtimeprogram-backend-requirements" />
-
-### backend\_requirements
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.backend_requirements" />
 
-`Dict`
+### backend\_requirements
 
 Backend requirements.
 
@@ -69,13 +65,9 @@ Backend requirements.
 
 Backend requirements for this program.
 
-<span id="runtimeprogram-creation-date" />
-
-### creation\_date
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.creation_date" />
 
-`str`
+### creation\_date
 
 Program creation date.
 
@@ -87,13 +79,9 @@ Program creation date.
 
 Program creation date.
 
-<span id="runtimeprogram-data" />
-
-### data
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.data" />
 
-`str`
+### data
 
 Program data.
 
@@ -109,13 +97,9 @@ Program data.
 
 **IBMNotAuthorizedError** – if user is not the program author.
 
-<span id="runtimeprogram-description" />
-
-### description
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.description" />
 
-`str`
+### description
 
 Program description.
 
@@ -127,13 +111,9 @@ Program description.
 
 Program description.
 
-<span id="runtimeprogram-interim-results" />
-
-### interim\_results
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.interim_results" />
 
-`Dict`
+### interim\_results
 
 Program interim result definitions.
 
@@ -145,13 +125,9 @@ Program interim result definitions.
 
 Interim result definitions for this program.
 
-<span id="runtimeprogram-is-public" />
-
-### is\_public
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.is_public" />
 
-`bool`
+### is\_public
 
 Whether the program is visible to all.
 
@@ -163,13 +139,9 @@ Whether the program is visible to all.
 
 Whether the program is public.
 
-<span id="runtimeprogram-max-execution-time" />
-
-### max\_execution\_time
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.max_execution_time" />
 
-`int`
+### max\_execution\_time
 
 Maximum execution time in seconds.
 
@@ -183,14 +155,10 @@ A program execution exceeding this time will be forcibly terminated.
 
 Maximum execution time.
 
-<span id="runtimeprogram-name" />
+<span id="qiskit_ibm_runtime.RuntimeProgram.name" />
 
 ### name
 
-<span id="qiskit_ibm_runtime.RuntimeProgram.name" />
-
-`str`
-
 Program name.
 
 **Return type**
@@ -200,14 +168,10 @@ Program name.
 **Returns**
 
 Program name.
-
-<span id="runtimeprogram-program-id" />
-
-### program\_id
 
 <span id="qiskit_ibm_runtime.RuntimeProgram.program_id" />
 
-`str`
+### program\_id
 
 Program ID.
 
@@ -219,13 +183,9 @@ Program ID.
 
 Program ID.
 
-<span id="runtimeprogram-return-values" />
-
-### return\_values
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.return_values" />
 
-`Dict`
+### return\_values
 
 Program return value definitions.
 
@@ -237,13 +197,9 @@ Program return value definitions.
 
 Return value definitions for this program.
 
-<span id="runtimeprogram-update-date" />
-
-### update\_date
-
 <span id="qiskit_ibm_runtime.RuntimeProgram.update_date" />
 
-`str`
+### update\_date
 
 Program last updated date.
 
@@ -257,13 +213,11 @@ Program last updated date.
 
 ## Methods
 
-<span id="runtimeprogram-parameters" />
-
 ### parameters
 
 <span id="qiskit_ibm_runtime.RuntimeProgram.parameters" />
 
-`RuntimeProgram.parameters()`
+`parameters()`
 
 Program parameter namespace.
 
@@ -279,13 +233,11 @@ Note that each call to this method returns a new namespace instance and does not
 
 Program parameter namespace.
 
-<span id="runtimeprogram-to-dict" />
-
 ### to\_dict
 
 <span id="qiskit_ibm_runtime.RuntimeProgram.to_dict" />
 
-`RuntimeProgram.to_dict()`
+`to_dict()`
 
 Convert program metadata to dictionary format.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler.md
@@ -16,7 +16,7 @@ Class for interacting with Qiskit Runtime Sampler primitive service.
 
 Qiskit Runtime Sampler primitive service calculates quasi-probability distribution of bitstrings from quantum circuits.
 
-The [`run()`](qiskit_ibm_runtime.Sampler#run "qiskit_ibm_runtime.Sampler.run") method can be used to submit circuits and parameters to the Sampler primitive.
+The [`run()`](#qiskit_ibm_runtime.Sampler.run "qiskit_ibm_runtime.Sampler.run") method can be used to submit circuits and parameters to the Sampler primitive.
 
 You are encouraged to use [`Session`](qiskit_ibm_runtime.Session "qiskit_ibm_runtime.Session") to open a session, during which you can invoke one or more primitives. Jobs submitted within a session are prioritized by the scheduler, and data is cached for efficiency.
 
@@ -37,10 +37,6 @@ with Session(service, backend="ibmq_qasm_simulator") as session:
     print(f"Job result: {job.result()}")
 
     # You can run more jobs inside the session
-
-    # Close the session only if all jobs are finished
-    # and you don't need to run more in the session.
-    session.close()
 ```
 
 Initializes the Sampler primitive.
@@ -59,13 +55,9 @@ Initializes the Sampler primitive.
 
 ## Attributes
 
-<span id="sampler-circuits" />
-
-### circuits
-
 <span id="qiskit_ibm_runtime.Sampler.circuits" />
 
-`tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]`
+### circuits
 
 Quantum circuits to be sampled.
 
@@ -77,13 +69,9 @@ Quantum circuits to be sampled.
 
 The quantum circuits to be sampled.
 
-<span id="sampler-options" />
-
-### options
-
 <span id="qiskit_ibm_runtime.Sampler.options" />
 
-`Options`
+### options
 
 Return options values for the sampler.
 
@@ -95,13 +83,9 @@ Return options values for the sampler.
 
 options
 
-<span id="sampler-parameters" />
-
-### parameters
-
 <span id="qiskit_ibm_runtime.Sampler.parameters" />
 
-`tuple[qiskit.circuit.parametertable.ParameterView, ...]`
+### parameters
 
 Parameters of quantum circuits.
 
@@ -113,13 +97,9 @@ Parameters of quantum circuits.
 
 List of the parameters in each quantum circuit.
 
-<span id="sampler-session" />
-
-### session
-
 <span id="qiskit_ibm_runtime.Sampler.session" />
 
-`Session | None`
+### session
 
 Return session used by this primitive.
 
@@ -133,13 +113,11 @@ Session used by this primitive, or `None` if session is not used.
 
 ## Methods
 
-<span id="sampler-run" />
-
 ### run
 
 <span id="qiskit_ibm_runtime.Sampler.run" />
 
-`Sampler.run(circuits, parameter_values=None, **kwargs)`
+`run(circuits, parameter_values=None, **kwargs)`
 
 Submit a request to the sampler primitive.
 
@@ -161,13 +139,11 @@ Submitted job. The result of the job is an instance of `qiskit.primitives.Sample
 
 **ValueError** – Invalid arguments are given.
 
-<span id="sampler-set-options" />
-
 ### set\_options
 
 <span id="qiskit_ibm_runtime.Sampler.set_options" />
 
-`Sampler.set_options(**fields)`
+`set_options(**fields)`
 
 Set options values for the sampler.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session.md
@@ -28,12 +28,9 @@ options = Options(optimization_level=3)
 
 with Session(backend="ibmq_qasm_simulator") as session:
     sampler = Sampler(session=session, options=options)
-    job = sampler.run(circ)
+    job = sampler.run(ReferenceCircuits.bell())
     print(f"Sampler job ID: {job.job_id()}")
-    print(f"Sampler job result:" {job.result()})
-    # Close the session only if all jobs are finished and
-    # you don't need to run more in the session.
-    session.close()
+    print(f"Sampler job result: {job.result()}")
 ```
 
 Session constructor.
@@ -42,7 +39,7 @@ Session constructor.
 
 *   **service** (`Optional`\[[`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService")]) – Optional instance of the `QiskitRuntimeService` class. If `None`, the service associated with the backend, if known, is used. Otherwise `QiskitRuntimeService()` is used to initialize your default saved account.
 *   **backend** (`Union`\[`str`, [`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend"), `None`]) – Optional instance of [`qiskit_ibm_runtime.IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend") class or string name of backend. An instance of `qiskit_ibm_provider.IBMBackend` will not work. If not specified, a backend will be selected automatically (IBM Cloud channel only).
-*   **max\_time** (`Union`\[`int`, `str`, `None`]) – (EXPERIMENTAL setting, can break between releases without warning) Maximum amount of time, a runtime session can be open before being forcibly closed. Can be specified as seconds (int) or a string like “2h 30m 40s”. This value must be in between 300 seconds and the [system imposed maximum](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/faqs/max_execution_time.html).
+*   **max\_time** (`Union`\[`int`, `str`, `None`]) – (EXPERIMENTAL setting, can break between releases without warning) Maximum amount of time, a runtime session can be open before being forcibly closed. Can be specified as seconds (int) or a string like “2h 30m 40s”. This value must be less than the [system imposed maximum](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/faqs/max_execution_time.html).
 
 **Raises**
 
@@ -50,13 +47,9 @@ Session constructor.
 
 ## Attributes
 
-<span id="session-service" />
-
-### service
-
 <span id="qiskit_ibm_runtime.Session.service" />
 
-`QiskitRuntimeService`
+### service
 
 Return service associated with this session.
 
@@ -68,13 +61,9 @@ Return service associated with this session.
 
 [`qiskit_ibm_runtime.QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") associated with this session.
 
-<span id="session-session-id" />
-
-### session\_id
-
 <span id="qiskit_ibm_runtime.Session.session_id" />
 
-`str`
+### session\_id
 
 Return the session ID.
 
@@ -88,13 +77,11 @@ Session ID. None until a job runs in the session.
 
 ## Methods
 
-<span id="session-backend" />
-
 ### backend
 
 <span id="qiskit_ibm_runtime.Session.backend" />
 
-`Session.backend()`
+`backend()`
 
 Return backend for this session.
 
@@ -106,27 +93,73 @@ Return backend for this session.
 
 Backend for this session. None if unknown.
 
-<span id="session-close" />
+### cancel
 
-### close
+<span id="qiskit_ibm_runtime.Session.cancel" />
 
-<span id="qiskit_ibm_runtime.Session.close" />
+`cancel()`
 
-`Session.close()`
-
-Close the session.
+Cancel all pending jobs in a session.
 
 **Return type**
 
 `None`
 
-<span id="session-run" />
+### close
+
+<span id="qiskit_ibm_runtime.Session.close" />
+
+`close()`
+
+Close the session so new jobs will no longer be accepted, but existing queued or running jobs will run to completion. The session will be terminated once there are no more pending jobs.
+
+**Return type**
+
+`None`
+
+### details
+
+<span id="qiskit_ibm_runtime.Session.details" />
+
+`details()`
+
+Return session details.
+
+**Returns**
+
+id: id of the session. backend\_name: backend used for the session. interactive\_timeout: The maximum idle time (in seconds) between jobs that is allowed to occur before the session is deactivated. max\_time: Maximum allowed time (in seconds) for the session, subject to plan limits. active\_timeout: The maximum time (in seconds) a session can stay active. state: State of the session - open, active, inactive, or closed. accepting\_jobs: Whether or not the session is accepting jobs. last\_job\_started: Timestamp of when the last job in the session started. last\_job\_completed: Timestamp of when the last job in the session completed. started\_at: Timestamp of when the session was started. closed\_at: Timestamp of when the session was closed.
+
+**Return type**
+
+A dictionary with the sessions details, including
+
+### from\_id
+
+<span id="qiskit_ibm_runtime.Session.from_id" />
+
+`classmethod from_id(session_id, service=None, backend=None)`
+
+Construct a Session object with a given session\_id
+
+**Parameters**
+
+*   **session\_id** (`str`) – the id of the session to be created. This can be an already existing session id.
+*   **service** (`Optional`\[[`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService")]) – instance of the `QiskitRuntimeService` class.
+*   **backend** (`Union`\[`str`, [`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend"), `None`]) – instance of [`qiskit_ibm_runtime.IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend") class or string name of backend.
+
+**Return type**
+
+[`Session`](#qiskit_ibm_runtime.Session "qiskit_ibm_runtime.session.Session")
+
+**Returns**
+
+A new Session with the given `session_id`
 
 ### run
 
 <span id="qiskit_ibm_runtime.Session.run" />
 
-`Session.run(program_id, inputs, options=None, callback=None, result_decoder=None)`
+`run(program_id, inputs, options=None, callback=None, result_decoder=None)`
 
 Run a program in the session.
 
@@ -134,7 +167,7 @@ Run a program in the session.
 
 *   **program\_id** (`str`) – Program ID.
 *   **inputs** (`Union`\[`Dict`, [`ParameterNamespace`](qiskit_ibm_runtime.ParameterNamespace "qiskit_ibm_runtime.runtime_program.ParameterNamespace")]) – Program input parameters. These input values are passed to the runtime program.
-*   **options** (`Optional`\[`Dict`]) – Runtime options that control the execution environment. See [`qiskit_ibm_runtime.RuntimeOptions`](qiskit_ibm_runtime.RuntimeOptions "qiskit_ibm_runtime.RuntimeOptions") for all available options, EXCEPT `backend`, which should be specified during session initialization.
+*   **options** (`Optional`\[`Dict`]) – Runtime options that control the execution environment. See [`qiskit_ibm_runtime.RuntimeOptions`](qiskit_ibm_runtime.RuntimeOptions "qiskit_ibm_runtime.RuntimeOptions") for all available options.
 *   **callback** (`Optional`\[`Callable`]) – Callback function to be invoked for any interim results and final result.
 
 **Return type**
@@ -145,7 +178,19 @@ Run a program in the session.
 
 Submitted job.
 
-**Raises**
+### status
 
-**IBMInputValueError** – If a backend is passed in through options that does not match the current session backend.
+<span id="qiskit_ibm_runtime.Session.status" />
+
+`status()`
+
+Return current session status.
+
+**Returns**
+
+Pending: Session is created but not active. It will become active when the next job of this session is dequeued. In progress, accepting new jobs: session is active and accepting new jobs. In progress, not accepting new jobs: session is active and not accepting new jobs. Closed: max\_time expired or session was explicitly closed. None: status details are not available.
+
+**Return type**
+
+The current status of the session, including
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EnvironmentOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EnvironmentOptions.md
@@ -29,39 +29,35 @@ Options related to the execution environment.
 
 ## Attributes
 
-<span id="environmentoptions-callback" />
+<span id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" />
 
 ### callback
 
-<span id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" />
+`Callable | None`
 
-`Callable | None = None`
-
-<span id="environmentoptions-job-tags" />
-
-### job\_tags
-
-<span id="qiskit_ibm_runtime.options.EnvironmentOptions.job_tags" />
-
-`List | None`
-
-<span id="environmentoptions-log-level" />
-
-### log\_level
+`= None`
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions.log_level" />
 
-`str = 'WARNING'`
+### log\_level
+
+`str`
+
+`= 'WARNING'`
+
+<span id="qiskit_ibm_runtime.options.EnvironmentOptions.job_tags" />
+
+### job\_tags
+
+`List | None`
 
 ## Methods
-
-<span id="environmentoptions-validate-environment-options" />
 
 ### validate\_environment\_options
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions.validate_environment_options" />
 
-`static EnvironmentOptions.validate_environment_options(environment_options)`
+`static validate_environment_options(environment_options)`
 
 Validate that environment options are legal. :raises ValueError: if log\_level is not in LogLevelType.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ExecutionOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ExecutionOptions.md
@@ -21,21 +21,33 @@ Execution options.
 
 ## Attributes
 
-<span id="executionoptions-init-qubits" />
+<span id="qiskit_ibm_runtime.options.ExecutionOptions.init_qubits" />
 
 ### init\_qubits
 
-<span id="qiskit_ibm_runtime.options.ExecutionOptions.init_qubits" />
+`bool`
 
-`bool = True`
-
-<span id="executionoptions-shots" />
-
-### shots
+`= True`
 
 <span id="qiskit_ibm_runtime.options.ExecutionOptions.shots" />
 
-`int = 4000`
+### shots
+
+`int`
+
+`= 4000`
 
 ## Methods
+
+### validate\_execution\_options
+
+<span id="qiskit_ibm_runtime.options.ExecutionOptions.validate_execution_options" />
+
+`static validate_execution_options(execution_options)`
+
+Validate that execution options are legal. :raises ValueError: if any execution option is not supported
+
+**Return type**
+
+`None`
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options.md
@@ -36,7 +36,11 @@ Options for the primitives.
 
     Refer to the [Qiskit Runtime documentation](https://qiskit.org/documentation/partners/qiskit_ibm_runtime). for more information about the error mitigation methods used at each level.
 
-*   **max\_execution\_time** (`Optional`\[`int`]) – Maximum execution time in seconds. If a job exceeds this time limit, it is forcibly cancelled. If `None`, the maximum execution time of the primitive is used. This value must be in between 300 seconds and the [system imposed maximum](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/faqs/max_execution_time.html).
+*   **max\_execution\_time** (`Optional`\[`int`]) –
+
+    Maximum execution time in seconds, which is based on system execution time (not wall clock time). System execution time is the amount of time that the system is dedicated to processing your job. If a job exceeds this time limit, it is forcibly cancelled. Simulator jobs continue to use wall clock time.
+
+    Refer to the [Max execution time documentation](https://docs.quantum-computing.ibm.com/run/max-execution-time#maximum-execution-time). for more information.
 
 *   **transpilation** (`Union`\[[`TranspilationOptions`](qiskit_ibm_runtime.options.TranspilationOptions "qiskit_ibm_runtime.options.transpilation_options.TranspilationOptions"), `Dict`]) – Transpilation options. See [`TranspilationOptions`](qiskit_ibm_runtime.options.TranspilationOptions "qiskit_ibm_runtime.options.TranspilationOptions") for all available options.
 
@@ -50,79 +54,67 @@ Options for the primitives.
 
 ## Attributes
 
-<span id="options-environment" />
-
-### environment
-
-<span id="qiskit_ibm_runtime.options.Options.environment" />
-
-`EnvironmentOptions | Dict`
-
-<span id="options-execution" />
-
-### execution
-
-<span id="qiskit_ibm_runtime.options.Options.execution" />
-
-`ExecutionOptions | Dict`
-
-<span id="options-max-execution-time" />
+<span id="qiskit_ibm_runtime.options.Options.max_execution_time" />
 
 ### max\_execution\_time
 
-<span id="qiskit_ibm_runtime.options.Options.max_execution_time" />
+`int | None`
 
-`int | None = None`
-
-<span id="options-optimization-level" />
-
-### optimization\_level
+`= None`
 
 <span id="qiskit_ibm_runtime.options.Options.optimization_level" />
 
-`int | None = None`
+### optimization\_level
 
-<span id="options-resilience" />
+`int | None`
 
-### resilience
-
-<span id="qiskit_ibm_runtime.options.Options.resilience" />
-
-`ResilienceOptions | Dict`
-
-<span id="options-resilience-level" />
-
-### resilience\_level
+`= None`
 
 <span id="qiskit_ibm_runtime.options.Options.resilience_level" />
 
-`int | None = None`
+### resilience\_level
 
-<span id="options-simulator" />
+`int | None`
 
-### simulator
-
-<span id="qiskit_ibm_runtime.options.Options.simulator" />
-
-`SimulatorOptions | Dict`
-
-<span id="options-transpilation" />
-
-### transpilation
+`= None`
 
 <span id="qiskit_ibm_runtime.options.Options.transpilation" />
 
+### transpilation
+
 `TranspilationOptions | Dict`
 
-## Methods
+<span id="qiskit_ibm_runtime.options.Options.resilience" />
 
-<span id="options-validate-options" />
+### resilience
+
+`ResilienceOptions | Dict`
+
+<span id="qiskit_ibm_runtime.options.Options.execution" />
+
+### execution
+
+`ExecutionOptions | Dict`
+
+<span id="qiskit_ibm_runtime.options.Options.environment" />
+
+### environment
+
+`EnvironmentOptions | Dict`
+
+<span id="qiskit_ibm_runtime.options.Options.simulator" />
+
+### simulator
+
+`SimulatorOptions | Dict`
+
+## Methods
 
 ### validate\_options
 
 <span id="qiskit_ibm_runtime.options.Options.validate_options" />
 
-`static Options.validate_options(options)`
+`static validate_options(options)`
 
 Validate that program inputs (options) are valid :raises ValueError: if optimization\_level is outside the allowed range. :raises ValueError: if max\_execution\_time is outside the allowed range.
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ResilienceOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.ResilienceOptions.md
@@ -10,53 +10,52 @@ python_api_name: qiskit_ibm_runtime.options.ResilienceOptions
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions" />
 
-`ResilienceOptions(noise_amplifier='TwoQubitAmplifier', noise_factors=(1, 3, 5), extrapolator='LinearExtrapolator')`
+`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`
 
 Resilience options.
 
 **Parameters**
 
-*   **noise\_factors** (`Sequence`\[`float`]) – An list of real valued noise factors that determine by what amount the circuits’ noise is amplified. Only applicable for `resilience_level=2`. Default: (1, 3, 5).
-*   **noise\_amplifier** (`Literal`\[‘TwoQubitAmplifier’, ‘GlobalFoldingAmplifier’, ‘LocalFoldingAmplifier’, ‘CxAmplifier’]) – A noise amplification strategy. One of `"TwoQubitAmplifier"`, `"GlobalFoldingAmplifier"`, `"LocalFoldingAmplifier"`, `"CxAmplifier"`. Only applicable for `resilience_level=2`. Default: “TwoQubitAmplifier”.
-*   **extrapolator** (`Literal`\[‘LinearExtrapolator’, ‘QuadraticExtrapolator’, ‘CubicExtrapolator’, ‘QuarticExtrapolator’]) – An extrapolation strategy. One of `"LinearExtrapolator"`, `"QuadraticExtrapolator"`, `"CubicExtrapolator"`, `"QuarticExtrapolator"`. Note that `"CubicExtrapolator"` and `"QuarticExtrapolator"` require more noise factors than the default. Only applicable for `resilience_level=2`. Default: “LinearExtrapolator”.
+*   **noise\_factors** (`Optional`\[`Sequence`\[`float`]]) – An list of real valued noise factors that determine by what amount the circuits’ noise is amplified. Only applicable for `resilience_level=2`. Default: `None`, and (1, 3, 5) if resilience level is 2.
+*   **noise\_amplifier** (*DEPRECATED*) – A noise amplification strategy. Currently only
+*   **resilience\_level=2.** (*"LocalFoldingAmplifier" is supported Only applicable for*) – Default: “LocalFoldingAmplifier”.
+*   **extrapolator** (`Optional`\[`Literal`\[‘LinearExtrapolator’, ‘QuadraticExtrapolator’, ‘CubicExtrapolator’, ‘QuarticExtrapolator’]]) – An extrapolation strategy. One of `"LinearExtrapolator"`, `"QuadraticExtrapolator"`, `"CubicExtrapolator"`, `"QuarticExtrapolator"`. Note that `"CubicExtrapolator"` and `"QuarticExtrapolator"` require more noise factors than the default. Only applicable for `resilience_level=2`. Default: `None`, and `LinearExtrapolator` if resilience level is 2.
 
 ## Attributes
 
-<span id="resilienceoptions-extrapolator" />
+<span id="qiskit_ibm_runtime.options.ResilienceOptions.extrapolator" />
 
 ### extrapolator
 
-<span id="qiskit_ibm_runtime.options.ResilienceOptions.extrapolator" />
+`Literal['LinearExtrapolator', 'QuadraticExtrapolator', 'CubicExtrapolator', 'QuarticExtrapolator']`
 
-`Literal['LinearExtrapolator', 'QuadraticExtrapolator', 'CubicExtrapolator', 'QuarticExtrapolator'] = 'LinearExtrapolator'`
-
-<span id="resilienceoptions-noise-amplifier" />
-
-### noise\_amplifier
+`= None`
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions.noise_amplifier" />
 
-`Literal['TwoQubitAmplifier', 'GlobalFoldingAmplifier', 'LocalFoldingAmplifier', 'CxAmplifier'] = 'TwoQubitAmplifier'`
+### noise\_amplifier
 
-<span id="resilienceoptions-noise-factors" />
+`Literal['LocalFoldingAmplifier']`
 
-### noise\_factors
+`= None`
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions.noise_factors" />
 
-`Sequence[float] = (1, 3, 5)`
+### noise\_factors
+
+`Sequence[float]`
+
+`= None`
 
 ## Methods
-
-<span id="resilienceoptions-validate-resilience-options" />
 
 ### validate\_resilience\_options
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions.validate_resilience_options" />
 
-`static ResilienceOptions.validate_resilience_options(resilience_options)`
+`static validate_resilience_options(resilience_options)`
 
-Validate that resilience options are legal. :raises ValueError: if noise\_amplifier is not in NoiseAmplifierType. :raises ValueError: if extrapolator is not in ExtrapolatorType. :raises ValueError: if extrapolator == “QuarticExtrapolator” and number of noise\_factors \< 5. :raises ValueError: if extrapolator == “CubicExtrapolator” and number of noise\_factors \< 4.
+Validate that resilience options are legal. :raises ValueError: if any resilience option is not supported :raises ValueError: if noise\_amplifier is not in NoiseAmplifierType. :raises ValueError: if extrapolator is not in ExtrapolatorType. :raises ValueError: if extrapolator == “QuarticExtrapolator” and number of noise\_factors \< 5. :raises ValueError: if extrapolator == “CubicExtrapolator” and number of noise\_factors \< 4.
 
 **Return type**
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SimulatorOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SimulatorOptions.md
@@ -25,53 +25,63 @@ For best practice in simulating a backend make sure to pass the basis gates and 
 
 ## Attributes
 
-<span id="simulatoroptions-basis-gates" />
+<span id="qiskit_ibm_runtime.options.SimulatorOptions.basis_gates" />
 
 ### basis\_gates
 
-<span id="qiskit_ibm_runtime.options.SimulatorOptions.basis_gates" />
+`List[str] | None`
 
-`List[str] | None = None`
-
-<span id="simulatoroptions-coupling-map" />
-
-### coupling\_map
+`= None`
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions.coupling_map" />
 
-`List[List[int]] | CouplingMap | None = None`
+### coupling\_map
 
-<span id="simulatoroptions-noise-model" />
+`List[List[int]] | CouplingMap | None`
 
-### noise\_model
+`= None`
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions.noise_model" />
 
-`dict | NoiseModel | None = None`
+### noise\_model
 
-<span id="simulatoroptions-seed-simulator" />
+`dict | NoiseModel | None`
 
-### seed\_simulator
+`= None`
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions.seed_simulator" />
 
-`int | None = None`
+### seed\_simulator
+
+`int | None`
+
+`= None`
 
 ## Methods
-
-<span id="simulatoroptions-set-backend" />
 
 ### set\_backend
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions.set_backend" />
 
-`SimulatorOptions.set_backend(backend)`
+`set_backend(backend)`
 
 Set backend for simulation. This method changes noise\_model, coupling\_map, basis\_gates according to given backend.
 
 **Parameters**
 
 **backend** (`Union`\[`BackendV1`, `BackendV2`]) – backend to be set.
+
+**Return type**
+
+`None`
+
+### validate\_simulator\_options
+
+<span id="qiskit_ibm_runtime.options.SimulatorOptions.validate_simulator_options" />
+
+`static validate_simulator_options(simulator_options)`
+
+Validate that simulator options are legal. :raises ValueError: if any simulator option is not supported
 
 **Return type**
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.TranspilationOptions.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.TranspilationOptions.md
@@ -24,57 +24,55 @@ Transpilation options.
 
 ## Attributes
 
-<span id="transpilationoptions-approximation-degree" />
+<span id="qiskit_ibm_runtime.options.TranspilationOptions.approximation_degree" />
 
 ### approximation\_degree
 
-<span id="qiskit_ibm_runtime.options.TranspilationOptions.approximation_degree" />
+`float | None`
 
-`float | None = None`
-
-<span id="transpilationoptions-initial-layout" />
-
-### initial\_layout
+`= None`
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions.initial_layout" />
 
-`dict | List | None = None`
+### initial\_layout
 
-<span id="transpilationoptions-layout-method" />
+`dict | List | None`
 
-### layout\_method
+`= None`
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions.layout_method" />
 
-`str | None = None`
+### layout\_method
 
-<span id="transpilationoptions-routing-method" />
+`str | None`
 
-### routing\_method
+`= None`
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions.routing_method" />
 
-`str | None = None`
+### routing\_method
 
-<span id="transpilationoptions-skip-transpilation" />
+`str | None`
 
-### skip\_transpilation
+`= None`
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions.skip_transpilation" />
 
-`bool = False`
+### skip\_transpilation
+
+`bool`
+
+`= False`
 
 ## Methods
-
-<span id="transpilationoptions-validate-transpilation-options" />
 
 ### validate\_transpilation\_options
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions.validate_transpilation_options" />
 
-`static TranspilationOptions.validate_transpilation_options(transpilation_options)`
+`static validate_transpilation_options(transpilation_options)`
 
-Validate that transpilation options are legal. :raises ValueError: if layout\_method is not in LayoutMethodType or None. :raises ValueError: if routing\_method is not in RoutingMethodType or None. :raises ValueError: if approximation\_degree in not None or in the range 0.0 to 1.0.
+Validate that transpilation options are legal. :raises ValueError: if any transpilation option is not supported :raises ValueError: if layout\_method is not in LayoutMethodType or None. :raises ValueError: if routing\_method is not in RoutingMethodType or None. :raises ValueError: if approximation\_degree in not None or in the range 0.0 to 1.0.
 
 **Return type**
 

--- a/docs/api/qiskit-ibm-runtime/runtime_service.md
+++ b/docs/api/qiskit-ibm-runtime/runtime_service.md
@@ -6,9 +6,9 @@ python_api_type: module
 python_api_name: qiskit_ibm_runtime
 ---
 
-<span id="module-qiskit_ibm_runtime" />
-
 <span id="qiskit-runtime-qiskit-ibm-runtime" />
+
+<span id="module-qiskit_ibm_runtime" />
 
 # Qiskit Runtime
 
@@ -58,8 +58,6 @@ with Session(service=service, backend="ibmq_qasm_simulator") as session:
         circuits=[psi], observables=[H1], parameter_values=[theta]
     )
     print(f"Estimator results: {job.result()}")
-    # Close the session only if all jobs are finished and you don't need to run more in the session.
-    session.close()
 ```
 
 ## Backend data
@@ -123,15 +121,15 @@ Files related to writing a runtime program are in the `qiskit_ibm_runtime/progra
 
 |                                                                                                                                          |                                                                        |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\[channel, token, url, ...]) | Class for interacting with the Qiskit Runtime service.                 |
-| [`Estimator`](qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\[backend, session, options])                                 | Class for interacting with Qiskit Runtime Estimator primitive service. |
-| [`Sampler`](qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler")(\[backend, session, options])                                       | Class for interacting with Qiskit Runtime Sampler primitive service.   |
-| [`Session`](qiskit_ibm_runtime.Session "qiskit_ibm_runtime.Session")(\[service, backend, max\_time])                                     | Class for creating a flexible Qiskit Runtime session.                  |
-| [`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend")(configuration, service, api\_client)                       | Backend class interfacing with an IBM Quantum backend.                 |
-| [`RuntimeJob`](qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")(backend, api\_client, ...\[, ...])                         | Representation of a runtime program execution.                         |
-| [`RuntimeProgram`](qiskit_ibm_runtime.RuntimeProgram "qiskit_ibm_runtime.RuntimeProgram")(program\_name, program\_id, ...)               | Class representing program metadata.                                   |
+| [`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\[channel, token, url, ...]) | Class for interacting with the Qiskit Runtime service.                 |
+| [`Estimator`](qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\[backend, session, options])                                 | Class for interacting with Qiskit Runtime Estimator primitive service. |
+| [`Sampler`](qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler")(\[backend, session, options])                                       | Class for interacting with Qiskit Runtime Sampler primitive service.   |
+| [`Session`](qiskit_ibm_runtime.Session "qiskit_ibm_runtime.Session")(\[service, backend, max\_time])                                     | Class for creating a flexible Qiskit Runtime session.                  |
+| [`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend")(configuration, service, api\_client)                       | Backend class interfacing with an IBM Quantum backend.                 |
+| [`RuntimeJob`](qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")(backend, api\_client, ...\[, ...])                         | Representation of a runtime program execution.                         |
+| [`RuntimeProgram`](qiskit_ibm_runtime.RuntimeProgram "qiskit_ibm_runtime.RuntimeProgram")(program\_name, program\_id, ...)               | Class representing program metadata.                                   |
 | [`ParameterNamespace`](qiskit_ibm_runtime.ParameterNamespace "qiskit_ibm_runtime.ParameterNamespace")(parameters)                        | A namespace for program parameters with validation.                    |
-| [`RuntimeOptions`](qiskit_ibm_runtime.RuntimeOptions "qiskit_ibm_runtime.RuntimeOptions")(\[backend, image, log\_level, ...])            | Class for representing generic runtime execution options.              |
-| [`RuntimeEncoder`](qiskit_ibm_runtime.RuntimeEncoder "qiskit_ibm_runtime.RuntimeEncoder")(\*\[, skipkeys, ensure\_ascii, ...])           | JSON Encoder used by runtime service.                                  |
-| [`RuntimeDecoder`](qiskit_ibm_runtime.RuntimeDecoder "qiskit_ibm_runtime.RuntimeDecoder")(\*args, \*\*kwargs)                            | JSON Decoder used by runtime service.                                  |
+| [`RuntimeOptions`](qiskit_ibm_runtime.RuntimeOptions "qiskit_ibm_runtime.RuntimeOptions")(\[backend, image, log\_level, ...])            | Class for representing generic runtime execution options.              |
+| [`RuntimeEncoder`](qiskit_ibm_runtime.RuntimeEncoder "qiskit_ibm_runtime.RuntimeEncoder")(\*\[, skipkeys, ensure\_ascii, ...])           | JSON Encoder used by runtime service.                                  |
+| [`RuntimeDecoder`](qiskit_ibm_runtime.RuntimeDecoder "qiskit_ibm_runtime.RuntimeDecoder")(\*args, \*\*kwargs)                            | JSON Decoder used by runtime service.                                  |
 


### PR DESCRIPTION
Now that we fixed https://github.com/Qiskit/documentation/issues/67, we can regenerate the API docs. The issues were due to changes with modern Sphinx 7.2.

There was one regression I noticed, but it's not enough of a show-stopper to block this PR: https://github.com/Qiskit/documentation/issues/224.