### PR TITLE
Fix broken links for migration guides

### DIFF
--- a/docs/api/migration-guides/qiskit-runtime-examples.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-examples.mdx
@@ -222,11 +222,11 @@ to the following:
 -   [Error mitigation
     tutorial](https://learning.quantum-computing.ibm.com/tutorial/error-suppression-and-error-mitigation-with-qiskit-runtime)
 -   [Setting execution options
-    topic](../run/advanced-runtime-options)
+    topic](../../run/advanced-runtime-options)
 -   [Primitive execution options API
-    reference](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options)
+    reference](../qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options)
 -   [How to run a session
-    topic](../run/run-jobs-in-session)
+    topic](../../run/run-jobs-in-session)
 
 #### 3. Other execution alternatives (non-Runtime)
 
@@ -304,7 +304,7 @@ expectation:  [-1.06365335]
 
 For more information on using the Aer primitives, see the [VQE tutorial](https://qiskit.org/documentation/tutorials/algorithms/03_vqe_simulation_with_noise.html).
 
-For more information about running noisy simulations with the **Runtime primitives**, see the [Noisy simulators in Qiskit Runtime](../verify/noisy-simulators) topic.
+For more information about running noisy simulations with the **Runtime primitives**, see the [Noisy simulators in Qiskit Runtime](../../verify/noisy-simulators) topic.
 
 <span id="sampler-algorithm"></span>
 ## Use Sampler to design an algorithm 
@@ -537,8 +537,8 @@ help improve your performance and results. For more information, refer
 to the following:
 
 -   [Error mitigation tutorial](https://learning.quantum-computing.ibm.com/tutorial/error-suppression-and-error-mitigation-with-qiskit-runtime)
--   [Setting execution options topic](../run/advanced-runtime-options)
--   [How to run a session topic](../run/run-jobs-in-session)
+-   [Setting execution options topic](../../run/advanced-runtime-options)
+-   [How to run a session topic](../../run/run-jobs-in-session)
 
 ### 3. Other execution alternatives (non-Runtime)
 
@@ -674,4 +674,4 @@ quasi_dists:  [{1: 0.2802734375, 2: 0.2412109375, 0: 0.2392578125, 3: 0.23925781
 binary_quasi_dist:  {'0001': 0.2802734375, '0010': 0.2412109375, '0000': 0.2392578125, '0011': 0.2392578125}
 ```
 
-For more information, see [Noisy simulators in Qiskit Runtime](../verify/noisy-simulators).
+For more information, see [Noisy simulators in Qiskit Runtime](../../verify/noisy-simulators).

--- a/docs/api/migration-guides/qiskit-runtime.mdx
+++ b/docs/api/migration-guides/qiskit-runtime.mdx
@@ -69,7 +69,7 @@ This guide is for algorithm developers who need to refactor algorithms to use pr
 The following topics are use cases with code migration examples:
 
 -   [Update parameter values while running](#parm-circ)
--   [Algorithm tuning options (shots, transpilation, error mitigation)](../run/advanced-runtime-options)
+-   [Algorithm tuning options (shots, transpilation, error mitigation)](../../run/advanced-runtime-options)
 
 ## FAQs
 
@@ -105,7 +105,7 @@ Platform. Some information that might help you decide includes:
 <summary>How do I set up my channel?</summary>
 
 After deciding which channel to use to interact with Qiskit Runtime, you
-can get set up on either platform by following the steps in [Install and set up.](../start/install)
+can get set up on either platform by following the steps in [Install and set up.](../../start/install)
 
 </details>
 
@@ -203,7 +203,7 @@ IBMQ.save_account("<IQX_TOKEN>", overwrite=True)
 
 **Updated: Save accounts** The new syntax accepts credentials for
 Qiskit Runtime on IBM Cloud or IBM Quantum Platform. For more
-information on retrieving account credentials, see [Install and set up](../start/install).
+information on retrieving account credentials, see [Install and set up](../../start/install).
 
 ``` python
 # IBM Cloud channel
@@ -460,17 +460,17 @@ print(result)
 One of the advantages of the primitives is that they abstract away the
 circuit execution setup so that algorithm developers can focus on the
 pure algorithmic components. However, sometimes, to get the most out of
-an algorithm, you might want to tune certain primitive options. For details, see the [Algorithm tuning options](../run/algorithm-tuning-options).
+an algorithm, you might want to tune certain primitive options. For details, see [Advanced runtime options](../../run/advanced-runtime-options).
 
 ## Next steps
 
 <Admonition type="tip" title="Recommendations">
     - Review some [migration examples](migrate-examples).
-    - [Get started with Estimator.](../run/primitives-get-started#start-estimator)
-    - [Get started with Sampler.](../run/primitives-get-started#start-sampler)
-    - Explore [sessions.](../run/sessions)
-    - [Run a primitive in a session.](../run/run-jobs-in-session)
-    - Experiment with the [migration tutorial.](https://qiskit.org/documentation/partners/qiskit_ibm_provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html) 
+    - [Get started with Estimator.](../../run/primitives-get-started#start-estimator)
+    - [Get started with Sampler.](../../run/primitives-get-started#start-sampler)
+    - Explore [sessions.](../../run/sessions)
+    - [Run a primitive in a session.](../../run/run-jobs-in-session)
+    - Experiment with the [migration tutorial.](https://qiskit.org/ecosystem/ibm-provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html) 
     - Experiment with the [Run custom transpiled circuits with primitives tutorial.](https://learning.quantum-computing.ibm.com/tutorial/submitting-user-transpiled-circuits-using-primitives)
 
 </Admonition>

--- a/docs/build/pulse.ipynb
+++ b/docs/build/pulse.ipynb
@@ -539,8 +539,6 @@
     "\n",
     "**Note**: The hardware may be implemented in other ways, but if we keep the instructions separate, we avoid losing explicit information, such as the value of the modulation frequency.\n",
     "\n",
-    "![alt text](pulse_modulation.png \"Pulse modulation image\")\n",
-    "\n",
     "There are many methods available to us for building up pulses. Our `library` within Qiskit Pulse contains helpful methods for building `Pulse`s. Let's take for example a simple Gaussian pulse -- a pulse with its envelope described by a sampled Gaussian function. We arbitrarily choose an amplitude of 1, standard deviation $\\sigma$ of 10, and 128 sample points.\n",
     "\n",
     "**Note**: The amplitude norm is arbitrarily limited to `1.0`. Each backend system may also impose further constraints -- for instance, a minimum pulse size of 64. These additional constraints, if available, would be provided through the `BackendConfiguration` which is described [here](https://qiskit.org/documentation/tutorials/circuits_advanced/08_gathering_system_information.html#Configuration)."

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -28,10 +28,6 @@ Already know what you’re looking for?
 
 - **API reference**: Find API references for [Qiskit](/api/qiskit), [Qiskit Runtime IBM Client](/api/qiskit-ibm-runtime/runtime_service), [Qiskit IBM Runtime Rest API](/api/runtime/tags/programs), and [Qiskit IBM Provider](/api/qiskit-ibm-provider/ibm_provider) in the API reference drop-down menu above. You can also find the [Error code registry](../errors) here.
 
-
-{/* Add back in when we have guides:
-- [Guides](../guides): Go here for walkthroughs of advanced methods drawn from real research and use cases.*/}
-
 ## Community
 
 Join other users in our quantum community to share ideas and see what others are up to.

--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -18,10 +18,14 @@ import markdownLinkExtractor from "markdown-link-extractor";
 const DOCS_ROOT = "./docs";
 const CONTENT_FILE_EXTENSIONS = [".md", ".mdx", ".ipynb"];
 
-const IGNORE_LIST = [
-  "docs/run/instances.mdx",
-  "docs/start/index.mdx",
-  "docs/build/pulse.ipynb",
+// These files are not searched to see if their own links are valid.
+const IGNORED_FILES: string[] = [];
+
+// While these files don't exist in this repository, the link
+// checker should assume that they exist in production.
+const SYNTHETIC_FILES: string[] = [
+  "docs/errors.mdx",
+  "docs/api/runtime/tags/programs.mdx",
 ];
 
 class Link {
@@ -80,7 +84,7 @@ class Link {
     return possibleFilePaths;
   }
 
-  check(filePathCache: string[] = []): boolean {
+  check(filePathCache: string[]): boolean {
     /*
      * True if link points to existing file, otherwise false
      * filePathCache: array of known existing files (to reduce disk I/O)
@@ -92,7 +96,10 @@ class Link {
 
     const possiblePaths = this.resolve();
     for (let filePath of possiblePaths) {
-      if (filePathCache.includes(filePath)) {
+      if (
+        filePathCache.includes(filePath) ||
+        SYNTHETIC_FILES.includes(filePath)
+      ) {
         return true;
       }
     }
@@ -119,10 +126,14 @@ function markdownFromNotebook(source: string): string {
 }
 
 function checkLinksInFile(filePath: string, filePaths: string[]): boolean {
-  if (filePath.startsWith("docs/api")) {
+  if (
+    filePath.startsWith("docs/api/qiskit") ||
+    filePath.startsWith("docs/api/qiskit-ibm-provider") ||
+    filePath.startsWith("docs/api/qiskit-ibm-runtime")
+  ) {
     return true;
   }
-  if (IGNORE_LIST.includes(filePath)) {
+  if (IGNORED_FILES.includes(filePath)) {
     return true;
   }
   const source = readFileSync(filePath, { encoding: "utf8" });


### PR DESCRIPTION
I accidentally broke this in https://github.com/Qiskit/documentation/pull/177.

This PR fixes the broken links and also a few others, such that our link checker now checks every non-API file 🎉 To fix some errors, it adds a `SYNTHETIC_FILES` list, which are files that only exist in closed source but not open source; so the links are valid, even though the files aren't present here.