### PR TITLE
Convert some Sphinx cross references to Markdown

### DIFF
--- a/docs/api/migration-guides/__migration-guide-algorithms.md.txt
+++ b/docs/api/migration-guides/__migration-guide-algorithms.md.txt
@@ -2,16 +2,16 @@
 
 ## TL;DR
 
-The {mod}`qiskit.algorithms` module has been fully refactored to use the {mod}`~qiskit.primitives`, for circuit execution, instead of the {class}`~qiskit.utils.QuantumInstance`, which is now deprecated.
+The [`qiskit.algorithms`](../qiskit/algorithms) module has been fully refactored to use the [`qiskit.primitives`](../qiskit/primitives), for circuit execution, instead of the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), which is now deprecated.
 
 There have been **3 types of refactoring**:
 
-1. Algorithms refactored in a new location to support {mod}`~qiskit.primitives`. These algorithms have the same
-   class names as the {class}`~qiskit.utils.QuantumInstance`-based ones but are in a new sub-package.
+1. Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives). These algorithms have the same
+   class names as the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance)-based ones but are in a new sub-package.
 
    > :::{attention}
    > **Careful with import paths!!** The legacy algorithms are still importable directly from
-   > {mod}`qiskit.algorithms`. Until the legacy imports are removed, this convenience import is not available
+   > [`qiskit.algorithms`](../qiskit/algorithms). Until the legacy imports are removed, this convenience import is not available
    > for the refactored algorithms. Thus, to import the refactored algorithms you must always
    > **specify the full import path** (e.g., `from qiskit.algorithms.eigensolvers import VQD`)
    > :::
@@ -20,14 +20,14 @@ There have been **3 types of refactoring**:
    > - [Eigensolvers]
    > - [Time Evolvers]
 
-2. Algorithms refactored in-place (same namespace) to support both {class}`~qiskit.utils.QuantumInstance` and
-   {mod}`~qiskit.primitives`. In the future, the use of {class}`~qiskit.utils.QuantumInstance` will be removed.
+2. Algorithms refactored in-place (same namespace) to support both [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) and
+   [`qiskit.primitives`](../qiskit/primitives). In the future, the use of [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) will be removed.
 
    > - [Amplitude Amplifiers]
    > - [Amplitude Estimators]
    > - [Phase Estimators]
 
-3. Algorithms that were deprecated and are now removed entirely from {mod}`qiskit.algorithms`. These are algorithms that do not currently serve
+3. Algorithms that were deprecated and are now removed entirely from [`qiskit.algorithms`](../qiskit/algorithms). These are algorithms that do not currently serve
    as building blocks for applications. Their main value is educational, and as such, will be kept as tutorials
    in the qiskit textbook. You can consult the tutorials in the following links:
 
@@ -35,25 +35,25 @@ There have been **3 types of refactoring**:
    > - [Factorizers (Shor)](https://learn.qiskit.org/course/ch-algorithms/shors-algorithm)
 
 The remainder of this migration guide will focus on the algorithms with migration alternatives within
-{mod}`qiskit.algorithms`, that is, those under refactoring types 1 and 2.
+[`qiskit.algorithms`](../qiskit/algorithms), that is, those under refactoring types 1 and 2.
 
 ## Background
 
 *Back to* [TL;DR]
 
-The {mod}`qiskit.algorithms` module was originally built on top of the {mod}`qiskit.opflow` library and the
-{class}`~qiskit.utils.QuantumInstance` utility. The development of the {mod}`~qiskit.primitives`
+The [`qiskit.algorithms`](../qiskit/algorithms) module was originally built on top of the [`qiskit.opflow`](../qiskit/opflow) library and the
+[`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) utility. The development of the [`qiskit.primitives`](../qiskit/primitives)
 introduced a higher-level execution paradigm, with the `Estimator` for computation of
 expectation values for observables, and `Sampler` for executing circuits and returning probability
-distributions. These tools allowed to refactor the {mod}`qiskit.algorithms` module, and deprecate both
-{mod}`qiskit.opflow` and {class}`~qiskit.utils.QuantumInstance`.
+distributions. These tools allowed to refactor the [`qiskit.algorithms`](../qiskit/algorithms) module, and deprecate both
+[`qiskit.opflow`](../qiskit/opflow) and [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance).
 
 :::{attention}
-The transition away from {mod}`qiskit.opflow` affects the classes that algorithms take as part of the problem
-setup. As a rule of thumb, most {mod}`qiskit.opflow` dependencies have a direct {mod}`qiskit.quantum_info`
-replacement. One common example is the class {mod}`qiskit.opflow.PauliSumOp`, used to define Hamiltonians
-(for example, to plug into VQE), that can be replaced by {mod}`qiskit.quantum_info.SparsePauliOp`.
-For information on how to migrate other {mod}`~qiskit.opflow` objects, you can refer to the
+The transition away from [`qiskit.opflow`](../qiskit/opflow) affects the classes that algorithms take as part of the problem
+setup. As a rule of thumb, most [`qiskit.opflow`](../qiskit/opflow) dependencies have a direct [`qiskit.quantum_info`](../qiskit/quantum_info)
+replacement. One common example is the class [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp), used to define Hamiltonians
+(for example, to plug into VQE), that can be replaced by [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
+For information on how to migrate other [`qiskit.opflow`](../qiskit/opflow) objects, you can refer to the
 [Opflow migration guide](https://qisk.it/opflow_migration).
 :::
 
@@ -67,18 +67,18 @@ For further background and detailed migration steps, see the:
 *Back to* [TL;DR]
 
 The classes in
-{mod}`qiskit.algorithms` are initialized with any implementation of {class}`qiskit.primitive.BaseSampler` or class:`qiskit.primitive.BaseEstimator`.
+[`qiskit.algorithms`](../qiskit/algorithms) are initialized with any implementation of {class}`qiskit.primitive.BaseSampler` or class:`qiskit.primitive.BaseEstimator`.
 
 Once the kind of primitive is known, you can choose between the primitive implementations that better adjust to your case. For example:
 
-> 1. For quick prototyping, you can use the **reference implementations of primitives** included in Qiskit: {class}`qiskit.primitives.Sampler` and {class}`qiskit.primitives.Estimator`.
+> 1. For quick prototyping, you can use the **reference implementations of primitives** included in Qiskit: [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator).
 >
-> 2. For finer algorithm tuning, a local simulator such as the **primitive implementation in Aer**: {class}`qiskit_aer.primitives.Sampler` and {class}`qiskit_aer.primitives.Estimator`.
+> 2. For finer algorithm tuning, a local simulator such as the **primitive implementation in Aer**: [`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html) and [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html).
 >
 > 3. For executing in quantum hardware you can:
 >
->    - access services with native primitive implementations, such as **IBM's Qiskit Runtime service** via {class}`qiskit_ibm_runtime.Sampler` and {class}`qiskit_ibm_runtime.Estimator`
->    - Wrap any backend with **Backend Primitives** ({class}`~qiskit.primitives.BackendSampler` and {class}`~qiskit.primitives.BackendEstimator`). These wrappers implement a primitive interface on top of a backend that only supports `Backend.run()`.
+>    - access services with native primitive implementations, such as **IBM's Qiskit Runtime service** via [`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)
+>    - Wrap any backend with **Backend Primitives** ([`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator)). These wrappers implement a primitive interface on top of a backend that only supports `Backend.run()`.
 
 For more detailed information and examples, particularly on the use of the **Backend Primitives**, please refer to
 the [Quantum Instance migration guide](https://qisk.it/qi_migration).
@@ -86,7 +86,7 @@ the [Quantum Instance migration guide](https://qisk.it/qi_migration).
 In this guide, we will cover 3 different common configurations for algorithms that determine
 **which primitive import** you should be selecting:
 
-1. Running an algorithm with a statevector simulator (i.e., using {mod}`qiskit.opflow`'s legacy
+1. Running an algorithm with a statevector simulator (i.e., using [`qiskit.opflow`](../qiskit/opflow)'s legacy
    {class}`.MatrixExpectation`), when you want the ideal outcome without shot noise:
 
    > - Reference Primitives with default configuration (see [QAOA] example):
@@ -105,7 +105,7 @@ In this guide, we will cover 3 different common configurations for algorithms th
    > ```
 
 2. Running an algorithm using a simulator/device with shot noise
-   (i.e., using {mod}`qiskit.opflow`'s legacy {class}`.PauliExpectation`):
+   (i.e., using [`qiskit.opflow`](../qiskit/opflow)'s legacy {class}`.PauliExpectation`):
 
    > - Reference Primitives **with shots** (see [VQE] examples):
    >
@@ -135,7 +135,7 @@ In this guide, we will cover 3 different common configurations for algorithms th
    > from qiskit_ibm_runtime import Sampler, Estimator
    > ```
 
-3\. Running an algorithm on an Aer simulator using a custom instruction (i.e., using {mod}`qiskit.opflow`'s legacy
+3\. Running an algorithm on an Aer simulator using a custom instruction (i.e., using [`qiskit.opflow`](../qiskit/opflow)'s legacy
 {class}`.AerPauliExpectation`):
 
 > - Aer Primitives with `shots=None`, `approximation=True` (see [TrotterQRTE] example):
@@ -152,13 +152,13 @@ In this guide, we will cover 3 different common configurations for algorithms th
 *Back to* [TL;DR]
 
 The minimum eigensolver algorithms belong to the first type of refactoring listed above
-(Algorithms refactored in a new location to support {mod}`~qiskit.primitives`).
-Instead of a {class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.minimum_eigensolvers` are now initialized
-using an instance of the {mod}`~qiskit.primitives.Sampler` or {mod}`~qiskit.primitives.Estimator` primitive, depending
+(Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/qiskit.algorithms.minimum_eigensolvers) are now initialized
+using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, depending
 on the algorithm. The legacy classes can still be found in {mod}`qiskit.algorithms.minimum_eigen_solvers`.
 
 :::{attention}
-For the {mod}`qiskit.algorithms.minimum_eigensolvers` classes, depending on the import path,
+For the [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/qiskit.algorithms.minimum_eigensolvers) classes, depending on the import path,
 you will access either the primitive-based or the quantum-instance-based
 implementation. You have to be extra-careful, because the class name does not change.
 
@@ -178,13 +178,13 @@ The legacy {class}`qiskit.algorithms.minimum_eigen_solvers.VQE` class has now be
   {class}`~qiskit.opflow.expectations.CVaRExpectation`.
 
 :::{note}
-In addition to taking in an {mod}`~qiskit.primitives.Estimator` instance instead of a {class}`~qiskit.utils.QuantumInstance`,
+In addition to taking in an [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
 the new {class}`~qiskit.algorithms.minimum_eigensolvers.VQE` signature has undergone the following changes:
 
 1. The `expectation` and `include_custom` parameters have been removed, as this functionality is now
    defined at the `Estimator` level.
 2. The `gradient` parameter now takes in an instance of a primitive-based gradient class from
-   {mod}`qiskit.algorithms.gradients` instead of the legacy {mod}`qiskit.opflow.gradients.Gradient` class.
+   [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient) class.
 3. The `max_evals_grouped` parameter has been removed, as it can be set directly on the optimizer class.
 4. The `estimator`, `ansatz` and `optimizer` are the only parameters that can be defined positionally
    (and in this order), all others have become keyword-only arguments.
@@ -361,13 +361,13 @@ extends {class}`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`.
 For this reason, **the new QAOA only supports diagonal operators**.
 
 :::{note}
-In addition to taking in an {mod}`~qiskit.primitives.Sampler` instance instead of a {class}`~qiskit.utils.QuantumInstance`,
+In addition to taking in an [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
 the new {class}`~qiskit.algorithms.minimum_eigensolvers.QAOA` signature has undergone the following changes:
 
 1. The `expectation` and `include_custom` parameters have been removed. In return, the `aggregation`
    parameter has been added (it used to be defined through a custom `expectation`).
 2. The `gradient` parameter now takes in an instance of a primitive-based gradient class from
-   {mod}`qiskit.algorithms.gradients` instead of the legacy {mod}`qiskit.opflow.gradients.Gradient` class.
+   [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient) class.
 3. The `max_evals_grouped` parameter has been removed, as it can be set directly on the optimizer class.
 4. The `sampler` and `optimizer` are the only parameters that can be defined positionally
    (and in this order), all others have become keyword-only arguments.
@@ -525,14 +525,14 @@ For complete code examples, see the following updated tutorials:
 *Back to* [TL;DR]
 
 The eigensolver algorithms also belong to the first type of refactoring
-(Algorithms refactored in a new location to support {mod}`~qiskit.primitives`). Instead of a
-{class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.eigensolvers` are now initialized
-using an instance of the {class}`~qiskit.primitives.Sampler` or {class}`~qiskit.primitives.Estimator` primitive, or
+(Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)). Instead of a
+[`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), [`qiskit.algorithms.eigensolvers`](../qiskit/qiskit.algorithms.eigensolvers) are now initialized
+using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, or
 **a primitive-based subroutine**, depending on the algorithm. The legacy classes can still be found
 in {mod}`qiskit.algorithms.eigen_solvers`.
 
 :::{attention}
-For the {mod}`qiskit.algorithms.eigensolvers` classes, depending on the import path,
+For the [`qiskit.algorithms.eigensolvers`](../qiskit/qiskit.algorithms.eigensolvers) classes, depending on the import path,
 you will access either the primitive-based or the quantum-instance-based
 implementation. You have to be extra-careful, because the class name does not change.
 
@@ -543,18 +543,18 @@ implementation. You have to be extra-careful, because the class name does not ch
 ### VQD
 
 The new {class}`qiskit.algorithms.eigensolvers.VQD` class is initialized with an instance of the
-{class}`~qiskit.primitives.Estimator` primitive instead of a {class}`~qiskit.utils.QuantumInstance`.
+[`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance).
 In addition to this, it takes an instance of a state fidelity class from mod:`qiskit.algorithms.state_fidelities`,
-such as the {class}`~qiskit.primitives.Sampler`-based {class}`~qiskit.algorithms.state_fidelities.ComputeUncompute`.
+such as the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler)-based {class}`~qiskit.algorithms.state_fidelities.ComputeUncompute`.
 
 :::{note}
-In addition to taking in an {mod}`~qiskit.primitives.Estimator` instance instead of a {class}`~qiskit.utils.QuantumInstance`,
+In addition to taking in an [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
 the new {class}`~qiskit.algorithms.eigensolvers.VQD` signature has undergone the following changes:
 
 1. The `expectation` and `include_custom` parameters have been removed, as this functionality is now
    defined at the `Estimator` level.
 2. The custom `fidelity` parameter has been added, and the custom `gradient` parameter has
-   been removed, as current classes in {mod}`qiskit.algorithms.gradients` cannot deal with state fidelity
+   been removed, as current classes in [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) cannot deal with state fidelity
    gradients.
 3. The `max_evals_grouped` parameter has been removed, as it can be set directly on the optimizer class.
 4. The `estimator`, `fidelity`, `ansatz` and `optimizer` are the only parameters that can be defined positionally
@@ -717,9 +717,9 @@ to {class}`qiskit.algorithms.eigensolvers.MinimumEigensolver` to conform to the 
 *Back to* [TL;DR]
 
 The time evolvers are the last group of algorithms to undergo the first type of refactoring
-(Algorithms refactored in a new location to support {mod}`~qiskit.primitives`).
-Instead of a {class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.time_evolvers` are now initialized
-using an instance of the {class}`~qiskit.primitives.Estimator` primitive. The legacy classes can still be found
+(Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.time_evolvers` are now initialized
+using an instance of the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. The legacy classes can still be found
 in {mod}`qiskit.algorithms.evolvers`.
 
 On top of the migration, the module has been substantially expanded to include **Variational Quantum Time Evolution**
@@ -737,7 +737,7 @@ implementation. You have to be extra-careful, because the class name does not ch
 :::
 
 :::{note}
-In addition to taking in an {mod}`~qiskit.primitives.Estimator` instance instead of a {class}`~qiskit.utils.QuantumInstance`,
+In addition to taking in an [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
 the new {class}`~qiskit.algorithms.eigensolvers.VQD` signature has undergone the following changes:
 
 1. The `expectation` parameter has been removed, as this functionality is now
@@ -819,8 +819,8 @@ the new {class}`~qiskit.algorithms.eigensolvers.VQD` signature has undergone the
 *Back to* [TL;DR]
 
 The amplitude amplifier algorithms belong to the second type of refactoring (Algorithms refactored in-place).
-Instead of a {class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.amplitude_amplifiers` are now initialized
-using an instance of any "Sampler" primitive e.g. {mod}`~qiskit.primitives.Sampler`.
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.amplitude_amplifiers` are now initialized
+using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 :::{note}
 The full {mod}`qiskit.algorithms.amplitude_amplifiers` module has been refactored in place. No need to
@@ -863,8 +863,8 @@ For complete code examples, see the following updated tutorials:
 
 Similarly to the amplitude amplifiers, the amplitude estimators also belong to the second type of refactoring
 (Algorithms refactored in-place).
-Instead of a {class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.amplitude_estimators` are now initialized
-using an instance of any "Sampler" primitive e.g. {mod}`~qiskit.primitives.Sampler`.
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.amplitude_estimators` are now initialized
+using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 :::{note}
 The full {mod}`qiskit.algorithms.amplitude_estimators` module has been refactored in place. No need to
@@ -913,8 +913,8 @@ For complete code examples, see the following updated tutorials:
 
 Finally, the phase estimators are the last group of algorithms to undergo the first type of refactoring
 (Algorithms refactored in-place).
-Instead of a {class}`~qiskit.utils.QuantumInstance`, {mod}`qiskit.algorithms.phase_estimators` are now initialized
-using an instance of any "Sampler" primitive e.g. {mod}`~qiskit.primitives.Sampler`.
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.phase_estimators` are now initialized
+using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 :::{note}
 The full {mod}`qiskit.algorithms.phase_estimators` module has been refactored in place. No need to

--- a/docs/api/migration-guides/__migration-guide-opflow.md.txt
+++ b/docs/api/migration-guides/__migration-guide-opflow.md.txt
@@ -2,46 +2,46 @@
 
 ## TL;DR
 
-The new {mod}`~qiskit.primitives`, in combination with the {mod}`~qiskit.quantum_info` module, have superseded
-functionality of {mod}`~qiskit.opflow`. Thus, the latter is being deprecated.
+The new [`qiskit.primitives`](../qiskit/primitives), in combination with the [`qiskit.quantum_info`](../qiskit/quantum_info) module, have superseded
+functionality of [`qiskit.opflow`](../qiskit/opflow). Thus, the latter is being deprecated.
 
 In this migration guide, you will find instructions and code examples for how to migrate your code based on
-the {mod}`~qiskit.opflow` module to the {mod}`~qiskit.primitives` and {mod}`~qiskit.quantum_info` modules.
+the [`qiskit.opflow`](../qiskit/opflow) module to the [`qiskit.primitives`](../qiskit/primitives) and [`qiskit.quantum_info`](../qiskit/quantum_info) modules.
 
 :::{note}
-The use of {mod}`~qiskit.opflow` was tightly coupled to the {class}`~qiskit.utils.QuantumInstance` class, which
-is also being deprecated. For more information on migrating the {class}`~qiskit.utils.QuantumInstance`, please
+The use of [`qiskit.opflow`](../qiskit/opflow) was tightly coupled to the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) class, which
+is also being deprecated. For more information on migrating the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), please
 read the [quantum instance migration guide](http://qisk.it/qi_migration).
 :::
 
 (attention-primitives)=
 
 :::{attention}
-Most references to the {class}`qiskit.primitives.Sampler` or {class}`qiskit.primitives.Estimator` in this guide
-can be replaced with instances of any primitive implementation. For example Aer primitives ({class}`qiskit_aer.primitives.Sampler`/{class}`qiskit_aer.primitives.Estimator`) or IBM's Qiskit Runtime primitives ({class}`qiskit_ibm_runtime.Sampler`/{class}`qiskit_ibm_runtime.Estimator`).
-Specific backends can be wrapped with ({class}`qiskit.primitives.BackendSampler`, {class}`qiskit.primitives.BackendEstimator`) to also present primitive-compatible interfaces.
+Most references to the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) in this guide
+can be replaced with instances of any primitive implementation. For example Aer primitives ([`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html)/[`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)) or IBM's Qiskit Runtime primitives ([`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler)/[`qiskit_ibm_runtime.Estimator`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)).
+Specific backends can be wrapped with ([`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler), [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator)) to also present primitive-compatible interfaces.
 
 Certain classes, such as the
 {class}`~qiskit.opflow.expectations.AerPauliExpectation`, can only be replaced by a specific primitive instance
-(in this case, {class}`qiskit_aer.primitives.Estimator`), or require a specific option configuration.
+(in this case, [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)), or require a specific option configuration.
 If this is the case, it will be explicitly indicated in the corresponding section.
 :::
 
 ## Background
 
-The {mod}`~qiskit.opflow` module was originally introduced as a layer between circuits and algorithms, a series of building blocks
+The [`qiskit.opflow`](../qiskit/opflow) module was originally introduced as a layer between circuits and algorithms, a series of building blocks
 for quantum algorithms research and development.
 
-The recent release of the {mod}`qiskit.primitives` introduced a new paradigm for interacting with backends. Now, instead of
+The recent release of the [`qiskit.primitives`](../qiskit/primitives) introduced a new paradigm for interacting with backends. Now, instead of
 preparing a circuit to execute with a `backend.run()` type of method, the algorithms can leverage the {class}`.Sampler` and
 {class}`.Estimator` primitives, send parametrized circuits and observables, and directly receive quasi-probability distributions or
 expectation values (respectively). This workflow simplifies considerably the pre-processing and post-processing steps
-that previously relied on this module; encouraging us to move away from {mod}`~qiskit.opflow`
-and find new paths for developing algorithms based on the {mod}`~qiskit.primitives` interface and
-the {mod}`~qiskit.quantum_info` module.
+that previously relied on this module; encouraging us to move away from [`qiskit.opflow`](../qiskit/opflow)
+and find new paths for developing algorithms based on the [`qiskit.primitives`](../qiskit/primitives) interface and
+the [`qiskit.quantum_info`](../qiskit/quantum_info) module.
 
 This guide traverses the opflow submodules and provides either a direct alternative
-(i.e., using {mod}`~qiskit.quantum_info`), or an explanation of how to replace their functionality in algorithms.
+(i.e., using [`qiskit.quantum_info`](../qiskit/quantum_info)), or an explanation of how to replace their functionality in algorithms.
 
 The functional equivalency can be roughly summarized as follows:
 
@@ -52,23 +52,23 @@ The functional equivalency can be roughly summarized as follows:
    * - Opflow Module
      - Alternative
    * - Operators (:class:`~qiskit.opflow.OperatorBase`, :ref:`operator_globals`,
-       :mod:`~qiskit.opflow.primitive_ops`, :mod:`~qiskit.opflow.list_ops`)
+       [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops), [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops))
      - ``qiskit.quantum_info`` :ref:`Operators <quantum_info_operators>`
 
-   * - :mod:`qiskit.opflow.state_fns`
+   * - [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns)
      - ``qiskit.quantum_info`` :ref:`States <quantum_info_states>`
 
-   * - :mod:`qiskit.opflow.converters`
-     - :mod:`qiskit.primitives`
+   * - [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters)
+     - [`qiskit.primitives`](../qiskit/primitives)
 
-   * - :mod:`qiskit.opflow.evolutions`
+   * - [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions)
      - ``qiskit.synthesis`` :ref:`Evolution <evolution_synthesis>`
 
-   * - :mod:`qiskit.opflow.expectations`
-     - :class:`qiskit.primitives.Estimator`
+   * - [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations)
+     - [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator)
 
-   * - :mod:`qiskit.opflow.gradients`
-     - :mod:`qiskit.algorithms.gradients`
+   * - [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients)
+     - [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients)
 ```
 
 ## Contents
@@ -115,9 +115,9 @@ Despite the similar class names, {class}`qiskit.opflow.OperatorBase` and
 should be handled with care. Namely:
 
 1\. {class}`qiskit.opflow.OperatorBase` implements a broader algebra mixin. Some operator overloads that were
-commonly used {mod}`~qiskit.opflow` (for example `~` for `.adjoint()`) are not defined for
+commonly used [`qiskit.opflow`](../qiskit/opflow) (for example `~` for `.adjoint()`) are not defined for
 {class}`qiskit.quantum_info.BaseOperator`. You might want to check the specific
-{mod}`~qiskit.quantum_info` subclass instead.
+[`qiskit.quantum_info`](../qiskit/quantum_info) subclass instead.
 
 2\. {class}`qiskit.opflow.OperatorBase` also implements methods such as `.to_matrix()` or `.to_spmatrix()`,
 which are only found in some of the {class}`qiskit.quantum_info.BaseOperator` subclasses.
@@ -134,7 +134,7 @@ Opflow provided shortcuts to define common single qubit states, operators, and n
 {ref}`operator_globals` module.
 
 These were mainly used for didactic purposes or quick prototyping, and can easily be replaced by their corresponding
-{mod}`~qiskit.quantum_info` class: {class}`~qiskit.quantum_info.Pauli`, {class}`~qiskit.quantum_info.Clifford` or
+[`qiskit.quantum_info`](../qiskit/quantum_info) class: {class}`~qiskit.quantum_info.Pauli`, {class}`~qiskit.quantum_info.Clifford` or
 {class}`~qiskit.quantum_info.Statevector`.
 
 ### 1-Qubit Paulis
@@ -144,7 +144,7 @@ These were mainly used for didactic purposes or quick prototyping, and can easil
 The 1-qubit paulis were commonly used for quick testing of algorithms, as they could be combined to create more complex operators
 (for example, `0.39 * (I ^ Z) + 0.5 * (X ^ X)`).
 These operations implicitly created operators of type  {class}`~qiskit.opflow.primitive_ops.PauliSumOp`, and can be replaced by
-directly creating a corresponding {class}`~qiskit.quantum_info.SparsePauliOp`, as shown in the examples below.
+directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), as shown in the examples below.
 
 ```{eval-rst}
 .. list-table::
@@ -157,7 +157,7 @@ directly creating a corresponding {class}`~qiskit.quantum_info.SparsePauliOp`, a
 
        ..  tip::
 
-           For direct compatibility with classes in :mod:`~qiskit.algorithms`, wrap in :class:`~qiskit.quantum_info.SparsePauliOp`.
+           For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
 
 ```
 
@@ -268,7 +268,7 @@ directly creating a corresponding {class}`~qiskit.quantum_info.SparsePauliOp`, a
 
        ..  note::
 
-            Constructing :mod:`~qiskit.quantum_info` operators from circuits is not efficient, as it is a dense operation and
+            Constructing [`qiskit.quantum_info`](../qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and
             scales exponentially with the size of the circuit, use with care.
 ```
 
@@ -350,7 +350,7 @@ directly creating a corresponding {class}`~qiskit.quantum_info.SparsePauliOp`, a
 
        ..  note::
 
-           For efficient simulation of stabilizer states, :mod:`~qiskit.quantum_info` includes a
+           For efficient simulation of stabilizer states, [`qiskit.quantum_info`](../qiskit/quantum_info) includes a
            :class:`~qiskit.quantum_info.StabilizerState` class. See API reference of :class:`~qiskit.quantum_info.StabilizerState` for more info.
 ```
 
@@ -413,8 +413,8 @@ directly creating a corresponding {class}`~qiskit.quantum_info.SparsePauliOp`, a
 
 *Back to* [Contents]
 
-Most of the workflows that previously relied on components from {mod}`~qiskit.opflow.primitive_ops` and
-{mod}`~qiskit.opflow.list_ops` can now leverage elements from {mod}`~qiskit.quantum_info`'s
+Most of the workflows that previously relied on components from [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) and
+[`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) can now leverage elements from [`qiskit.quantum_info`](../qiskit/quantum_info)'s
 operators instead.
 Some of these classes do not require a 1-1 replacement because they were created to interface with other
 opflow components.
@@ -423,7 +423,7 @@ opflow components.
 
 *Back to* [Contents]
 
-{class}`~qiskit.opflow.primitive_ops.PrimitiveOp` is the {mod}`~qiskit.opflow.primitive_ops` module's base class.
+{class}`~qiskit.opflow.primitive_ops.PrimitiveOp` is the [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) module's base class.
 It also acts as a factory to instantiate a corresponding sub-class depending on the computational primitive used
 to initialize it.
 
@@ -469,11 +469,11 @@ are used "under the hood" in the original code:
      - :class:`~qiskit.quantum_info.Operator`
 
    * - :class:`~qiskit.opflow.primitive_ops.PauliOp`
-     - :class:`~qiskit.quantum_info.Pauli`. For direct compatibility with classes in :mod:`qiskit.algorithms`,
-       wrap in :class:`~qiskit.quantum_info.SparsePauliOp`.
+     - :class:`~qiskit.quantum_info.Pauli`. For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms),
+       wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
 
    * - :class:`~qiskit.opflow.primitive_ops.PauliSumOp`
-     - :class:`~qiskit.quantum_info.SparsePauliOp`. See example :ref:`below <example_pauli_sum_op>`.
+     - [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example :ref:`below <example_pauli_sum_op>`.
 
    * - :class:`~qiskit.opflow.primitive_ops.TaperedPauliSumOp`
      - This class was used to combine a :class:`.PauliSumOp` with its identified symmetries in one object.
@@ -625,9 +625,9 @@ are used "under the hood" in the original code:
 
 *Back to* [Contents]
 
-The {mod}`~qiskit.opflow.list_ops` module contained classes for manipulating lists of {mod}`~qiskit.opflow.primitive_ops`
-or {mod}`~qiskit.opflow.state_fns`. The {mod}`~qiskit.quantum_info` alternatives for this functionality are the
-{class}`~qiskit.quantum_info.PauliList` and {class}`~qiskit.quantum_info.SparsePauliOp` (for sums of {class}`~qiskit.quantum_info.Pauli`s).
+The [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) module contained classes for manipulating lists of [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops)
+or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](../qiskit/quantum_info) alternatives for this functionality are the
+{class}`~qiskit.quantum_info.PauliList` and [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp) (for sums of {class}`~qiskit.quantum_info.Pauli`s).
 
 ```{eval-rst}
 .. list-table::
@@ -646,10 +646,10 @@ or {mod}`~qiskit.opflow.state_fns`. The {mod}`~qiskit.quantum_info` alternatives
        one object (no lazy evaluation).
 
    * - :class:`~qiskit.opflow.list_ops.SummedOp`
-     - No direct replacement. For :class:`~qiskit.quantum_info.Pauli` operators, use :class:`~qiskit.quantum_info.SparsePauliOp`.
+     - No direct replacement. For :class:`~qiskit.quantum_info.Pauli` operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
 
    * - :class:`~qiskit.opflow.list_ops.TensoredOp`
-     - No direct replacement. For :class:`~qiskit.quantum_info.Pauli` operators, use :class:`~qiskit.quantum_info.SparsePauliOp`.
+     - No direct replacement. For :class:`~qiskit.quantum_info.Pauli` operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
 
 ```
 
@@ -657,7 +657,7 @@ or {mod}`~qiskit.opflow.state_fns`. The {mod}`~qiskit.quantum_info` alternatives
 
 *Back to* [Contents]
 
-The {mod}`~qiskit.opflow.state_fns` module can be generally replaced by subclasses of {mod}`~qiskit.quantum_info`'s
+The [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) module can be generally replaced by subclasses of [`qiskit.quantum_info`](../qiskit/quantum_info)'s
 {class}`qiskit.quantum_info.QuantumState`.
 
 Similarly to {class}`~qiskit.opflow.primitive_ops.PrimitiveOp`, {class}`~qiskit.opflow.state_fns.StateFn`
@@ -705,8 +705,8 @@ identify the subclass that is being used, to then look for an alternative.
 
    * - :class:`~qiskit.opflow.state_fns.DictStateFn`
      - This class was used to store efficient representations of sparse measurement results. The
-       :class:`~qiskit.primitives.Sampler` now returns the measurements as an instance of
-       :class:`~qiskit.result.QuasiDistribution` (see example in `Converters`_).
+       [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) now returns the measurements as an instance of
+       [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) (see example in `Converters`_).
 
    * - :class:`~qiskit.opflow.state_fns.VectorStateFn`
      - This class can be replaced with :class:`~qiskit.quantum_info.Statevector` or
@@ -799,11 +799,11 @@ See more applied examples in [Expectations]  and [Converters].
 
 *Back to* [Contents]
 
-The role of the {class}`qiskit.opflow.converters` submodule was to convert the operators into other opflow operator classes
+The role of the [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters) submodule was to convert the operators into other opflow operator classes
 ({class}`~qiskit.opflow.converters.TwoQubitReduction`, {class}`~qiskit.opflow.converters.PauliBasisChange`...).
 In the case of the {class}`~qiskit.opflow.converters.CircuitSampler`, it traversed an operator and outputted
 approximations of its state functions using a quantum backend.
-Notably, this functionality has been replaced by the {mod}`~qiskit.primitives`.
+Notably, this functionality has been replaced by the [`qiskit.primitives`](../qiskit/primitives).
 
 ```{eval-rst}
 .. list-table::
@@ -813,12 +813,12 @@ Notably, this functionality has been replaced by the {mod}`~qiskit.primitives`.
      - Alternative
 
    * - :class:`~qiskit.opflow.converters.CircuitSampler`
-     - :class:`~qiskit.primitives.Sampler` or :class:`~qiskit.primitives.Estimator` if used with
-       :class:`~qiskit.oflow.expectations`. See examples :ref:`below <example_convert_state>`.
+     - [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with
+       [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations). See examples :ref:`below <example_convert_state>`.
    * - :class:`~qiskit.opflow.converters.AbelianGrouper`
      - This class allowed a sum a of Pauli operators to be grouped, a similar functionality can be achieved
-       through the :meth:`~qiskit.quantum_info.SparsePauliOp.group_commuting` method of
-       :class:`qiskit.quantum_info.SparsePauliOp`, although this is not a 1-1 replacement, as you can see
+       through the [`qiskit.quantum_info.SparsePauliOp.group_commuting`](../qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting) method of
+       [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), although this is not a 1-1 replacement, as you can see
        in the example :ref:`below <example_commuting>`.
    * - :class:`~qiskit.opflow.converters.DictToCircuitSum`
      - No direct replacement. This class was used to convert from :class:`~qiskit.opflow.state_fns.DictStateFn`\s or
@@ -828,8 +828,8 @@ Notably, this functionality has been replaced by the {mod}`~qiskit.primitives`.
    * -  :class:`~qiskit.opflow.converters.TwoQubitReduction`
      -  No direct replacement. This class implements a chemistry-specific reduction for the :class:`.ParityMapper`
         class in :mod:`qiskit_nature`.
-        The general symmetry logic this mapper depends on has been refactored to other classes in :mod:`~qiskit.quantum_info`,
-        so this specific :mod:`~qiskit.opflow` implementation is no longer necessary.
+        The general symmetry logic this mapper depends on has been refactored to other classes in [`qiskit.quantum_info`](../qiskit/quantum_info),
+        so this specific [`qiskit.opflow`](../qiskit/opflow) implementation is no longer necessary.
 
 ```
 
@@ -1009,7 +1009,7 @@ Notably, this functionality has been replaced by the {mod}`~qiskit.primitives`.
 
 *Back to* [Contents]
 
-The {mod}`qiskit.opflow.evolutions` submodule was created to provide building blocks for Hamiltonian simulation algorithms,
+The [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
 including various methods for Trotterization. The original opflow workflow for Hamiltonian simulation did not allow for
 delayed synthesis of the gates or efficient transpilation of the circuits, so this functionality was migrated to the
 `qiskit.synthesis` {ref}`Evolution <evolution_synthesis>` module.
@@ -1026,7 +1026,7 @@ or by supplying a method instance of {class}`qiskit.opflow.evolutions.Trotter`,
 {class}`qiskit.opflow.evolutions.Suzuki` or {class}`qiskit.opflow.evolutions.QDrift`.
 
 The different Trotterization methods that extend {class}`qiskit.opflow.evolutions.TrotterizationBase` were migrated to
-{mod}`qiskit.synthesis`,
+[`qiskit.synthesis`](../qiskit/synthesis),
 and now extend the {class}`qiskit.synthesis.ProductFormula` base class. They no longer contain a `.convert()` method for
 standalone use, but are now designed to be plugged into the {class}`.PauliEvolutionGate` and called via `.synthesize()`.
 In this context, the job of the {class}`qiskit.opflow.evolutions.PauliTrotterEvolution` class can now be handled directly by the algorithms
@@ -1234,7 +1234,7 @@ This class is no longer necessary, as the {class}`~.library.HamiltonianGate`s ca
 *Back to* [Contents]
 
 Expectations are converters which enable the computation of the expectation value of an observable with respect to some state function.
-This functionality can now be found in the {class}`~qiskit.primitives.Estimator` primitive. Please remember that there
+This functionality can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Please remember that there
 are different `Estimator` implementations, as noted {ref}`here <attention_primitives>`
 
 ### Algorithm-Agnostic Expectations
@@ -1252,16 +1252,16 @@ are different `Estimator` implementations, as noted {ref}`here <attention_primit
      - No direct replacement. This class was used to create instances of one of the classes listed below.
 
    * - :class:`~qiskit.opflow.expectations.AerPauliExpectation`
-     - Use :class:`qiskit_aer.primitives.Estimator`  with ``approximation=True``, and then ``shots=None`` as ``run_options``.
+     - Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)  with ``approximation=True``, and then ``shots=None`` as ``run_options``.
        See example below.
 
    * - :class:`~qiskit.opflow.expectations.MatrixExpectation`
-     - Use :class:`qiskit.primitives.Estimator` primitive (if no shots are set, it performs an exact Statevector calculation).
+     - Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive (if no shots are set, it performs an exact Statevector calculation).
        See example below.
 
    * - :class:`~qiskit.opflow.expectations.PauliExpectation`
-     - Use any Estimator primitive (for :class:`qiskit.primitives.Estimator`, set ``shots!=None`` for a shot-based
-       simulation, for :class:`qiskit_aer.primitives.Estimator` , this is the default).
+     - Use any Estimator primitive (for [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set ``shots!=None`` for a shot-based
+       simulation, for [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html) , this is the default).
 
 ```
 
@@ -1458,9 +1458,9 @@ are different `Estimator` implementations, as noted {ref}`here <attention_primit
 
 *Back to* [Contents]
 
-The opflow {mod}`~qiskit.opflow.gradients` framework has been replaced by the new {mod}`qiskit.algorithms.gradients`
+The opflow [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) framework has been replaced by the new [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients)
 module. The new gradients are **primitive-based subroutines** commonly used by algorithms and applications, which
-can also be executed in a standalone manner. For this reason, they now reside under {mod}`qiskit.algorithms`.
+can also be executed in a standalone manner. For this reason, they now reside under [`qiskit.algorithms`](../qiskit/algorithms).
 
 The former gradient framework contained base classes, converters and derivatives. The "derivatives"
 followed a factory design pattern, where different methods could be provided via string identifiers
@@ -1566,7 +1566,7 @@ list:
 
    * - :class:`~qiskit.opflow.gradients.DerivativeBase`
      - No replacement. This was the base class for the gradient, hessian and QFI base classes.
-   * - :class:`.GradientBase` and :class:`~qiskit.opflow.gradients.Gradient`
+   * - :class:`.GradientBase` and [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient)
      - :class:`.BaseSamplerGradient` or :class:`.BaseEstimatorGradient`, and specific subclasses per method,
        as explained above.
    * - :class:`.HessianBase` and :class:`~qiskit.opflow.gradients.Hessian`

--- a/docs/api/migration-guides/__migration-guide-qi.md.txt
+++ b/docs/api/migration-guides/__migration-guide-qi.md.txt
@@ -1,22 +1,22 @@
 # Quantum Instance Migration Guide
 
-The {class}`~qiskit.utils.QuantumInstance` is a utility class that allows the joint
+The [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) is a utility class that allows the joint
 configuration of the circuit transpilation and execution steps, and provides functions
 at a higher level of abstraction for a more convenient integration with algorithms.
 These include measurement error mitigation, splitting/combining execution to
 conform to job limits,
 and ensuring reliable execution of circuits with additional job management tools.
 
-The {class}`~qiskit.utils.QuantumInstance` is being deprecated for several reasons:
-On one hand, the functionality of {meth}`~qiskit.utils.QuantumInstance.execute` has
-now been delegated to the different implementations of the {mod}`~qiskit.primitives` base classes.
+The [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) is being deprecated for several reasons:
+On one hand, the functionality of [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute) has
+now been delegated to the different implementations of the [`qiskit.primitives`](../qiskit/primitives) base classes.
 On the other hand, with the direct implementation of transpilation at the primitives level,
 the algorithms no longer
-need to manage that aspect of execution, and thus {meth}`~qiskit.utils.QuantumInstance.transpile` is no longer
+need to manage that aspect of execution, and thus [`qiskit.utils.QuantumInstance.transpile`](../qiskit/qiskit.utils.QuantumInstance#transpile) is no longer
 required by the workflow. If desired, custom transpilation routines can still be performed at the
-user level through the {mod}`~qiskit.transpiler` module (see table below).
+user level through the [`qiskit.transpiler`](../qiskit/transpiler) module (see table below).
 
-The following table summarizes the migration alternatives for the {class}`~qiskit.utils.QuantumInstance` class:
+The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) class:
 
 ```{eval-rst}
 .. list-table::
@@ -24,16 +24,16 @@ The following table summarizes the migration alternatives for the {class}`~qiski
 
    * - QuantumInstance method
      - Alternative
-   * - :meth:`.QuantumInstance.execute`
-     - :meth:`qiskit.primitives.Sampler.run` or :meth:`qiskit.primitives.Estimator.run`
-   * - :meth:`.QuantumInstance.transpile`
-     - :meth:`qiskit.compiler.transpile`
-   * - :meth:`.QuantumInstance.assemble`
-     - :meth:`qiskit.compiler.assemble`
+   * - [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute)
+     - [`qiskit.primitives.Sampler.run`](../qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](../qiskit/qiskit.primitives.Estimator#run)
+   * - [`qiskit.utils.QuantumInstance.transpile`](../qiskit/qiskit.utils.QuantumInstance#transpile)
+     - [`qiskit.compiler.transpile`](../qiskit/compiler#qiskit.compiler.transpile)
+   * - [`qiskit.utils.QuantumInstance.assemble`](../qiskit/qiskit.utils.QuantumInstance#assemble)
+     - [`qiskit.compiler.assemble`](../qiskit/compiler#qiskit.compiler.assemble)
 ```
 
-The remainder of this guide will focus on the {meth}`.QuantumInstance.execute` to
-{mod}`~qiskit.primitives` migration path.
+The remainder of this guide will focus on the [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute) to
+[`qiskit.primitives`](../qiskit/primitives) migration path.
 
 ## Contents
 
@@ -50,31 +50,31 @@ for an easy integration into algorithm workflows.
 The current pool of primitives includes **two** different types of primitives: Sampler and
 Estimator.
 
-Qiskit provides reference implementations in {class}`qiskit.primitives.Sampler` and {class}`qiskit.primitives.Estimator`. Additionally,
-{class}`qiskit.primitives.BackendSampler` and a {class}`qiskit.primitives.BackendEstimator` are
+Qiskit provides reference implementations in [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator). Additionally,
+[`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and a [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator) are
 wrappers for `backend.run()` that follow the primitives interface.
 
-Providers can implement these primitives as subclasses of {class}`~qiskit.primitives.BaseSampler` and {class}`~qiskit.primitives.BaseEstimator` respectively.
-IBM's Qiskit Runtime ({mod}`qiskit_ibm_runtime`) and Aer ({mod}`qiskit_aer.primitives`) are examples of native implementations of primitives.
+Providers can implement these primitives as subclasses of [`qiskit.primitives.BaseSampler`](../qiskit/qiskit.primitives.BaseSampler) and [`qiskit.primitives.BaseEstimator`](../qiskit/qiskit.primitives.BaseEstimator) respectively.
+IBM's Qiskit Runtime ([`qiskit_ibm_runtime`](../qiskit-ibm-runtime/runtime_service)) and Aer ([`qiskit_aer.primitives`](https://qiskit.org/ecosystem/aer/apidocs/aer_primitives.html)) are examples of native implementations of primitives.
 
 This guide uses the following naming convention:
 
-- *Primitives* - Any Sampler/Estimator implementation using base classes {class}`qiskit.primitives.BackendSampler` and a {class}`qiskit.primitives.BackendEstimator`.
-- *Reference Primitives* -  {class}`qiskit.primitives.Sampler` and {class}`qiskit.primitives.Estimator` are reference implementations that come with Qiskit.
-- *Aer Primitives* - The [Aer](https://qiskit.org/ecosystem/aer) primitive implementations {class}`qiskit_aer.primitives.Sampler` and {class}`qiskit_aer.primitives.Estimator`.
-- *Qiskit Runtime Primitives* - IBM's Qiskit Runtime primitive implementations {class}`qiskit_ibm_runtime.Sampler` and {class}`qiskit_ibm_runtime.Estimator`.
-- *Backend Primitives* - Instances of {class}`qiskit.primitives.BackendSampler` and {class}`qiskit.primitives.BackendEstimator`. These allow any backend to implement primitive interfaces
+- *Primitives* - Any Sampler/Estimator implementation using base classes [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and a [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator).
+- *Reference Primitives* -  [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) are reference implementations that come with Qiskit.
+- *Aer Primitives* - The [Aer](https://qiskit.org/ecosystem/aer) primitive implementations [`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html) and [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html).
+- *Qiskit Runtime Primitives* - IBM's Qiskit Runtime primitive implementations [`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator).
+- *Backend Primitives* - Instances of [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator). These allow any backend to implement primitive interfaces
 
 For guidelines on which primitives to choose for your task, please continue reading.
 :::
 
 ## Choosing the right primitive for your task
 
-The {class}`~qiskit.utils.QuantumInstance` was designed to be an abstraction over transpile/run.
-It took inspiration from {func}`~qiskit.execute_function.execute`, but retained config information that could be set
+The [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) was designed to be an abstraction over transpile/run.
+It took inspiration from [`qiskit.execute_function.execute`](../qiskit/execute#qiskit.execute_function.execute), but retained config information that could be set
 at the algorithm level, to save the user from defining the same parameters for every transpile/execute call.
 
-The {mod}`qiskit.primitives` share some of these features, but unlike the {class}`~qiskit.utils.QuantumInstance`,
+The [`qiskit.primitives`](../qiskit/primitives) share some of these features, but unlike the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
 there are multiple primitive classes, and each is optimized for a specific
 purpose. Selecting the right primitive (`Sampler` or `Estimator`) requires some knowledge about
 **what** it is expected to do and **where/how** it is expected to run.
@@ -87,7 +87,7 @@ On the other hand, they are **algorithmic** abstractions with defined tasks:
 - The `Sampler` takes in circuits, measures them, and returns their  **quasi-probability distributions**.
 :::
 
-In order to know which primitive to use instead of {class}`~qiskit.utils.QuantumInstance`, you should ask
+In order to know which primitive to use instead of [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), you should ask
 yourself two questions:
 
 1. What is the minimal unit of information used by your algorithm?
@@ -97,7 +97,7 @@ yourself two questions:
 2. How do you want to execute your circuits?
 
    > This question is not new. In the legacy algorithm workflow, you would have to decide to set up a
-   > {class}`~qiskit.utils.QuantumInstance` with either a real backend from a provider, or a simulator.
+   > [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) with either a real backend from a provider, or a simulator.
    > Now, this "backend selection" process is translated to **where** do you import your primitives
    > from:
    >
@@ -106,20 +106,20 @@ yourself two questions:
    > 3. Accessing **runtime-enabled backends** (or cloud simulators): **Qiskit Runtime Primitives**
    > 4. Accessing **non runtime-enabled backends** : **Backend Primitives**
 
-Arguably, the `Sampler` is the closest primitive to {class}`~qiskit.utils.QuantumInstance`, as they
-both execute circuits and provide a result back. However, with the {class}`~qiskit.utils.QuantumInstance`,
-the result data was backend dependent (it could be a counts `dict`, a {class}`numpy.array` for
+Arguably, the `Sampler` is the closest primitive to [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), as they
+both execute circuits and provide a result back. However, with the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance),
+the result data was backend dependent (it could be a counts `dict`, a `numpy.array` for
 statevector simulations, etc), while the `Sampler` normalizes its `SamplerResult` to
-return a {class}`~qiskit.result.QuasiDistribution` object with the resulting quasi-probability distribution.
+return a [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) object with the resulting quasi-probability distribution.
 
 The `Estimator` provides a specific abstraction for the expectation value calculation that can replace
-the use of {class}`.QuantumInstance` as well as the associated pre- and post-processing steps, usually performed
-with an additional library such as {mod}`qiskit.opflow`.
+the use of [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) as well as the associated pre- and post-processing steps, usually performed
+with an additional library such as [`qiskit.opflow`](../qiskit/opflow).
 
 ## Choosing the right primitive for your settings
 
-Certain {class}`~qiskit.utils.QuantumInstance` features are only available in certain primitive implementations.
-The following table summarizes the most common {class}`~qiskit.utils.QuantumInstance` settings and which
+Certain [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) features are only available in certain primitive implementations.
+The following table summarizes the most common [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) settings and which
 primitives **expose a similar setting through their interface**:
 
 :::{attention}
@@ -240,7 +240,7 @@ please refer to the API reference or source code of the desired primitive implem
 
     **a. Using the Reference Primitives**
 
-    Basic simulation implemented using the :mod:`qiskit.quantum_info` module. If shots are
+    Basic simulation implemented using the [`qiskit.quantum_info`](../qiskit/quantum_info) module. If shots are
     specified, the results will include shot noise. Please note that
     the resulting quasi-probability distribution does not use bitstrings but **integers** to identify the states.
 
@@ -269,18 +269,18 @@ please refer to the API reference or source code of the desired primitive implem
     **b. Using the Aer Primitives**
 
     Aer simulation following the statevector method. This would be the closer replacement of the
-    :class:`~qiskit.utils.QuantumInstance`
+    [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance)
     example, as they are both accessing the same simulator. For this reason, the output metadata is
     closer to the Quantum Instance's output. Please note that
     the resulting quasi-probability distribution does not use bitstrings but **integers** to identify the states.
 
     .. note::
 
-        The :class:`qiskit.result.QuasiDistribution` class returned as part of the :class:`qiskit.primitives.SamplerResult`
+        The [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) class returned as part of the [`qiskit.primitives.SamplerResult`](../qiskit/qiskit.primitives.SamplerResult)
         exposes two methods to convert the result keys from integer to binary strings/hexadecimal:
 
-            - :meth:`qiskit.result.QuasiDistribution.binary_probabilities`
-            - :meth:`qiskit.result.QuasiDistribution.hex_probabilities`
+            - [`qiskit.result.QuasiDistribution.binary_probabilities`](../qiskit/qiskit.result.QuasiDistribution#binary_probabilities)
+            - [`qiskit.result.QuasiDistribution.hex_probabilities`](../qiskit/qiskit.result.QuasiDistribution#hex_probabilities)
 
 
     .. code-block:: python
@@ -317,13 +317,13 @@ please refer to the API reference or source code of the desired primitive implem
     :animate: fade-in-slide-down
 
     While this example does not include a direct call to ``QuantumInstance.execute()``, it shows
-    how to migrate from a :class:`~qiskit.utils.QuantumInstance`-based to a :mod:`~qiskit.primitives`-based
+    how to migrate from a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance)-based to a [`qiskit.primitives`](../qiskit/primitives)-based
     workflow.
 
     **Using Quantum Instance**
 
     The most common use case for computing expectation values with the Quantum Instance was as in combination with the
-    :mod:`~qiskit.opflow` library. You can see more information in the `opflow migration guide <http://qisk.it/opflow_migration>`_.
+    [`qiskit.opflow`](../qiskit/opflow) library. You can see more information in the `opflow migration guide <http://qisk.it/opflow_migration>`_.
 
     .. code-block:: python
 
@@ -510,7 +510,7 @@ please refer to the API reference or source code of the desired primitive implem
     * You cannot explicitly access their transpilation routine.
     * The mechanism to apply custom transpilation passes to the Aer, Runtime and Backend primitives is to pre-transpile
       locally and set ``skip_transpilation=True`` in the corresponding primitive.
-    * The only primitives that currently accept a custom **bound** transpiler pass manager are instances of :class:`~qiskit.primitives.BackendSampler` or :class:`~qiskit.primitives.BackendEstimator`.
+    * The only primitives that currently accept a custom **bound** transpiler pass manager are instances of [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator).
       If a ``bound_pass_manager`` is defined, the ``skip_transpilation=True`` option will **not** skip this bound pass.
 
     .. attention::
@@ -525,12 +525,12 @@ please refer to the API reference or source code of the desired primitive implem
         so if the circuit ended up on more qubits it did not matter.
 
     Note that the primitives **do** handle parameter bindings, meaning that even if a ``bound_pass_manager`` is defined in a
-    :class:`~qiskit.primitives.BackendSampler` or :class:`~qiskit.primitives.BackendEstimator`, you do not have to manually assign parameters as expected in the Quantum Instance workflow.
+    [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator), you do not have to manually assign parameters as expected in the Quantum Instance workflow.
 
     The use-case that motivated the addition of the two-stage transpilation to the ``QuantumInstance`` was to allow
-    running pulse-efficient transpilation passes with the :class:`~qiskit.opflow.CircuitSampler` class. The following
+    running pulse-efficient transpilation passes with the [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler) class. The following
     example shows to migrate this particular use-case, where the ``QuantumInstance.execute()`` method is called
-    under the hood by the :class:`~qiskit.opflow.CircuitSampler`.
+    under the hood by the [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler).
 
     **Using Quantum Instance**
 


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/213. 

This doesn't finish converting all the cross references, but gets most of them.

My original attempt manually converted things, but I realized this wasn't scalable so I instead switched to writing this script. The cross-references have several different possible styles, like this:

```
:meth:`qiskit.my_module`
:meth:`~qiskit.my_module`
{meth}`qiskit.my_module`
{meth}`~qiskit.my_module`
```

The script looks for all these different variations, then replaces it with the markdown-style link. It also validates that the new reference actually exists.

```python
from __future__ import annotations

from dataclasses import dataclass
from pathlib import Path


GUIDES = [
    Path(f"docs/api/migration-guides/__migration-guide-{guide}.md.txt")
    for guide in ("algorithms", "opflow", "qi")
]


@dataclass(frozen=True)
class Conversion:
    qualified_name: str
    new_reference: str | None
    fixed_qualified_name: str | None = None

    def sphinx_values(self) -> set[str]:
        prefixes = []
        for role in ["class", "meth", "mod", "func"]:
            for tilde in ["", "~"]:
                for initial, end in [(":", ":"), ("{", "}")]:
                    # E.g.:
                    #   * :meth:`
                    #   * :meth:`~
                    #   * {meth}`
                    #   * {meth}`~
                    prefixes.append(f"{initial}{role}{end}`{tilde}")
        return {f"{prefix}{self.qualified_name}`" for prefix in prefixes}

    def new_value(self) -> str:
        name = self.fixed_qualified_name or self.qualified_name
        if self.new_reference is None:
            return f"`{name}`"
        return f"[`{name}`]({self.new_reference})"

    def validate_new_reference(self) -> None:
        """Check that the reference exists."""
        if self.new_reference is None or not self.new_reference.startswith("../"):
            return
        file_name = self.new_reference.split("#")[0]
        normalized_path = Path("docs/api/migration-guides", f"{file_name}.md")
        if not normalized_path.exists():
            raise ValueError(
                f"The reference for `{self.qualified_name}` does not exist! {normalized_path}"
            )


CONVERSIONS = {
    # Modules
    Conversion("qiskit.algorithms", "../qiskit/algorithms"),
    Conversion("qiskit.opflow", "../qiskit/opflow"),
    Conversion("qiskit.primitives", "../qiskit/primitives"),
    Conversion("qiskit.quantum_info", "../qiskit/quantum_info"),
    Conversion("qiskit.transpiler", "../qiskit/transpiler"),
    Conversion("qiskit.synthesis", "../qiskit/synthesis"),
    Conversion("qiskit.opflow.converters", "../qiskit/qiskit.opflow.converters"),
    Conversion("qiskit.opflow.evolutions", "../qiskit/qiskit.opflow.evolutions"),
    Conversion("qiskit.opflow.expectations", "../qiskit/qiskit.opflow.expectations"),
    Conversion("qiskit.opflow.list_ops", "../qiskit/qiskit.opflow.list_ops"),
    Conversion("qiskit.opflow.gradients", "../qiskit/qiskit.opflow.gradients"),
    Conversion("qiskit.opflow.primitive_ops", "../qiskit/qiskit.opflow.primitive_ops"),
    Conversion("qiskit.opflow.state_fns", "../qiskit/qiskit.opflow.state_fns"),
    Conversion("qiskit.algorithms.gradients", "../qiskit/qiskit.algorithms.gradients"),
    Conversion(
        "qiskit.algorithms.minimum_eigensolvers",
        "../qiskit/qiskit.algorithms.minimum_eigensolvers",
    ),
    Conversion(
        "qiskit.algorithms.eigensolvers",
        "../qiskit/qiskit.algorithms.eigensolvers",
    ),

    # Classes
    Conversion(
        "qiskit.utils.QuantumInstance", "../qiskit/qiskit.utils.QuantumInstance"
    ),
    Conversion(
        "qiskit.quantum_info.SparsePauliOp",
        "../qiskit/qiskit.quantum_info.SparsePauliOp",
    ),
    Conversion(
        "qiskit.result.QuasiDistribution",
        "../qiskit/qiskit.result.QuasiDistribution",
    ),
    Conversion("qiskit.primitives.Sampler", "../qiskit/qiskit.primitives.Sampler"),
    Conversion("qiskit.primitives.Estimator", "../qiskit/qiskit.primitives.Estimator"),
    Conversion(
        "qiskit.primitives.BaseSampler", "../qiskit/qiskit.primitives.BaseSampler"
    ),
    Conversion(
        "qiskit.primitives.BaseEstimator", "../qiskit/qiskit.primitives.BaseEstimator"
    ),
    Conversion(
        "qiskit.primitives.BackendSampler", "../qiskit/qiskit.primitives.BackendSampler"
    ),
    Conversion(
        "qiskit.primitives.BackendEstimator",
        "../qiskit/qiskit.primitives.BackendEstimator",
    ),
    Conversion(
        "qiskit.opflow.gradients.Gradient", "../qiskit/qiskit.opflow.gradients.Gradient"
    ),
    Conversion(
        "qiskit.primitives.SamplerResult", "../qiskit/qiskit.primitives.SamplerResult"
    ),

    # Methods
    Conversion(
        "qiskit.utils.QuantumInstance.execute",
        "../qiskit/qiskit.utils.QuantumInstance#execute",
    ),
    Conversion(
        "qiskit.utils.QuantumInstance.transpile",
        "../qiskit/qiskit.utils.QuantumInstance#transpile",
    ),
    Conversion(
        "qiskit.utils.QuantumInstance.assemble",
        "../qiskit/qiskit.utils.QuantumInstance#assemble",
    ),
    Conversion(
        "qiskit.result.QuasiDistribution.binary_probabilities",
        "../qiskit/qiskit.result.QuasiDistribution#binary_probabilities",
    ),
    Conversion(
        "qiskit.result.QuasiDistribution.hex_probabilities",
        "../qiskit/qiskit.result.QuasiDistribution#hex_probabilities",
    ),
    Conversion(
        "qiskit.primitives.Sampler.run",
        "../qiskit/qiskit.primitives.Sampler#run",
    ),
    Conversion(
        "qiskit.primitives.Estimator.run", "../qiskit/qiskit.primitives.Estimator#run"
    ),
    Conversion(
        "qiskit.quantum_info.SparsePauliOp.group_commuting",
        "../qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting",
    ),

    # Functions
    Conversion(
        "qiskit.compiler.transpile", "../qiskit/compiler#qiskit.compiler.transpile"
    ),
    Conversion(
        "qiskit.compiler.assemble", "../qiskit/compiler#qiskit.compiler.assemble"
    ),
    Conversion(
        "qiskit.execute_function.execute",
        "../qiskit/execute#qiskit.execute_function.execute",
    ),

    # Aer
    Conversion(
        "qiskit_aer.primitives.Sampler",
        "https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html",
    ),
    Conversion(
        "qiskit_aer.primitives.Estimator",
        "https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html",
    ),
    Conversion(
        "qiskit_aer.primitives",
        "https://qiskit.org/ecosystem/aer/apidocs/aer_primitives.html",
    ),

    # Runtime
    Conversion("qiskit_ibm_runtime", "../qiskit-ibm-runtime/runtime_service"),
    Conversion(
        "qiskit_ibm_runtime.Sampler", "../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler"
    ),
    Conversion(
        "qiskit_ibm_runtime.Estimator",
        "../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator",
    ),

    # Abbreviated qualified names
    Conversion(
        ".QuantumInstance",
        "../qiskit/qiskit.utils.QuantumInstance",
        fixed_qualified_name="qiskit.utils.QuantumInstance",
    ),
    Conversion(
        ".QuantumInstance.execute",
        "../qiskit/qiskit.utils.QuantumInstance#execute",
        fixed_qualified_name="qiskit.utils.QuantumInstance.execute",
    ),
    Conversion(
        ".QuantumInstance.transpile",
        "../qiskit/qiskit.utils.QuantumInstance#transpile",
        fixed_qualified_name="qiskit.utils.QuantumInstance.transpile",
    ),
    Conversion(
        ".QuantumInstance.assemble",
        "../qiskit/qiskit.utils.QuantumInstance#assemble",
        fixed_qualified_name="qiskit.utils.QuantumInstance.assemble",
    ),

    # Typos
    Conversion(
        "qiskit.oflow.expectations",
        new_reference="../qiskit/qiskit.opflow.expectations",
        fixed_qualified_name="qiskit.opflow.expectations",
    ),

    # Incomplete import paths
    Conversion(
        "qiskit.opflow.PauliSumOp",
        "../qiskit/qiskit.opflow.primitive_ops.PauliSumOp",
        fixed_qualified_name="qiskit.opflow.primitive_ops.PauliSumOp",
    ),
    Conversion(
        "qiskit.opflow.CircuitSampler",
        "../qiskit/qiskit.opflow.converters.CircuitSampler",
        fixed_qualified_name="qiskit.opflow.converters.CircuitSampler",
    ),

    # Remove reference
    Conversion("numpy.array", None),
}


REPLACEMENTS = {
    sphinx_value: conversion.new_value()
    for conversion in CONVERSIONS
    for sphinx_value in conversion.sphinx_values()
}


def update_line(line: str) -> str:
    for bad, new in REPLACEMENTS.items():
        line = line.replace(bad, new)
    return line


def main() -> None:
    for conversion in CONVERSIONS:
        conversion.validate_new_reference()

    for guide in GUIDES:
        result = [update_line(line) for line in guide.read_text().splitlines()]
        guide.write_text("\n".join(result) + "\n")


main()
```