### PR TITLE
Clarify session job execution order

### DIFF
--- a/docs/run/sessions.mdx
+++ b/docs/run/sessions.mdx
@@ -180,7 +180,7 @@ that is, to maintain device characterization.
 -   The classical computation, such as compilation, of the jobs is run in parallel. This means running multiple jobs in a batch would be significantly faster than running them serially. 
 
 <Admonition type="note">
-    When batching, jobs are not guaranteed to run in the order they are submitted.
+    When batching, jobs are not guaranteed to execute on the QPU in the order they are submitted.
 </Admonition>
 
 ![Batch session execution diagram.](/images/run/batch.png 'Figure 3: Batch session execution')

--- a/docs/run/sessions.mdx
+++ b/docs/run/sessions.mdx
@@ -180,7 +180,7 @@ that is, to maintain device characterization.
 -   The classical computation, such as compilation, of the jobs is run in parallel. This means running multiple jobs in a batch would be significantly faster than running them serially. 
 
 <Admonition type="note">
-    When batching, jobs are not guaranteed to execute on the QPU in the order they are submitted.
+    When batching, jobs are not guaranteed to run on the QPU in the order they are submitted.
 </Admonition>
 
 ![Batch session execution diagram.](/images/run/batch.png 'Figure 3: Batch session execution')


### PR DESCRIPTION
Clarify why jobs don't always run in the order they were submitted. 