### PR TITLE
Attempted to fix broken API ref links

### DIFF
--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
@@ -34,7 +34,7 @@ retrieved_job = provider.backend.retrieve_job(job.job_id())
   *   You should not instantiate the `IBMBackend` class directly. Instead, use the methods provided by an [`IBMProvider`](qiskit_ibm_provider.IBMProvider "qiskit_ibm_provider.IBMProvider") instance to retrieve and handle backends.
 </Admonition>
 
-Other methods return information about the backend. For example, the [`status()`](qiskit_ibm_provider.IBMBackend#status "qiskit_ibm_provider.IBMBackend.status") method returns a [`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus.html#qiskit.providers.models.BackendStatus "(in Qiskit v0.44)") instance. The instance contains the `operational` and `pending_jobs` attributes, which state whether the backend is operational and also the number of jobs in the server queue for the backend, respectively:
+Other methods return information about the backend. For example, the [`status()`](qiskit_ibm_provider.IBMBackend#status "qiskit_ibm_provider.IBMBackend.status") method returns a [`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus "(in Qiskit v0.44)") instance. The instance contains the `operational` and `pending_jobs` attributes, which state whether the backend is operational and also the number of jobs in the server queue for the backend, respectively:
 
 ```python
 status = backend.status()

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
@@ -14,7 +14,7 @@ python_api_name: qiskit_ibm_provider.IBMBackend
 
 Backend class interfacing with an IBM Quantum device.
 
-You can run experiments on a backend using the [`run()`](qiskit_ibm_provider.IBMBackend#run "qiskit_ibm_provider.IBMBackend.run") method. The [`run()`](qiskit_ibm_provider.IBMBackend#run "qiskit_ibm_provider.IBMBackend.run") method takes one or more [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)") and returns an `IBMJob` instance that represents the submitted job. Each job has a unique job ID, which can later be used to retrieve the job. An example of this flow:
+You can run experiments on a backend using the [`run()`](qiskit_ibm_provider.IBMBackend#run "qiskit_ibm_provider.IBMBackend.run") method. The [`run()`](qiskit_ibm_provider.IBMBackend#run "qiskit_ibm_provider.IBMBackend.run") method takes one or more [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)") and returns an `IBMJob` instance that represents the submitted job. Each job has a unique job ID, which can later be used to retrieve the job. An example of this flow:
 
 ```python
 from qiskit import transpile
@@ -50,7 +50,7 @@ jobs_in_queue = status.pending_jobs
 
 *   num\_qubits: number of qubits.
 
-*   target: A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target.html#qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend.
+*   target: A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend.
 
 *   basis\_gates: list of basis gates names on the backend.
 
@@ -144,7 +144,7 @@ IBMBackend constructor.
 
 **Parameters**
 
-*   **configuration** (`Union`\[[`QasmBackendConfiguration`](/api/qiskit/qiskit.providers.models.QasmBackendConfiguration.html#qiskit.providers.models.QasmBackendConfiguration "(in Qiskit v0.44)"), [`PulseBackendConfiguration`](/api/qiskit/qiskit.providers.models.PulseBackendConfiguration.html#qiskit.providers.models.PulseBackendConfiguration "(in Qiskit v0.44)")]) – Backend configuration.
+*   **configuration** (`Union`\[[`QasmBackendConfiguration`](/api/qiskit/qiskit.providers.models.QasmBackendConfiguration "(in Qiskit v0.44)"), [`PulseBackendConfiguration`](/api/qiskit/qiskit.providers.models.PulseBackendConfiguration "(in Qiskit v0.44)")]) – Backend configuration.
 *   **provider** ([`IBMProvider`](qiskit_ibm_provider.IBMProvider "qiskit_ibm_provider.ibm_provider.IBMProvider")) – IBM Quantum account provider.
 *   **api\_client** (`AccountClient`) – IBM Quantum client used to communicate with the server.
 
@@ -154,7 +154,7 @@ IBMBackend constructor.
 
 ### coupling\_map
 
-Return the [`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap.html#qiskit.transpiler.CouplingMap "(in Qiskit v0.44)") object
+Return the [`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap "(in Qiskit v0.44)") object
 
 <span id="ibmbackend-dt" />
 
@@ -198,13 +198,13 @@ Return the system time resolution of output signals :returns: The output signal 
 
 ### instruction\_durations
 
-Return the [`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations.html#qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)") object.
+Return the [`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)") object.
 
 <span id="ibmbackend-instruction-schedule-map" />
 
 ### instruction\_schedule\_map
 
-Return the [`InstructionScheduleMap`](/api/qiskit/qiskit.pulse.InstructionScheduleMap.html#qiskit.pulse.InstructionScheduleMap "(in Qiskit v0.44)") for the instructions defined in this backend’s target.
+Return the [`InstructionScheduleMap`](/api/qiskit/qiskit.pulse.InstructionScheduleMap "(in Qiskit v0.44)") for the instructions defined in this backend’s target.
 
 <span id="ibmbackend-instructions" />
 
@@ -218,7 +218,7 @@ A list of Instruction tuples on the backend of the form `(instruction, (qubits)`
 
 **Return type**
 
-`List`\[`Tuple`\[[`Instruction`](/api/qiskit/qiskit.circuit.Instruction.html#qiskit.circuit.Instruction "(in Qiskit v0.44)"), `Tuple`\[`int`]]]
+`List`\[`Tuple`\[[`Instruction`](/api/qiskit/qiskit.circuit.Instruction "(in Qiskit v0.44)"), `Tuple`\[`int`]]]
 
 <span id="ibmbackend-max-circuits" />
 
@@ -280,11 +280,11 @@ A list of instruction names that the backend supports.
 
 `List[Instruction]`
 
-A list of [`Instruction`](/api/qiskit/qiskit.circuit.Instruction.html#qiskit.circuit.Instruction "(in Qiskit v0.44)") instances that the backend supports.
+A list of [`Instruction`](/api/qiskit/qiskit.circuit.Instruction "(in Qiskit v0.44)") instances that the backend supports.
 
 **Return type**
 
-`List`\[[`Instruction`](/api/qiskit/qiskit.circuit.Instruction.html#qiskit.circuit.Instruction "(in Qiskit v0.44)")]
+`List`\[[`Instruction`](/api/qiskit/qiskit.circuit.Instruction "(in Qiskit v0.44)")]
 
 <span id="ibmbackend-options" />
 
@@ -330,7 +330,7 @@ Return session
 
 `Target`
 
-A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target.html#qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend. :rtype: [`Target`](/api/qiskit/qiskit.transpiler.Target.html#qiskit.transpiler.Target "(in Qiskit v0.44)") :returns: Target
+A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend. :rtype: [`Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.44)") :returns: Target
 
 <span id="ibmbackend-version" />
 
@@ -390,7 +390,7 @@ The schema for backend configuration can be found in [Qiskit/ibm-quantum-schemas
 
 **Return type**
 
-`Union`\[[`QasmBackendConfiguration`](/api/qiskit/qiskit.providers.models.QasmBackendConfiguration.html#qiskit.providers.models.QasmBackendConfiguration "(in Qiskit v0.44)"), [`PulseBackendConfiguration`](/api/qiskit/qiskit.providers.models.PulseBackendConfiguration.html#qiskit.providers.models.PulseBackendConfiguration "(in Qiskit v0.44)")]
+`Union`\[[`QasmBackendConfiguration`](/api/qiskit/qiskit.providers.models.QasmBackendConfiguration "(in Qiskit v0.44)"), [`PulseBackendConfiguration`](/api/qiskit/qiskit.providers.models.PulseBackendConfiguration "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -438,7 +438,7 @@ The schema for default pulse configuration can be found in [Qiskit/ibm-quantum-s
 
 **Return type**
 
-`Optional`\[[`PulseDefaults`](/api/qiskit/qiskit.providers.models.PulseDefaults.html#qiskit.providers.models.PulseDefaults "(in Qiskit v0.44)")]
+`Optional`\[[`PulseDefaults`](/api/qiskit/qiskit.providers.models.PulseDefaults "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -525,11 +525,11 @@ The schema for backend properties can be found in [Qiskit/ibm-quantum-schemas](h
 **Parameters**
 
 *   **refresh** (`bool`) – If `True`, re-query the server for the backend properties. Otherwise, return a cached version.
-*   **datetime** (`Optional`\[`datetime`]) – By specifying datetime, this function returns an instance of the [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties.html#qiskit.providers.models.BackendProperties "(in Qiskit v0.44)") whose timestamp is closest to, but older than, the specified datetime.
+*   **datetime** (`Optional`\[`datetime`]) – By specifying datetime, this function returns an instance of the [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "(in Qiskit v0.44)") whose timestamp is closest to, but older than, the specified datetime.
 
 **Return type**
 
-`Optional`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties.html#qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")]
+`Optional`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -579,13 +579,13 @@ Run on the backend. If a keyword specified here is also present in the `options`
 
 **Parameters**
 
-*   **circuits** (`Union`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)"), `str`, `List`\[`Union`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)"), `str`]]]) – An individual or a list of `QuantumCircuit`.
+*   **circuits** (`Union`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)"), `str`, `List`\[`Union`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)"), `str`]]]) – An individual or a list of `QuantumCircuit`.
 
 *   **dynamic** (`Optional`\[`bool`]) – Whether the circuit is dynamic (uses in-circuit conditionals)
 
 *   **job\_tags** (`Optional`\[`List`\[`str`]]) – Tags to be assigned to the job. The tags can subsequently be used as a filter in the `jobs()` function call.
 
-*   **init\_circuit** (`Optional`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]) – A quantum circuit to execute for initializing qubits before each circuit. If specified, `init_num_resets` is ignored. Applicable only if `dynamic=True` is specified.
+*   **init\_circuit** (`Optional`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]) – A quantum circuit to execute for initializing qubits before each circuit. If specified, `init_num_resets` is ignored. Applicable only if `dynamic=True` is specified.
 
 *   **init\_num\_resets** (`Optional`\[`int`]) – The number of qubit resets to insert before each circuit execution.
 
@@ -675,12 +675,12 @@ This method is used to update the options of a backend. If you need to change an
 Return the backend status.
 
 <Admonition title="Note" type="note">
-  If the returned [`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus.html#qiskit.providers.models.BackendStatus "(in Qiskit v0.44)") instance has `operational=True` but `status_msg="internal"`, then the backend is accepting jobs but not processing them.
+  If the returned [`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus "(in Qiskit v0.44)") instance has `operational=True` but `status_msg="internal"`, then the backend is accepting jobs but not processing them.
 </Admonition>
 
 **Return type**
 
-[`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus.html#qiskit.providers.models.BackendStatus "(in Qiskit v0.44)")
+[`BackendStatus`](/api/qiskit/qiskit.providers.models.BackendStatus "(in Qiskit v0.44)")
 
 **Returns**
 
@@ -698,5 +698,5 @@ The status of the backend.
 
 `IBMBackend.target_history(datetime=None)`
 
-A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target.html#qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend. :rtype: [`Target`](/api/qiskit/qiskit.transpiler.Target.html#qiskit.transpiler.Target "(in Qiskit v0.44)") :returns: Target with properties found on datetime
+A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.44)") object for the backend. :rtype: [`Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.44)") :returns: Target with properties found on datetime
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendService.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendService.md
@@ -118,7 +118,7 @@ Retrieve jobs that match the given filters and paginate the results if desired. 
 *   **limit** (`Optional`\[`int`]) – Number of jobs to retrieve. `None` means no limit. Note that the number of sub-jobs within a composite job count towards the limit.
 *   **skip** (`int`) – Starting index for the job retrieval.
 *   **backend\_name** (`Optional`\[`str`]) – Name of the backend to retrieve jobs from.
-*   **status** (`Union`\[`Literal`\[‘pending’, ‘completed’], `List`\[`Union`\[[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus.html#qiskit.providers.JobStatus "(in Qiskit v0.44)"), `str`]], [`JobStatus`](/api/qiskit/qiskit.providers.JobStatus.html#qiskit.providers.JobStatus "(in Qiskit v0.44)"), `str`, `None`]) – Filter jobs with either “pending” or “completed” status. You can also specify by
+*   **status** (`Union`\[`Literal`\[‘pending’, ‘completed’], `List`\[`Union`\[[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus "(in Qiskit v0.44)"), `str`]], [`JobStatus`](/api/qiskit/qiskit.providers.JobStatus "(in Qiskit v0.44)"), `str`, `None`]) – Filter jobs with either “pending” or “completed” status. You can also specify by
 *   **example** (*exact status. For*) – or status=\[“RUNNING”, “ERROR”].
 *   **status="RUNNING"** (*status=JobStatus.RUNNING or*) – or status=\[“RUNNING”, “ERROR”].
 *   **start\_datetime** (`Optional`\[`datetime`]) – Filter by the given start date, in local time. This is used to find jobs whose creation dates are after (greater than or equal to) this local date/time.

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCircuitJob.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCircuitJob.md
@@ -16,7 +16,7 @@ Representation of a job that executes on an IBM Quantum backend.
 
 The job may be executed on a simulator or a real device. A new `IBMCircuitJob` instance is returned when you call `IBMBackend.run()` to submit a job to a particular backend.
 
-If the job is successfully submitted, you can inspect the job’s status by calling [`status()`](qiskit_ibm_provider.job.IBMCircuitJob#status "qiskit_ibm_provider.job.IBMCircuitJob.status"). Job status can be one of the [`JobStatus`](/api/qiskit/qiskit.providers.JobStatus.html#qiskit.providers.JobStatus "(in Qiskit v0.44)") members. For example:
+If the job is successfully submitted, you can inspect the job’s status by calling [`status()`](qiskit_ibm_provider.job.IBMCircuitJob#status "qiskit_ibm_provider.job.IBMCircuitJob.status"). Job status can be one of the [`JobStatus`](/api/qiskit/qiskit.providers.JobStatus "(in Qiskit v0.44)") members. For example:
 
 ```python
 from qiskit.providers.jobstatus import JobStatus
@@ -131,7 +131,7 @@ Return the backend where this job was executed.
 
 **Return type**
 
-[`Backend`](/api/qiskit/qiskit.providers.Backend.html#qiskit.providers.Backend "(in Qiskit v0.44)")
+[`Backend`](/api/qiskit/qiskit.providers.Backend "(in Qiskit v0.44)")
 
 <span id="ibmcircuitjob-backend-options" />
 
@@ -206,7 +206,7 @@ Return the circuits for this job.
 
 **Return type**
 
-`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]
+`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -346,7 +346,7 @@ Return the backend properties for this job.
 
 **Return type**
 
-`Optional`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties.html#qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")]
+`Optional`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -439,7 +439,7 @@ Return the result of the job.
 </Admonition>
 
 <Admonition title="Note" type="note">
-  When partial=True, this method will attempt to retrieve partial results of failed jobs. In this case, precaution should be taken when accessing individual experiments, as doing so might cause an exception. The `success` attribute of the returned [`Result`](/api/qiskit/qiskit.result.Result.html#qiskit.result.Result "(in Qiskit v0.44)") instance can be used to verify whether it contains partial results.
+  When partial=True, this method will attempt to retrieve partial results of failed jobs. In this case, precaution should be taken when accessing individual experiments, as doing so might cause an exception. The `success` attribute of the returned [`Result`](/api/qiskit/qiskit.result.Result "(in Qiskit v0.44)") instance can be used to verify whether it contains partial results.
 
   For example, if one of the experiments in the job failed, trying to get the counts of the unsuccessful experiment would raise an exception since there are no counts to return:
 
@@ -460,7 +460,7 @@ If the job failed, you can use [`error_message()`](qiskit_ibm_provider.job.IBMCi
 
 **Return type**
 
-[`Result`](/api/qiskit/qiskit.result.Result.html#qiskit.result.Result "(in Qiskit v0.44)")
+[`Result`](/api/qiskit/qiskit.result.Result "(in Qiskit v0.44)")
 
 **Returns**
 
@@ -524,7 +524,7 @@ Query the server for the latest job status.
 
 **Return type**
 
-[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus.html#qiskit.providers.JobStatus "(in Qiskit v0.44)")
+[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus "(in Qiskit v0.44)")
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCompositeJob.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCompositeJob.md
@@ -35,7 +35,7 @@ IBMCompositeJob constructor.
 *   **job\_id** (`Optional`\[`str`]) – Job ID.
 *   **creation\_date** (`Optional`\[`datetime`]) – Job creation date.
 *   **jobs** (`Optional`\[`List`\[[`IBMCircuitJob`](qiskit_ibm_provider.job.IBMCircuitJob "qiskit_ibm_provider.job.ibm_circuit_job.IBMCircuitJob")]]) – A list of sub-jobs.
-*   **circuits\_list** (`Optional`\[`List`\[`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]]]) – Circuits for this job.
+*   **circuits\_list** (`Optional`\[`List`\[`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]]]) – Circuits for this job.
 *   **run\_config** (`Optional`\[`Dict`]) – Runtime configuration for this job.
 *   **name** (`Optional`\[`str`]) – Job name.
 *   **tags** (`Optional`\[`List`\[`str`]]) – Job tags.
@@ -89,7 +89,7 @@ Return the backend where this job was executed.
 
 **Return type**
 
-[`Backend`](/api/qiskit/qiskit.providers.Backend.html#qiskit.providers.Backend "(in Qiskit v0.44)")
+[`Backend`](/api/qiskit/qiskit.providers.Backend "(in Qiskit v0.44)")
 
 <span id="ibmcompositejob-backend-options" />
 
@@ -177,7 +177,7 @@ Return the circuits for this job.
 
 **Return type**
 
-`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit.html#qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]
+`List`\[[`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "(in Qiskit v0.44)")]
 
 **Returns**
 
@@ -349,7 +349,7 @@ Return the backend properties for this job.
 
 **Return type**
 
-`Union`\[`List`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties.html#qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")], [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties.html#qiskit.providers.models.BackendProperties "(in Qiskit v0.44)"), `None`]
+`Union`\[`List`\[[`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "(in Qiskit v0.44)")], [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "(in Qiskit v0.44)"), `None`]
 
 **Returns**
 
@@ -494,7 +494,7 @@ Return the result of the job.
 </Admonition>
 
 <Admonition title="Note" type="note">
-  When partial=True, this method will attempt to retrieve partial results of failed jobs. In this case, precaution should be taken when accessing individual experiments, as doing so might cause an exception. The `success` attribute of the returned [`Result`](/api/qiskit/qiskit.result.Result.html#qiskit.result.Result "(in Qiskit v0.44)") instance can be used to verify whether it contains partial results.
+  When partial=True, this method will attempt to retrieve partial results of failed jobs. In this case, precaution should be taken when accessing individual experiments, as doing so might cause an exception. The `success` attribute of the returned [`Result`](/api/qiskit/qiskit.result.Result "(in Qiskit v0.44)") instance can be used to verify whether it contains partial results.
 
   For example, if one of the circuits in the job failed, trying to get the counts of the unsuccessful circuit would raise an exception since there are no counts to return:
 
@@ -517,7 +517,7 @@ If the job failed, you can use [`error_message()`](qiskit_ibm_provider.job.IBMCo
 
 **Return type**
 
-[`Result`](/api/qiskit/qiskit.result.Result.html#qiskit.result.Result "(in Qiskit v0.44)")
+[`Result`](/api/qiskit/qiskit.result.Result "(in Qiskit v0.44)")
 
 **Returns**
 
@@ -599,7 +599,7 @@ Query the server for the latest job status.
 
 **Return type**
 
-[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus.html#qiskit.providers.JobStatus "(in Qiskit v0.44)")
+[`JobStatus`](/api/qiskit/qiskit.providers.JobStatus "(in Qiskit v0.44)")
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
@@ -20,11 +20,11 @@ Return the least busy available backend for those that have a `pending_jobs` in 
 
 **Parameters**
 
-**backends** (`List`\[[`Backend`](/api/qiskit/qiskit.providers.Backend.html#qiskit.providers.Backend "(in Qiskit v0.44)")]) – The backends to choose from.
+**backends** (`List`\[[`Backend`](/api/qiskit/qiskit.providers.Backend "(in Qiskit v0.44)")]) – The backends to choose from.
 
 **Return type**
 
-[`Backend`](/api/qiskit/qiskit.providers.Backend.html#qiskit.providers.Backend "(in Qiskit v0.44)")
+[`Backend`](/api/qiskit/qiskit.providers.Backend "(in Qiskit v0.44)")
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
@@ -32,7 +32,7 @@ Scheduler for dynamic circuit backends.
 
 **Parameters**
 
-**durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations.html#qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
+**durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
 
 ## Attributes
 
@@ -97,7 +97,7 @@ Return the name of the pass.
 
 `ALAPScheduleAnalysis.run(dag)`
 
-Run the ASAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)") :param dag: DAG to schedule. :type dag: DAGCircuit
+Run the ASAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)") :param dag: DAG to schedule. :type dag: DAGCircuit
 
 **Raises**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
@@ -32,7 +32,7 @@ Scheduler for dynamic circuit backends.
 
 **Parameters**
 
-**durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations.html#qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
+**durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
 
 ## Attributes
 
@@ -97,7 +97,7 @@ Return the name of the pass.
 
 `ASAPScheduleAnalysis.run(dag)`
 
-Run the ALAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)") :param dag: DAG to schedule. :type dag: DAGCircuit
+Run the ALAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)") :param dag: DAG to schedule. :type dag: DAGCircuit
 
 **Raises**
 
@@ -106,7 +106,7 @@ Run the ALAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.d
 
 **Return type**
 
-[`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")
+[`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.md
@@ -92,7 +92,7 @@ Run the padding pass on `dag`.
 
 **Parameters**
 
-**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
+**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
@@ -48,7 +48,7 @@ Construct an `InstructionDurations` object from the backend.
 
 **Parameters**
 
-**backend** ([`Backend`](/api/qiskit/qiskit.providers.Backend.html#qiskit.providers.Backend "(in Qiskit v0.44)")) – backend from which durations (gate lengths) and dt are extracted.
+**backend** ([`Backend`](/api/qiskit/qiskit.providers.Backend "(in Qiskit v0.44)")) – backend from which durations (gate lengths) and dt are extracted.
 
 **Returns**
 
@@ -80,7 +80,7 @@ Some instructions may have a parameter dependent duration.
 
 **Parameters**
 
-*   **inst** (*str |* [*qiskit.circuit.Instruction*](/api/qiskit/qiskit.circuit.Instruction.html#qiskit.circuit.Instruction "(in Qiskit v0.44)")) – An instruction or its name to be queried.
+*   **inst** (*str |* [*qiskit.circuit.Instruction*](/api/qiskit/qiskit.circuit.Instruction "(in Qiskit v0.44)")) – An instruction or its name to be queried.
 *   **qubits** (*int | list\[int] | Qubit | list\[Qubit] | list\[int | Qubit]*) – Qubits or its indices that the instruction acts on.
 *   **unit** (*str*) – The unit of duration to be returned. It must be ‘s’ or ‘dt’.
 *   **parameters** (*list\[float] | None*) – The value of the parameters of the desired instruction.
@@ -127,7 +127,7 @@ Update self with inst\_durations (inst\_durations overwrite self). Overrides the
 
 **Parameters**
 
-*   **inst\_durations** (`Union`\[`List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `Optional`\[`Iterable`\[`float`]], `str`]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `Optional`\[`Iterable`\[`float`]]]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `str`]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`]], [`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations.html#qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)"), `None`]) – Instruction durations to be merged into self (overwriting self).
+*   **inst\_durations** (`Union`\[`List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `Optional`\[`Iterable`\[`float`]], `str`]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `Optional`\[`Iterable`\[`float`]]]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`, `str`]], `List`\[`Tuple`\[`str`, `Optional`\[`Iterable`\[`int`]], `float`]], [`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)"), `None`]) – Instruction durations to be merged into self (overwriting self).
 *   **dt** (`Optional`\[`float`]) – Sampling duration in seconds of the target backend.
 
 **Returns**

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay.md
@@ -104,7 +104,7 @@ Run the padding pass on `dag`.
 
 **Parameters**
 
-**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
+**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling.md
@@ -137,9 +137,9 @@ Dynamical decoupling initializer.
 
 **Parameters**
 
-*   **durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations.html#qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
+*   **durations** ([`InstructionDurations`](/api/qiskit/qiskit.transpiler.InstructionDurations "(in Qiskit v0.44)")) – Durations of instructions to be used in scheduling.
 
-*   **dd\_sequences** (`Union`\[`List`\[[`Gate`](/api/qiskit/qiskit.circuit.Gate.html#qiskit.circuit.Gate "(in Qiskit v0.44)")], `List`\[`List`\[[`Gate`](/api/qiskit/qiskit.circuit.Gate.html#qiskit.circuit.Gate "(in Qiskit v0.44)")]]]) – Sequence of gates to apply in idle spots. Alternatively a list of gate sequences may be supplied that will preferentially be inserted if there is a delay of sufficient duration. This may be tuned by the optionally supplied `sequence_min_length_ratios`.
+*   **dd\_sequences** (`Union`\[`List`\[[`Gate`](/api/qiskit/qiskit.circuit.Gate "(in Qiskit v0.44)")], `List`\[`List`\[[`Gate`](/api/qiskit/qiskit.circuit.Gate "(in Qiskit v0.44)")]]]) – Sequence of gates to apply in idle spots. Alternatively a list of gate sequences may be supplied that will preferentially be inserted if there is a delay of sufficient duration. This may be tuned by the optionally supplied `sequence_min_length_ratios`.
 
 *   **qubits** (`Optional`\[`List`\[`int`]]) – Physical qubits on which to apply DD. If None, all qubits will undergo DD (when possible).
 
@@ -160,7 +160,7 @@ Dynamical decoupling initializer.
 
 *   **insert\_multiple\_cycles** (`bool`) – If the available duration exceeds 2\*sequence\_min\_length\_ratio\*duration(dd\_sequence) enable the insertion of multiple rounds of the dynamical decoupling sequence in that delay.
 
-*   **coupling\_map** (`Optional`\[[`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap.html#qiskit.transpiler.CouplingMap "(in Qiskit v0.44)")]) – directed graph representing the coupling map for the device. Specifying a coupling map partitions the device into subcircuits, in order to apply DD sequences with different pulse spacings within each. Currently support 2 subcircuits.
+*   **coupling\_map** (`Optional`\[[`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap "(in Qiskit v0.44)")]) – directed graph representing the coupling map for the device. Specifying a coupling map partitions the device into subcircuits, in order to apply DD sequences with different pulse spacings within each. Currently support 2 subcircuits.
 
 *   **alt\_spacings** (`Union`\[`List`\[`List`\[`float`]], `List`\[`float`], `None`]) – A list of lists of spacings between the DD gates, for the second subcircuit, as determined by the coupling map. If None, a balanced spacing that is staggered with respect to the first subcircuit will be used \[d, d, d, …, d, d, 0].
 
@@ -239,7 +239,7 @@ Run the padding pass on `dag`.
 
 **Parameters**
 
-**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit.html#qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
+**dag** ([`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.44)")) – DAG to be checked.
 
 **Returns**
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.md
@@ -21,7 +21,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling
 A collection of scheduling passes for working with IBM Quantum’s next-generation backends that support advanced “dynamic circuit” capabilities. Ie., circuits with support for classical control-flow/feedback based off of measurement results.
 
 <Admonition title="Warning" type="caution">
-  You should not mix these scheduling passes with Qiskit’s builtin scheduling passes as they will negatively interact with the scheduling routines for dynamic circuits. This includes setting `scheduling_method` in [`transpile()`](/api/qiskit/compiler.html#qiskit.compiler.transpile "(in Qiskit v0.44)") or [`generate_preset_pass_manager()`](/api/qiskit/transpiler_preset.html#qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager "(in Qiskit v0.44)").
+  You should not mix these scheduling passes with Qiskit’s builtin scheduling passes as they will negatively interact with the scheduling routines for dynamic circuits. This includes setting `scheduling_method` in `transpile()` or `generate_preset_pass_manager()`.
 </Admonition>
 
 Below we demonstrate how to schedule and pad a teleportation circuit with delays for a dynamic circuit backend’s execution model:
@@ -103,7 +103,7 @@ dd_teleport.draw(output="mpl")
 
 ![../\_images/qiskit\_ibm\_provider.transpiler.passes.scheduling\_1\_0.png](/images/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling_1_0.png)
 
-When compiling a circuit with Qiskit, it is more efficient and more robust to perform all the transformations in a single transpilation. This has been done above by extending Qiskit’s preset pass managers. For example, Qiskit’s [`transpile()`](/api/qiskit/compiler.html#qiskit.compiler.transpile "(in Qiskit v0.44)") function internally builds its pass set by using [`generate_preset_pass_manager()`](/api/qiskit/transpiler_preset.html#qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager "(in Qiskit v0.44)"). This returns instances of [`StagedPassManager`](/api/qiskit/qiskit.transpiler.StagedPassManager.html#qiskit.transpiler.StagedPassManager "(in Qiskit v0.44)"), which can be extended.
+When compiling a circuit with Qiskit, it is more efficient and more robust to perform all the transformations in a single transpilation. This has been done above by extending Qiskit’s preset pass managers. For example, Qiskit’s `transpile()` function internally builds its pass set by using `generate_preset_pass_manager()`. This returns instances of [`StagedPassManager`](/api/qiskit/qiskit.transpiler.StagedPassManager "(in Qiskit v0.44)"), which can be extended.
 
 <span id="scheduling-old-format-c-if-conditioned-gates" />
 
@@ -119,7 +119,7 @@ qc_c_if.draw(output="mpl")
 
 ![../\_images/qiskit\_ibm\_provider.transpiler.passes.scheduling\_2\_0.png](/images/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling_2_0.png)
 
-The [`IBMBackend`](qiskit_ibm_provider.IBMBackend "qiskit_ibm_provider.IBMBackend") configures a translation plugin `IBMTranslationPlugin` to automatically apply transformations and optimizations for IBM hardware backends when invoking [`transpile()`](/api/qiskit/compiler.html#qiskit.compiler.transpile "(in Qiskit v0.44)"). This will automatically convert all old style `c_if` conditioned gates to new-style control-flow. We may then schedule the transpiled circuit without further modification.
+The [`IBMBackend`](qiskit_ibm_provider.IBMBackend "qiskit_ibm_provider.IBMBackend") configures a translation plugin `IBMTranslationPlugin` to automatically apply transformations and optimizations for IBM hardware backends when invoking `transpile()`. This will automatically convert all old style `c_if` conditioned gates to new-style control-flow. We may then schedule the transpiled circuit without further modification.
 
 ```python
 # Temporary workaround for mock backends. For real backends this is not required.
@@ -139,7 +139,7 @@ qc_if_dd.draw(output="mpl")
 
 ![../\_images/qiskit\_ibm\_provider.transpiler.passes.scheduling\_3\_0.png](/images/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling_3_0.png)
 
-If you are not using the transpiler plugin stages to work around this please manually run the pass [`qiskit.transpiler.passes.ConvertConditionsToIfOps`](/api/qiskit/qiskit.transpiler.passes.ConvertConditionsToIfOps.html#qiskit.transpiler.passes.ConvertConditionsToIfOps "(in Qiskit v0.44)") prior to your scheduling pass.
+If you are not using the transpiler plugin stages to work around this please manually run the pass [`qiskit.transpiler.passes.ConvertConditionsToIfOps`](/api/qiskit/qiskit.transpiler.passes.ConvertConditionsToIfOps "(in Qiskit v0.44)") prior to your scheduling pass.
 
 ```python
 from qiskit.transpiler.passes import ConvertConditionsToIfOps


### PR DESCRIPTION
I've done my best to fix up the links that were broken due to https://github.com/Qiskit/documentation/pull/202

There were some links that we just don't have ways to link to in onedocs, because we are missing anchor tags for methods within api ref pages. So for these links I just removed the link entirely