### PR TITLE
fix references in migration guides

### DIFF
--- a/docs/api/migration-guides/__migration-guide-algorithms.md.txt
+++ b/docs/api/migration-guides/__migration-guide-algorithms.md.txt
@@ -155,7 +155,7 @@ The minimum eigensolver algorithms belong to the first type of refactoring liste
 (Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
 Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/qiskit.algorithms.minimum_eigensolvers) are now initialized
 using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, depending
-on the algorithm. The legacy classes can still be found in {mod}`qiskit.algorithms.minimum_eigen_solvers`.
+on the algorithm. The legacy classes can still be found in `qiskit.algorithms.minimum_eigen_solvers`.
 
 <Admonition type="warning">
   For the [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/qiskit.algorithms.minimum_eigensolvers) classes, depending on the import path,
@@ -529,7 +529,7 @@ The eigensolver algorithms also belong to the first type of refactoring
 [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), [`qiskit.algorithms.eigensolvers`](../qiskit/qiskit.algorithms.eigensolvers) are now initialized
 using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, or
 **a primitive-based subroutine**, depending on the algorithm. The legacy classes can still be found
-in {mod}`qiskit.algorithms.eigen_solvers`.
+in `qiskit.algorithms.eigen_solvers`.
 
 <Admonition type="warning">
   For the [`qiskit.algorithms.eigensolvers`](../qiskit/qiskit.algorithms.eigensolvers) classes, depending on the import path,
@@ -718,9 +718,9 @@ to [`qiskit.algorithms.eigensolvers.NumPyEigensolver`](../qiskit/qiskit.algorith
 
 The time evolvers are the last group of algorithms to undergo the first type of refactoring
 (Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.time_evolvers` are now initialized
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.time_evolvers` are now initialized
 using an instance of the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. The legacy classes can still be found
-in {mod}`qiskit.algorithms.evolvers`.
+in `qiskit.algorithms.evolvers`.
 
 On top of the migration, the module has been substantially expanded to include **Variational Quantum Time Evolution**
 (`qiskit.algorithms.time_evolvers.VarQTE`) solvers.
@@ -819,11 +819,11 @@ On top of the migration, the module has been substantially expanded to include *
 *Back to* [TL;DR]
 
 The amplitude amplifier algorithms belong to the second type of refactoring (Algorithms refactored in-place).
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.amplitude_amplifiers` are now initialized
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_amplifiers` are now initialized
 using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
-  The full {mod}`qiskit.algorithms.amplitude_amplifiers` module has been refactored in place. No need to
+  The full `qiskit.algorithms.amplitude_amplifiers` module has been refactored in place. No need to
   change import paths.
 </Admonition>
 
@@ -863,11 +863,11 @@ For complete code examples, see the following updated tutorials:
 
 Similarly to the amplitude amplifiers, the amplitude estimators also belong to the second type of refactoring
 (Algorithms refactored in-place).
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.amplitude_estimators` are now initialized
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_estimators` are now initialized
 using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
-  The full {mod}`qiskit.algorithms.amplitude_estimators` module has been refactored in place. No need to
+  The full `qiskit.algorithms.amplitude_estimators` module has been refactored in place. No need to
   change import paths.
 </Admonition>
 
@@ -913,11 +913,11 @@ For complete code examples, see the following updated tutorials:
 
 Finally, the phase estimators are the last group of algorithms to undergo the first type of refactoring
 (Algorithms refactored in-place).
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), {mod}`qiskit.algorithms.phase_estimators` are now initialized
+Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.phase_estimators` are now initialized
 using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
-  The full {mod}`qiskit.algorithms.phase_estimators` module has been refactored in place. No need to
+  The full `qiskit.algorithms.phase_estimators` module has been refactored in place. No need to
   change import paths.
 </Admonition>
 

--- a/docs/api/migration-guides/__migration-guide-opflow.md.txt
+++ b/docs/api/migration-guides/__migration-guide-opflow.md.txt
@@ -131,7 +131,7 @@ keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its
 *Back to* [Contents]
 
 Opflow provided shortcuts to define common single qubit states, operators, and non-parametrized gates in the
-{ref}`operator_globals` module.
+[`operator_globals`](../qiskit/opflow#operator-globals) module.
 
 These were mainly used for didactic purposes or quick prototyping, and can easily be replaced by their corresponding
 [`qiskit.quantum_info`](../qiskit/quantum_info) class: [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli), [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) or
@@ -1012,7 +1012,7 @@ Notably, this functionality has been replaced by the [`qiskit.primitives`](../qi
 The [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
 including various methods for Trotterization. The original opflow workflow for Hamiltonian simulation did not allow for
 delayed synthesis of the gates or efficient transpilation of the circuits, so this functionality was migrated to the
-`qiskit.synthesis` {ref}`Evolution <evolution_synthesis>` module.
+`qiskit.synthesis` [Evolution Synthesis](../qiskit/synthesis#evolution-synthesis) module.
 
 <Admonition type="note">
   The [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/qiskit.opflow.evolutions.PauliTrotterEvolution) class computes evolutions for exponentiated
@@ -1235,7 +1235,7 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 Expectations are converters which enable the computation of the expectation value of an observable with respect to some state function.
 This functionality can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Please remember that there
-are different `Estimator` implementations, as noted {ref}`here <attention_primitives>`
+are different `Estimator` implementations, as noted in the warning box [here](#TL;DR)
 
 ### Algorithm-Agnostic Expectations
 


### PR DESCRIPTION
Step 2 of #213 

Some references don't work even on the original page, so I just deleted them.

With this, https://github.com/Qiskit/documentation/pull/237 can be merged.