### PR TITLE
Shorten title temporarily until truncation in toc is fixed

### DIFF
--- a/docs/run/_toc.json
+++ b/docs/run/_toc.json
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "title": "Run workloads with Quantum Serverless",
+      "title": "Quantum Serverless workloads",
       "url": "/run/quantum-serverless"
     },
     {


### PR DESCRIPTION
@javabster noted that the most important part of this title in the table of contents is cut off (until the toc truncation issue is fixed), so pushing through a temporary fix on just the toc and leaving the "better" title on the page itself -- changing to "Quantum Serverless workloads" until the truncation fix is in production. FYI @psschwei @jenglick