### PR TITLE
Convert list tables in migration guides to Markdown tables

### DIFF
--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -49,31 +49,14 @@ This guide traverses the opflow submodules and provides either a direct alternat
 
 The functional equivalency can be roughly summarized as follows:
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow Module
-     - Alternative
-   * - Operators ([`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase), :ref:`operator_globals`,
-       [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops), [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops))
-     - ``qiskit.quantum_info`` :ref:`Operators <quantum_info_operators>`
-
-   * - [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns)
-     - ``qiskit.quantum_info`` :ref:`States <quantum_info_states>`
-
-   * - [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters)
-     - [`qiskit.primitives`](../qiskit/primitives)
-
-   * - [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions)
-     - ``qiskit.synthesis`` :ref:`Evolution <evolution_synthesis>`
-
-   * - [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations)
-     - [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator)
-
-   * - [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients)
-     - [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients)
-```
+| Opflow Module | Alternative |
+| --- | --- |
+| Operators ([`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase), :ref:`operator_globals`, | `qiskit.quantum_info` :ref:`Operators <quantum_info_operators>` |
+| [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) | `qiskit.quantum_info` :ref:`States <quantum_info_states>` |
+| [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters) | [`qiskit.primitives`](../qiskit/primitives) |
+| [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) | `qiskit.synthesis` :ref:`Evolution <evolution_synthesis>` |
+| [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations) | [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) |
+| [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) | [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) |
 
 ## Contents
 
@@ -103,15 +86,9 @@ This document covers the migration from these opflow submodules:
 The [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) abstract class can be replaced with `qiskit.quantum_info.BaseOperator` ,
 keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its opflow counterpart.
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-   * - [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase)
-     - `qiskit.quantum_info.BaseOperator`
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) | `qiskit.quantum_info.BaseOperator` |
 
 <Admonition type="warning">
   Despite the similar class names, [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) and
@@ -150,20 +127,9 @@ The 1-qubit paulis were commonly used for quick testing of algorithms, as they c
 These operations implicitly created operators of type  [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp), and can be replaced by
 directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), as shown in the examples below.
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-   * - `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I`
-     - [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli)
-
-       ..  tip::
-
-           For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I` | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) |
 
 (q-pauli)=
 
@@ -256,25 +222,9 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`,
-       `qiskit.opflow.CZ`, `qiskit.opflow.Swap`
-     - Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary,
-       [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator)\s can be directly constructed from quantum circuits.
-       Another alternative is to wrap the circuit in [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) and call
-       ``Clifford.to_operator()``.
-
-       ..  note::
-
-            Constructing [`qiskit.quantum_info`](../qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and
-            scales exponentially with the size of the circuit, use with care.
-```
+| Opflow | Alternative |
+| --- | --- |
+| `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary, |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Defining the HH operator
@@ -342,21 +292,9 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus`
-     - [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or simply [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case.
-
-       ..  note::
-
-           For efficient simulation of stabilizer states, [`qiskit.quantum_info`](../qiskit/quantum_info) includes a
-           [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) class. See API reference of [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) for more info.
-```
+| Opflow | Alternative |
+| --- | --- |
+| `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or simply [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Working with stabilizer states
@@ -455,38 +393,15 @@ to initialize it.
 Thus, when migrating opflow code, it is important to look for alternatives to replace the specific subclasses that
 are used "under the hood" in the original code:
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp)
-     - As mentioned above, this class is used to generate an instance of one of the classes below, so there is
-       no direct replacement.
-
-   * - [`qiskit.opflow.primitive_ops.CircuitOp`](../qiskit/qiskit.opflow.primitive_ops.CircuitOp)
-     - [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit)
-
-   * - [`qiskit.opflow.primitive_ops.MatrixOp`](../qiskit/qiskit.opflow.primitive_ops.MatrixOp)
-     - [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator)
-
-   * - [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/qiskit.opflow.primitive_ops.PauliOp)
-     - [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms),
-       wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
-
-   * - [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp)
-     - [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example :ref:`below <example_pauli_sum_op>`.
-
-   * - [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.TaperedPauliSumOp)
-     - This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object.
-       This functionality is not currently used in any workflow, and has been deprecated without replacement.
-       See [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries) example for updated workflow.
-
-   * - [`qiskit.opflow.primitive_ops.Z2Symmetries`](../qiskit/qiskit.opflow.primitive_ops.Z2Symmetries)
-     - [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries). See example :ref:`below <example_z2_sym>`.
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp) | As mentioned above, this class is used to generate an instance of one of the classes below, so there is |
+| [`qiskit.opflow.primitive_ops.CircuitOp`](../qiskit/qiskit.opflow.primitive_ops.CircuitOp) | [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit) |
+| [`qiskit.opflow.primitive_ops.MatrixOp`](../qiskit/qiskit.opflow.primitive_ops.MatrixOp) | [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator) |
+| [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/qiskit.opflow.primitive_ops.PauliOp) | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), |
+| [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) | [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example :ref:`below <example_pauli_sum_op>`. |
+| [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.TaperedPauliSumOp) | This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object. |
+| [`qiskit.opflow.primitive_ops.Z2Symmetries`](../qiskit/qiskit.opflow.primitive_ops.Z2Symmetries) | [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries). See example :ref:`below <example_z2_sym>`. |
 
 (example-pauli-sum-op)=
 
@@ -633,29 +548,12 @@ The [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) module containe
 or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](../qiskit/quantum_info) alternatives for this functionality are the
 [`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList) and [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp) (for sums of [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli)s).
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.list_ops.ListOp`](../qiskit/qiskit.opflow.list_ops.ListOp)
-     - No direct replacement. This is the base class for operator lists. In general, these could be replaced with
-       Python ``list``\s. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, there are a few alternatives, depending on the use-case.
-       One alternative is [`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList).
-
-   * - [`qiskit.opflow.list_ops.ComposedOp`](../qiskit/qiskit.opflow.list_ops.ComposedOp)
-     - No direct replacement. Current workflows do not require composition of states and operators within
-       one object (no lazy evaluation).
-
-   * - [`qiskit.opflow.list_ops.SummedOp`](../qiskit/qiskit.opflow.list_ops.SummedOp)
-     - No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
-
-   * - [`qiskit.opflow.list_ops.TensoredOp`](../qiskit/qiskit.opflow.list_ops.TensoredOp)
-     - No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.list_ops.ListOp`](../qiskit/qiskit.opflow.list_ops.ListOp) | No direct replacement. This is the base class for operator lists. In general, these could be replaced with |
+| [`qiskit.opflow.list_ops.ComposedOp`](../qiskit/qiskit.opflow.list_ops.ComposedOp) | No direct replacement. Current workflows do not require composition of states and operators within |
+| [`qiskit.opflow.list_ops.SummedOp`](../qiskit/qiskit.opflow.list_ops.SummedOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
+| [`qiskit.opflow.list_ops.TensoredOp`](../qiskit/qiskit.opflow.list_ops.TensoredOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
 
 ## State Functions
 
@@ -694,39 +592,15 @@ acts as a factory to create the corresponding subclass depending on the computat
 This means that references to [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) in opflow code should be examined to
 identify the subclass that is being used, to then look for an alternative.
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn)
-     - In most cases, [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector). However, please remember that [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) is a factory class.
-
-   * - [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/qiskit.opflow.state_fns.CircuitStateFn)
-     - [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector)
-
-   * - [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn)
-     - This class was used to store efficient representations of sparse measurement results. The
-       [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) now returns the measurements as an instance of
-       [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) (see example in `Converters`_).
-
-   * - [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn)
-     - This class can be replaced with [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or
-       [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) (for Clifford-based vectors).
-
-   * - [`qiskit.opflow.state_fns.SparseVectorStateFn`](../qiskit/qiskit.opflow.state_fns.SparseVectorStateFn)
-     - No direct replacement. This class was used for sparse statevector representations.
-
-   * - [`qiskit.opflow.state_fns.OperatorStateFn`](../qiskit/qiskit.opflow.state_fns.OperatorStateFn)
-     - No direct replacement. This class was used to represent measurements against operators.
-
-   * - [`qiskit.opflow.state_fns.CVaRMeasurement`](../qiskit/qiskit.opflow.state_fns.CVaRMeasurement)
-     - Used in [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation).
-       Functionality now covered by [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE). See example in `Expectations`_.
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) | In most cases, [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector). However, please remember that [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) is a factory class. |
+| [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/qiskit.opflow.state_fns.CircuitStateFn) | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) |
+| [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn) | This class was used to store efficient representations of sparse measurement results. The |
+| [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn) | This class can be replaced with [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or |
+| [`qiskit.opflow.state_fns.SparseVectorStateFn`](../qiskit/qiskit.opflow.state_fns.SparseVectorStateFn) | No direct replacement. This class was used for sparse statevector representations. |
+| [`qiskit.opflow.state_fns.OperatorStateFn`](../qiskit/qiskit.opflow.state_fns.OperatorStateFn) | No direct replacement. This class was used to represent measurements against operators. |
+| [`qiskit.opflow.state_fns.CVaRMeasurement`](../qiskit/qiskit.opflow.state_fns.CVaRMeasurement) | Used in [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation). |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Applying an operator to a state
@@ -809,33 +683,13 @@ In the case of the [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.
 approximations of its state functions using a quantum backend.
 Notably, this functionality has been replaced by the [`qiskit.primitives`](../qiskit/primitives).
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler)
-     - [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with
-       [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations). See examples :ref:`below <example_convert_state>`.
-   * - [`qiskit.opflow.converters.AbelianGrouper`](../qiskit/qiskit.opflow.converters.AbelianGrouper)
-     - This class allowed a sum a of Pauli operators to be grouped, a similar functionality can be achieved
-       through the [`qiskit.quantum_info.SparsePauliOp.group_commuting`](../qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting) method of
-       [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), although this is not a 1-1 replacement, as you can see
-       in the example :ref:`below <example_commuting>`.
-   * - [`qiskit.opflow.converters.DictToCircuitSum`](../qiskit/qiskit.opflow.converters.DictToCircuitSum)
-     - No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn)\s or
-       [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn)\s to equivalent [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/qiskit.opflow.state_fns.CircuitStateFn)\s.
-   * - [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/qiskit.opflow.converters.PauliBasisChange)
-     - No direct replacement. This class was used for changing Paulis into other bases.
-   * -  [`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction)
-     -  No direct replacement. This class implements a chemistry-specific reduction for the `ParityMapper`
-        class in [Qiskit Nature](https://qiskit.org/ecosystem/nature/).
-        The general symmetry logic this mapper depends on has been refactored to other classes in [`qiskit.quantum_info`](../qiskit/quantum_info),
-        so this specific [`qiskit.opflow`](../qiskit/opflow) implementation is no longer necessary.
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler) | [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with |
+| [`qiskit.opflow.converters.AbelianGrouper`](../qiskit/qiskit.opflow.converters.AbelianGrouper) | This class allowed a sum a of Pauli operators to be grouped, a similar functionality can be achieved |
+| [`qiskit.opflow.converters.DictToCircuitSum`](../qiskit/qiskit.opflow.converters.DictToCircuitSum) | No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn)\s or |
+| [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/qiskit.opflow.converters.PauliBasisChange) | No direct replacement. This class was used for changing Paulis into other bases. |
+| [`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction) | No direct replacement. This class implements a chemistryspecific reduction for the `ParityMapper` |
 
 (example-convert-state)=
 
@@ -1045,50 +899,23 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.evolutions.TrotterizationFactory`](../qiskit/qiskit.opflow.evolutions.TrotterizationFactory)
-     - No direct replacement. This class was used to create instances of one of the classes listed below.
-
-   * - [`qiskit.opflow.evolutions.Trotter`](../qiskit/qiskit.opflow.evolutions.Trotter)
-     - [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter) or [`qiskit.synthesis.LieTrotter`](../qiskit/qiskit.synthesis.LieTrotter)
-
-   * - [`qiskit.opflow.evolutions.Suzuki`](../qiskit/qiskit.opflow.evolutions.Suzuki)
-     - [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter)
-
-   * - [`qiskit.opflow.evolutions.QDrift`](../qiskit/qiskit.opflow.evolutions.QDrift)
-     - [`qiskit.synthesis.QDrift`](../qiskit/qiskit.synthesis.QDrift)
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.evolutions.TrotterizationFactory`](../qiskit/qiskit.opflow.evolutions.TrotterizationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.evolutions.Trotter`](../qiskit/qiskit.opflow.evolutions.Trotter) | [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter) or [`qiskit.synthesis.LieTrotter`](../qiskit/qiskit.synthesis.LieTrotter) |
+| [`qiskit.opflow.evolutions.Suzuki`](../qiskit/qiskit.opflow.evolutions.Suzuki) | [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter) |
+| [`qiskit.opflow.evolutions.QDrift`](../qiskit/qiskit.opflow.evolutions.QDrift) | [`qiskit.synthesis.QDrift`](../qiskit/qiskit.synthesis.QDrift) |
 
 ### Other Evolution Classes
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.evolutions.EvolutionFactory`](../qiskit/qiskit.opflow.evolutions.EvolutionFactory)
-     - No direct replacement. This class was used to create instances of one of the classes listed below.
-
-   * - [`qiskit.opflow.evolutions.EvolvedOp`](../qiskit/qiskit.opflow.evolutions.EvolvedOp)
-     - No direct replacement. The workflow no longer requires a specific operator for evolutions.
-
-   * - [`qiskit.opflow.evolutions.MatrixEvolution`](../qiskit/qiskit.opflow.evolutions.MatrixEvolution)
-     - [`qiskit.extensions.HamiltonianGate`](../qiskit/qiskit.extensions.HamiltonianGate)
-
-   * - [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/qiskit.opflow.evolutions.PauliTrotterEvolution)
-     - [`qiskit.circuit.library.PauliEvolutionGate`](../qiskit/qiskit.circuit.library.PauliEvolutionGate)
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.evolutions.EvolutionFactory`](../qiskit/qiskit.opflow.evolutions.EvolutionFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.evolutions.EvolvedOp`](../qiskit/qiskit.opflow.evolutions.EvolvedOp) | No direct replacement. The workflow no longer requires a specific operator for evolutions. |
+| [`qiskit.opflow.evolutions.MatrixEvolution`](../qiskit/qiskit.opflow.evolutions.MatrixEvolution) | [`qiskit.extensions.HamiltonianGate`](../qiskit/qiskit.extensions.HamiltonianGate) |
+| [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/qiskit.opflow.evolutions.PauliTrotterEvolution) | [`qiskit.circuit.library.PauliEvolutionGate`](../qiskit/qiskit.circuit.library.PauliEvolutionGate) |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Trotter evolution
@@ -1245,29 +1072,12 @@ are different `Estimator` implementations, as noted in the warning box [here](#a
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.expectations.ExpectationFactory`](../qiskit/qiskit.opflow.expectations.ExpectationFactory)
-     - No direct replacement. This class was used to create instances of one of the classes listed below.
-
-   * - [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/qiskit.opflow.expectations.AerPauliExpectation)
-     - Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)  with ``approximation=True``, and then ``shots=None`` as ``run_options``.
-       See example below.
-
-   * - [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/qiskit.opflow.expectations.MatrixExpectation)
-     - Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive (if no shots are set, it performs an exact Statevector calculation).
-       See example below.
-
-   * - [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/qiskit.opflow.expectations.PauliExpectation)
-     - Use any Estimator primitive (for [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set ``shots!=None`` for a shot-based
-       simulation, for [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html) , this is the default).
-
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.expectations.ExpectationFactory`](../qiskit/qiskit.opflow.expectations.ExpectationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/qiskit.opflow.expectations.AerPauliExpectation) | Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)  with `approximation=True`, and then `shots=None` as `run_options`. |
+| [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/qiskit.opflow.expectations.MatrixExpectation) | Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive (if no shots are set, it performs an exact Statevector calculation). |
+| [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/qiskit.opflow.expectations.PauliExpectation) | Use any Estimator primitive (for [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set `shots!=None` for a shotbased |
 
 (expect-state)=
 
@@ -1389,16 +1199,9 @@ are different `Estimator` implementations, as noted in the warning box [here](#a
 
 *Back to* [Contents]
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation)
-     - Functionality migrated into new VQE algorithm: [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE)
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation) | Functionality migrated into new VQE algorithm: [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) |
 
 (cvar)=
 
@@ -1561,32 +1364,15 @@ qfi = QFI(qgt)
 Other auxiliary classes in the legacy gradient framework have now been deprecated. Here is the complete migration
 list:
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - Opflow
-     - Alternative
-
-   * - [`qiskit.opflow.gradients.DerivativeBase`](../qiskit/qiskit.opflow.gradients.DerivativeBase)
-     - No replacement. This was the base class for the gradient, hessian and QFI base classes.
-   * - [`qiskit.opflow.gradients.GradientBase`](../qiskit/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient)
-     - [`qiskit.algorithms.gradients.BaseSamplerGradient`](../qiskit/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](../qiskit/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method,
-       as explained above.
-   * - [`qiskit.opflow.gradients.HessianBase`](../qiskit/qiskit.opflow.gradients.HessianBase) and [`qiskit.opflow.gradients.Hessian`](../qiskit/qiskit.opflow.gradients.Hessian)
-     - No replacement. The new gradient framework does not work with hessians as independent objects.
-   * - [`qiskit.opflow.gradients.QFIBase`](../qiskit/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](../qiskit/qiskit.opflow.gradients.QFI)
-     - The new [`qiskit.algorithms.gradients.QFI`](../qiskit/qiskit.algorithms.gradients.QFI) class extends QGT, so the
-       corresponding base class is [`qiskit.algorithms.gradients.BaseQGT`](../qiskit/qiskit.algorithms.gradients.BaseQGT)
-   * - [`qiskit.opflow.gradients.CircuitGradient`](../qiskit/qiskit.opflow.gradients.CircuitGradient)
-     - No replacement. This class was used to convert between circuit and gradient
-       [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp), and this functionality is no longer necessary.
-   * - [`qiskit.opflow.gradients.CircuitQFI`](../qiskit/qiskit.opflow.gradients.CircuitQFI)
-     - No replacement. This class was used to convert between circuit and QFI
-       [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp), and this functionality is no longer necessary.
-   * - [`qiskit.opflow.gradients.NaturalGradient`](../qiskit/qiskit.opflow.gradients.NaturalGradient)
-     - No replacement. The same functionality can be achieved with the QFI module.
-```
+| Opflow | Alternative |
+| --- | --- |
+| [`qiskit.opflow.gradients.DerivativeBase`](../qiskit/qiskit.opflow.gradients.DerivativeBase) | No replacement. This was the base class for the gradient, hessian and QFI base classes. |
+| [`qiskit.opflow.gradients.GradientBase`](../qiskit/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient) | [`qiskit.algorithms.gradients.BaseSamplerGradient`](../qiskit/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](../qiskit/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method, |
+| [`qiskit.opflow.gradients.HessianBase`](../qiskit/qiskit.opflow.gradients.HessianBase) and [`qiskit.opflow.gradients.Hessian`](../qiskit/qiskit.opflow.gradients.Hessian) | No replacement. The new gradient framework does not work with hessians as independent objects. |
+| [`qiskit.opflow.gradients.QFIBase`](../qiskit/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](../qiskit/qiskit.opflow.gradients.QFI) | The new [`qiskit.algorithms.gradients.QFI`](../qiskit/qiskit.algorithms.gradients.QFI) class extends QGT, so the |
+| [`qiskit.opflow.gradients.CircuitGradient`](../qiskit/qiskit.opflow.gradients.CircuitGradient) | No replacement. This class was used to convert between circuit and gradient |
+| [`qiskit.opflow.gradients.CircuitQFI`](../qiskit/qiskit.opflow.gradients.CircuitQFI) | No replacement. This class was used to convert between circuit and QFI |
+| [`qiskit.opflow.gradients.NaturalGradient`](../qiskit/qiskit.opflow.gradients.NaturalGradient) | No replacement. The same functionality can be achieved with the QFI module. |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Finite Differences Batched Gradient

--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -51,10 +51,10 @@ The functional equivalency can be roughly summarized as follows:
 
 | Opflow Module | Alternative |
 | --- | --- |
-| Operators ([`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase), :ref:`operator_globals`, | `qiskit.quantum_info` :ref:`Operators <quantum_info_operators>` |
-| [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) | `qiskit.quantum_info` :ref:`States <quantum_info_states>` |
+| Operators ([`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase), [`Operator Globals`](#operator-globals), [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops), [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops)) | `qiskit.quantum_info` [`Operators`](../qiskit/quantum_info#operators) |
+| [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) | `qiskit.quantum_info` [`States`](../qiskit/quantum_info#states) |
 | [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters) | [`qiskit.primitives`](../qiskit/primitives) |
-| [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) | `qiskit.synthesis` :ref:`Evolution <evolution_synthesis>` |
+| [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) | `qiskit.synthesis` [`Evolution`](../qiskit/synthesis#evolution-synthesis) |
 | [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations) | [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) |
 | [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) | [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) |
 
@@ -64,24 +64,24 @@ This document covers the migration from these opflow submodules:
 
 **Operators**
 
-- [Operator Base Class]
-- [Operator Globals]
-- [Primitive and List Ops]
-- [State Functions]
+- [Operator Base Class](#operator-base-class)
+- [Operator Globals](#operator-globals)
+- [Primitive and List Ops](#primitive-and-list-ops)
+- [State Functions](#state-functions)
 
 **Converters**
 
-- [Converters]
-- [Evolutions]
-- [Expectations]
+- [Converters](#converters)
+- [Evolutions](#evolutions)
+- [Expectations](#expectations)
 
 **Gradients**
 
-- [Gradients]
+- [Gradients](#gradients)
 
 ## Operator Base Class
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) abstract class can be replaced with `qiskit.quantum_info.BaseOperator` ,
 keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its opflow counterpart.
@@ -95,12 +95,12 @@ keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its
   `qiskit.quantum_info.BaseOperator` are not completely equivalent to each other, and the transition
   should be handled with care. Namely:
 
-  1\. [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) implements a broader algebra mixin. Some operator overloads that were
+  1. [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) implements a broader algebra mixin. Some operator overloads that were
   commonly used [`qiskit.opflow`](../qiskit/opflow) (for example `~` for `.adjoint()`) are not defined for
   `qiskit.quantum_info.BaseOperator`. You might want to check the specific
   [`qiskit.quantum_info`](../qiskit/quantum_info) subclass instead.
 
-  2\. [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) also implements methods such as `.to_matrix()` or `.to_spmatrix()`,
+  2. [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) also implements methods such as `.to_matrix()` or `.to_spmatrix()`,
   which are only found in some of the `qiskit.quantum_info.BaseOperator` subclasses.
 
   See [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) and `qiskit.quantum_info.BaseOperator` API references
@@ -109,7 +109,7 @@ keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its
 
 ## Operator Globals
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 Opflow provided shortcuts to define common single qubit states, operators, and non-parametrized gates in the
 [`operator_globals`](../qiskit/opflow#operator-globals) module.
@@ -120,7 +120,7 @@ These were mainly used for didactic purposes or quick prototyping, and can easil
 
 ### 1-Qubit Paulis
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The 1-qubit paulis were commonly used for quick testing of algorithms, as they could be combined to create more complex operators
 (for example, `0.39 * (I ^ Z) + 0.5 * (X ^ X)`).
@@ -129,9 +129,7 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I` | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) |
-
-(q-pauli)=
+| `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I` | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) <Admonition type="warning">For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).</Admonition> |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Defining the XX operator
@@ -220,11 +218,11 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 ### Common non-parametrized gates (Clifford)
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary, |
+| `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, `qiskit.opflow.CZ`, `qiskit.opflow.Swap` | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary, [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator)s can be directly constructed from quantum circuits. Another alternative is to wrap the circuit in [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) and call `Clifford.to_operator()` <Admonition type="note">Constructing [`qiskit.quantum_info`](../qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and scales exponentially with the size of the circuit, use with care.</Admonition> |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Defining the HH operator
@@ -290,11 +288,11 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 ### 1-Qubit States
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or simply [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. |
+| `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or simply [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. <Admonition type="note">For efficient simulation of stabilizer states, [`qiskit.quantum_info`](../qiskit/quantum_info) includes a [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) class. See API reference of [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) for more info.</Admonition> |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Working with stabilizer states
@@ -353,7 +351,7 @@ directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiski
 
 ## Primitive and List Ops
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 Most of the workflows that previously relied on components from [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) and
 [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) can now leverage elements from [`qiskit.quantum_info`](../qiskit/quantum_info)'s
@@ -363,7 +361,7 @@ opflow components.
 
 ### Primitive Ops
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp) is the [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) module's base class.
 It also acts as a factory to instantiate a corresponding sub-class depending on the computational primitive used
@@ -395,15 +393,15 @@ are used "under the hood" in the original code:
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp) | As mentioned above, this class is used to generate an instance of one of the classes below, so there is |
+| [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp) | As mentioned above, this class is used to generate an instance of one of the classes below, so there is no direct replacement. |
 | [`qiskit.opflow.primitive_ops.CircuitOp`](../qiskit/qiskit.opflow.primitive_ops.CircuitOp) | [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit) |
 | [`qiskit.opflow.primitive_ops.MatrixOp`](../qiskit/qiskit.opflow.primitive_ops.MatrixOp) | [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator) |
-| [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/qiskit.opflow.primitive_ops.PauliOp) | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), |
-| [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) | [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example :ref:`below <example_pauli_sum_op>`. |
-| [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.TaperedPauliSumOp) | This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object. |
-| [`qiskit.opflow.primitive_ops.Z2Symmetries`](../qiskit/qiskit.opflow.primitive_ops.Z2Symmetries) | [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries). See example :ref:`below <example_z2_sym>`. |
+| [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/qiskit.opflow.primitive_ops.PauliOp) | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
+| [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) | [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example [below](#example-pauli-sum-op). |
+| [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.TaperedPauliSumOp) | This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object. This functionality is not currently used in any workflow, and has been deprecated without replacement. See [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries) example for updated workflow. |
+| [`qiskit.opflow.primitive_ops.Z2Symmetries`](../qiskit/qiskit.opflow.primitive_ops.Z2Symmetries) | [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries). See example [below](#example-z2-sym). |
 
-(example-pauli-sum-op)=
+<span id="example-pauli-sum-op"></span>
 
 ```{eval-rst}
 .. dropdown:: Example 1: ``PauliSumOp``
@@ -440,7 +438,7 @@ are used "under the hood" in the original code:
                       coeffs=[0.-6.j])
 ```
 
-(example-z2-sym)=
+<span id="example-z2-sym"></span>
 
 ```{eval-rst}
 .. dropdown:: Example 2: ``Z2Symmetries`` and ``TaperedPauliSumOp``
@@ -542,7 +540,7 @@ are used "under the hood" in the original code:
 
 ### ListOps
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) module contained classes for manipulating lists of [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops)
 or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](../qiskit/quantum_info) alternatives for this functionality are the
@@ -550,14 +548,14 @@ or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.list_ops.ListOp`](../qiskit/qiskit.opflow.list_ops.ListOp) | No direct replacement. This is the base class for operator lists. In general, these could be replaced with |
-| [`qiskit.opflow.list_ops.ComposedOp`](../qiskit/qiskit.opflow.list_ops.ComposedOp) | No direct replacement. Current workflows do not require composition of states and operators within |
+| [`qiskit.opflow.list_ops.ListOp`](../qiskit/qiskit.opflow.list_ops.ListOp) | No direct replacement. This is the base class for operator lists. In general, these could be replaced with Python `list`s. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, there are a few alternatives, depending on the use-case. One alternative is [`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList). |
+| [`qiskit.opflow.list_ops.ComposedOp`](../qiskit/qiskit.opflow.list_ops.ComposedOp) | No direct replacement. Current workflows do not require composition of states and operators within one object (no lazy evaluation). |
 | [`qiskit.opflow.list_ops.SummedOp`](../qiskit/qiskit.opflow.list_ops.SummedOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
 | [`qiskit.opflow.list_ops.TensoredOp`](../qiskit/qiskit.opflow.list_ops.TensoredOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
 
 ## State Functions
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) module can be generally replaced by subclasses of [`qiskit.quantum_info`](../qiskit/quantum_info)'s
 `qiskit.quantum_info.states.quantum_state.QuantumState`.
@@ -596,11 +594,11 @@ identify the subclass that is being used, to then look for an alternative.
 | --- | --- |
 | [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) | In most cases, [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector). However, please remember that [`qiskit.opflow.state_fns.StateFn`](../qiskit/qiskit.opflow.state_fns.StateFn) is a factory class. |
 | [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/qiskit.opflow.state_fns.CircuitStateFn) | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) |
-| [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn) | This class was used to store efficient representations of sparse measurement results. The |
-| [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn) | This class can be replaced with [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or |
+| [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn) | This class was used to store efficient representations of sparse measurement results. The [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) now returns the measurements as an instance of [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) (see example in [`Converters`](#converters)). |
+| [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn) | This class can be replaced with [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) (for Clifford-based vectors).|
 | [`qiskit.opflow.state_fns.SparseVectorStateFn`](../qiskit/qiskit.opflow.state_fns.SparseVectorStateFn) | No direct replacement. This class was used for sparse statevector representations. |
 | [`qiskit.opflow.state_fns.OperatorStateFn`](../qiskit/qiskit.opflow.state_fns.OperatorStateFn) | No direct replacement. This class was used to represent measurements against operators. |
-| [`qiskit.opflow.state_fns.CVaRMeasurement`](../qiskit/qiskit.opflow.state_fns.CVaRMeasurement) | Used in [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation). |
+| [`qiskit.opflow.state_fns.CVaRMeasurement`](../qiskit/qiskit.opflow.state_fns.CVaRMeasurement) | Used in [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation). Functionality now covered by [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE). See example in [`Expectations`](#expectations). |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Applying an operator to a state
@@ -675,7 +673,7 @@ See more applied examples in [Expectations]  and [Converters].
 
 ## Converters
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The role of the [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters) submodule was to convert the operators into other opflow operator classes
 ([`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction), [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/qiskit.opflow.converters.PauliBasisChange)...).
@@ -685,13 +683,13 @@ Notably, this functionality has been replaced by the [`qiskit.primitives`](../qi
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler) | [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with |
-| [`qiskit.opflow.converters.AbelianGrouper`](../qiskit/qiskit.opflow.converters.AbelianGrouper) | This class allowed a sum a of Pauli operators to be grouped, a similar functionality can be achieved |
-| [`qiskit.opflow.converters.DictToCircuitSum`](../qiskit/qiskit.opflow.converters.DictToCircuitSum) | No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn)\s or |
+| [`qiskit.opflow.converters.CircuitSampler`](../qiskit/qiskit.opflow.converters.CircuitSampler) | [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations). See examples [below]( #example-convert-state). |
+| [`qiskit.opflow.converters.AbelianGrouper`](../qiskit/qiskit.opflow.converters.AbelianGrouper) | This class allowed a sum a of Pauli operators to be grouped, a similar functionality can be achieved through the [`qiskit.quantum_info.SparsePauliOp.group_commuting`](../qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting) method of [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), although this is not a 1-1 replacement, as you can see in the example [below](#example-commuting). |
+| [`qiskit.opflow.converters.DictToCircuitSum`](../qiskit/qiskit.opflow.converters.DictToCircuitSum) | No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/qiskit.opflow.state_fns.DictStateFn)s or [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/qiskit.opflow.state_fns.VectorStateFn)s to equivalent [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/qiskit.opflow.state_fns.CircuitStateFn)s. |
 | [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/qiskit.opflow.converters.PauliBasisChange) | No direct replacement. This class was used for changing Paulis into other bases. |
-| [`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction) | No direct replacement. This class implements a chemistryspecific reduction for the `ParityMapper` |
+| [`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction) | No direct replacement. This class implements a chemistryspecific reduction for the `ParityMapper` class in [Qiskit Nature](https://qiskit.org/ecosystem/nature/). The general symmetry logic this mapper depends on has been refactored to other classes in [`qiskit.quantum_info`](../qiskit/quantum_info), so this specific [`qiskit.opflow`](../qiskit/opflow) implementation is no longer necessary. |
 
-(example-convert-state)=
+<span id="example-convert-state"></span>
 
 ```{eval-rst}
 .. dropdown:: Example 1: ``CircuitSampler`` for sampling parametrized circuits
@@ -813,7 +811,7 @@ Notably, this functionality has been replaced by the [`qiskit.primitives`](../qi
         [1.]
 ```
 
-(example-commuting)=
+<span id="example-commuting"></span>
 
 ```{eval-rst}
 .. dropdown:: Example 3: ``AbelianGrouper`` for grouping operators
@@ -865,7 +863,7 @@ Notably, this functionality has been replaced by the [`qiskit.primitives`](../qi
 
 ## Evolutions
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
 including various methods for Trotterization. The original opflow workflow for Hamiltonian simulation did not allow for
@@ -897,7 +895,7 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 ### Trotterizations
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
@@ -908,7 +906,7 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 ### Other Evolution Classes
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
@@ -1062,7 +1060,7 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 ## Expectations
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 Expectations are converters which enable the computation of the expectation value of an observable with respect to some state function.
 This functionality can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Please remember that there
@@ -1070,16 +1068,14 @@ are different `Estimator` implementations, as noted in the warning box [here](#a
 
 ### Algorithm-Agnostic Expectations
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
 | [`qiskit.opflow.expectations.ExpectationFactory`](../qiskit/qiskit.opflow.expectations.ExpectationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
-| [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/qiskit.opflow.expectations.AerPauliExpectation) | Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)  with `approximation=True`, and then `shots=None` as `run_options`. |
-| [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/qiskit.opflow.expectations.MatrixExpectation) | Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive (if no shots are set, it performs an exact Statevector calculation). |
-| [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/qiskit.opflow.expectations.PauliExpectation) | Use any Estimator primitive (for [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set `shots!=None` for a shotbased |
-
-(expect-state)=
+| [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/qiskit.opflow.expectations.AerPauliExpectation) | Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)  with `approximation=True`, and then `shots=None` as `run_options`. See example below. |
+| [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/qiskit.opflow.expectations.MatrixExpectation) | Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive (if no shots are set, it performs an exact Statevector calculation). See example below. |
+| [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/qiskit.opflow.expectations.PauliExpectation) | Use any Estimator primitive (for [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set `shots!=None` for a shotbased simulation, for [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html) , this is the default). |
 
 ```{eval-rst}
 .. dropdown:: Example 1: Aer Pauli expectation
@@ -1197,7 +1193,7 @@ are different `Estimator` implementations, as noted in the warning box [here](#a
 
 ### CVaRExpectation
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
@@ -1263,7 +1259,7 @@ are different `Estimator` implementations, as noted in the warning box [here](#a
 
 ## Gradients
 
-*Back to* [Contents]
+*Back to* [Contents](#contents)
 
 The opflow [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) framework has been replaced by the new [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients)
 module. The new gradients are **primitive-based subroutines** commonly used by algorithms and applications, which
@@ -1367,11 +1363,11 @@ list:
 | Opflow | Alternative |
 | --- | --- |
 | [`qiskit.opflow.gradients.DerivativeBase`](../qiskit/qiskit.opflow.gradients.DerivativeBase) | No replacement. This was the base class for the gradient, hessian and QFI base classes. |
-| [`qiskit.opflow.gradients.GradientBase`](../qiskit/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient) | [`qiskit.algorithms.gradients.BaseSamplerGradient`](../qiskit/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](../qiskit/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method, |
+| [`qiskit.opflow.gradients.GradientBase`](../qiskit/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](../qiskit/qiskit.opflow.gradients.Gradient) | [`qiskit.algorithms.gradients.BaseSamplerGradient`](../qiskit/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](../qiskit/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method, as explained above. |
 | [`qiskit.opflow.gradients.HessianBase`](../qiskit/qiskit.opflow.gradients.HessianBase) and [`qiskit.opflow.gradients.Hessian`](../qiskit/qiskit.opflow.gradients.Hessian) | No replacement. The new gradient framework does not work with hessians as independent objects. |
-| [`qiskit.opflow.gradients.QFIBase`](../qiskit/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](../qiskit/qiskit.opflow.gradients.QFI) | The new [`qiskit.algorithms.gradients.QFI`](../qiskit/qiskit.algorithms.gradients.QFI) class extends QGT, so the |
-| [`qiskit.opflow.gradients.CircuitGradient`](../qiskit/qiskit.opflow.gradients.CircuitGradient) | No replacement. This class was used to convert between circuit and gradient |
-| [`qiskit.opflow.gradients.CircuitQFI`](../qiskit/qiskit.opflow.gradients.CircuitQFI) | No replacement. This class was used to convert between circuit and QFI |
+| [`qiskit.opflow.gradients.QFIBase`](../qiskit/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](../qiskit/qiskit.opflow.gradients.QFI) | The new [`qiskit.algorithms.gradients.QFI`](../qiskit/qiskit.algorithms.gradients.QFI) class extends QGT, so the corresponding base class is [`qiskit.algorithms.gradients.BaseQGT`](../qiskit/qiskit.algorithms.gradients.BaseQGT) |
+| [`qiskit.opflow.gradients.CircuitGradient`](../qiskit/qiskit.opflow.gradients.CircuitGradient) | No replacement. This class was used to convert between circuit and gradient [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp), and this functionality is no longer necessary. |
+| [`qiskit.opflow.gradients.CircuitQFI`](../qiskit/qiskit.opflow.gradients.CircuitQFI) | No replacement. This class was used to convert between circuit and QFI [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp), and this functionality is no longer necessary. |
 | [`qiskit.opflow.gradients.NaturalGradient`](../qiskit/qiskit.opflow.gradients.NaturalGradient) | No replacement. The same functionality can be achieved with the QFI module. |
 
 ```{eval-rst}

--- a/docs/api/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/api/migration-guides/qiskit-quantum-instance.mdx
@@ -23,19 +23,11 @@ user level through the [`qiskit.transpiler`](../qiskit/transpiler) module (see t
 
 The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) class:
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - QuantumInstance method
-     - Alternative
-   * - [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute)
-     - [`qiskit.primitives.Sampler.run`](../qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](../qiskit/qiskit.primitives.Estimator#run)
-   * - [`qiskit.utils.QuantumInstance.transpile`](../qiskit/qiskit.utils.QuantumInstance#transpile)
-     - [`qiskit.compiler.transpile`](../qiskit/compiler#qiskit.compiler.transpile)
-   * - [`qiskit.utils.QuantumInstance.assemble`](../qiskit/qiskit.utils.QuantumInstance#assemble)
-     - [`qiskit.compiler.assemble`](../qiskit/compiler#qiskit.compiler.assemble)
-```
+| QuantumInstance method | Alternative |
+| --- | --- |
+| [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](../qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](../qiskit/qiskit.primitives.Estimator#run) |
+| [`qiskit.utils.QuantumInstance.transpile`](../qiskit/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](../qiskit/compiler#qiskit.compiler.transpile) |
+| [`qiskit.utils.QuantumInstance.assemble`](../qiskit/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](../qiskit/compiler#qiskit.compiler.assemble) |
 
 The remainder of this guide will focus on the [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute) to
 [`qiskit.primitives`](../qiskit/primitives) migration path.
@@ -133,63 +125,17 @@ primitives **expose a similar setting through their interface**:
   please refer to the API reference or source code of the desired primitive implementation.
 </Admonition>
 
-```{eval-rst}
-.. list-table::
-   :header-rows: 1
-
-   * - QuantumInstance
-     - Reference Primitives
-     - Aer Primitives
-     - Qiskit Runtime Primitives
-     - Backend Primitives
-   * - Select ``backend``
-     - No
-     - No
-     - Yes
-     - Yes
-   * - Set ``shots``
-     - Yes
-     - Yes
-     - Yes
-     - Yes
-   * - Simulator settings: ``basis_gates``, ``coupling_map``, ``initial_layout``, ``noise_model``, ``backend_options``
-     - No
-     - Yes
-     - Yes
-     - No (inferred from internal ``backend``)
-   * - Transpiler settings: ``seed_transpiler``, ``optimization_level``
-     - No
-     - No
-     - Yes (via ``options``) (*)
-     - Yes (via ``.set_transpile_options()``)
-   * - Set unbound ``pass_manager``
-     - No
-     - No
-     - No (but can ``skip_transpilation``)
-     - No (but can ``skip_transpilation``)
-   * - Set ``bound_pass_manager``
-     - No
-     - No
-     - No
-     - Yes
-   * - Set ``backend_options``: common ones were ``memory`` and ``meas_level``
-     - No
-     - No
-     - No (only ``qubit_layout``)
-     - No
-   * - Measurement error mitigation: ``measurement_error_mitigation_cls``, ``cals_matrix_refresh_period``,
-       ``measurement_error_mitigation_shots``, ``mit_pattern``
-     - No
-     - No
-     - Sampler default -> M3 (*)
-     - No
-   * - Job management: ``job_callback``, ``max_job_retries``, ``timeout``, ``wait``
-     - Does not apply
-     - Does not apply
-     - Sessions, callback (**)
-     - No
-
-```
+| QuantumInstance | Reference Primitives | Aer Primitives | Qiskit Runtime Primitives | Backend Primitives |
+| --- | --- | --- | --- | --- |
+| Select `backend` | No | No | Yes | Yes |
+| Set `shots` | Yes | Yes | Yes | Yes |
+| Simulator settings: `basis_gates`, `coupling_map`, `initial_layout`, `noise_model`, `backend_options` | No | Yes | Yes | No (inferred from internal `backend`) |
+| Transpiler settings: `seed_transpiler`, `optimization_level` | No | No | Yes (via `options`) (*) | Yes (via `.set_transpile_options()`) |
+| Set unbound `pass_manager` | No | No | No (but can `skip_transpilation`) | No (but can `skip_transpilation`) |
+| Set `bound_pass_manager` | No | No | No | Yes |
+| Set `backend_options`: common ones were `memory` and `meas_level` | No | No | No (only `qubit_layout`) | No |
+| Measurement error mitigation: `measurement_error_mitigation_cls`, `cals_matrix_refresh_period`, | No | No | Sampler default > M3 (*) | No |
+| Job management: `job_callback`, `max_job_retries`, `timeout`, `wait` | Does not apply | Does not apply | Sessions, callback (**) | No |
 
 (\*) For more information on error mitigation and setting options on Qiskit Runtime Primitives, visit
 [this link](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.options.Options.html#qiskit_ibm_runtime.options.Options).


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/213.

I used the below script. Warning: it doesn't handle when the list item has multiple lines for the entry. Those were manually fixed in the second commit.

```python
from __future__ import annotations

from dataclasses import dataclass
from pathlib import Path
from typing import Iterator


GUIDES = [
    Path(f"docs/api/migration-guides/qiskit-{guide}.mdx")
    for guide in ("algorithms-module", "opflow-module", "quantum-instance")
]


@dataclass
class Table:
    header: list[str]
    entries: list[list[str]]

    @classmethod
    def from_rst(cls, rst: str) -> Table:
        parsed_rows: list[list[str]] = []
        current_row: list[str] = []

        for line in rst.splitlines():
            line = line.strip()
            if line.startswith("* -"):  # new row
                # Before processing the new row, save the previous row.
                if current_row:
                    parsed_rows.append(current_row)
                current_row = [line.replace("* -", "").strip()]
            elif line.startswith("-"):  # continue current_row
                current_row.append(line.replace("-", "").strip())

        # Save the final row (ince normally a row only
        # gets saved once we already have started parsing
        # a new row).
        if current_row:
            parsed_rows.append(current_row)

        return cls(header=parsed_rows[0], entries=parsed_rows[1:])

    def to_md(self) -> str:
        result = "| " + " | ".join(self.header) + " |\n"
        result += "| " + " | ".join(["---"] * len(self.header)) + " |\n"
        for entry in self.entries:
            result += "| " + " | ".join(entry) + " |\n"
        
        # Convert RST to MD
        result = result.replace("``", "`")
        return result


def parse_rst_table(lines: list[str]) -> str:
    result = []
    while lines and not lines[0].startswith("```"):
        result.append(lines.pop(0))
    # Remove the final ``` line
    lines.pop(0)
    return "\n".join(result)


def process_lines(lines: list[str]) -> Iterator[str]:
    """Replace RST tables with Markdown.

    This function intentionally uses `pop()` to iterate through every line. If
    we encounter a list-table, we use parse_rst_table() to replace the entire
    block with the markdown table. Otherwise, we simply preserve the line.
    """
    while lines:
        line = lines.pop(0)
        if line.startswith("```{eval-rst}") and lines[0].startswith(".. list-table::"):
            rst_block = parse_rst_table(lines)
            converted = Table.from_rst(rst_block).to_md()
            yield from converted.splitlines()
        else:
            yield line


def main() -> None:
    for guide in GUIDES:
        original = guide.read_text().splitlines()
        updated = list(process_lines(original))
        guide.write_text("\n".join(updated) + "\n")


main()
```