### PR TITLE
Replace most links to qiskit.org

### DIFF
--- a/docs/api/migration-guides/qiskit-algorithms-module.mdx
+++ b/docs/api/migration-guides/qiskit-algorithms-module.mdx
@@ -33,11 +33,10 @@ There have been **3 types of refactoring**:
    > - [Phase Estimators]
 
 3. Algorithms that were deprecated and are now removed entirely from [`qiskit.algorithms`](../qiskit/algorithms). These are algorithms that do not currently serve
-   as building blocks for applications. Their main value is educational, and as such, will be kept as tutorials
-   in the qiskit textbook. You can consult the tutorials in the following links:
+   as building blocks for applications. Their main value is educational. You can consult the below tutorials:
 
-   > - [Linear Solvers (HHL)](https://learn.qiskit.org/course/ch-applications/solving-linear-systems-of-equations-using-hhl-and-its-qiskit-implementation) ,
-   > - [Factorizers (Shor)](https://learn.qiskit.org/course/ch-algorithms/shors-algorithm)
+   > - [Linear Solvers (HHL)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-applications/hhl_tutorial.ipynb) ,
+   > - [Factorizers (Shor)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-algorithms/shor.ipynb)
 
 The remainder of this migration guide will focus on the algorithms with migration alternatives within
 [`qiskit.algorithms`](../qiskit/algorithms), that is, those under refactoring types 1 and 2.
@@ -59,13 +58,13 @@ distributions. These tools allowed to refactor the [`qiskit.algorithms`](../qisk
   replacement. One common example is the class [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/qiskit.opflow.primitive_ops.PauliSumOp), used to define Hamiltonians
   (for example, to plug into VQE), that can be replaced by [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
   For information on how to migrate other [`qiskit.opflow`](../qiskit/opflow) objects, you can refer to the
-  [Opflow migration guide](https://qisk.it/opflow_migration).
+  [Opflow migration guide](./qiskit-opflow-module).
 </Admonition>
 
 For further background and detailed migration steps, see the:
 
-- [Opflow migration guide](https://qisk.it/opflow_migration)
-- [Quantum Instance migration guide](https://qisk.it/qi_migration)
+- [Opflow migration guide](./qiskit-opflow-module)
+- [Quantum Instance migration guide](./qiskit-quantum-instance)
 
 ## How to choose a primitive configuration for your algorithm
 
@@ -86,7 +85,7 @@ Once the kind of primitive is known, you can choose between the primitive implem
 >    - Wrap any backend with **Backend Primitives** ([`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator)). These wrappers implement a primitive interface on top of a backend that only supports `Backend.run()`.
 
 For more detailed information and examples, particularly on the use of the **Backend Primitives**, please refer to
-the [Quantum Instance migration guide](https://qisk.it/qi_migration).
+the [Quantum Instance migration guide](./qiskit-quantum-instance).
 
 In this guide, we will cover 3 different common configurations for algorithms that determine
 **which primitive import** you should be selecting:
@@ -328,9 +327,9 @@ print(result.eigenvalue.real)
 
 For complete code examples, see the following updated tutorials:
 
-- [VQE Introduction](https://qiskit.org/documentation/tutorials/algorithms/01_algorithms_introduction.html)
-- [VQE, Callback, Gradients, Initial Point](https://qiskit.org/documentation/tutorials/algorithms/02_vqe_advanced_options.html)
-- [VQE with Aer Primitives](https://qiskit.org/documentation/tutorials/algorithms/03_vqe_simulation_with_noise.html)
+- [VQE Introduction](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/01_algorithms_introduction.ipynb)
+- [VQE, Callback, Gradients, Initial Point](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/02_vqe_advanced_options.ipynb)
+- [VQE with Aer Primitives](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/03_vqe_simulation_with_noise.ipynb)
 
 ### QAOA
 
@@ -423,7 +422,7 @@ print(result.eigenvalue)
 
 For complete code examples, see the following updated tutorials:
 
-- [QAOA](https://qiskit.org/documentation/tutorials/algorithms/05_qaoa.html)
+- [QAOA](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/05_qaoa.ipynb)
 
 ### NumPyMinimumEigensolver
 
@@ -473,7 +472,7 @@ print(result.eigenvalue)
 
 For complete code examples, see the following updated tutorials:
 
-- [VQE, Callback, Gradients, Initial Point](https://qiskit.org/documentation/tutorials/algorithms/02_vqe_advanced_options.html)
+- [VQE, Callback, Gradients, Initial Point](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/02_vqe_advanced_options.ipynb)
 
 ## Eigensolvers
 
@@ -588,7 +587,7 @@ print(result.eigenvalues)
 
 For complete code examples, see the following updated tutorial:
 
-- [VQD](https://qiskit.org/documentation/tutorials/algorithms/04_vqd.html)
+- [VQD](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/04_vqd.ipynb)
 
 ### NumPyEigensolver
 
@@ -772,8 +771,8 @@ grover = Grover(sampler=Sampler())
 
 For complete code examples, see the following updated tutorials:
 
-- [Amplitude Amplification and Grover](https://qiskit.org/documentation/tutorials/algorithms/06_grover.html)
-- [Grover Examples](https://qiskit.org/documentation/tutorials/algorithms/07_grover_examples.html)
+- [Amplitude Amplification and Grover](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/06_grover.ipynb)
+- [Grover Examples](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/07_grover_examples.ipynb)
 
 ## Amplitude Estimators
 
@@ -820,7 +819,7 @@ iae = IterativeAmplitudeEstimation(
 
 For complete code examples, see the following updated tutorials:
 
-- [Amplitude Estimation](https://qiskit.org/documentation/finance/tutorials/00_amplitude_estimation.html)
+- [Amplitude Estimation](https://qiskit.org/ecosystem/finance/tutorials/00_amplitude_estimation.html)
 
 ## Phase Estimators
 
@@ -865,4 +864,4 @@ ipe = IterativePhaseEstimation(
 
 For complete code examples, see the following updated tutorials:
 
-- [Iterative Phase Estimation](https://qiskit.org/documentation/tutorials/algorithms/09_IQPE.html)
+- [Iterative Phase Estimation](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/09_IQPE.ipynb)

--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -16,7 +16,7 @@ the [`qiskit.opflow`](../qiskit/opflow) module to the [`qiskit.primitives`](../q
 <Admonition type="note">
   The use of [`qiskit.opflow`](../qiskit/opflow) was tightly coupled to the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) class, which
   is also being deprecated. For more information on migrating the [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), please
-  read the [quantum instance migration guide](http://qisk.it/qi_migration).
+  read the [quantum instance migration guide](./qiskit-quantum-instance).
 </Admonition>
 
 <span id="attention_primitives"></span>

--- a/docs/api/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/api/migration-guides/qiskit-quantum-instance.mdx
@@ -138,9 +138,9 @@ primitives **expose a similar setting through their interface**:
 | Job management: `job_callback`, `max_job_retries`, `timeout`, `wait` | Does not apply | Does not apply | Sessions, callback (**) | No |
 
 (\*) For more information on error mitigation and setting options on Qiskit Runtime Primitives, visit
-[this link](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.options.Options.html#qiskit_ibm_runtime.options.Options).
+[Advanced Runtime Options](../../run/advanced-runtime-options).
 
-(\*\*) For more information on Runtime sessions, visit [this how-to](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/how_to/run_session.html).
+(\*\*) For more information on Runtime sessions, visit [About Sessions](../../run/sessions).
 
 ## Code examples
 
@@ -273,7 +273,7 @@ primitives **expose a similar setting through their interface**:
     **Using Quantum Instance**
 
     The most common use case for computing expectation values with the Quantum Instance was as in combination with the
-    [`qiskit.opflow`](../qiskit/opflow) library. You can see more information in the `opflow migration guide <http://qisk.it/opflow_migration>`_.
+    [`qiskit.opflow`](../qiskit/opflow) library. You can see more information in the [opflow migration guide](./qiskit-opflow-module).
 
     .. code-block:: python
 
@@ -407,8 +407,7 @@ primitives **expose a similar setting through their interface**:
     is the closest alternative to the Quantum Instance's measurement error mitigation implementation, but this
     is not a 1-1 replacement.
 
-    For more information on the error mitigation options in the Qiskit Runtime Primitives, you can check out the following
-    `link <https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.options.Options.html#qiskit_ibm_runtime.options.Options>`_.
+    For more information on the error mitigation options in the Qiskit Runtime Primitives, you can check out [Configure Error Mitigation](../../run/configure-error-mitigation).
 
     .. code-block:: python
 

--- a/docs/api/migration-guides/qiskit-runtime-examples.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-examples.mdx
@@ -148,7 +148,7 @@ opflow_state = CircuitStateFn(state)
 This step is no longer necessary when using the primitives.
 
 <Admonition type="note">
-    For instructions to migrate from `qiskit.opflow`, see the [opflow migration guide](https://qiskit.org/documentation/migration_guides/opflow_migration.html).
+    For instructions to migrate from `qiskit.opflow`, see the [Opflow migration guide](./qiskit-opflow-module).
 </Admonition>
 
 #### 2. Calculate expectation values on real device or cloud simulator
@@ -302,7 +302,7 @@ expectation_value = estimator.run(state, op, shots=100).result().values
 expectation:  [-1.06365335]
 ```
 
-For more information on using the Aer primitives, see the [VQE tutorial](https://qiskit.org/documentation/tutorials/algorithms/03_vqe_simulation_with_noise.html).
+For more information on using the Aer primitives, see the [VQE tutorial](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/03_vqe_simulation_with_noise.ipynb).
 
 For more information about running noisy simulations with the **Runtime primitives**, see the [Noisy simulators in Qiskit Runtime](../../verify/noisy-simulators) topic.
 

--- a/docs/run/configure-error-mitigation.mdx
+++ b/docs/run/configure-error-mitigation.mdx
@@ -3,8 +3,6 @@ title: Configure error mitigation
 description: Configure error mitigation
 ---
 
-{/*Content comes from https://qiskit.org/ecosystem/ibm-runtime/how_to/error-mitigation.html and should be removed from qiskit.org.*/}
-
 # Configure error mitigation for Qiskit Runtime
 
 Error mitigation techniques allow users to mitigate circuit errors by

--- a/docs/run/instances.mdx
+++ b/docs/run/instances.mdx
@@ -22,7 +22,7 @@ To see the instances to which you have access, look at the bottom of your [Accou
 
 ## Find your instances
 
-You can view a list of your instances on your [account settings page](https://quantum-computing.ibm.com/account), or you can use [the `instances()` method](https://qiskit.org/ecosystem/ibm-runtime/stubs/qiskit_ibm_runtime.QiskitRuntimeService.html#qiskit_ibm_runtime.QiskitRuntimeService.instances).
+You can view a list of your instances on your [account settings page](https://quantum-computing.ibm.com/account), or you can use [the `instances()` method](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#instances).
 
 ## Instances and jobs
 

--- a/docs/verify/noisy-simulators.mdx
+++ b/docs/verify/noisy-simulators.mdx
@@ -4,8 +4,6 @@ description: Set up ibmq_qasm_simulator and map a basic noise model for an IBM Q
 
 ---
 
-{/*Content comes from https://qiskit.org/ecosystem/ibm-runtime/how_to/noisy_simulators.html and needs to be removed from qiskit.org*/}
-
 # Noisy simulators
 
 Set up ``ibmq_qasm_simulator`` and map a basic noise model for an IBM Quantum hardware device in Qiskit Runtime, then use this noise model to perform noisy simulations of ``QuantumCircuits`` by using ``Sampler`` and ``Estimator`` to study the effects of errors that occur on real devices.

--- a/docs/verify/simulate-with-qiskit-primitives.mdx
+++ b/docs/verify/simulate-with-qiskit-primitives.mdx
@@ -27,7 +27,7 @@ Follow these instructions to get the expected value of an observable for a given
   estimator = BackendEstimator(backend)
   ```
 
-  There are some providers that implement primitives natively (see [this page](https://qiskit.org/providers/#primitives) for more details).
+  There are some providers that implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem/#primitives) for more details).
 </Admonition>
 
 ### Initialize observables
@@ -255,7 +255,7 @@ Follow these instructions to get the probability distribution of a quantum circu
   sampler = BackendSampler(backend)
   ```
 
-  There are some providers that implement primitives natively (see [this page](http://qiskit.org/providers/#primitives) for more details).
+  There are some providers that implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#providers) for more details).
 </Admonition>
 
 ### Initialize QuantumCircuit


### PR DESCRIPTION
First pass at https://github.com/Qiskit/documentation/issues/297. qiskit.org will be going away, per https://medium.com/qiskit/important-changes-to-qiskit-documentation-and-learning-resources-7f4e346b19ab. So these links need to be fixed.

Some of the tutorials were not ported over 1:1, such as the Learn materials and Algorithms tutorials (algorithms no longer are part of Qiskit). Because the links are for migration guides that need the exact examples, I instead used stable GitHub links to the original source files.