### PR TITLE
Remove manual table of contents from migration guides

### DIFF
--- a/docs/api/migration-guides/qiskit-algorithms-module.mdx
+++ b/docs/api/migration-guides/qiskit-algorithms-module.mdx
@@ -59,8 +59,6 @@ The remainder of this migration guide will focus on the algorithms with migratio
 
 ## Background
 
-*Back to* [TL;DR](#tldr)
-
 The [`qiskit.algorithms`](../qiskit/algorithms) module was originally built on top of the [`qiskit.opflow`](../qiskit/opflow) library and the
 [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance) utility. The development of the [`qiskit.primitives`](../qiskit/primitives)
 introduced a higher-level execution paradigm, with the `Estimator` for computation of
@@ -83,8 +81,6 @@ For further background and detailed migration steps, see the:
 - [Quantum Instance migration guide](./qiskit-quantum-instance)
 
 ## How to choose a primitive configuration for your algorithm
-
-*Back to* [TL;DR](#tldr)
 
 The classes in
 [`qiskit.algorithms`](../qiskit/algorithms) are initialized with any implementation of [`qiskit.primitives.BaseSampler`](../qiskit/qiskit.primitives.BaseSampler) or [`qiskit.primitives.BaseEstimator`](../qiskit/qiskit.primitives.BaseEstimator).
@@ -168,8 +164,6 @@ In this guide, we will cover 3 different common configurations for algorithms th
 > ```
 
 ## Minimum Eigensolvers
-
-*Back to* [TL;DR](#tldr)
 
 The minimum eigensolver algorithms belong to the first type of refactoring listed above
 (Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
@@ -492,8 +486,6 @@ For complete code examples, see the following updated tutorials:
 
 ## Eigensolvers
 
-*Back to* [TL;DR](#tldr)
-
 The eigensolver algorithms also belong to the first type of refactoring
 (Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)). Instead of a
 [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), [`qiskit.algorithms.eigensolvers`](../qiskit/qiskit.algorithms.eigensolvers) are now initialized
@@ -653,8 +645,6 @@ print(result.eigenvalues)
 
 ## Time Evolvers
 
-*Back to* [TL;DR](#tldr)
-
 The time evolvers are the last group of algorithms to undergo the first type of refactoring
 (Algorithms refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives)).
 Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.time_evolvers` are now initialized
@@ -752,8 +742,6 @@ q:  ┤ exp(it X) ├┤ exp(it Z) ├
 
 ## Amplitude Amplifiers
 
-*Back to* [TL;DR](#tldr)
-
 The amplitude amplifier algorithms belong to the second type of refactoring (Algorithms refactored in-place).
 Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_amplifiers` are now initialized
 using an instance of any "Sampler" primitive e.g. [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
@@ -791,8 +779,6 @@ For complete code examples, see the following updated tutorials:
 - [Grover Examples](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/07_grover_examples.ipynb)
 
 ## Amplitude Estimators
-
-*Back to* [TL;DR](#tldr)
 
 Similarly to the amplitude amplifiers, the amplitude estimators also belong to the second type of refactoring
 (Algorithms refactored in-place).
@@ -838,8 +824,6 @@ For complete code examples, see the following updated tutorials:
 - [Amplitude Estimation](https://qiskit.org/ecosystem/finance/tutorials/00_amplitude_estimation.html)
 
 ## Phase Estimators
-
-*Back to* [TL;DR](#tldr)
 
 Finally, the phase estimators are the last group of algorithms to undergo the first type of refactoring
 (Algorithms refactored in-place).

--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -58,30 +58,7 @@ The functional equivalency can be roughly summarized as follows:
 | [`qiskit.opflow.expectations`](../qiskit/qiskit.opflow.expectations) | [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) |
 | [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) | [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients) |
 
-## Contents
-
-This document covers the migration from these opflow submodules:
-
-**Operators**
-
-- [Operator Base Class](#operator-base-class)
-- [Operator Globals](#operator-globals)
-- [Primitive and List Ops](#primitive-and-list-ops)
-- [State Functions](#state-functions)
-
-**Converters**
-
-- [Converters](#converters)
-- [Evolutions](#evolutions)
-- [Expectations](#expectations)
-
-**Gradients**
-
-- [Gradients](#gradients)
-
 ## Operator Base Class
-
-*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.OperatorBase`](../qiskit/qiskit.opflow.OperatorBase) abstract class can be replaced with `qiskit.quantum_info.BaseOperator` ,
 keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its opflow counterpart.
@@ -109,8 +86,6 @@ keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its
 
 ## Operator Globals
 
-*Back to* [Contents](#contents)
-
 Opflow provided shortcuts to define common single qubit states, operators, and non-parametrized gates in the
 [`operator_globals`](../qiskit/opflow#operator-globals) module.
 
@@ -119,8 +94,6 @@ These were mainly used for didactic purposes or quick prototyping, and can easil
 [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector).
 
 ### 1-Qubit Paulis
-
-*Back to* [Contents](#contents)
 
 The 1-qubit paulis were commonly used for quick testing of algorithms, as they could be combined to create more complex operators
 (for example, `0.39 * (I ^ Z) + 0.5 * (X ^ X)`).
@@ -212,8 +185,6 @@ SparsePauliOp(['IZI', 'IXX'],
 
 ### Common non-parametrized gates (Clifford)
 
-*Back to* [Contents](#contents)
-
 | Opflow | Alternative |
 | --- | --- |
 | `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, `qiskit.opflow.CZ`, `qiskit.opflow.Swap` | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary, [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator)s can be directly constructed from quantum circuits. Another alternative is to wrap the circuit in [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) and call `Clifford.to_operator()` <Admonition type="note">Constructing [`qiskit.quantum_info`](../qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and scales exponentially with the size of the circuit, use with care.</Admonition> |
@@ -278,8 +249,6 @@ Operator([[ 0.5+0.j,  0.5+0.j,  0.5+0.j,  0.5+0.j],
 
 ### 1-Qubit States
 
-*Back to* [Contents](#contents)
-
 | Opflow | Alternative |
 | --- | --- |
 | `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or simply [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. <Admonition type="note">For efficient simulation of stabilizer states, [`qiskit.quantum_info`](../qiskit/quantum_info) includes a [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) class. See API reference of [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) for more info.</Admonition> |
@@ -338,8 +307,6 @@ State 2:  StabilizerState(StabilizerTable: ['-IX', '+XI'])
 
 ## Primitive and List Ops
 
-*Back to* [Contents](#contents)
-
 Most of the workflows that previously relied on components from [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) and
 [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) can now leverage elements from [`qiskit.quantum_info`](../qiskit/quantum_info)'s
 operators instead.
@@ -347,8 +314,6 @@ Some of these classes do not require a 1-1 replacement because they were created
 opflow components.
 
 ### Primitive Ops
-
-*Back to* [Contents](#contents)
 
 [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/qiskit.opflow.primitive_ops.PrimitiveOp) is the [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops) module's base class.
 It also acts as a factory to instantiate a corresponding sub-class depending on the computational primitive used
@@ -508,8 +473,6 @@ Tapered Op from Z2 symmetries:  [SparsePauliOp(['I', 'X'],
 
 ### ListOps
 
-*Back to* [Contents](#contents)
-
 The [`qiskit.opflow.list_ops`](../qiskit/qiskit.opflow.list_ops) module contained classes for manipulating lists of [`qiskit.opflow.primitive_ops`](../qiskit/qiskit.opflow.primitive_ops)
 or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](../qiskit/quantum_info) alternatives for this functionality are the
 [`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList) and [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp) (for sums of [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli)s).
@@ -522,8 +485,6 @@ or [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns). The [`qiskit.
 | [`qiskit.opflow.list_ops.TensoredOp`](../qiskit/qiskit.opflow.list_ops.TensoredOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
 
 ## State Functions
-
-*Back to* [Contents](#contents)
 
 The [`qiskit.opflow.state_fns`](../qiskit/qiskit.opflow.state_fns) module can be generally replaced by subclasses of [`qiskit.quantum_info`](../qiskit/quantum_info)'s
 `qiskit.quantum_info.states.quantum_state.QuantumState`.
@@ -625,8 +586,6 @@ Statevector([0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j],
 See more applied examples in [Expectations](#expectations)  and [Converters](#converters).
 
 ## Converters
-
-*Back to* [Contents](#contents)
 
 The role of the [`qiskit.opflow.converters`](../qiskit/qiskit.opflow.converters) submodule was to convert the operators into other opflow operator classes
 ([`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/qiskit.opflow.converters.TwoQubitReduction), [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/qiskit.opflow.converters.PauliBasisChange)...).
@@ -806,8 +765,6 @@ print(repr(grouped_sum))
 
 ## Evolutions
 
-*Back to* [Contents](#contents)
-
 The [`qiskit.opflow.evolutions`](../qiskit/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
 including various methods for Trotterization. The original opflow workflow for Hamiltonian simulation did not allow for
 delayed synthesis of the gates or efficient transpilation of the circuits, so this functionality was migrated to the
@@ -838,8 +795,6 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 
 ### Trotterizations
 
-*Back to* [Contents](#contents)
-
 | Opflow | Alternative |
 | --- | --- |
 | [`qiskit.opflow.evolutions.TrotterizationFactory`](../qiskit/qiskit.opflow.evolutions.TrotterizationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
@@ -848,8 +803,6 @@ delayed synthesis of the gates or efficient transpilation of the circuits, so th
 | [`qiskit.opflow.evolutions.QDrift`](../qiskit/qiskit.opflow.evolutions.QDrift) | [`qiskit.synthesis.QDrift`](../qiskit/qiskit.synthesis.QDrift) |
 
 ### Other Evolution Classes
-
-*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
@@ -992,15 +945,11 @@ q: ┤ U3(2,-π/2,π/2) ├
 
 ## Expectations
 
-*Back to* [Contents](#contents)
-
 Expectations are converters which enable the computation of the expectation value of an observable with respect to some state function.
 This functionality can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Please remember that there
 are different `Estimator` implementations, as noted in the warning box [here](#attention_primitives)
 
 ### Algorithm-Agnostic Expectations
-
-*Back to* [Contents](#contents)
 
 | Opflow | Alternative |
 | --- | --- |
@@ -1116,8 +1065,6 @@ print(values_plus)
 
 ### CVaRExpectation
 
-*Back to* [Contents](#contents)
-
 | Opflow | Alternative |
 | --- | --- |
 | [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/qiskit.opflow.expectations.CVaRExpectation) | Functionality migrated into new VQE algorithm: [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) |
@@ -1175,8 +1122,6 @@ print(result.eigenvalue)
 ```
 
 ## Gradients
-
-*Back to* [Contents](#contents)
 
 The opflow [`qiskit.opflow.gradients`](../qiskit/qiskit.opflow.gradients) framework has been replaced by the new [`qiskit.algorithms.gradients`](../qiskit/qiskit.algorithms.gradients)
 module. The new gradients are **primitive-based subroutines** commonly used by algorithms and applications, which

--- a/docs/api/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/api/migration-guides/qiskit-quantum-instance.mdx
@@ -32,12 +32,6 @@ The following table summarizes the migration alternatives for the [`qiskit.utils
 The remainder of this guide will focus on the [`qiskit.utils.QuantumInstance.execute`](../qiskit/qiskit.utils.QuantumInstance#execute) to
 [`qiskit.primitives`](../qiskit/primitives) migration path.
 
-## Contents
-
-- [Choosing the right primitive for your task](#choosing-the-right-primitive-for-your-task)
-- [Choosing the right primitive for your settings](#choosing-the-right-primitive-for-your-settings)
-- [Code examples](#code-examples)
-
 <Admonition type="caution">
   **Background on the Qiskit Primitives**
 


### PR DESCRIPTION
We decided these weren't necessary since the right sidebar (page table of contents) already has this functionality.

Removing it makes the guides a little smaller, so easier to read.