### PR TITLE
API docs use the new version selector mechanism

### DIFF
--- a/docs/api/qiskit-ibm-provider/_package.json
+++ b/docs/api/qiskit-ibm-provider/_package.json
@@ -1,0 +1,4 @@
+{
+  "name": "qiskit-ibm-provider",
+  "version": "0.7.2"
+}

--- a/docs/api/qiskit-ibm-provider/_toc.json
+++ b/docs/api/qiskit-ibm-provider/_toc.json
@@ -1,6 +1,5 @@
 {
   "title": "Qiskit IBM Provider",
-  "subtitle": "v0.7.1",
   "children": [
     {
       "title": "qiskit_ibm_provider",

--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,0 +1,4 @@
+{
+  "name": "qiskit-ibm-runtime",
+  "version": "0.14.0"
+}

--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -1,6 +1,5 @@
 {
   "title": "Qiskit Runtime IBM Client",
-  "subtitle": "v0.14.0",
   "children": [
     {
       "title": "qiskit_ibm_runtime",

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -267,7 +267,6 @@ async function convertHtmlToMarkdown(
     pkg: {
       title: pkg.title,
       name: pkg.name,
-      version,
       changelogUrl: `https://github.com/${pkg.githubSlug}/releases`,
       tocOptions: pkg.tocOptions,
     },
@@ -276,6 +275,13 @@ async function convertHtmlToMarkdown(
   await writeFile(
     `${markdownPath}/_toc.json`,
     JSON.stringify(toc, null, 2) + "\n",
+  );
+
+  console.log("Generating version file");
+  const pkg_json = { name: pkg.name, version: version };
+  await writeFile(
+    `${markdownPath}/_package.json`,
+    JSON.stringify(pkg_json, null, 2) + "\n",
   );
 
   console.log("Downloading images");

--- a/scripts/lib/sphinx/generateToc.test.ts
+++ b/scripts/lib/sphinx/generateToc.test.ts
@@ -95,7 +95,6 @@ describe("generateTocFromPythonApiFiles", () => {
             "url": "https://github.com/qiskit_ibm_runtime/releases",
           },
         ],
-        "subtitle": "v1.0.0",
         "title": "Qiskit Runtime IBM Client",
       }
     `);
@@ -181,7 +180,6 @@ describe("generateTocFromPythonApiFiles", () => {
             "url": "https://github.com/qiskit_ibm_runtime/releases",
           },
         ],
-        "subtitle": "v1.0.0",
         "title": "Qiskit Runtime IBM Client",
       }
     `);
@@ -302,7 +300,6 @@ describe("generateTocFromPythonApiFiles", () => {
             "url": "https://github.com/qiskit_ibm_runtime/releases",
           },
         ],
-        "subtitle": "v1.0.0",
         "title": "Qiskit Runtime IBM Client",
       }
     `);

--- a/scripts/lib/sphinx/generateToc.ts
+++ b/scripts/lib/sphinx/generateToc.ts
@@ -31,7 +31,6 @@ export function generateToc(options: {
   pkg: {
     title: string;
     name: string;
-    version: string;
     changelogUrl: string;
     tocOptions?: {
       collapsed?: boolean;
@@ -132,7 +131,6 @@ export function generateToc(options: {
 
   const toc: Toc = {
     title: pkg.title,
-    subtitle: `v${pkg.version}`,
     children: tocChildren,
   };
   if (pkg.tocOptions?.collapsed) {


### PR DESCRIPTION
This switches API docs to the new scheme described in https://github.com/Qiskit/documentation/issues/8. 

Even though we don't yet have any historical versions for Provider and Runtime, we will want to add them moving forward. We can switch over to the new version selector now.

A follow up PR will regenerate Qiskit docs. The version changed, so I want a dedicated PR for closer review of those generated docs. A follow up PR will also add historical versions to Qiskit docs.