### PR TITLE
Generate Runtime 0.15 docs

### DIFF
--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.IBMBackend.md
@@ -148,13 +148,13 @@ Return the system time resolution of input signals
 
 This is required to be implemented if the backend supports Pulse scheduling.
 
-**Returns**
-
-The input signal timestep in seconds. If the backend doesn’t define `dt` `None` will be returned
-
 **Return type**
 
-dt
+`Optional`\[`float`]
+
+**Returns**
+
+The input signal timestep in seconds. If the backend doesn’t define `dt`, `None` will be returned.
 
 <span id="qiskit_ibm_runtime.IBMBackend.dtm" />
 
@@ -292,6 +292,16 @@ instance of QiskitRuntimeService
 
 service
 
+<span id="qiskit_ibm_runtime.IBMBackend.session" />
+
+### session
+
+Return session
+
+**Return type**
+
+`Session`
+
 <span id="qiskit_ibm_runtime.IBMBackend.target" />
 
 ### target
@@ -311,6 +321,30 @@ Target
 ### version
 
 `= 2`
+
+<span id="qiskit_ibm_runtime.IBMBackend.name" />
+
+### name
+
+Name of the backend.
+
+<span id="qiskit_ibm_runtime.IBMBackend.description" />
+
+### description
+
+Optional human-readable description.
+
+<span id="qiskit_ibm_runtime.IBMBackend.online_date" />
+
+### online\_date
+
+Date that the backend came online.
+
+<span id="qiskit_ibm_runtime.IBMBackend.backend_version" />
+
+### backend\_version
+
+Version of the backend being provided. This is not the same as `BackendV2.version`, which is the version of the `Backend` abstract interface.
 
 ## Methods
 
@@ -342,6 +376,18 @@ The Qubit measurement acquisition line.
 
 AcquireChannel
 
+### cancel\_session
+
+<span id="qiskit_ibm_runtime.IBMBackend.cancel_session" />
+
+`cancel_session()`
+
+Cancel session. All pending jobs will be cancelled.
+
+**Return type**
+
+`None`
+
 ### check\_faulty
 
 <span id="qiskit_ibm_runtime.IBMBackend.check_faulty" />
@@ -357,6 +403,18 @@ Check if the input circuit uses faulty qubits or edges.
 **Raises**
 
 **ValueError** – If an instruction operating on a faulty qubit or edge is found.
+
+**Return type**
+
+`None`
+
+### close\_session
+
+<span id="qiskit_ibm_runtime.IBMBackend.close_session" />
+
+`close_session()`
+
+Close the session so new jobs will no longer be accepted, but existing queued or running jobs will run to completion. The session will be terminated once there are no more pending jobs.
 
 **Return type**
 
@@ -458,6 +516,18 @@ The Qubit measurement stimulus line
 
 MeasureChannel
 
+### open\_session
+
+<span id="qiskit_ibm_runtime.IBMBackend.open_session" />
+
+`open_session()`
+
+Open session
+
+**Return type**
+
+`Session`
+
 ### properties
 
 <span id="qiskit_ibm_runtime.IBMBackend.properties" />
@@ -502,13 +572,13 @@ If there are no defined or the backend doesn’t support querying these details 
 
 **qubit** (`Union`\[`int`, `List`\[`int`]]) – The qubit to get the `QubitProperties` object for. This can be a single integer for 1 qubit or a list of qubits and a list of `QubitProperties` objects will be returned in the same order
 
+**Return type**
+
+`Union`\[`QubitProperties`, `List`\[`QubitProperties`]]
+
 **Returns**
 
 The `QubitProperties` object for the specified qubit. If a list of qubits is provided a list will be returned. If properties are missing for a qubit this can be `None`.
-
-**Return type**
-
-qubit\_properties
 
 **Raises**
 
@@ -518,13 +588,76 @@ qubit\_properties
 
 <span id="qiskit_ibm_runtime.IBMBackend.run" />
 
-`run(*args, **kwargs)`
+`run(circuits, dynamic=None, job_tags=None, init_circuit=None, init_num_resets=None, header=None, shots=None, memory=None, meas_level=None, meas_return=None, rep_delay=None, init_qubits=None, use_measure_esp=None, noise_model=None, seed_simulator=None, **run_config)`
 
-Not supported method
+Run on the backend. If a keyword specified here is also present in the `options` attribute/object, the value specified here will be used for this run.
+
+**Parameters**
+
+*   **circuits** (`Union`\[`QuantumCircuit`, `str`, `List`\[`Union`\[`QuantumCircuit`, `str`]]]) – An individual or a list of `QuantumCircuit`.
+
+*   **dynamic** (`Optional`\[`bool`]) – Whether the circuit is dynamic (uses in-circuit conditionals)
+
+*   **job\_tags** (`Optional`\[`List`\[`str`]]) – Tags to be assigned to the job. The tags can subsequently be used as a filter in the `jobs()` function call.
+
+*   **init\_circuit** (`Optional`\[`QuantumCircuit`]) – A quantum circuit to execute for initializing qubits before each circuit. If specified, `init_num_resets` is ignored. Applicable only if `dynamic=True` is specified.
+
+*   **init\_num\_resets** (`Optional`\[`int`]) – The number of qubit resets to insert before each circuit execution.
+
+*   **or** (*The following parameters are applicable only if dynamic=False is specified*) –
+
+*   **to.** (*defaulted*) –
+
+*   **header** (`Optional`\[`Dict`]) – User input that will be attached to the job and will be copied to the corresponding result header. Headers do not affect the run. This replaces the old `Qobj` header.
+
+*   **shots** (`Union`\[`int`, `float`, `None`]) – Number of repetitions of each circuit, for sampling. Default: 4000 or `max_shots` from the backend configuration, whichever is smaller.
+
+*   **memory** (`Optional`\[`bool`]) – If `True`, per-shot measurement bitstrings are returned as well (provided the backend supports it). For OpenPulse jobs, only measurement level 2 supports this option.
+
+*   **meas\_level** (`Union`\[`int`, `MeasLevel`, `None`]) –
+
+    Level of the measurement output for pulse experiments. See [OpenPulse specification](https://arxiv.org/pdf/1809.03452.pdf) for details:
+
+    *   `0`, measurements of the raw signal (the measurement output pulse envelope)
+    *   `1`, measurement kernel is selected (a complex number obtained after applying the measurement kernel to the measurement output signal)
+    *   `2` (default), a discriminator is selected and the qubit state is stored (0 or 1)
+
+*   **meas\_return** (`Union`\[`str`, `MeasReturnType`, `None`]) –
+
+    Level of measurement data for the backend to return. For `meas_level` 0 and 1:
+
+    *   `single` returns information from every shot.
+    *   `avg` returns average measurement output (averaged over number of shots).
+
+*   **rep\_delay** (`Optional`\[`float`]) – Delay between programs in seconds. Only supported on certain backends (if `backend.configuration().dynamic_reprate_enabled=True`). If supported, `rep_delay` must be from the range supplied by the backend (`backend.configuration().rep_delay_range`). Default is given by `backend.configuration().default_rep_delay`.
+
+*   **init\_qubits** (`Optional`\[`bool`]) – Whether to reset the qubits to the ground state for each shot. Default: `True`.
+
+*   **use\_measure\_esp** (`Optional`\[`bool`]) – Whether to use excited state promoted (ESP) readout for measurements which are the terminal instruction to a qubit. ESP readout can offer higher fidelity than standard measurement sequences. See [here](https://arxiv.org/pdf/2008.08571.pdf). Default: `True` if backend supports ESP readout, else `False`. Backend support for ESP readout is determined by the flag `measure_esp_enabled` in `backend.configuration()`.
+
+*   **noise\_model** (`Optional`\[`Any`]) – Noise model. (Simulators only)
+
+*   **seed\_simulator** (`Optional`\[`int`]) – Random seed to control sampling. (Simulators only)
+
+*   **\*\*run\_config** – Extra arguments used to configure the run.
 
 **Return type**
 
-`None`
+[`RuntimeJob`](qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.runtime_job.RuntimeJob")
+
+**Returns**
+
+The job to be executed.
+
+**Raises**
+
+*   **IBMBackendApiError** – If an unexpected error occurred while submitting the job.
+
+*   **IBMBackendApiProtocolError** – If an unexpected value received from the server.
+
+*   **IBMBackendValueError** –
+
+    *   If an input parameter value is not valid. - If ESP readout is used and the backend does not support this.
 
 ### set\_options
 

--- a/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session.md
@@ -137,15 +137,19 @@ A dictionary with the sessions details, including
 
 <span id="qiskit_ibm_runtime.Session.from_id" />
 
-`classmethod from_id(session_id, service=None, backend=None)`
+`classmethod from_id(session_id, service, backend=None)`
 
 Construct a Session object with a given session\_id
 
 **Parameters**
 
-*   **session\_id** (`str`) – the id of the session to be created. This can be an already existing session id.
-*   **service** (`Optional`\[[`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService")]) – instance of the `QiskitRuntimeService` class.
+*   **session\_id** (`str`) – the id of the session to be created. This must be an already existing session id.
+*   **service** ([`QiskitRuntimeService`](qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.qiskit_runtime_service.QiskitRuntimeService")) – instance of the `QiskitRuntimeService` class.
 *   **backend** (`Union`\[`str`, [`IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.ibm_backend.IBMBackend"), `None`]) – instance of [`qiskit_ibm_runtime.IBMBackend`](qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend") class or string name of backend.
+
+**Raises**
+
+**IBMInputValueError** – If given session\_id does not exist. or the backend passed in does not match the original session backend.
 
 **Return type**
 

--- a/docs/api/qiskit-ibm-runtime/release-notes.md
+++ b/docs/api/qiskit-ibm-runtime/release-notes.md
@@ -6,15 +6,84 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes" />
 
-# Qiskit Runtime IBM Client 0.14 release notes
+# Qiskit Runtime IBM Client 0.15 release notes
+
+<span id="release-notes-0-15-0" />
+
+<span id="id1" />
+
+## 0.15.0
+
+<span id="release-notes-0-15-0-new-features" />
+
+### New Features
+
+*   A new module `qiskit_ibm_runtime.fake_provider`, has been added to provide access to a series of fake backends derived from snapshots of IBM Quantum devices. This functionality was originally provided by the `qiskit.providers.fake_provider` module, but will soon be deprecated in favor of `qiskit_ibm_runtime.fake_provider`.
+
+    The snapshots provided by the fake backends are useful for local testing of the transpiler and performing local noisy simulations of the system before running on real devices. Here is an example of using a fake backend for transpilation and simulation:
+
+    ```python
+    from qiskit import QuantumCircuit
+    from qiskit import transpile
+    from qiskit_ibm_runtime.fake_provider import FakeManilaV2
+
+    # Get a fake backend from the fake provider
+    backend = FakeManilaV2()
+
+    # Create a simple circuit
+    circuit = QuantumCircuit(3)
+    circuit.h(0)
+    circuit.cx(0,1)
+    circuit.cx(0,2)
+    circuit.measure_all()
+
+    # Transpile the ideal circuit to a circuit that can be directly executed by the backend
+    transpiled_circuit = transpile(circuit, backend)
+
+    # Run the transpiled circuit using the simulated fake backend
+    job = backend.run(transpiled_circuit)
+    counts = job.result().get_counts()
+    ```
+
+*   Added support for `backend.run()`. The functionality is similar to that in `qiskit-ibm-provider`.
+
+*   An error will be raised during initialization if `q-ctrl` is passed in as the `channel_strategy` and the account instance does not have `q-ctrl` enabled.
+
+*   Removed storing result in `RuntimeJob._results`. Instead retrieve results every time the `results()` method is called.
+
+<span id="release-notes-0-15-0-deprecation-notes" />
+
+### Deprecation Notes
+
+*   Usage of the `~/.qiskit/qiskitrc.json` file for account information has been deprecated. Use `~/.qiskit/qiskit-ibm.json` instead.
+
+<span id="release-notes-0-15-0-bug-fixes" />
+
+### Bug Fixes
+
+*   Fixed an issue where canceled and failed jobs would return an invalid result that resulted in a type error, preventing the actual error from being returned to the user.
+
+*   A warning will be raised at initialization if the DE environment is being used since not all features are supported there.
+
+*   The `backend` parameter in [`from_id()`](qiskit_ibm_runtime.Session#from_id "qiskit_ibm_runtime.Session.from_id") is being deprecated because sessions do not support multiple backends. Additionally, the `service` parameter is no longer optional.
+
+*   The `circuit_indices` and `observable_indices` run inputs for [`Estimator`](qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator") and [`Sampler`](qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler") have been completely removed.
+
+<span id="release-notes-0-15-0-other-notes" />
+
+### Other Notes
+
+*   Added migration code for running `backend.run` in qiskit\_ibm\_runtime instead of in qiskit\_ibm\_provider.
 
 <span id="release-notes-0-14-0" />
 
-<span id="id1" />
+<span id="id2" />
 
 ## 0.14.0
 
 <span id="release-notes-0-14-0-new-features" />
+
+<span id="id3" />
 
 ### New Features
 
@@ -24,19 +93,21 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-14-0-deprecation-notes" />
 
+<span id="id4" />
+
 ### Deprecation Notes
 
 *   Custom programs are being deprecated as of qiskit-ibm-runtime 0.14.0 and will be removed on November 27, 2023. Users can instead convert their custom programs to use Qiskit Runtime primitives with Quantum Serverless. Refer to the migration guide for instructions: [https://qiskit-extensions.github.io/quantum-serverless/migration/migration\_from\_qiskit\_runtime\_programs.html](https://qiskit-extensions.github.io/quantum-serverless/migration/migration_from_qiskit_runtime_programs.html)
 
 <span id="release-notes-0-13-0" />
 
-<span id="id2" />
+<span id="id5" />
 
 ## 0.13.0
 
 <span id="release-notes-0-13-0-new-features" />
 
-<span id="id3" />
+<span id="id6" />
 
 ### New Features
 
@@ -56,6 +127,8 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-13-0-bug-fixes" />
 
+<span id="id7" />
+
 ### Bug Fixes
 
 *   Fixed a bug where `shots` passed in as a numpy type were not being serialized correctly.
@@ -64,13 +137,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-2" />
 
-<span id="id4" />
+<span id="id8" />
 
 ## 0.12.2
 
 <span id="release-notes-0-12-2-new-features" />
 
-<span id="id5" />
+<span id="id9" />
 
 ### New Features
 
@@ -84,7 +157,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-2-upgrade-notes" />
 
-<span id="id6" />
+<span id="id10" />
 
 ### Upgrade Notes
 
@@ -92,13 +165,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-1" />
 
-<span id="id7" />
+<span id="id11" />
 
 ## 0.12.1
 
 <span id="release-notes-0-12-1-new-features" />
 
-<span id="id8" />
+<span id="id12" />
 
 ### New Features
 
@@ -110,7 +183,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-1-bug-fixes" />
 
-<span id="id9" />
+<span id="id13" />
 
 ### Bug Fixes
 
@@ -124,13 +197,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-0" />
 
-<span id="id10" />
+<span id="id14" />
 
 ## 0.12.0
 
 <span id="release-notes-0-12-0-new-features" />
 
-<span id="id11" />
+<span id="id15" />
 
 ### New Features
 
@@ -151,7 +224,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-0-upgrade-notes" />
 
-<span id="id12" />
+<span id="id16" />
 
 ### Upgrade Notes
 
@@ -159,7 +232,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-0-deprecation-notes" />
 
-<span id="id13" />
+<span id="id17" />
 
 ### Deprecation Notes
 
@@ -167,7 +240,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-12-0-bug-fixes" />
 
-<span id="id14" />
+<span id="id18" />
 
 ### Bug Fixes
 
@@ -179,13 +252,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-3" />
 
-<span id="id15" />
+<span id="id19" />
 
 ## 0.11.3
 
 <span id="release-notes-0-11-3-new-features" />
 
-<span id="id16" />
+<span id="id20" />
 
 ### New Features
 
@@ -201,13 +274,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-2" />
 
-<span id="id17" />
+<span id="id21" />
 
 ## 0.11.2
 
 <span id="release-notes-0-11-2-new-features" />
 
-<span id="id18" />
+<span id="id22" />
 
 ### New Features
 
@@ -230,7 +303,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-2-bug-fixes" />
 
-<span id="id19" />
+<span id="id23" />
 
 ### Bug Fixes
 
@@ -240,13 +313,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-1" />
 
-<span id="id20" />
+<span id="id24" />
 
 ## 0.11.1
 
 <span id="release-notes-0-11-1-deprecation-notes" />
 
-<span id="id21" />
+<span id="id25" />
 
 ### Deprecation Notes
 
@@ -254,13 +327,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-0" />
 
-<span id="id22" />
+<span id="id26" />
 
 ## 0.11.0
 
 <span id="release-notes-0-11-0-new-features" />
 
-<span id="id23" />
+<span id="id27" />
 
 ### New Features
 
@@ -282,7 +355,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-0-upgrade-notes" />
 
-<span id="id24" />
+<span id="id28" />
 
 ### Upgrade Notes
 
@@ -292,7 +365,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-11-0-deprecation-notes" />
 
-<span id="id25" />
+<span id="id29" />
 
 ### Deprecation Notes
 
@@ -300,13 +373,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-10-0" />
 
-<span id="id26" />
+<span id="id30" />
 
 ## 0.10.0
 
 <span id="release-notes-0-10-0-new-features" />
 
-<span id="id27" />
+<span id="id31" />
 
 ### New Features
 
@@ -314,7 +387,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-10-0-upgrade-notes" />
 
-<span id="id28" />
+<span id="id32" />
 
 ### Upgrade Notes
 
@@ -322,7 +395,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-10-0-bug-fixes" />
 
-<span id="id29" />
+<span id="id33" />
 
 ### Bug Fixes
 
@@ -332,13 +405,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-4" />
 
-<span id="id31" />
+<span id="id35" />
 
 ## 0.9.4
 
 <span id="release-notes-0-9-4-new-features" />
 
-<span id="id32" />
+<span id="id36" />
 
 ### New Features
 
@@ -346,7 +419,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-4-upgrade-notes" />
 
-<span id="id33" />
+<span id="id37" />
 
 ### Upgrade Notes
 
@@ -354,7 +427,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-4-deprecation-notes" />
 
-<span id="id34" />
+<span id="id38" />
 
 ### Deprecation Notes
 
@@ -368,7 +441,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-4-bug-fixes" />
 
-<span id="id35" />
+<span id="id39" />
 
 ### Bug Fixes
 
@@ -376,13 +449,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-3" />
 
-<span id="id36" />
+<span id="id40" />
 
 ## 0.9.3
 
 <span id="release-notes-0-9-3-upgrade-notes" />
 
-<span id="id37" />
+<span id="id41" />
 
 ### Upgrade Notes
 
@@ -392,7 +465,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-3-bug-fixes" />
 
-<span id="id38" />
+<span id="id42" />
 
 ### Bug Fixes
 
@@ -400,13 +473,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-2" />
 
-<span id="id39" />
+<span id="id43" />
 
 ## 0.9.2
 
 <span id="release-notes-0-9-2-new-features" />
 
-<span id="id40" />
+<span id="id44" />
 
 ### New Features
 
@@ -416,7 +489,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-2-upgrade-notes" />
 
-<span id="id41" />
+<span id="id45" />
 
 ### Upgrade Notes
 
@@ -428,7 +501,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-2-bug-fixes" />
 
-<span id="id42" />
+<span id="id46" />
 
 ### Bug Fixes
 
@@ -442,13 +515,13 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-1" />
 
-<span id="id43" />
+<span id="id47" />
 
 ## 0.9.1
 
 <span id="release-notes-0-9-1-upgrade-notes" />
 
-<span id="id44" />
+<span id="id48" />
 
 ### Upgrade Notes
 
@@ -468,7 +541,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-1-deprecation-notes" />
 
-<span id="id45" />
+<span id="id49" />
 
 ### Deprecation Notes
 
@@ -476,13 +549,15 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes-0-9-1-bug-fixes" />
 
-<span id="id46" />
+<span id="id50" />
 
 ### Bug Fixes
 
 *   `ECRGate` and `CZGate` mappings have been added to the `Target` constructor to fix a tranpile bug.
 
 <span id="release-notes-0-9-1-other-notes" />
+
+<span id="id51" />
 
 ### Other Notes
 


### PR DESCRIPTION
These changes are all auto-generated, including the new release notes.

Once we have https://github.com/Qiskit/documentation/issues/332, we can add back the 0.14 API docs by running it on this repository before we this PR was merged.