### PR TITLE
Port migration guide for Runtime 0.15

### DIFF
--- a/docs/api/migration-guides/_toc.json
+++ b/docs/api/migration-guides/_toc.json
@@ -15,6 +15,10 @@
           {
             "title": "Examples",
             "url": "/api/migration-guides/qiskit-runtime-examples"
+          },
+          {
+            "title": "qiskit_ibm_provider to qiskit_ibm_runtime",
+            "url": "/api/migration-guides/qiskit-runtime-from-provider"
           }
         ]
       },

--- a/docs/api/migration-guides/index.mdx
+++ b/docs/api/migration-guides/index.mdx
@@ -11,6 +11,7 @@ We've prepared various migration guides to help you more effectively use Qiskit 
 * Migrate to Qiskit Runtime
    * [How to migrate](./qiskit-runtime)
    * [Examples](./qiskit-runtime-examples)
+   * [Migrate `backend.run()` from `qiskit_ibm_provider` to `qiskit_ibm_runtime`](./qiskit-runtime-from-provider)
 * Qiskit 0.44 changes
    * [`qiskit.algorithms` new interface](./qiskit-algorithms-module)
    * [`qiskit.opflow` deprecation](./qiskit-opflow-module)

--- a/docs/api/migration-guides/qiskit-runtime-from-provider.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-from-provider.mdx
@@ -1,0 +1,102 @@
+---
+title: Migrate from qiskit_ibm_provider to qiskit_ibm_runtime
+description: How to migrate `backend.run()` from Qiskit IBM Provider to Qiskit IBM Runtime
+---
+
+# Migrate `backend.run()` from `qiskit_ibm_provider` to `qiskit_ibm_runtime`
+
+The Qiskit Runtime interface includes two packages:
+Qiskit IBM Provider (the [`qiskit_ibm_provider`](../qiskit-ibm-provider) package) and
+Qiskit IBM Runtime (the [`qiskit_ibm_runtime`](../qiskit-ibm-runtime) package). Until now,
+primitives (`Sampler` and `Estimator`)
+were run in Runtime. Custom circuits that were manually transpiled and used `IBMBackend.run()`
+were run in Provider.
+
+In the `qiskit-ibm-runtime` 0.15 release, we added support for running custom circuits using `IBMBackend.run()` in Runtime,
+so users can run all programs through Runtime.
+
+This guide describes how to migrate code that implemented `IBMBackend.run()`
+using Qiskit IBM Provider to use Qiskit IBM Runtime instead.
+
+**Example 1: Straightforward execution of IBMBackend.run()**
+
+```python
+from qiskit import *
+from qiskit.compiler import transpile, assemble
+
+circuit = QuantumCircuit(2, 2)
+circuit.h(0)
+circuit.cx(0, 1)
+circuit.measure_all()
+```
+
+In Provider, the code is:
+
+```python
+from qiskit_ibm_provider import IBMProvider
+
+provider = IBMProvider()
+backend = provider.get_backend("ibmq_qasm_simulator")
+transpiled_circuit = transpile(circuit, backend=backend)
+job = backend.run(transpiled_circuit)
+print(job.result())
+```
+
+In Runtime, the code is:
+
+```python
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+service = QiskitRuntimeService(channel="ibm_quantum")
+backend = service.backend("ibmq_qasm_simulator")
+transpiled_circuit = transpile(circuit, backend=backend)
+job = backend.run(transpiled_circuit)
+print(job.result())
+```
+
+**Example 2: Execution of backend.run() within a session:**
+
+This section of code is identical in Provider and in Runtime.
+
+```python
+with backend.open_session() as session:
+    job1 = backend.run(transpiled_circuit)
+    job2 = backend.run(transpiled_circuit)
+    print(job1.session_id)
+    print(job2.session_id)
+backend.cancel_session()
+```
+
+Sessions are implemented differently in `IBMBackend` than when using primitives.
+Therefore, we cannot run a primitive and use backend.run() within a single session. If you specify both, one will be run outside of the session.
+
+**Example 3: Primitive session containing backend.run:**
+
+In this example, `sampler` is run within session, but `backend` is run independently
+of the session.
+
+```python
+from qiskit_ibm_runtime import Session, Sampler
+
+with Session(backend=backend) as session:
+    sampler = Sampler(session=session)
+    job1 = sampler.run(transpiled_circuit)
+    job2 = backend.run(transpiled_circuit) # runs outside the session
+    print(job1.session_id)
+    print(job2.session_id)  # is None
+```
+
+**Example 4: Backend session containing Sampler:**
+
+In this example, `backend` is run within a session, but `sampler` is run independently
+of the session.
+
+```python
+with backend.open_session() as session:
+    sampler = Sampler(backend=backend)
+    job1 = sampler.run(transpiled_circuit)  # runs outside the session
+    job2 = backend.run(transpiled_circuit)
+    session_id = session.session_id
+    print(job1.session_id)  # is None
+    print(job2.session_id)
+```


### PR DESCRIPTION
Brings over https://github.com/Qiskit/qiskit-ibm-runtime/pull/1214. I did this by:

1. Copying and pasting the RST file
2. Running `st2myst convert docs/api/migration-guides/qiskit-runtime-backend-run.rst`, which generated a MD file
3. Renaming the file to end in `.mdx` and adding "front matter" (metadata)
4. Manually tweaking any issues
5. Attributing the original author in the Git commit with `git log --pretty="%an <%ae>" -- docs/migrate/backend_run_migration_guide.rst | sort -u | awk '{print "Co-authored-by: " $0}'` run in the qiskit-ibm-runtime repo

I'll set up a redirect in https://github.com/Qiskit/documentation/issues/216 for Nov 29.