### PR TITLE
[Learning uploader] Switch to URLs rather than just IDs

### DIFF
--- a/scripts/ibm-quantum-learning-uploader/src/learning_uploader/__init__.py
+++ b/scripts/ibm-quantum-learning-uploader/src/learning_uploader/__init__.py
@@ -79,14 +79,14 @@ def sync_lessons():
         hide_urls=hide_urls,
     )
 
-    lesson_ids = parse_yaml(api_name)
+    lesson_urls = parse_yaml(api_name)
     if len(sys.argv) > 1:
         paths = sys.argv[1:]
     else:
-        paths = lesson_ids.keys()
+        paths = lesson_urls.keys()
 
     for lesson_path in paths:
-        lesson = Lesson(lesson_path, lesson_ids[lesson_path])
+        lesson = Lesson(lesson_path, lesson_urls[lesson_path])
         api.push(lesson)
 
     print("✨ Sync complete! ✨\n")
@@ -94,11 +94,11 @@ def sync_lessons():
 
 def parse_yaml(api_name):
     """
-    Get dict of lesson paths and lesson IDs
+    Get dict of lesson paths and lesson URLs
     Args:
         api_name (str): "staging" or "production"
     Returns:
-        dict: { lesson_path: lesson_id }
+        dict: { lesson_path: lesson_url }
     """
     with open(CONF_FILE) as f:
         api_info = yaml.safe_load(f.read())
@@ -106,7 +106,7 @@ def parse_yaml(api_name):
     output = {}
     for lesson in api_info["lessons"]:
         path = lesson["path"]
-        lesson_id = lesson[f"id{api_name.lower().capitalize()}"]
-        output[path] = lesson_id
+        lesson_url = lesson[f"url{api_name.lower().capitalize()}"]
+        output[path] = lesson_url
 
     return output

--- a/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
+++ b/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
@@ -11,10 +11,10 @@ from yaspin.spinners import Spinners
 
 
 class Lesson:
-    def __init__(self, lesson_path, lesson_id):
+    def __init__(self, lesson_path, lesson_url):
         self.path = Path(lesson_path)
         self.name = self.path.parts[-1]
-        self.id = lesson_id
+        self.url = lesson_url
         self.zip_path = None
 
     def zip(self):
@@ -99,7 +99,7 @@ class API:
         if not self.hide_urls:
             print(f"   \033[30m╷\033[0m Web page: \033[96m{web_page}\033[0m")
             print(
-                f"   \033[30m╵\033[0m Lesson data: \033[96m{self.url}/admin/content/lessons/{lesson.id}\033[0m"
+                f"   \033[30m╵\033[0m Lesson data: \033[96m{self.url}/admin/content/{lesson.url}\033[0m"
             )
 
     def _push(self, lesson: Lesson, log):
@@ -120,7 +120,7 @@ class API:
         # 1. Get ID of english translation (needed for upload)
         log("Finding English translation...")
         response = requests.get(
-            f"{self.url}/items/lessons/{lesson.id}"
+            f"{self.url}/items/{lesson.url}"
             "?fields[]=translations.id,translations.languages_code",
             headers=self.auth_header,
         )
@@ -151,7 +151,7 @@ class API:
         log("Linking upload...")
         # 4. Link .zip to content
         response = requests.patch(
-            f"{self.url}/items/lessons/{lesson.id}",
+            f"{self.url}/items/{lesson.url}",
             json={
                 "translations": [{"id": translation_id, "temporal_file": temp_file_id}]
             },
@@ -166,7 +166,7 @@ class API:
         # 6. Return URLs
         log("Getting URLs...")
         response = requests.get(
-            f"{self.url}/items/lessons/{lesson.id}", headers=self.auth_header
+            f"{self.url}/items/{lesson.url}", headers=self.auth_header
         )
         response.raise_for_status()
         lesson_slug = response.json()["data"]["slug"]

--- a/scripts/ibm-quantum-learning-uploader/test/learning-platform.conf.yaml
+++ b/scripts/ibm-quantum-learning-uploader/test/learning-platform.conf.yaml
@@ -1,3 +1,3 @@
 lessons:
   - path: test-lesson
-    idStaging: 37bce289-fe09-4018-8a39-67749bcd5385
+    urlStaging: lessons/37bce289-fe09-4018-8a39-67749bcd5385


### PR DESCRIPTION
Originally, every page in the learning database was a "lesson", but it now has distinct "tutorial" pages. This uploader needs to handle both, so this PR changes the `id...` field of the conf file to `url...` fields.
