### PR TITLE
Audited qiskit.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qiskit docs
 
-The documentation content home for https://docs.quantum-computing.ibm.com. Note this repo does not contain content for https://learning.quantum-computing.ibm.com/ or https://qiskit.org. Refer to https://github.com/Qiskit/qiskit to make changes to the docs at https://qiskit.org/documentation.
+The documentation content home for https://docs.quantum-computing.ibm.com (excluding API reference).
 
 # Improving IBM Quantum & Qiskit Documentation
 
@@ -173,5 +173,5 @@ To check that formatting is valid without actually making changes, run `npm run 
 ## Regenerate the API docs
 
 1. Choose which documentation you want to regenerate: `qiskit`, `qiskit-ibm-provider`, or `qiskit-ibm-runtime`
-2. Determine the current version of the published stable documentation, e.g. at https://qiskit.org/documentation/
+2. Determine the current version of the published stable documentation, e.g. at https://github.com/Qiskit/qiskit/releases
 3. Run `npm run gen-api -- -p <pkg-name> -v <version>`, e.g. `npm run gen-api -- -p qiskit -v 0.45.0`

--- a/docs/api/migration-guides/qiskit-runtime.mdx
+++ b/docs/api/migration-guides/qiskit-runtime.mdx
@@ -470,7 +470,6 @@ an algorithm, you might want to tune certain primitive options. For details, see
     - [Get started with Sampler.](../../run/primitives-get-started#start-sampler)
     - Explore [sessions.](../../run/sessions)
     - [Run a primitive in a session.](../../run/run-jobs-in-session)
-    - Experiment with the [migration tutorial.](./qiskit-runtime) 
     - Experiment with the [Run custom transpiled circuits with primitives tutorial.](https://learning.quantum-computing.ibm.com/tutorial/submitting-user-transpiled-circuits-using-primitives)
 
 </Admonition>

--- a/docs/api/migration-guides/qiskit-runtime.mdx
+++ b/docs/api/migration-guides/qiskit-runtime.mdx
@@ -30,7 +30,7 @@ level.
 
 The Qiskit Runtime primitives implement the reference `Sampler` and
 `Estimator` interfaces found in
-[qiskit.primitives](https://qiskit.org/documentation/apidoc/primitives.html).
+[qiskit.primitives](../qiskit/primitives).
 These interfaces let you switch between primitive implementations with
 minimal code changes. Different primitive implementations can be found
 in the `qiskit`, `qiskit_aer`, and `qiskit_ibm_runtime` libraries. Each
@@ -470,7 +470,7 @@ an algorithm, you might want to tune certain primitive options. For details, see
     - [Get started with Sampler.](../../run/primitives-get-started#start-sampler)
     - Explore [sessions.](../../run/sessions)
     - [Run a primitive in a session.](../../run/run-jobs-in-session)
-    - Experiment with the [migration tutorial.](https://qiskit.org/ecosystem/ibm-provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html) 
+    - Experiment with the [migration tutorial.](./qiskit-runtime) 
     - Experiment with the [Run custom transpiled circuits with primitives tutorial.](https://learning.quantum-computing.ibm.com/tutorial/submitting-user-transpiled-circuits-using-primitives)
 
 </Admonition>

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -25,8 +25,8 @@ The following pages are resources for anyone interested in contributing code to 
 
 - [Code of conduct](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
 - [Contributing guide](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md)
-- [Deprecation policy](https://qiskit.org/documentation/deprecation_policy.html)
-- [Maintainers guide](https://qiskit.org/documentation/maintainers_guide.html)
+- [Deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md)
+- [Maintainers guide](hhttps://github.com/Qiskit/qiskit/blob/main/MAINTAINING.md)
 
 ## Other discussions
 

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -26,7 +26,7 @@ The following pages are resources for anyone interested in contributing code to 
 - [Code of conduct](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
 - [Contributing guide](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md)
 - [Deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md)
-- [Maintainers guide](hhttps://github.com/Qiskit/qiskit/blob/main/MAINTAINING.md)
+- [Maintainers guide](https://github.com/Qiskit/qiskit/blob/main/MAINTAINING.md)
 
 ## Other discussions
 

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -23,8 +23,8 @@ For help with Qiskit, access our Slack community: [Qiskit Slack](https://qisk.it
 
 The following pages are resources for anyone interested in contributing code to Qiskit.
 
-- [Code of conduct](https://github.com/Qiskit/qiskit-metapackage/blob/master/CODE_OF_CONDUCT.md)
-- [Contributing guide](https://qiskit.org/documentation/contributing_to_qiskit.html#contributing-links)
+- [Code of conduct](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
+- [Contributing guide](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md)
 - [Deprecation policy](https://qiskit.org/documentation/deprecation_policy.html)
 - [Maintainers guide](https://qiskit.org/documentation/maintainers_guide.html)
 


### PR DESCRIPTION
This PR replaces any qiskit.org links with 1XP or github equivalents. Need to wait to merge until I can update the deprecation policy and maintainer guide links after https://github.com/Qiskit/qiskit/pull/11218/ merges.

This should partially resolve #297 , however for the api links we'll need to make updates for those directly in the repos where the API refs live (maybe this is beyond the scope of the original issue?)