### PR TITLE
Enable CI to run on merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 name: Lint
-on: [pull_request]
+on: [pull_request, merge_group]
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions