### PR TITLE
Use the minor version in _package.json

### DIFF
--- a/docs/api/qiskit-ibm-provider/_package.json
+++ b/docs/api/qiskit-ibm-provider/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-provider",
-  "version": "0.7.2"
+  "version": "0.7"
 }

--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.15.0"
+  "version": "0.15"
 }

--- a/docs/api/qiskit/0.44/_package.json
+++ b/docs/api/qiskit/0.44/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit",
-  "version": "0.44.0"
+  "version": "0.44"
 }

--- a/docs/api/qiskit/_package.json
+++ b/docs/api/qiskit/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit",
-  "version": "0.45.0"
+  "version": "0.45"
 }

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -410,7 +410,7 @@ async function convertHtmlToMarkdown(
   }
 
   console.log("Generating version file");
-  const pkg_json = { name: pkg.name, version: version };
+  const pkg_json = { name: pkg.name, version: versionWithoutPatch };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",


### PR DESCRIPTION
The PR changes the` _package.json` in every API to use only the minor version instead of the full version.

This is a temporary change to unblock the deployment of Qiskit 0.44, which, in the navigation menu, will only show the minor version without each patch following the directory structure created in https://github.com/Qiskit/documentation/pull/377.