### PR TITLE
Update Qiskit platform support for Qiskit 1.0

### DIFF
--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -105,7 +105,7 @@ Additionally, Qiskit only supports CPython. Running with other Python interprete
   Tier 1 operating systems:
 
   - Linux x86_64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification).
-  - macOS x86_64 (10.9 or later)
+  - macOS x86_64 (10.12 or later)
   - Windows 64 bit
 </details>
 
@@ -117,8 +117,6 @@ Additionally, Qiskit only supports CPython. Running with other Python interprete
 
   Tier 2 operating systems:
 
-  - Linux i686 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification) for Python releases earlier than 3.10
-  - Windows 32 bit for Python releases earlier than 3.10
   - Linux AArch64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
 </details>
 
@@ -133,8 +131,8 @@ Additionally, Qiskit only supports CPython. Running with other Python interprete
   - Linux ppc64le (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/)packaging specification)
   - Linux s390x (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
   - macOS ARM64 (10.15 or newer)
-  - Linux i686 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification) for Python 3.10 or later
-  - Windows 32 bit for Python 3.10 or later
+  - Linux i686 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
+  - Windows 32 bit
 </details>
 
 ## Troubleshooting


### PR DESCRIPTION
As part of Qiskit 1.0 we've increased the minimum requirements and platform support tiers (see #10902). This commit makes these updates to the hosted documentation so that the documented support tiers for each platform reflects the current state for Qiskit 1.0.0.