### PR TITLE
Add Q-CTRL info to install and run sections

### DIFF
--- a/docs/run/_toc.json
+++ b/docs/run/_toc.json
@@ -27,16 +27,16 @@
       "title": "Configure runtime options",
       "children": [
         {
-          "title": "Advanced runtime options",
-          "url": "/run/advanced-runtime-options"
-        },
-        {
           "title": "Configure runtime compilation",
           "url": "/run/configure-runtime-compilation"
         },
         {
           "title": "Configure runtime error mitigation",
           "url": "/run/configure-error-mitigation"
+        },
+        {
+          "title": "Advanced runtime options",
+          "url": "/run/advanced-runtime-options"
         }
       ]
     },

--- a/docs/run/configure-error-mitigation.mdx
+++ b/docs/run/configure-error-mitigation.mdx
@@ -56,6 +56,15 @@ basis. Specific error mitigation methods are not guaranteed to be
 applied at each resilience level.
 </Admonition>
 
+<Admonition type="note">
+  If using an IBM Cloud Qiskit Runtime service instance with Q-CTRL performance management enabled, there is no need to specify runtime optimization or resilience levels, as the strategy includes an automatic preset.
+  
+  Setting `optimization_level` or `resilience_level` equal to 0 will result in an
+  execution error. Levels 1, 2, and 3 are permitted but will not impact performance.
+  Setting other options will likewise not impact performance, and it may result in a
+  runtime warning. For more information visit Q-CTRL documentation (TODO: ADD LINK).
+</Admonition>
+
 ## Configure the Estimator with resilience levels
 
 

--- a/docs/run/configure-error-mitigation.mdx
+++ b/docs/run/configure-error-mitigation.mdx
@@ -62,7 +62,7 @@ applied at each resilience level.
   Setting `optimization_level` or `resilience_level` equal to 0 will result in an
   execution error. Levels 1, 2, and 3 are permitted but will not impact performance.
   Setting other options will likewise not impact performance, and it may result in a
-  runtime warning. For more information visit Q-CTRL documentation (TODO: ADD LINK).
+  runtime warning. For more information visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
 </Admonition>
 
 ## Configure the Estimator with resilience levels

--- a/docs/run/configure-runtime-compilation.mdx
+++ b/docs/run/configure-runtime-compilation.mdx
@@ -65,7 +65,7 @@ At present, the primitives will attempt low-cost transformations if given a circ
   Setting `optimization_level` or `resilience_level` equal to 0 will result in an
   execution error. Levels 1, 2, and 3 are permitted but will not impact performance.
   Setting other options will likewise not impact performance, and it may result in a
-  runtime warning. For more information visit Q-CTRL documentation (TODO: ADD LINK).
+  runtime warning. For more information visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
 </Admonition>
 
 ### Example: configure Estimator with optimization levels

--- a/docs/run/configure-runtime-compilation.mdx
+++ b/docs/run/configure-runtime-compilation.mdx
@@ -58,6 +58,16 @@ At present, the primitives will attempt low-cost transformations if given a circ
   For instructions on preparing circuits for primitive queries, see the [Submitting user-transpiled circuits using primitives](https://learning.quantum-computing.ibm.com/tutorial/submitting-user-transpiled-circuits-using-primitives) tutorial.
 </Admonition>
 
+<Admonition type="note">
+  If using an IBM Cloud Qiskit Runtime service instance with Q-CTRL performance management enabled, there is no need to specify runtime optimization or resilience levels, as the strategy includes an automatic preset.
+  
+  Q-CTRL defaults to `optimization_level=3` and `resilience_level=1`.
+  Setting `optimization_level` or `resilience_level` equal to 0 will result in an
+  execution error. Levels 1, 2, and 3 are permitted but will not impact performance.
+  Setting other options will likewise not impact performance, and it may result in a
+  runtime warning. For more information visit Q-CTRL documentation (TODO: ADD LINK).
+</Admonition>
+
 ### Example: configure Estimator with optimization levels
 
 ```python

--- a/docs/start/setup-channel.mdx
+++ b/docs/start/setup-channel.mdx
@@ -55,7 +55,26 @@ You need access credentials to use cloud-based IBM Quantum systems.
     python3
     ```
 
-1. Optionally use the `save_account()` method to save your credentials for easy access, as shown in the code block.
+1. Authenticate to the service by calling `QiskitRuntimeService` with your IBM Cloud API key and CRN:
+
+   ```python
+   from qiskit_ibm_runtime import QiskitRuntimeService
+
+   service = QiskitRuntimeService(channel="ibm_quantum", token="<MY_IBM_QUANTUM_TOKEN>")
+
+   ```
+  
+   Or, optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.
+
+    ```python
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    # Save an IBM Quantum account and set it as your default account.
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token="<MY_IBM_QUANTUM_TOKEN>", set_as_default=True)
+
+    # Load saved credentials
+    service = QiskitRuntimeService()
+    ```
 
     * If you save your credentials to disk, you can use `QiskitRuntimeService()` in the future to initialize your account. The `channel` parameter distinguishes between different account types. If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them. 
     * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them. 
@@ -67,29 +86,9 @@ You need access credentials to use cloud-based IBM Quantum systems.
       Account credentials are saved in plain text, so only do so if you are using a trusted device.
     </Admonition>
 
-<Admonition type="note">
-IBM Cloud is the default account used if you don't specify a different channel or account name. 
-</Admonition>
-
-```python
-from qiskit_ibm_runtime import QiskitRuntimeService
-
-# Save an IBM Quantum account and set it as your default account.
-QiskitRuntimeService.save_account(channel="ibm_quantum", token="<MY_IBM_QUANTUM_TOKEN>", set_as_default=True)
-```
-
-1. Authenticate to the service by calling `QiskitRuntimeService` with your saved credentials or with your IBM Cloud API key and CRN:
-
-   ```python
-   from qiskit_ibm_runtime import QiskitRuntimeService
-
-   # Use this command if you didn't save your credentials:
-   # service = QiskitRuntimeService(channel="ibm_quantum", token="<MY_IBM_QUANTUM_TOKEN>")
-
-   # Load saved credentials
-   service = QiskitRuntimeService()
-
-   ```
+    <Admonition type="note">
+    IBM Cloud is the default account used if you don't specify a different channel or account name. 
+    </Admonition>
 
 1. Test your setup.  Run a simple circuit using Sampler to ensure that your environment is set up properly:
 
@@ -115,17 +114,43 @@ QiskitRuntimeService.save_account(channel="ibm_quantum", token="<MY_IBM_QUANTUM_
     python3
     ```
 1. If you do not already have one, set up an IBM Cloud account from the [IBM Cloud Registration page](https://cloud.ibm.com/registration).
-1. Create a service instance, if necessary. Open your [IBM Cloud Instances page](https://cloud.ibm.com/quantum/instances). If you have one or more instances shown, continue to the next step. Otherwise, click **Create instance**, then agree to the license agreements by checking the box in the bottom right corner of the page, and click **Create**.
+1. Create a service instance, if necessary. Open your [IBM Cloud Instances page](https://cloud.ibm.com/quantum/instances). If you have one or more instances shown, continue to the next step. Otherwise, click **Create instance**. When creating your instance you can name it, tag it, select a resource group for it, and select a performance strategy. Then agree to the license agreements by checking the box in the bottom right corner of the page, and click **Create**.
 
     <Admonition type="note">
       If you are an administrator who needs to set up Qiskit Runtime on Cloud for your organization, refer to [Plan Qiskit Runtime for an organization](https://cloud.ibm.com/docs/quantum-computing?topic=quantum-computing-quickstart-org).
+    </Admonition>
+
+    <Admonition type="note">
+     When selecting a performance strategy there are two options available. One from IBM (default) another from Q-CTRL. The IBM performance strategy allows you to leverage all of the standard options available with [Qiskit Runtime](../api/qiskit-ibm-runtime) and the Q-CTRL strategy uses an automated preset.  To learn more about the Q-CTRL option, click here.  (TODO: ADD LINK)
     </Admonition>
 
 1. Find your access credentials.
     1. Find your API key. From the [API keys page](https://cloud.ibm.com/iam/apikeys), view or create your API key, then copy it to a secure location so you can use it for authentication.
     2. Find your Cloud Resource Name (CRN). Open the [Instances page](https://cloud.ibm.com/quantum/instances) and click your instance. In the page that opens, click the icon to copy your CRN. Save it in a secure location so you can use it for authentication.
 
-1. Optionally  use the save_account() method to save your credentials for easy access (see below).
+1. Authenticate to the service by calling `QiskitRuntimeService` with your saved credentials or with your IBM Cloud API key and CRN:
+
+   ```python
+   from qiskit_ibm_runtime import QiskitRuntimeService
+
+   service = QiskitRuntimeService(channel="ibm_cloud", token="<IBM Cloud API key>", instance="<IBM Cloud CRN>")
+   ```
+
+   <Admonition type="note">
+     If you set up your instance in step 3 to include Q-CTRL performance management, when initializing the `QiskitRuntimeService()` you should include the additional argument `channel_strategy="q-ctrl"`. To learn more about Q-CTRL performance management strategy check out the Q-CTRL documentation (TODO: ADD LINK)
+   </Admonition>
+
+   Or, optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.
+
+   ```python
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    # Save account to disk. 
+    QiskitRuntimeService.save_account(channel="ibm_cloud", token="<IBM Cloud API key>", instance="<IBM Cloud CRN>", name="<account-name>")
+
+    # Load saved credentials
+    service = QiskitRuntimeService(name="<account-name>")
+    ```
 
     * If you save your credentials to disk, you can use `QiskitRuntimeService()` in the future to initialize your account. The `channel` parameter distinguishes between different account types. When initializing the account, IBM Cloud is the default account used if have saved credentials for an IBM Quantum Platform and an IBM Cloud account.
     * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them. 
@@ -135,26 +160,6 @@ QiskitRuntimeService.save_account(channel="ibm_quantum", token="<MY_IBM_QUANTUM_
     <Admonition type="important">
         Account credentials are saved in plain text, so only do so if you are using a trusted device.
     </Admonition>
-
-    ```python
-    from qiskit_ibm_runtime import QiskitRuntimeService
-
-    # Save account to disk. 
-    QiskitRuntimeService.save_account(channel="ibm_cloud", token="<IBM Cloud API key>", instance="<IBM Cloud CRN>", name="<account-name>")
-    ```
-
-1. Authenticate to the service by calling `QiskitRuntimeService` with your saved credentials or with your IBM Cloud API key and CRN:
-
-   ```python
-   from qiskit_ibm_runtime import QiskitRuntimeService
-
-   # Use this command if you didn't save your credentials:
-   # service = QiskitRuntimeService(channel="ibm_cloud", token="<IBM Cloud API key>", instance="<IBM Cloud CRN>")
-
-   # Load saved credentials
-   service = QiskitRuntimeService(name="<account-name>")
-
-   ```
 
  1. Test your setup.  Run a simple circuit using Sampler to ensure that your environment is set up properly:
 

--- a/docs/start/setup-channel.mdx
+++ b/docs/start/setup-channel.mdx
@@ -114,7 +114,7 @@ You need access credentials to use cloud-based IBM Quantum systems.
     python3
     ```
 1. If you do not already have one, set up an IBM Cloud account from the [IBM Cloud Registration page](https://cloud.ibm.com/registration).
-1. Create a service instance, if necessary. Open your [IBM Cloud Instances page](https://cloud.ibm.com/quantum/instances). If you have one or more instances shown, continue to the next step. Otherwise, click **Create instance**. When creating your instance you can name it, tag it, select a resource group for it, and select a performance strategy. Then agree to the license agreements by checking the box in the bottom right corner of the page, and click **Create**.
+1. Create a service instance, if necessary. Open your [IBM Cloud Instances page](https://cloud.ibm.com/quantum/instances). If you have one or more instances shown, continue to the next step. Otherwise, click **Create instance**. When creating your instance you can name it, tag it, select a resource group for it, and select a performance strategy. Next, agree to the license agreements by checking the box in the bottom right corner of the page, and click **Create**.
 
     <Admonition type="note">
       If you are an administrator who needs to set up Qiskit Runtime on Cloud for your organization, refer to [Plan Qiskit Runtime for an organization](https://cloud.ibm.com/docs/quantum-computing?topic=quantum-computing-quickstart-org).
@@ -140,7 +140,7 @@ You need access credentials to use cloud-based IBM Quantum systems.
      If you set up your instance in step 3 to include Q-CTRL performance management, when initializing the `QiskitRuntimeService()` you should include the additional argument `channel_strategy="q-ctrl"`. To learn more about Q-CTRL performance management strategy visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
    </Admonition>
 
-   Or, optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.
+   You can optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.
 
    ```python
     from qiskit_ibm_runtime import QiskitRuntimeService
@@ -152,7 +152,7 @@ You need access credentials to use cloud-based IBM Quantum systems.
     service = QiskitRuntimeService(name="<account-name>")
     ```
 
-    * If you save your credentials to disk, you can use `QiskitRuntimeService()` in the future to initialize your account. The `channel` parameter distinguishes between different account types. When initializing the account, IBM Cloud is the default account used if have saved credentials for an IBM Quantum Platform and an IBM Cloud account.
+    * If you save your credentials to disk, you can use `QiskitRuntimeService()` in the future to initialize your account. The `channel` parameter distinguishes between different account types. When initializing the account, IBM Cloud is the default account used if you have saved credentials for both an IBM Quantum Platform and an IBM Cloud account.
     * If you are saving multiple accounts per channel, consider using the `name` parameter to differentiate them. 
     * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file. 
     * If you don't save your credentials, you must specify them every time you start a new session. 

--- a/docs/start/setup-channel.mdx
+++ b/docs/start/setup-channel.mdx
@@ -121,7 +121,7 @@ You need access credentials to use cloud-based IBM Quantum systems.
     </Admonition>
 
     <Admonition type="note">
-     When selecting a performance strategy there are two options available. One from IBM (default) another from Q-CTRL. The IBM performance strategy allows you to leverage all of the standard options available with [Qiskit Runtime](../api/qiskit-ibm-runtime) and the Q-CTRL strategy uses an automated preset.  To learn more about the Q-CTRL option, click here.  (TODO: ADD LINK)
+     When selecting a performance strategy there are two options available. One from IBM (default) another from Q-CTRL. The IBM performance strategy allows you to leverage all of the standard options available with [Qiskit Runtime](../api/qiskit-ibm-runtime) and the Q-CTRL strategy uses an automated preset.  To learn more about the Q-CTRL option, visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
     </Admonition>
 
 1. Find your access credentials.
@@ -137,7 +137,7 @@ You need access credentials to use cloud-based IBM Quantum systems.
    ```
 
    <Admonition type="note">
-     If you set up your instance in step 3 to include Q-CTRL performance management, when initializing the `QiskitRuntimeService()` you should include the additional argument `channel_strategy="q-ctrl"`. To learn more about Q-CTRL performance management strategy check out the Q-CTRL documentation (TODO: ADD LINK)
+     If you set up your instance in step 3 to include Q-CTRL performance management, when initializing the `QiskitRuntimeService()` you should include the additional argument `channel_strategy="q-ctrl"`. To learn more about Q-CTRL performance management strategy visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
    </Admonition>
 
    Or, optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.


### PR DESCRIPTION
This PR updates the install and run sections to include note boxes about upcoming Q-CTRL features.

**View a preview of the install updates:** 
https://qiskit-docs-preview-pr-397.1799mxdls7qz.us-south.codeengine.appdomain.cloud/start/setup-channel#set-up-to-use-ibm-cloud (note box in step 3 and another note box in step 5)

**View a preview of the run updates:**
- https://qiskit-docs-preview-pr-397.1799mxdls7qz.us-south.codeengine.appdomain.cloud/run/configure-runtime-compilation (second notebox under the table)
- https://qiskit-docs-preview-pr-397.1799mxdls7qz.us-south.codeengine.appdomain.cloud/run/configure-error-mitigation (second note box under the table)

(at the same time I also reshuffled a few things for general improvements to install and run)

These changes should be merged and deployed on Tues 28th November