### PR TITLE
Revert "Use the minor version in _package.json"

### DIFF
--- a/docs/api/qiskit-ibm-provider/_package.json
+++ b/docs/api/qiskit-ibm-provider/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-provider",
-  "version": "0.7"
+  "version": "0.7.2"
 }

--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.15"
+  "version": "0.15.0"
 }

--- a/docs/api/qiskit/0.44/_package.json
+++ b/docs/api/qiskit/0.44/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit",
-  "version": "0.44"
+  "version": "0.44.0"
 }

--- a/docs/api/qiskit/_package.json
+++ b/docs/api/qiskit/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit",
-  "version": "0.45"
+  "version": "0.45.0"
 }

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -419,7 +419,7 @@ async function convertHtmlToMarkdown(
   }
 
   console.log("Generating version file");
-  const pkg_json = { name: pkg.name, version: versionWithoutPatch };
+  const pkg_json = { name: pkg.name, version: version };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",


### PR DESCRIPTION
This PR reverts Qiskit/documentation#394. The change was a temporary solution until we had a different way of building the version URLs.