### PR TITLE
Add support for Qiskit versions previous to 0.44

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -191,7 +191,8 @@ zxMain(async () => {
       throw new Error("`--historical` can only be used with `-p qiskit`");
     }
     pkg.baseUrl = `https://qiskit.org/documentation/stable/${versionWithoutPatch}`;
-    pkg.initialUrls = [`${pkg.baseUrl}/apidoc/index.html`];
+    const htmlFile = +versionWithoutPatch >= 0.44 ? "index.html" : "terra.html";
+    pkg.initialUrls = [`${pkg.baseUrl}/apidoc/${htmlFile}`];
   }
 
   const destination = `${getRoot()}/.out/python/sources/${pkg.name}/${

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -191,8 +191,7 @@ zxMain(async () => {
       throw new Error("`--historical` can only be used with `-p qiskit`");
     }
     pkg.baseUrl = `https://qiskit.org/documentation/stable/${versionWithoutPatch}`;
-    const htmlFile = +versionWithoutPatch >= 0.44 ? "index.html" : "terra.html";
-    pkg.initialUrls = [`${pkg.baseUrl}/apidoc/${htmlFile}`];
+    pkg.initialUrls = [`${pkg.baseUrl}/apidoc/index.html`];
   }
 
   const destination = `${getRoot()}/.out/python/sources/${pkg.name}/${
@@ -420,7 +419,7 @@ async function convertHtmlToMarkdown(
   }
 
   console.log("Generating version file");
-  const pkg_json = { name: pkg.name, version: version };
+  const pkg_json = { name: pkg.name, version: versionWithoutPatch };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -420,7 +420,7 @@ async function convertHtmlToMarkdown(
   }
 
   console.log("Generating version file");
-  const pkg_json = { name: pkg.name, version: versionWithoutPatch };
+  const pkg_json = { name: pkg.name, version: version };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",


### PR DESCRIPTION
This PR adds support for downloading versions of Qiskit previous to 0.44. The old version of Qiskit used https://qiskit.org/documentation/apidoc/terra.html instead of https://qiskit.org/documentation/apidoc/index.html