### PR TITLE
Fix broken links qiskit.pulse

### DIFF
--- a/docs/api/qiskit/_toc.json
+++ b/docs/api/qiskit/_toc.json
@@ -2338,16 +2338,32 @@
           "url": "/api/qiskit/qiskit.pulse.instructions.Call"
         },
         {
+          "title": "Constant",
+          "url": "/api/qiskit/qiskit.pulse.library.Constant_class.rst"
+        },
+        {
           "title": "ControlChannel",
           "url": "/api/qiskit/qiskit.pulse.channels.ControlChannel"
+        },
+        {
+          "title": "Cos",
+          "url": "/api/qiskit/qiskit.pulse.library.Cos_class.rst"
         },
         {
           "title": "Delay",
           "url": "/api/qiskit/qiskit.pulse.instructions.Delay"
         },
         {
+          "title": "Drag",
+          "url": "/api/qiskit/qiskit.pulse.library.Drag_class.rst"
+        },
+        {
           "title": "DriveChannel",
           "url": "/api/qiskit/qiskit.pulse.channels.DriveChannel"
+        },
+        {
+          "title": "Gaussian",
+          "url": "/api/qiskit/qiskit.pulse.library.Gaussian_class.rst"
         },
         {
           "title": "gaussian_square_echo",
@@ -2398,12 +2414,20 @@
           "url": "/api/qiskit/qiskit.pulse.instructions.RelativeBarrier"
         },
         {
+          "title": "Sawtooth",
+          "url": "/api/qiskit/qiskit.pulse.library.Sawtooth_class.rst"
+        },
+        {
           "title": "Schedule",
           "url": "/api/qiskit/qiskit.pulse.Schedule"
         },
         {
           "title": "ScheduleBlock",
           "url": "/api/qiskit/qiskit.pulse.ScheduleBlock"
+        },
+        {
+          "title": "Sech",
+          "url": "/api/qiskit/qiskit.pulse.library.Sech_fun.rst"
         },
         {
           "title": "SechDeriv",
@@ -2426,6 +2450,10 @@
           "url": "/api/qiskit/qiskit.pulse.instructions.ShiftPhase"
         },
         {
+          "title": "Sin",
+          "url": "/api/qiskit/qiskit.pulse.library.Sin_class.rst"
+        },
+        {
           "title": "Snapshot",
           "url": "/api/qiskit/qiskit.pulse.instructions.Snapshot"
         },
@@ -2434,12 +2462,20 @@
           "url": "/api/qiskit/qiskit.pulse.channels.SnapshotChannel"
         },
         {
+          "title": "Square",
+          "url": "/api/qiskit/qiskit.pulse.library.Square_fun.rst"
+        },
+        {
           "title": "SymbolicPulse",
           "url": "/api/qiskit/qiskit.pulse.library.SymbolicPulse"
         },
         {
           "title": "TimeBlockade",
           "url": "/api/qiskit/qiskit.pulse.instructions.TimeBlockade"
+        },
+        {
+          "title": "Triangle",
+          "url": "/api/qiskit/qiskit.pulse.library.Triangle_class.rst"
         },
         {
           "title": "Waveform",

--- a/docs/api/qiskit/qiskit.pulse.library.Constant_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Constant_class.rst.md
@@ -1,0 +1,45 @@
+---
+title: Constant
+description: API reference for qiskit.pulse.library.Constant
+in_page_toc_min_heading_level: 1
+python_api_type: class
+python_api_name: qiskit.pulse.library.Constant
+---
+
+# Constant
+
+<span id="qiskit.pulse.library.Constant" />
+
+`qiskit.pulse.library.Constant(duration, amp, angle=None, name=None, limit_amplitude=None)`
+
+Bases: [`object`](https://docs.python.org/3/library/functions.html#object "(in Python v3.12)")
+
+A simple constant pulse, with an amplitude value and a duration:
+
+$$
+f(x) = \text{amp}\times\exp\left(i\text{angle}\right)    ,  0 <= x < duration
+f(x) = 0      ,  elsewhere
+$$
+
+Create new pulse instance.
+
+**Parameters**
+
+*   **duration** – Pulse length in terms of the sampling period dt.
+*   **amp** – The magnitude of the amplitude of the square envelope. Complex amp support is deprecated.
+*   **angle** – The angle of the complex amplitude of the square envelope. Default value 0.
+*   **name** – Display name for this pulse envelope.
+*   **limit\_amplitude** – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+## Attributes
+
+<span id="qiskit.pulse.library.Constant.alias" />
+
+### alias
+
+`= 'Constant'`
+

--- a/docs/api/qiskit/qiskit.pulse.library.Cos_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Cos_class.rst.md
@@ -1,0 +1,44 @@
+---
+title: Cos
+description: API reference for qiskit.pulse.library.Cos
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Cos
+---
+
+<span id="qiskit-pulse-library-cos" />
+
+# qiskit.pulse.library.Cos
+
+<span id="qiskit.pulse.library.Cos" />
+
+`qiskit.pulse.library.Cos(duration, amp, phase, freq=None, angle=0.0, name=None, limit_amplitude=None)`
+
+A cosine pulse.
+
+The envelope of the pulse is given by:
+
+$$
+f(x) = \text{A}\cos\left(2\pi\text{freq}x+\text{phase}\right)  ,  0 <= x < duration
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the cosine wave. Wave range is \[-amp,\`amp\`].
+*   **phase** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The phase of the cosine wave (note that this is not equivalent to the angle of the complex amplitude).
+*   **freq** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The frequency of the cosine wave, in terms of 1 over sampling period. If not provided defaults to a single cycle (i.e :math:’frac\{1}\{text\{duration}}’). The frequency is limited to the range $\left(0,0.5\right]$ (the Nyquist frequency).
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+

--- a/docs/api/qiskit/qiskit.pulse.library.Drag_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Drag_class.rst.md
@@ -1,0 +1,59 @@
+---
+title: Drag
+description: API reference for qiskit.pulse.library.Drag
+in_page_toc_min_heading_level: 1
+python_api_type: class
+python_api_name: qiskit.pulse.library.Drag
+---
+
+# Drag
+
+<span id="qiskit.pulse.library.Drag" />
+
+`qiskit.pulse.library.Drag(duration, amp, sigma, beta, angle=None, name=None, limit_amplitude=None)`
+
+Bases: [`object`](https://docs.python.org/3/library/functions.html#object "(in Python v3.12)")
+
+The Derivative Removal by Adiabatic Gate (DRAG) pulse is a standard Gaussian pulse with an additional Gaussian derivative component and lifting applied.
+
+It can be calibrated either to reduce the phase error due to virtual population of the $|2\rangle$ state during the pulse or to reduce the frequency spectrum of a standard Gaussian pulse near the $|1\rangle\leftrightarrow|2\rangle$ transition, reducing the chance of leakage to the $|2\rangle$ state.
+
+$$
+\begin{split}g(x) &= \exp\Bigl(-\frac12 \frac{(x - \text{duration}/2)^2}{\text{sigma}^2}\Bigr)\\
+g'(x) &= \text{A}\times\frac{g(x)-g(-1)}{1-g(-1)}\\
+f(x) &=  g'(x) \times \Bigl(1 + 1j \times \text{beta} \times            \Bigl(-\frac{x - \text{duration}/2}{\text{sigma}^2}\Bigr)  \Bigr),
+    \quad 0 \le x < \text{duration}\end{split}
+$$
+
+where $g(x)$ is a standard unlifted Gaussian waveform, $g'(x)$ is the lifted [`Gaussian`](qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian "qiskit.pulse.library.Gaussian") waveform, and $\text{A} = \text{amp} \times \exp\left(i\times\text{angle}\right)$.
+
+## References
+
+1.  [*Gambetta, J. M., Motzoi, F., Merkel, S. T. & Wilhelm, F. K. Analytic control methods for high-fidelity unitary operations in a weakly nonlinear oscillator. Phys. Rev. A 83, 012308 (2011).*](https://link.aps.org/doi/10.1103/PhysRevA.83.012308)
+
+2.  [*F. Motzoi, J. M. Gambetta, P. Rebentrost, and F. K. Wilhelm Phys. Rev. Lett. 103, 110501 – Published 8 September 2009.*](https://link.aps.org/doi/10.1103/PhysRevLett.103.110501)
+
+Create new pulse instance.
+
+**Parameters**
+
+*   **duration** – Pulse length in terms of the sampling period dt.
+*   **amp** – The magnitude of the amplitude of the DRAG envelope. Complex amp support is deprecated.
+*   **sigma** – A measure of how wide or narrow the Gaussian peak is; described mathematically in the class docstring.
+*   **beta** – The correction amplitude.
+*   **angle** – The angle of the complex amplitude of the DRAG envelope. Default value 0.
+*   **name** – Display name for this pulse envelope.
+*   **limit\_amplitude** – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+## Attributes
+
+<span id="qiskit.pulse.library.Drag.alias" />
+
+### alias
+
+`= 'Drag'`
+

--- a/docs/api/qiskit/qiskit.pulse.library.Gaussian_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Gaussian_class.rst.md
@@ -1,0 +1,48 @@
+---
+title: Gaussian
+description: API reference for qiskit.pulse.library.Gaussian
+in_page_toc_min_heading_level: 1
+python_api_type: class
+python_api_name: qiskit.pulse.library.Gaussian
+---
+
+# Gaussian
+
+<span id="qiskit.pulse.library.Gaussian" />
+
+`qiskit.pulse.library.Gaussian(duration, amp, sigma, angle=None, name=None, limit_amplitude=None)`
+
+Bases: [`object`](https://docs.python.org/3/library/functions.html#object "(in Python v3.12)")
+
+A lifted and truncated pulse envelope shaped according to the Gaussian function whose mean is centered at the center of the pulse (duration / 2):
+
+$$
+\begin{split}f'(x) &= \exp\Bigl( -\frac12 \frac{{(x - \text{duration}/2)}^2}{\text{sigma}^2} \Bigr)\\
+f(x) &= \text{A} \times  \frac{f'(x) - f'(-1)}{1-f'(-1)}, \quad 0 \le x < \text{duration}\end{split}
+$$
+
+where $f'(x)$ is the gaussian waveform without lifting or amplitude scaling, and $\text{A} = \text{amp} \times \exp\left(i\times\text{angle}\right)$.
+
+Create new pulse instance.
+
+**Parameters**
+
+*   **duration** – Pulse length in terms of the sampling period dt.
+*   **amp** – The magnitude of the amplitude of the Gaussian envelope. Complex amp support is deprecated.
+*   **sigma** – A measure of how wide or narrow the Gaussian peak is; described mathematically in the class docstring.
+*   **angle** – The angle of the complex amplitude of the Gaussian envelope. Default value 0.
+*   **name** – Display name for this pulse envelope.
+*   **limit\_amplitude** – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+## Attributes
+
+<span id="qiskit.pulse.library.Gaussian.alias" />
+
+### alias
+
+`= 'Gaussian'`
+

--- a/docs/api/qiskit/qiskit.pulse.library.Sawtooth_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Sawtooth_class.rst.md
@@ -1,0 +1,45 @@
+---
+title: Sawtooth
+description: API reference for qiskit.pulse.library.Sawtooth
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Sawtooth
+---
+
+<span id="qiskit-pulse-library-sawtooth" />
+
+# qiskit.pulse.library.Sawtooth
+
+<span id="qiskit.pulse.library.Sawtooth" />
+
+`qiskit.pulse.library.Sawtooth(duration, amp, phase, freq=None, angle=0.0, name=None, limit_amplitude=None)`
+
+A sawtooth pulse.
+
+The envelope of the pulse is given by:
+
+$$
+f(x) = 2\text{A}\left[g\left(x\right)-
+    \lfloor g\left(x\right)+\frac{1}{2}\rfloor\right]
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$, $g\left(x\right)=x\times\text{freq}+\frac{\text{phase}}{2\pi}$, and $\lfloor ...\rfloor$ is the floor operation.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the sawtooth wave. Wave range is \[-amp,\`amp\`].
+*   **phase** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The phase of the sawtooth wave (note that this is not equivalent to the angle of the complex amplitude)
+*   **freq** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The frequency of the sawtooth wave, in terms of 1 over sampling period. If not provided defaults to a single cycle (i.e :math:’frac\{1}\{text\{duration}}’). The frequency is limited to the range $\left(0,0.5\right]$ (the Nyquist frequency).
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+

--- a/docs/api/qiskit/qiskit.pulse.library.Sech_fun.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Sech_fun.rst.md
@@ -1,0 +1,53 @@
+---
+title: Sech
+description: API reference for qiskit.pulse.library.Sech
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Sech
+---
+
+<span id="qiskit-pulse-library-sech" />
+
+# qiskit.pulse.library.Sech
+
+<span id="qiskit.pulse.library.Sech" />
+
+`qiskit.pulse.library.Sech(duration, amp, sigma, angle=0.0, name=None, zero_ends=True, limit_amplitude=None)`
+
+An unnormalized sech pulse.
+
+The sech function is centered around the halfway point of the pulse, and the envelope of the pulse is given by:
+
+$$
+f(x) = \text{A}\text{sech}\left(
+    \frac{x-\mu}{\text{sigma}}\right)  ,  0 <= x < duration
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$, and $\mu=\text{duration}/2$.
+
+If zero\_ends is set to True, the output y is modified: .. math:
+
+```python
+y\left(x\right) \mapsto \text{A}\frac{y-y^{*}}{\text{A}-y^{*}},
+```
+
+where $y^{*}$ is the value of $y$ at the endpoints (at $x=-1 and :math:`x=\text{duration}+1$). This shifts the endpoints value to zero, while also rescaling to preserve the amplitude at :math:text\{duration}/2\`\`.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the pulse (the value at the midpoint duration/2).
+*   **sigma** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – A measure of how wide or narrow the sech peak is in terms of dt; described mathematically in the class docstring.
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **zero\_ends** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If True, zeros the ends at x = -1, x = duration + 1, but rescales to preserve amp. Default value True.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+

--- a/docs/api/qiskit/qiskit.pulse.library.Sin_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Sin_class.rst.md
@@ -1,0 +1,44 @@
+---
+title: Sin
+description: API reference for qiskit.pulse.library.Sin
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Sin
+---
+
+<span id="qiskit-pulse-library-sin" />
+
+# qiskit.pulse.library.Sin
+
+<span id="qiskit.pulse.library.Sin" />
+
+`qiskit.pulse.library.Sin(duration, amp, phase, freq=None, angle=0.0, name=None, limit_amplitude=None)`
+
+A sinusoidal pulse.
+
+The envelope of the pulse is given by:
+
+$$
+f(x) = \text{A}\sin\left(2\pi\text{freq}x+\text{phase}\right)  ,  0 <= x < duration
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the sinusoidal wave. Wave range is \[-amp,\`amp\`].
+*   **phase** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The phase of the sinusoidal wave (note that this is not equivalent to the angle of the complex amplitude)
+*   **freq** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The frequency of the sinusoidal wave, in terms of 1 over sampling period. If not provided defaults to a single cycle (i.e :math:’frac\{1}\{text\{duration}}’). The frequency is limited to the range $\left(0,0.5\right]$ (the Nyquist frequency).
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+

--- a/docs/api/qiskit/qiskit.pulse.library.Square_fun.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Square_fun.rst.md
@@ -1,0 +1,45 @@
+---
+title: Square
+description: API reference for qiskit.pulse.library.Square
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Square
+---
+
+<span id="qiskit-pulse-library-square" />
+
+# qiskit.pulse.library.Square
+
+<span id="qiskit.pulse.library.Square" />
+
+`qiskit.pulse.library.Square(duration, amp, phase, freq=None, angle=0.0, name=None, limit_amplitude=None)`
+
+A square wave pulse.
+
+The envelope of the pulse is given by:
+
+$$
+f(x) = \text{A}\text{sign}\left[\sin
+    \left(2\pi x\times\text{freq}+\text{phase}\right)\right]  ,  0 <= x < duration
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$, and $\text{sign}$ is the sign function with the convention $\text{sign}\left(0\right)=1$.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the square wave. Wave range is \[-amp,\`amp\`].
+*   **phase** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The phase of the square wave (note that this is not equivalent to the angle of the complex amplitude).
+*   **freq** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The frequency of the square wave, in terms of 1 over sampling period. If not provided defaults to a single cycle (i.e :math:’frac\{1}\{text\{duration}}’). The frequency is limited to the range $\left(0,0.5\right]$ (the Nyquist frequency).
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+

--- a/docs/api/qiskit/qiskit.pulse.library.Triangle_class.rst.md
+++ b/docs/api/qiskit/qiskit.pulse.library.Triangle_class.rst.md
@@ -1,0 +1,44 @@
+---
+title: Triangle
+description: API reference for qiskit.pulse.library.Triangle
+in_page_toc_min_heading_level: 1
+python_api_type: function
+python_api_name: qiskit.pulse.library.Triangle
+---
+
+<span id="qiskit-pulse-library-triangle" />
+
+# qiskit.pulse.library.Triangle
+
+<span id="qiskit.pulse.library.Triangle" />
+
+`qiskit.pulse.library.Triangle(duration, amp, phase, freq=None, angle=0.0, name=None, limit_amplitude=None)`
+
+A triangle wave pulse.
+
+The envelope of the pulse is given by:
+
+$$
+f(x) = \text{A}\left[\text{sawtooth}\left(x\right)\right]  ,  0 <= x < duration
+$$
+
+where $\text{A} = \text{amp} \times\exp\left(i\times\text{angle}\right)$, and $\text{sawtooth}\left(x\right)$ is a sawtooth wave with the same frequency as the triangle wave, but a phase shifted by $\frac{\pi}{2}$.
+
+**Parameters**
+
+*   **duration** ([*int*](https://docs.python.org/3/library/functions.html#int "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – Pulse length in terms of the sampling period dt.
+*   **amp** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The magnitude of the amplitude of the triangle wave. Wave range is \[-amp,\`amp\`].
+*   **phase** ([*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)")  *|*[*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")) – The phase of the triangle wave (note that this is not equivalent to the angle of the complex amplitude)
+*   **freq** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The frequency of the triangle wave, in terms of 1 over sampling period. If not provided defaults to a single cycle (i.e :math:’frac\{1}\{text\{duration}}’). The frequency is limited to the range $\left(0,0.5\right]$ (the Nyquist frequency).
+*   **angle** ([*ParameterExpression*](qiskit.circuit.ParameterExpression "qiskit.circuit.parameterexpression.ParameterExpression")  *|*[*float*](https://docs.python.org/3/library/functions.html#float "(in Python v3.12)") *| None*) – The angle in radians of the complex phase factor uniformly scaling the pulse. Default value 0.
+*   **name** ([*str*](https://docs.python.org/3/library/stdtypes.html#str "(in Python v3.12)") *| None*) – Display name for this pulse envelope.
+*   **limit\_amplitude** ([*bool*](https://docs.python.org/3/library/functions.html#bool "(in Python v3.12)") *| None*) – If `True`, then limit the amplitude of the waveform to 1. The default is `True` and the amplitude is constrained to 1.
+
+**Returns**
+
+ScalableSymbolicPulse instance.
+
+**Return type**
+
+*ScalableSymbolicPulse*
+


### PR DESCRIPTION
This PR adds some missing docs for qiskit.pulse. We weren't downloading these files due to an error of redirections in qiskit.org, which is now solved. See https://github.com/Qiskit/qiskit/issues/11239 for more information.