### PR TITLE
[merge AFTER transpile tab goes live] Add transpile to start/index page

### DIFF
--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -22,7 +22,7 @@ Already know what you’re looking for?
 
 - [Build](../build): Design and develop quantum circuits with primitives and advanced methods like dynamic circuits and mid-circuit measurements. You can also find our circuit library here.
 
-- [Transpile](../transpile): Compile locally to transform your circuits to be hardware-executable, with varying degrees of error awareness.
+- [Transpile](../transpile): Compile locally to optimize your circuits to run efficiently on hardware, with varying degrees of error awareness.
 
 - [Verify](../verify): Validate and evaluate your quantum circuits.
 

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -22,6 +22,8 @@ Already know what you’re looking for?
 
 - [Build](../build): Design and develop quantum circuits with primitives and advanced methods like dynamic circuits and mid-circuit measurements. You can also find our circuit library here.
 
+- [Transpile](../transpile): Compile locally to transform your circuits to be hardware-executable, with varying degrees of error awareness.
+
 - [Verify](../verify): Validate and evaluate your quantum circuits.
 
 - [Run](../run): Run on our hardware with job configuration options such as sessions.


### PR DESCRIPTION
Once the transpile tab is live, this PR can be merged, which adds a brief description and pointer to the Transpile section alongside the other sections described there.