### PR TITLE
Fix permalinks for old Qiskit API docs

### DIFF
--- a/scripts/lib/sphinx/sphinxHtmlToMarkdown.ts
+++ b/scripts/lib/sphinx/sphinxHtmlToMarkdown.ts
@@ -88,6 +88,7 @@ export async function sphinxHtmlToMarkdown(options: {
     });
 
   // remove permalink links
+  $main.find('a[title="Permalink to this headline"]').remove();
   $main.find('a[title="Permalink to this heading"]').remove();
   $main.find('a[title="Permalink to this definition"]').remove();
   $main.find('a[title="Link to this heading"]').remove();


### PR DESCRIPTION
In https://github.com/Qiskit/documentation/pull/418, we have some lines like this:

```
Qiskit Aer API Reference[¶](#qiskit-aer-api-reference "Permalink to this headline")
```

That's happening because Sphinx changed the word "headline" to "header" in later versions, and we weren't accounting for "headline".