### PR TITLE
Fix typo

### DIFF
--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -942,7 +942,7 @@ q: ┤ U3(2,-π/2,π/2) ├
 ## Expectations
 
 Expectations are converters that enable an observable's expectation value to be computed with respect to some state function.
-This functionn can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Remember that there
+This function can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Remember that there
 are different `Estimator` implementations, as noted [previously.](#attention_primitives)
 
 ### Algorithm-Agnostic Expectations


### PR DESCRIPTION
Fix a typo in a migration guide. I would also like to update the cSpell file with other words that the linter picked up, but they are already in this repo's cSpell. @Eric-Arellano should the cSpell file on the inner repo side get updated by the one in this repo when we sync?