### PR TITLE
Fix API generation when the folder doesn't exist

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -183,6 +183,19 @@ zxMain(async () => {
     ? `${getRoot()}/docs/api/${pkg.name}/${pkg.versionWithoutPatch}`
     : `${getRoot()}/docs/api/${pkg.name}`;
 
+  if (!(await pathExists(outputDir))) {
+    mkdirp(outputDir);
+  }
+
+  // All projects have a single release notes file except Qiskit, which has a
+  // subfolder to store the release notes for each historical version.
+  if (
+    pkg.name == "qiskit" &&
+    !(await pathExists(`${outputDir}/release-notes`))
+  ) {
+    mkdirp(`${outputDir}/release-notes`);
+  }
+
   pkg.releaseNoteEntries = await findLegacyReleaseNotes(pkg);
 
   await rmFilesInFolder(outputDir, `${pkg.name}:${pkg.versionWithoutPatch}`);
@@ -341,9 +354,9 @@ async function convertHtmlToMarkdown(
   }
 
   if (pkg.historical) {
-    copyReleaseNotesToHistoricalVersions(pkg.name, markdownPath);
+    await copyReleaseNotesToHistoricalVersions(pkg.name, markdownPath);
   } else {
-    syncReleaseNotes(pkg.name, markdownPath);
+    await syncReleaseNotes(pkg.name, markdownPath);
   }
 
   console.log("Generating version file");

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -183,17 +183,8 @@ zxMain(async () => {
     ? `${getRoot()}/docs/api/${pkg.name}/${pkg.versionWithoutPatch}`
     : `${getRoot()}/docs/api/${pkg.name}`;
 
-  if (!(await pathExists(outputDir))) {
-    mkdirp(outputDir);
-  }
-
-  // All projects have a single release notes file except Qiskit, which has a
-  // subfolder to store the release notes for each historical version.
-  if (
-    pkg.name == "qiskit" &&
-    !(await pathExists(`${outputDir}/release-notes`))
-  ) {
-    mkdirp(`${outputDir}/release-notes`);
+  if (pkg.historical && !(await pathExists(outputDir))) {
+    await createHistoricalFolder(pkg.name, outputDir);
   }
 
   pkg.releaseNoteEntries = await findLegacyReleaseNotes(pkg);
@@ -377,4 +368,17 @@ async function convertHtmlToMarkdown(
 
 function urlToPath(url: string) {
   return `${getRoot()}/docs${url}.md`;
+}
+
+async function createHistoricalFolder(pkgName: string, outputDir: string) {
+  mkdirp(outputDir);
+
+  // All projects have a single release notes file except Qiskit, which has a
+  // subfolder to store the release notes for each historical version.
+  if (
+    pkgName == "qiskit" &&
+    !(await pathExists(`${outputDir}/release-notes`))
+  ) {
+    mkdirp(`${outputDir}/release-notes`);
+  }
 }


### PR DESCRIPTION
This PR adds a method to create the historical folders of the historical version we try to generate in case this folder doesn't exist. Previously, the script failed without doing anything.

Closes #425 