### PR TITLE
Link to learning in transpile section next steps

### DIFF
--- a/docs/transpile/common-parameters.mdx
+++ b/docs/transpile/common-parameters.mdx
@@ -102,4 +102,6 @@ These options influence how the transpiler works and are used to try and get bet
 <Admonition type="tip" title="Recommendation">
     - [Default options and configuration settings](defaults-and-configuration-options)
     - [Set the optimization level](set-optimization)
+    - [Submit transpiled circuits](https://learning.quantum.ibm.com/tutorial/submit-transpiled-circuits) with Qiskit Runtime on IBM Quantum Learning
+    - Take the [Variational algorithm design](https://learning.quantum.ibm.com/course/variational-algorithm-design) course on IBM Quantum Learning
 </Admonition>


### PR DESCRIPTION
Closes #439

The https://learning.quantum.ibm.com/tutorial/reduce-transpiled-circuit-depth-with-circuit-cutting tutorial does not exist any more, but I've included a link to the variational algorithm design course instead as those circuits are good candidates for the approximate transpiling mentioned on the page.

Would also like to link to the quantum volume page on learning when that's online.
