### PR TITLE
Updating processor type links

### DIFF
--- a/docs/run/processor-types.mdx
+++ b/docs/run/processor-types.mdx
@@ -21,7 +21,7 @@ Quantum volume: 512
 
 At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that pulls in substantial innovations in signal delivery that were previously deployed in [Osprey](#osprey). The signals required to enable the fast, high-fidelity two-qubit and single-qubit control are delivered with high-density flex cabling.
 
-*   [View available Heron systems](https://quantum-computing.ibm.com/services/resources?type=Heron)
+*   [View available Heron systems](https://quantum-computing.ibm.com/services/resources?tab=systems&type=Heron)
 
 ## Osprey
 
@@ -29,7 +29,7 @@ At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that
 
 Osprey is nearly quadruple the size of Eagle at 433 qubits. The larger chip sizes have required further enhancements to device packaging, as well as custom flex cabling in the cryostat to fit the greater I/O requirements within the same wiring footprint.
 
-*   [View available Osprey systems](https://quantum.ibm.com/services/resources?type=Osprey)
+*   [View available Osprey systems](https://quantum.ibm.com/services/resources?tab=systems&type=Osprey)
 
 ## Eagle
 
@@ -41,7 +41,7 @@ At 127 qubits, the Eagle processor family incorporates more scalable packaging t
 
 See [this blog post](https://research.ibm.com/blog/127-qubit-quantum-processor-eagle) for more about the Eagle processor family.
 
-*   [View available Eagle systems](https://quantum.ibm.com/services/resources?type=Eagle)
+*   [View available Eagle systems](https://quantum.ibm.com/services/resources?tab=systems&type=Eagle)
 
 <Admonition type="info" title="Revisions">
   `r3` (December 2022) Eagle r3 is a version of the 127-qubit processor with enhanced coherence properties but otherwise similar design parameters to Eagle r1.
@@ -57,7 +57,7 @@ Quantum volume: 128
 
 Using a heavy-hexagonal qubit layout, the Hummingbird family allows up to 65 qubits.
 
-*   [View available Hummingbird systems](https://quantum.ibm.com/services/resources?type=Hummingbird)
+*   [View available Hummingbird systems](https://quantum.ibm.com/services/resources?tab=systems&type=Hummingbird)
 
 <Admonition type="info" title="Revisions">
   `r3` (December 2021) This version of Hummingbird with 65 qubits has enhanced coherence properties.
@@ -75,7 +75,7 @@ Quantum volume: 512
 
 Egret brings the innovations of tunable couplers onto a 33-qubit platform, resulting in faster and higher-fidelity two-qubit gates.
 
-*   [View available Egret systems](https://quantum.ibm.com/services/resources?type=Egret)
+*   [View available Egret systems](https://quantum.ibm.com/services/resources?tab=systems&type=Egret)
 
 <Admonition type="info" title="Revisions">
   `r1` (December 2022) The first realization of the Egret processor has demonstrated the highest Quantum Volume among IBM Quantum systems and a substantial improvement in two-qubit gate error rates ([https://research.ibm.com/blog/quantum-volume-256](https://research.ibm.com/blog/quantum-volume-256)). This new quantum processor boasts a substantial speedup and fidelity improvement (many gates approaching 99.9%) in two-qubit gates while reducing spectator errors.
@@ -89,7 +89,7 @@ Quantum volume: 128
 
 The Falcon family of devices offers a valuable platform for medium-scale circuits, and also serves as a valuable platform for demonstrating performance and scalability improvements before they’re pushed onto the larger devices.
 
-*   [View available Falcon systems](https://quantum.ibm.com/services/resources?type=Falcon)
+*   [View available Falcon systems](https://quantum.ibm.com/services/resources?tab=systems&type=Falcon)
 
 <Admonition type="info" title="Revisions">
   `r8` (September 2021) In addition to the features of r5.11, Falcon r8 has enhanced coherence properties.
@@ -108,7 +108,7 @@ The Falcon family of devices offers a valuable platform for medium-scale circuit
 ![Canary processor icon](/images/migration/canary.svg)
 
 The Canary family comprises small designs containing anywhere from 5 to 16 qubits. It uses an optimized 2D lattice.  That is, all of the qubits and readout resonators are on the same layer.
-*   [View available Canary systems](https://quantum.ibm.com/services/resources?type=Canary)
+*   [View available Canary systems](https://quantum.ibm.com/services/resources?tab=systems&type=Canary)
 
 <Admonition type="info" title="Revisions">
   `r1.3` (December 2019) A stripped-down offering containing only a single qubit.


### PR DESCRIPTION
Pointing them to "All systems" tab instead of "Instance resources".