### PR TITLE
update straggler quantum-computing domain urls

### DIFF
--- a/docs/run/processor-types.mdx
+++ b/docs/run/processor-types.mdx
@@ -21,7 +21,7 @@ Quantum volume: 512
 
 At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that pulls in substantial innovations in signal delivery that were previously deployed in [Osprey](#osprey). The signals required to enable the fast, high-fidelity two-qubit and single-qubit control are delivered with high-density flex cabling.
 
-*   [View available Heron systems](https://quantum-computing.ibm.com/services/resources?tab=systems&type=Heron)
+*   [View available Heron systems](https://quantum.ibm.com/services/resources?tab=systems&type=Heron)
 
 ## Osprey
 

--- a/docs/run/run-jobs-in-session.mdx
+++ b/docs/run/run-jobs-in-session.mdx
@@ -173,4 +173,4 @@ with Session(service=service, backend="ibmq_qasm_simulator") as session:
     print(session.details())
 ```
 
- You can also view session details on the [Quantum Platform Jobs page](https://quantum-computing.ibm.com/jobs) or on the IBM Cloud Jobs page, which you access from your [Instances page](https://cloud.ibm.com/quantum/instances). 
+ You can also view session details on the [Quantum Platform Jobs page](https://quantum.ibm.com/jobs) or on the IBM Cloud Jobs page, which you access from your [Instances page](https://cloud.ibm.com/quantum/instances). 

--- a/docs/transpile/common-parameters.mdx
+++ b/docs/transpile/common-parameters.mdx
@@ -94,7 +94,7 @@ These options influence how the transpiler works and are used to try and get bet
 * `unitary_synthesis_method` (str) - The name of the unitary synthesis method to use. By default `default` is used. 
 
 <Admonition>
-  To see a list of all installed plugins for a given stage you can run [`list_stage_plugins("stage_name")`](https://docs.quantum-computing.ibm.com/api/qiskit/transpiler_plugins#plugin-api). For example if you want to see a list of all installed plugins for the routing stage run `list_stage_plugins(routing)`.
+  To see a list of all installed plugins for a given stage you can run [`list_stage_plugins("stage_name")`](https://docs.quantum.ibm.com/api/qiskit/transpiler_plugins#plugin-api). For example if you want to see a list of all installed plugins for the routing stage run `list_stage_plugins(routing)`.
 </Admonition>  
 
 ## Next steps

--- a/docs/transpile/defaults-and-configuration-options.mdx
+++ b/docs/transpile/defaults-and-configuration-options.mdx
@@ -57,7 +57,7 @@ transpiled_circ.draw(output='mpl')
 Following are all of the available parameters for the `transpile()` method.  There are two classes of arguments: those that describe the target of compilation, and those that influence how the transpiler works.
 
 
-All parameters except `circuits` are optional.  For full details, see the [Transpiler API documentation](https://docs.quantum-computing.ibm.com/api/qiskit/transpiler#transpiler-api).
+All parameters except `circuits` are optional.  For full details, see the [Transpiler API documentation](/api/qiskit/transpiler#transpiler-api).
 
 `circuits` (`_CircuitT`) - One or more circuits to transpile. This is the only required parameter.
 
@@ -211,5 +211,5 @@ qiskit.compiler.transpile(unitary_synthesis_method='default', translation_method
     - [Set the optimization level when using Qiskit Runtime.](../run/advanced-runtime-options)
     - [Transpile with pass managers](transpile-with-pass-managers)
     - For examples, see [Representing quantum computers](representing_quantum_computers)
-    - [Transpile API](https://docs.quantum-computing.ibm.com/api/qiskit/transpiler)
+    - [Transpile API](/api/qiskit/transpiler)
 </Admonition>


### PR DESCRIPTION
Related to #453 

Find all remaining urls using the quantum-computing.ibm.com domain and change to quantum.ibm.com.

This does not remove from the api docs; those will need to be fixed in their home repos.