### PR TITLE
Fix code examples

### DIFF
--- a/docs/build/circuit-visualization.ipynb
+++ b/docs/build/circuit-visualization.ipynb
@@ -116,7 +116,11 @@
    "source": [
     "### Alternative renderers\n",
     "\n",
-    "A text output is useful for quickly seeing the output while developing a circuit, but it doesn't provide the most flexibility. There are two alternative output renderers for the quantum circuit. One uses [matplotlib](https://matplotlib.org/), and the other uses [LaTeX](https://www.latex-project.org/), which leverages the [qcircuit package](https://github.com/CQuIC/qcircuit). These can be specified with `mpl` and `latex` values for the `output` kwarg on the draw() method."
+    "A text output is useful for quickly seeing the output while developing a circuit, but it doesn't provide the most flexibility. There are two alternative output renderers for the quantum circuit. One uses [matplotlib](https://matplotlib.org/), and the other uses [LaTeX](https://www.latex-project.org/), which leverages the [qcircuit package](https://github.com/CQuIC/qcircuit). These can be specified with `mpl` and `latex` values for the `output` kwarg on the draw() method.\n",
+    "\n",
+    "<Admonition type=\"tip\">\n",
+    "  OSX users can get the required LaTeX packages through the [mactex package](https://www.tug.org/mactex/)\n",
+    "</Admonition>"
    ]
   },
   {

--- a/docs/transpile/custom-transpiler-pass.ipynb
+++ b/docs/transpile/custom-transpiler-pass.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "from qiskit.dagcircuit import DAGCircuit\n",
-    "from qiskit.circuit import Gate\n",
+    "from qiskit.circuit import QuantumCircuit, QuantumRegister, Gate\n",
     "from qiskit.circuit.library import CXGate, ECRGate\n",
     "from qiskit.transpiler import PassManager\n",
     "from qiskit.transpiler.basepasses import TransformationPass\n",

--- a/scripts/nb-tester/test-notebook.py
+++ b/scripts/nb-tester/test-notebook.py
@@ -21,12 +21,7 @@ NOTEBOOKS_EXCLUDE = [
     "docs/api/**",
     "**/.ipynb_checkpoints/**",
     # Following notebooks have code errors
-    "docs/build/circuit-construction.ipynb",
-    "docs/build/pulse.ipynb",
-    "docs/transpile/custom-transpiler-pass.ipynb",
     "docs/transpile/transpiler-stages.ipynb",
-    # Following notebook has some non-python dependency I can't figure out
-    "docs/build/circuit-visualization.ipynb",
     # Following notebooks make requests so can't be tested yet
     "docs/run/get-backend-information.ipynb",
     "docs/start/hello-world.ipynb",


### PR DESCRIPTION
- Adds imports to fix  `transpile/custom-transpiler-pass`
- Adds note on installing latex dependencies for OSX in `build/circuit-visualization`
- `build/pulse` was fixed in #460
- `build/circuit-construction` seems to work now :shrug:

I couldn't fix `transpile/transpiler-stages`; I've made #480 to track that.

***

Closes #472
