### PR TITLE
Correct qiskit.providers.fake_provider.FakeTokyo.md

### DIFF
--- a/docs/api/qiskit/qiskit.providers.fake_provider.FakeTokyo.md
+++ b/docs/api/qiskit/qiskit.providers.fake_provider.FakeTokyo.md
@@ -17,13 +17,13 @@ Bases: [`FakeBackend`](providers_fake_provider#qiskit.providers.fake_provider.Fa
 A fake 20 qubit backend.
 
 ```python
-00 ↔ 01 ↔ 02 ↔ 03 ↔ 04
- ↕    ↕    ↕    ↕ ⤫  ↕
+00 ↔ 01 ↔ 02   03   04
+ ↕    ↕ ⤫ 　    ↕ ／ ↕
 05 ↔ 06 ↔ 07 ↔ 08 ↔ 09
- ↕ ⤫ ↕    ↕ ⤫ ↕
+ ↕ ⤫ ↕    ↕ ／ ↕
 10 ↔ 11 ↔ 12 ↔ 13 ↔ 14
  ↕    ↕ ⤫      ↕ ⤫  ↕
-15 ↔ 16 ↔ 17   18   19
+15 ↔ 16 ↔ 17 ↔ 18   19
 ```
 
 ## Attributes


### PR DESCRIPTION
Change quantum chain according to the output image of `FakeTokyo()` command.
