### PR TITLE
Fix make-historical toc.json files

### DIFF
--- a/scripts/commands/convertApiDocsToHistorical.ts
+++ b/scripts/commands/convertApiDocsToHistorical.ts
@@ -125,12 +125,12 @@ async function generateJsonFiles(
   // by any subfolder starting with a number (historical version folders)
   // or a release note file
   const linksToUptade = new RegExp(
-    '"url": "/api/' + pkgName + "/(?!release-notes)(?![0-9])",
+    '"url": "/api/' + pkgName + '(?=/|")(?!/release-notes)(?!/[0-9])',
     "g",
   );
   tocFile = tocFile.replace(
     linksToUptade,
-    `"url": "/api/${pkgName}/${versionWithoutPatch}/`,
+    `"url": "/api/${pkgName}/${versionWithoutPatch}`,
   );
   await writeFile(`${projectNewHistoricalFolder}/_toc.json`, tocFile + "\n");
 }


### PR DESCRIPTION
In #500, I changed the `/api/projectName/index` entry for every toc file and made the make-historical conversation to be wrong. In the `convertApiDocsToHistorical.ts` script, we modify the current toc file to convert it into historical by changing all the links to point but the release notes to the new subfolder. 

We update the links with a regex that assumes we always have a file name at the end, or in other words, a slash after the project name (e.g. `/api/qiskit/`). This assumption is not true anymore because we changed the entries `/api/projectName/index` to `/api/projectName`.

The new regex is the same but adds the possibility of ending without any slash. The entries now are followed by a slash or a double quote to indicate the line ends: (?=/|").