### PR TITLE
Fix `get-backend-information.ipynb`

### DIFF
--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -27,14 +27,18 @@
      "data": {
       "text/plain": [
        "[<IBMBackend('ibmq_qasm_simulator')>,\n",
-       " <IBMBackend('simulator_mps')>,\n",
-       " <IBMBackend('simulator_statevector')>,\n",
-       " <IBMBackend('ibm_lagos')>,\n",
-       " <IBMBackend('ibm_perth')>,\n",
+       " <IBMBackend('ibmq_mumbai')>,\n",
+       " <IBMBackend('ibm_hanoi')>,\n",
+       " <IBMBackend('ibm_osaka')>,\n",
+       " <IBMBackend('ibm_cusco')>,\n",
+       " <IBMBackend('ibm_sherbrooke')>,\n",
+       " <IBMBackend('ibm_nazca')>,\n",
+       " <IBMBackend('ibm_kyoto')>,\n",
+       " <IBMBackend('ibm_cairo')>,\n",
+       " <IBMBackend('ibmq_kolkata')>,\n",
        " <IBMBackend('ibm_brisbane')>,\n",
-       " <IBMBackend('simulator_extended_stabilizer')>,\n",
-       " <IBMBackend('simulator_stabilizer')>,\n",
-       " <IBMBackend('ibm_nairobi')>]"
+       " <IBMBackend('ibm_algiers')>,\n",
+       " <IBMBackend('ibm_torino')>]"
       ]
      },
      "execution_count": 1,
@@ -100,10 +104,18 @@
     {
      "data": {
       "text/plain": [
-       "[<IBMBackend('ibm_lagos')>,\n",
-       " <IBMBackend('ibm_perth')>,\n",
+       "[<IBMBackend('ibmq_mumbai')>,\n",
+       " <IBMBackend('ibm_hanoi')>,\n",
+       " <IBMBackend('ibm_osaka')>,\n",
+       " <IBMBackend('ibm_cusco')>,\n",
+       " <IBMBackend('ibm_sherbrooke')>,\n",
+       " <IBMBackend('ibm_nazca')>,\n",
+       " <IBMBackend('ibm_kyoto')>,\n",
+       " <IBMBackend('ibm_cairo')>,\n",
+       " <IBMBackend('ibmq_kolkata')>,\n",
        " <IBMBackend('ibm_brisbane')>,\n",
-       " <IBMBackend('ibm_nairobi')>]"
+       " <IBMBackend('ibm_algiers')>,\n",
+       " <IBMBackend('ibm_torino')>]"
       ]
      },
      "execution_count": 3,
@@ -162,9 +174,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Name: ibm_lagos\n",
+      "Name: ibm_kyoto\n",
       "Version: 2\n",
-      "No. of qubits: 7\n",
+      "No. of qubits: 127\n",
       "\n"
      ]
     }
@@ -208,7 +220,7 @@
     {
      "data": {
       "text/plain": [
-       "IBMQubitProperties(t1=0.00010568006375765179, t2=3.753491927659795e-05, frequency=5235355398.037262, anharmonicity=-339867138.55915606)"
+       "IBMQubitProperties(t1=0.00016855861574467424, t2=2.3453094185862303e-05, frequency=4908867208.080845, anharmonicity=-308028796.19250304)"
       ]
      },
      "execution_count": 6,
@@ -237,7 +249,7 @@
     {
      "data": {
       "text/plain": [
-       "InstructionProperties(duration=5.76e-07, error=0.010379675306311759, calibration=Schedule cx)"
+       "InstructionProperties(duration=6.6e-07, error=0.020534632893441818, calibration=Schedule ecr)"
       ]
      },
      "execution_count": 7,
@@ -264,7 +276,7 @@
     {
      "data": {
       "text/plain": [
-       "InstructionProperties(duration=7.893333333333333e-07, error=0.011199999999999988, calibration=Schedule measure)"
+       "InstructionProperties(duration=1.4e-06, error=0.11159999999999992, calibration=Schedule measure)"
       ]
      },
      "execution_count": 8,

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -170,7 +170,7 @@
     }
    ],
    "source": [
-    "backend = service.backend(\"ibm_lagos\")\n",
+    "backend = service.backend(\"ibm_kyoto\")\n",
     "\n",
     "print(\n",
     "    f\"Name: {backend.name}\\n\"\n",
@@ -226,7 +226,7 @@
    "source": [
     "### Instruction properties\n",
     "\n",
-    "The `backend.target` attribute is a `qiskit.transpiler.Target` object: an object that contains all the information needed to transpile a circuit for that backend. This includes instruction errors and durations. For example, the following cell gets the properties for a `cx` gate acting between qubits 0 and 1."
+    "The `backend.target` attribute is a `qiskit.transpiler.Target` object: an object that contains all the information needed to transpile a circuit for that backend. This includes instruction errors and durations. For example, the following cell gets the properties for an [`ecr` gate](/api/qiskit/qiskit.circuit.library.ECRGate) acting between qubits 1 and 0."
    ]
   },
   {
@@ -246,7 +246,7 @@
     }
    ],
    "source": [
-    "backend.target[\"cx\"][(0,1)]"
+    "backend.target[\"ecr\"][(1,0)]"
    ]
   },
   {

--- a/scripts/nb-tester/test-notebook.py
+++ b/scripts/nb-tester/test-notebook.py
@@ -27,7 +27,6 @@ NOTEBOOKS_EXCLUDE = [
     "**/.ipynb_checkpoints/**",
     # Following notebooks are broken
     "docs/transpile/transpiler-stages.ipynb",
-    "docs/run/get-backend-information.ipynb",
 ]
 NOTEBOOKS_THAT_SUBMIT_JOBS = [
     "docs/start/hello-world.ipynb",


### PR DESCRIPTION
`ibm_lagos` is retired so switching to `ibm_kyoto`.
Also had to switch gate example from `cx` to `ecr` as kyoto doesn't support `cx`.
