### PR TITLE
Suggestion: Do not create preview if no content changed

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -23,6 +23,7 @@ on:
     types: [opened, reopened, synchronize, closed]
     paths:
       - "docs/**/*"
+      - "public/images/**/*"
 
 jobs:
   setup:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -21,6 +21,8 @@ name: Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    paths:
+      - "docs/**/*"
 
 jobs:
   setup:


### PR DESCRIPTION
I believe content changes are the only changes that should affect the preview. If so, it's a bit wasteful to create a preview for non-content changes, plus it clutters up the PR thread.
