### PR TITLE
Add a Markdown guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ To use an `Admonition`, use the following syntax
 
 Available types are `note, tip, info, caution, danger`
 
-By default, the title is the `type` capitalized. You can customize it by using the `title` prop:
+By default, the title is the `type` capitalized. You can customize it by setting `title`:
 
 ```mdx
 <Admonition type="note" title="Custom title">
@@ -362,7 +362,7 @@ To use a `Tabs` component, use the following syntax:
   </TabItem>
 
   <TabItem value="qasm" label="QASM">
-    This in cloud the text for QASM
+    This is the text for QASM
   </TabItem>
 </Tabs>
 ```
@@ -376,7 +376,7 @@ By default, the first tab is selected. You can change that by using the `default
   </TabItem>
 
   <TabItem value="qasm" label="QASM">
-    This in cloud the text for QASM
+    This is the text for QASM
   </TabItem>
 </Tabs>
 ```
@@ -390,7 +390,7 @@ There are situations where you want to repeat the same tabs in several part of t
   </TabItem>
 
   <TabItem value="qasm" label="QASM">
-    This in cloud the text for QASM
+    This is the text for QASM
   </TabItem>
 </Tabs>
 ```
@@ -402,15 +402,12 @@ There is a specific use case where you want to show instructions for different o
   <TabItem value="mac" label="macOS">
     Open a terminal and write the command
   </TabItem>
-
-{" "}
-
-<TabItem value="linux" label="Linux">
-  Open a terminal and write the command
-</TabItem>
-
+  <TabItem value="linux" label="Linux">
+    Open a terminal and write the command
+  </TabItem>
   <TabItem value="win" label="Windows">
-    Go to windows/run and write `cmd`. It will open a command line. Execute this command
+    Go to windows/run and write `cmd`. It will open a command line. Execute this
+    command
   </TabItem>
 </OperatingSystemTabs>
 ```

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ Ayyyyy, this is a fake description.
 
 If the word appears in multiple files, prefer the second approach to add it to `cSpell.json`.
 
-## Format files
+## Format TypeScript files
 
-Run `npm run fmt` to automatically format MDX files.
+If you're working on our support code in `scripts/`, run `npm run fmt` to automatically format the files.
 
 To check that formatting is valid without actually making changes, run `npm run check:fmt` or `npm run check`.
 
@@ -197,7 +197,7 @@ To check that formatting is valid without actually making changes, run `npm run 
 1. Install and configure GitHub CLI: https://docs.github.com/en/github-cli/github-cli/quickstart
 2. Choose which documentation you want to regenerate: `qiskit`, `qiskit-ibm-provider`, or `qiskit-ibm-runtime`
 3. Determine the current version of the published stable documentation, e.g. at https://github.com/Qiskit/qiskit/releases
-4. Find a link to a CI artifact with the project's documentation, e.g at https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160. To find this, go to the "Summary" page in GitHub Actions for the CI run you want to build, then scroll down to "Artifacts".
+4. Find a link to a CI artifact with the project's documentation, e.g at https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160. To find this, first find the CI run for the commit you are trying to build docs for. This should come from a stable commit, not from a Pull Request. Then, go to the "Summary" page in GitHub Actions for the CI run. Scroll down to "Artifacts" and look for the artifact related to documentation, such as `html_docs`. Copy the link by right-clicking on the artifact.
 5. Run `npm run gen-api -- -p <pkg-name> -v <version> -a <artifact-url>`,
    e.g. `npm run gen-api -- -p qiskit -v 0.45.0 -a https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160`
 6. When opening your PR, include the CLI arguments you used. That helps us to know exactly how the docs have been generated over time.
@@ -205,3 +205,232 @@ To check that formatting is valid without actually making changes, run `npm run 
 If the version is not for the latest stable minor release series, then add `--historical` to the arguments. For example, use `--historical` if the latest stable release is 0.45.\* but you're generating docs for the patch release 0.44.3.
 
 In case you want to save the current version and convert it into a historical one, you can run `npm run make-historical -- -p <pkg-name>` beforehand.
+
+# How to write the documentation
+
+We use [MDX](https://mdxjs.com), which is like normal markdown but adds extensions for custom components we have.
+
+Refer to the [Common Markdown syntax](https://commonmark.org/) for a primer on Markdown. The below guide focuses on the other features you can use when writing docs.
+
+## How to add a new page
+
+Choose which existing folder from `docs/` your new page belongs to. 
+
+Next, choose the file name. The file name will determine the URL. For example, `start/my-new-page.mdx` results in the URL `start/my-new-page`. Choose a file name that will be stable over the page's lifespan and that is unlikely to clash with other topics. Use `-` rather than `_` as the delimiter. You can also ask for help choosing a name in the GitHub issue or pull request.
+
+If your file will have non-trivial code in it, please create a Jupyter notebook ending in `.ipynb`, rather than an MDX file. We prefer Jupyter notebooks when there is code because we have tests to make sure that the code still executes properly, whereas MDX is not tested.
+
+Once the file is created, you need to add metadata. Run `npm run check:metadata` for instructions on how to do this. (Refer to [Check file metadata](#check-file-metadata))
+
+Finally, add the file to the folder's `_toc.json`, such as `start/_toc.json`. The `title` is what will show up in the left side bar. Note that the `url` leaves off the file extension.
+
+## Images
+
+Images are stored in the `public/images` folder. You should use subfolders to organize the files. For example, images for `start/my-file.mdx` should be stored like `public/images/start/my-file/img1.png`.
+
+To use the image inside an MDX page:
+
+```markdown
+![Your image](/images/build/your-file/your_image.png)
+```
+
+To add an inline images,
+
+```markdown
+Inline ![Inline image](/images/build/your-file/your_image.png) image
+```
+
+To include a caption
+
+```markdown
+![Your image](/images/build/your-file/your_image.png 'Image caption')
+```
+
+You can include a version of the image to be with the dark theme. You only need to create an image with the same name ending in `@dark`. So for example, if you have a `sampler.png` image, the dark version would be `sampler@dark.png`. This is important for images that have a white background.
+
+## Math
+
+We use [LaTeX](https://www.latex-project.org) to write math, which gets rendered by the library [KaTeX](https://katex.org).
+
+Inline math expressions should start with `$` and end with `$`, e.g. `$\frac{123}{2}`.
+
+Multi-line expressions should start with `$$` and end with `$$`:
+
+```markdown
+$$
+L = \frac{123}{2} \rho v^2 S C_1s
+$$
+```
+
+## Tables
+
+Tables are supported: https://www.markdownguide.org/extended-syntax/.
+
+## Comments
+
+Example comment: {/* Comes from https://qiskit.org/documentation/partners/qiskit_ibm_runtime/getting_started.html */}
+
+## Collapsible sections
+
+For content that you don't want to show by default, use a collapsible section. The user will need to expand the section to read its contents. Refer to GitHub's guide on [`<details>` and `<summary>`](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections).
+
+## Footnotes
+
+```
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Second footnote text.
+```
+
+## Custom components
+
+These are components that we expose through MDX. You can use them in both
+`.mdx` and `.ipynb` files. In Jupyter notebooks, use Markdown blocks.
+
+### Admonitions
+
+To use an `Admonition`, use the following syntax
+
+```mdx
+<Admonition type="note">This is a __note__ example</Admonition>
+```
+
+Available types are `note, tip, info, caution, danger`
+
+By default, the title is the `type` capitalized. You can customize it by using the `title` prop
+
+```mdx
+<Admonition type="note" title="Custom title">
+  This is a __note__ example
+</Admonition>
+```
+
+### Definition Tooltip
+
+To use a `DefinitionTooltip`, use the following syntax:
+
+```mdx
+<DefinitionTooltip definition="Definition for the Term">Term</DefinitionTooltip>
+```
+
+For full list of props, please check [here](https://react.carbondesignsystem.com/?path=/docs/components-definitiontooltip--playground#component-api).
+
+
+### Composer
+
+You can use this component to render a circuit as it will be displayed in the composer. It does not have any interaction.
+
+```mdx
+<Composer qasm={`
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[5];
+creg c[5];
+
+U(0, 0, pi / 2) q[0];
+CX q[0], q[1];
+u3(0, 0, pi /2) q[0];
+u2(0, 0) q[0];
+
+`}/>
+```
+
+### Tabs
+
+To use a `Tabs` component, use the following syntax
+
+```mdx
+<Tabs>
+  <TabItem value="pulses" label="Pulses">
+    This is the text for pulses
+  </TabItem>
+
+  <TabItem value="qasm" label="QASM">
+    This in cloud the text for QASM
+  </TabItem>
+</Tabs>
+```
+
+By default, the first tab is selected. You can change that by using the `defaultValue` prop.
+
+```mdx
+<Tabs defaultValue="qasm">
+  <TabItem value="pulses" label="Pulses">
+    This is the text for pulses
+  </TabItem>
+
+  <TabItem value="qasm" label="QASM">
+    This in cloud the text for QASM
+  </TabItem>
+</Tabs>
+```
+
+There are situation where you want to repeat the same tabs in several part of the page. In this situation, you can use the prop `group` to synchronize the selected tab in all usages.
+
+```mdx
+<Tabs group="my-group">
+  <TabItem value="pulses" label="Pulses">
+    This is the text for pulses
+  </TabItem>
+
+  <TabItem value="qasm" label="QASM">
+    This in cloud the text for QASM
+  </TabItem>
+</Tabs>
+```
+
+There is a specific use case where you want to show instructions for different operating systems. In this situation, you can replace the `Tabs` component by a `OperatingSystemTabs`. The default value of the tab will be selected based on the users operating system.
+
+```mdx
+<OperatingSystemTabs>
+  <TabItem value="mac" label="macOS">
+    Open a terminal and write the command
+  </TabItem>
+
+  <TabItem value="linux" label="Linux">
+    Open a terminal and write the command
+  </TabItem>
+
+  <TabItem value="win" label="Windows">
+    Go to windows/run and write `cmd`. It will open a command line. Execute this command
+  </TabItem>
+</OperatingSystemTabs>
+```
+
+### CircuitTabs
+
+This component show tabs with the Composer and the OpenQasm code. It also shows an Open in Composer link at the bottom.
+
+```mdx
+<CircuitTabs name="Bell" qasm={`
+  OPENQASM 2.0;
+  include "qelib1.inc";
+
+  qreg q[2];
+  creg c[2];
+
+  reset q[0];
+  h q[0];
+  reset q[1];
+  cx q[0],q[1];
+  measure q[0] -> c[0];
+  measure q[1] -> c[1];
+`}/>
+```
+
+### Operation
+
+To display a qasm operation (like a not gate), you can use the `Operation` component
+
+```mdx
+<Operation name="x" />
+```

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ To use an `Admonition`, use the following syntax
 
 Available types are `note, tip, info, caution, danger`
 
-By default, the title is the `type` capitalized. You can customize it by using the `title` prop
+By default, the title is the `type` capitalized. You can customize it by using the `title` prop:
 
 ```mdx
 <Admonition type="note" title="Custom title">
@@ -353,7 +353,7 @@ u2(0, 0) q[0];
 
 ### Tabs
 
-To use a `Tabs` component, use the following syntax
+To use a `Tabs` component, use the following syntax:
 
 ```mdx
 <Tabs>
@@ -381,7 +381,7 @@ By default, the first tab is selected. You can change that by using the `default
 </Tabs>
 ```
 
-There are situation where you want to repeat the same tabs in several part of the page. In this situation, you can use the prop `group` to synchronize the selected tab in all usages.
+There are situations where you want to repeat the same tabs in several part of the page. In this situation, you can use the prop `group` to synchronize the selected tab in all usages.
 
 ```mdx
 <Tabs group="my-group">
@@ -395,7 +395,7 @@ There are situation where you want to repeat the same tabs in several part of th
 </Tabs>
 ```
 
-There is a specific use case where you want to show instructions for different operating systems. In this situation, you can replace the `Tabs` component by a `OperatingSystemTabs`. The default value of the tab will be selected based on the users operating system.
+There is a specific use case where you want to show instructions for different operating systems. In this situation, you can replace the `Tabs` component by a `OperatingSystemTabs`. The default value of the tab will be selected based on the user's operating system.
 
 ```mdx
 <OperatingSystemTabs>
@@ -417,7 +417,7 @@ There is a specific use case where you want to show instructions for different o
 
 ### CircuitTabs
 
-This component show tabs with the Composer and the OpenQasm code. It also shows an Open in Composer link at the bottom.
+This component show tabs with the Composer and the OpenQASM code. It also shows an Open in Composer link at the bottom.
 
 ```mdx
 <CircuitTabs name="Bell" qasm={`
@@ -438,7 +438,7 @@ measure q[1] -> c[1];
 
 ### Operation
 
-To display a qasm operation (like a not gate), you can use the `Operation` component
+To display a qasm operation (like a not gate), you can use the `Operation` component:
 
 ```mdx
 <Operation name="x" />

--- a/README.md
+++ b/README.md
@@ -197,7 +197,15 @@ To check that formatting is valid without actually making changes, run `npm run 
 1. Install and configure GitHub CLI: https://docs.github.com/en/github-cli/github-cli/quickstart
 2. Choose which documentation you want to regenerate: `qiskit`, `qiskit-ibm-provider`, or `qiskit-ibm-runtime`
 3. Determine the current version of the published stable documentation, e.g. at https://github.com/Qiskit/qiskit/releases
-4. Find a link to a CI artifact with the project's documentation, e.g at https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160. To find this, first find the CI run for the commit you are trying to build docs for. This should come from a stable commit, not from a Pull Request. Then, go to the "Summary" page in GitHub Actions for the CI run. Scroll down to "Artifacts" and look for the artifact related to documentation, such as `html_docs`. Copy the link by right-clicking on the artifact.
+4. Find a link to a CI artifact with the project's documentation, e.g at https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160. To find this:
+   1. Pull up the CI runs for the stable commit that you want to build docs from. This should not be from a Pull Request
+   2. Open up the "Details" for the relevant workflow.
+      - Qiskit: "Documentation / Build (push)"
+      - Runtime: "CI / Build documentation (push)"
+      - Provider: "CI / Build documentation (push)"
+   3. Click the "Summary" page at the top of the left navbar.
+   4. Scroll down to "Artifacts" and look for the artifact related to documentation, such as `html_docs`.
+   5. Copy the link by right-clicking on the artifact.
 5. Run `npm run gen-api -- -p <pkg-name> -v <version> -a <artifact-url>`,
    e.g. `npm run gen-api -- -p qiskit -v 0.45.0 -a https://github.com/Qiskit/qiskit/suites/17881600359/artifacts/1026798160`
 6. When opening your PR, include the CLI arguments you used. That helps us to know exactly how the docs have been generated over time.
@@ -252,7 +260,7 @@ You can include a version of the image to be with the dark theme. You only need 
 
 We use [LaTeX](https://www.latex-project.org) to write math, which gets rendered by the library [KaTeX](https://katex.org).
 
-Inline math expressions should start with `$` and end with `$`, e.g. `$\frac{123}{2}`.
+Inline math expressions should start with `$` and end with `$`, e.g. `$\frac{123}{2}$`.
 
 Multi-line expressions should start with `$$` and end with `$$`:
 
@@ -293,7 +301,7 @@ Duplicated footnote reference[^second].
 ## Custom components
 
 These are components that we expose through MDX. You can use them in both
-`.mdx` and `.ipynb` files. In Jupyter notebooks, use Markdown blocks.
+`.mdx` and `.ipynb` files. In Jupyter notebooks, use Markdown cells.
 
 ### Admonitions
 
@@ -396,6 +404,7 @@ There is a specific use case where you want to show instructions for different o
   </TabItem>
 
 {" "}
+
 <TabItem value="linux" label="Linux">
   Open a terminal and write the command
 </TabItem>

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Refer to the [Common Markdown syntax](https://commonmark.org/) for a primer on M
 
 ## How to add a new page
 
-Choose which existing folder from `docs/` your new page belongs to. 
+Choose which existing folder from `docs/` your new page belongs to.
 
 Next, choose the file name. The file name will determine the URL. For example, `start/my-new-page.mdx` results in the URL `start/my-new-page`. Choose a file name that will be stable over the page's lifespan and that is unlikely to clash with other topics. Use `-` rather than `_` as the delimiter. You can also ask for help choosing a name in the GitHub issue or pull request.
 
@@ -243,7 +243,7 @@ Inline ![Inline image](/images/build/your-file/your_image.png) image
 To include a caption
 
 ```markdown
-![Your image](/images/build/your-file/your_image.png 'Image caption')
+![Your image](/images/build/your-file/your_image.png "Image caption")
 ```
 
 You can include a version of the image to be with the dark theme. You only need to create an image with the same name ending in `@dark`. So for example, if you have a `sampler.png` image, the dark version would be `sampler@dark.png`. This is important for images that have a white background.
@@ -268,7 +268,7 @@ Tables are supported: https://www.markdownguide.org/extended-syntax/.
 
 ## Comments
 
-Example comment: {/* Comes from https://qiskit.org/documentation/partners/qiskit_ibm_runtime/getting_started.html */}
+Example comment: {/_ Comes from https://qiskit.org/documentation/partners/qiskit_ibm_runtime/getting_started.html _/}
 
 ## Collapsible sections
 
@@ -322,7 +322,6 @@ To use a `DefinitionTooltip`, use the following syntax:
 ```
 
 For full list of props, please check [here](https://react.carbondesignsystem.com/?path=/docs/components-definitiontooltip--playground#component-api).
-
 
 ### Composer
 
@@ -396,9 +395,10 @@ There is a specific use case where you want to show instructions for different o
     Open a terminal and write the command
   </TabItem>
 
-  <TabItem value="linux" label="Linux">
-    Open a terminal and write the command
-  </TabItem>
+{" "}
+<TabItem value="linux" label="Linux">
+  Open a terminal and write the command
+</TabItem>
 
   <TabItem value="win" label="Windows">
     Go to windows/run and write `cmd`. It will open a command line. Execute this command
@@ -415,15 +415,15 @@ This component show tabs with the Composer and the OpenQasm code. It also shows 
   OPENQASM 2.0;
   include "qelib1.inc";
 
-  qreg q[2];
-  creg c[2];
+qreg q[2];
+creg c[2];
 
-  reset q[0];
-  h q[0];
-  reset q[1];
-  cx q[0],q[1];
-  measure q[0] -> c[0];
-  measure q[1] -> c[1];
+reset q[0];
+h q[0];
+reset q[1];
+cx q[0],q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
 `}/>
 ```
 


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/367.

@axelhzf had written an excellent guide for how to work with MDX in the closed source repository, but it wasn't copied over here when docs moved to open source.

This PR:

* Copies over Axel's guide with some small tweaks
* Adds guidance on adding a new page, including how to choose between MDX vs. Jupyter and how to name the file
* Mentions collapsible sections