### PR TITLE
Rename terra.md to index.md

### DIFF
--- a/scripts/lib/sphinx/renameUrls.ts
+++ b/scripts/lib/sphinx/renameUrls.ts
@@ -20,6 +20,7 @@ export function renameUrls(results: SphinxToMdResultWithUrl[]): void {
       // We can't fix their setup until qiskit.org is removed, so
       // instead we fix it here.
       .replace(/\/ibm_provider$/g, "/index")
-      .replace(/\/runtime_service$/g, "/index");
+      .replace(/\/runtime_service$/g, "/index")
+      .replace(/\/terra$/g, "/index");
   }
 }


### PR DESCRIPTION
When generating docs for Terra before 0.44, the index page was called `terra.html`. We need it to be called `index`.