### PR TITLE
Fix some async errors in updateApiDocs.ts

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -127,7 +127,7 @@ const readArgs = (): Arguments => {
       type: "string",
       demandOption: true,
       description:
-        "The URL for the CI artifict to download. Must be from GitHub Actions.",
+        "The URL for the CI artifact to download. Must be from GitHub Actions.",
     })
     .parseSync();
 };

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -126,7 +126,8 @@ const readArgs = (): Arguments => {
       alias: "a",
       type: "string",
       demandOption: true,
-      description: "The URL for the CI artifict to download. Must be from GitHub Actions.",
+      description:
+        "The URL for the CI artifict to download. Must be from GitHub Actions.",
     })
     .parseSync();
 };


### PR DESCRIPTION
We weren't calling `await` on `startWebServer` and `mkdirp`. This could result in order-of-operation issues.

While fixing that, I realized that we can simplify the code. We only need to start the web server if we're downloading the artifact from CI. So, only have that code in the `else` block. We can reduce the amount of code by moving the server's start to inside `downloadApiSources`.