### PR TITLE
Extract link checker ignores to a dedicated file

### DIFF
--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -10,10 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { globby } from "globby";
 import { readFile } from "fs/promises";
 import path from "node:path";
-import { Link, File } from "../lib/LinkChecker";
+
+import { globby } from "globby";
 import markdownLinkExtractor from "markdown-link-extractor";
 import { visit } from "unist-util-visit";
 import { unified } from "unified";
@@ -24,6 +24,9 @@ import rehypeParse from "rehype-parse";
 import remarkGfm from "remark-gfm";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
+
+import { Link, File } from "../lib/LinkChecker";
+import FILES_TO_IGNORES from "../lib/linkCheckerIgnores";
 
 const DOCS_GLOBS_TO_CHECK = [
   "docs/**/*.{ipynb,md,mdx}",
@@ -41,79 +44,6 @@ const DOCS_GLOBS_TO_LOAD = [
   "docs/api/qiskit/0.44/qiskit.utils.QuantumInstance.md",
   "docs/api/qiskit/release-notes/index.md",
 ];
-
-// The links in the files are not searched to see if they are valid.
-// The files need a list of links to be ignored.
-//
-// If all links in the file should be ignored, then modify GLOBS_TO_CHECK, such
-// as adding '!docs/my_file.md` to the list. If other files link to the file,
-// then you may need to add it to GLOBS_TO_LOAD.
-const FILES_TO_IGNORES: { [id: string]: string[] } = {
-  "docs/api/qiskit-ibm-provider/ibm-provider.md": ["ibm_provider"],
-  "docs/api/qiskit-ibm-runtime/ibm-runtime.md": ["runtime_service"],
-  "docs/api/qiskit/pulse.md": [
-    "qiskit.pulse.library.Constant_class.rst#qiskit.pulse.library.Constant",
-    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
-    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
-    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
-    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
-    "qiskit.pulse.library.Sin_class.rst#qiskit.pulse.library.Sin",
-    "qiskit.pulse.library.Cos_class.rst#qiskit.pulse.library.Cos",
-    "qiskit.pulse.library.Sawtooth_class.rst#qiskit.pulse.library.Sawtooth",
-    "qiskit.pulse.library.Triangle_class.rst#qiskit.pulse.library.Triangle",
-    "qiskit.pulse.library.Square_fun.rst#qiskit.pulse.library.Square",
-    "qiskit.pulse.library.Sech_fun.rst#qiskit.pulse.library.Sech",
-  ],
-  "docs/api/qiskit/qiskit.algorithms.optimizers.NFT.md": ["#id2", "#id1"],
-  "docs/api/qiskit/qpy.md": [
-    "circuit#qiskit.circuit.CASE_DEFAULT",
-    "#id8",
-    "#id2",
-    "#f8",
-    "#id6",
-    "#id4",
-    "#f3",
-    "#f2",
-    "#f1",
-    "/api/qiskit/circuit#qiskit.circuit.CircuitError",
-    "id2",
-    "/api/qiskit/qpy#id1",
-    "/api/qiskit/circuit#qiskit.circuit.CircuitError'",
-  ],
-  "docs/api/qiskit/qiskit.circuit.QuantumCircuit.md": [
-    "qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations",
-    "circuit#qiskit.circuit.CASE_DEFAULT",
-  ],
-  "docs/api/qiskit/qiskit.circuit.SwitchCaseOp.md": [
-    "circuit#qiskit.circuit.CASE_DEFAULT",
-  ],
-  "docs/api/qiskit/qiskit.pulse.library.GaussianSquareDrag.md": [
-    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
-    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
-  ],
-  "docs/api/qiskit/utils.md": [
-    "https://github.com/python-constraint/python-constraint%3E__",
-    "#qiskit.utils.optionals.HAS_TESTTOOLS",
-    "#qiskit.utils.optionals.HAS_GRAPHVIZ",
-    "#qiskit.utils.optionals.HAS_PYDOT",
-  ],
-  "docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProvider.md": [
-    "https://auth.quantum.ibm.com/api",
-  ],
-  "docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService.md": [
-    "https://auth.quantum.ibm.com/api",
-  ],
-  "docs/api/qiskit/algorithms.md": ["https://www.qiskit.org/terra"],
-  "docs/api/qiskit/qiskit.algorithms.Grover.md": [
-    "https://qiskit.org/textbook/ch-algorithms/grover.html",
-  ],
-  "docs/api/qiskit/qiskit.algorithms.optimizers.ISRES.md": [
-    "https://notendur.hi.is/tpr/software/sres/Tec311r.pdf",
-  ],
-  "docs/api/qiskit/qiskit.algorithms.optimizers.SPSA.md": [
-    "https://ieeexplore.ieee.org/document/657661",
-  ],
-};
 
 // While these files don't exist in this repository, the link
 // checker should assume that they exist in production.

--- a/scripts/lib/linkCheckerIgnores.ts
+++ b/scripts/lib/linkCheckerIgnores.ts
@@ -10,13 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-// The links in the files are not searched to see if they are valid.
-// The files need a list of links to be ignored.
+// A mapping of files to lists of links that will not be searched.
 //
 // If all links in the file should be ignored, then modify GLOBS_TO_CHECK in checkLinks.ts, such
 // as adding '!docs/my_file.md` to the list. If other files link to the file,
 // then you may need to add it to GLOBS_TO_LOAD in checkLinks.ts.
-const FILES_TO_IGNORES: { [id: string]: string[] } = {
+type FilesToIgnores = { [id: string]: string[] };
+
+// These are legit problems that we had to punt on, usually because fixing the
+// problem requires fixing the original source documentation for API docs.
+const SHOULD_BE_FIXED: FilesToIgnores = {
   "docs/api/qiskit-ibm-provider/ibm-provider.md": ["ibm_provider"],
   "docs/api/qiskit-ibm-runtime/ibm-runtime.md": ["runtime_service"],
   "docs/api/qiskit/pulse.md": [
@@ -75,6 +78,11 @@ const FILES_TO_IGNORES: { [id: string]: string[] } = {
   "docs/api/qiskit/qiskit.algorithms.Grover.md": [
     "https://qiskit.org/textbook/ch-algorithms/grover.html",
   ],
+};
+
+// Issues that are okay, such as because the link checker times out
+// when trying to access the links.
+const EXPECTED: FilesToIgnores = {
   "docs/api/qiskit/qiskit.algorithms.optimizers.ISRES.md": [
     "https://notendur.hi.is/tpr/software/sres/Tec311r.pdf",
   ],
@@ -83,4 +91,4 @@ const FILES_TO_IGNORES: { [id: string]: string[] } = {
   ],
 };
 
-export default FILES_TO_IGNORES;
+export default { ...SHOULD_BE_FIXED, ...EXPECTED };

--- a/scripts/lib/linkCheckerIgnores.ts
+++ b/scripts/lib/linkCheckerIgnores.ts
@@ -1,0 +1,86 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// The links in the files are not searched to see if they are valid.
+// The files need a list of links to be ignored.
+//
+// If all links in the file should be ignored, then modify GLOBS_TO_CHECK in checkLinks.ts, such
+// as adding '!docs/my_file.md` to the list. If other files link to the file,
+// then you may need to add it to GLOBS_TO_LOAD in checkLinks.ts.
+const FILES_TO_IGNORES: { [id: string]: string[] } = {
+  "docs/api/qiskit-ibm-provider/ibm-provider.md": ["ibm_provider"],
+  "docs/api/qiskit-ibm-runtime/ibm-runtime.md": ["runtime_service"],
+  "docs/api/qiskit/pulse.md": [
+    "qiskit.pulse.library.Constant_class.rst#qiskit.pulse.library.Constant",
+    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
+    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
+    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
+    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
+    "qiskit.pulse.library.Sin_class.rst#qiskit.pulse.library.Sin",
+    "qiskit.pulse.library.Cos_class.rst#qiskit.pulse.library.Cos",
+    "qiskit.pulse.library.Sawtooth_class.rst#qiskit.pulse.library.Sawtooth",
+    "qiskit.pulse.library.Triangle_class.rst#qiskit.pulse.library.Triangle",
+    "qiskit.pulse.library.Square_fun.rst#qiskit.pulse.library.Square",
+    "qiskit.pulse.library.Sech_fun.rst#qiskit.pulse.library.Sech",
+  ],
+  "docs/api/qiskit/qiskit.algorithms.optimizers.NFT.md": ["#id2", "#id1"],
+  "docs/api/qiskit/qpy.md": [
+    "circuit#qiskit.circuit.CASE_DEFAULT",
+    "#id8",
+    "#id2",
+    "#f8",
+    "#id6",
+    "#id4",
+    "#f3",
+    "#f2",
+    "#f1",
+    "/api/qiskit/circuit#qiskit.circuit.CircuitError",
+    "id2",
+    "/api/qiskit/qpy#id1",
+    "/api/qiskit/circuit#qiskit.circuit.CircuitError'",
+  ],
+  "docs/api/qiskit/qiskit.circuit.QuantumCircuit.md": [
+    "qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations",
+    "circuit#qiskit.circuit.CASE_DEFAULT",
+  ],
+  "docs/api/qiskit/qiskit.circuit.SwitchCaseOp.md": [
+    "circuit#qiskit.circuit.CASE_DEFAULT",
+  ],
+  "docs/api/qiskit/qiskit.pulse.library.GaussianSquareDrag.md": [
+    "qiskit.pulse.library.Drag_class.rst#qiskit.pulse.library.Drag",
+    "qiskit.pulse.library.Gaussian_class.rst#qiskit.pulse.library.Gaussian",
+  ],
+  "docs/api/qiskit/utils.md": [
+    "https://github.com/python-constraint/python-constraint%3E__",
+    "#qiskit.utils.optionals.HAS_TESTTOOLS",
+    "#qiskit.utils.optionals.HAS_GRAPHVIZ",
+    "#qiskit.utils.optionals.HAS_PYDOT",
+  ],
+  "docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProvider.md": [
+    "https://auth.quantum.ibm.com/api",
+  ],
+  "docs/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService.md": [
+    "https://auth.quantum.ibm.com/api",
+  ],
+  "docs/api/qiskit/algorithms.md": ["https://www.qiskit.org/terra"],
+  "docs/api/qiskit/qiskit.algorithms.Grover.md": [
+    "https://qiskit.org/textbook/ch-algorithms/grover.html",
+  ],
+  "docs/api/qiskit/qiskit.algorithms.optimizers.ISRES.md": [
+    "https://notendur.hi.is/tpr/software/sres/Tec311r.pdf",
+  ],
+  "docs/api/qiskit/qiskit.algorithms.optimizers.SPSA.md": [
+    "https://ieeexplore.ieee.org/document/657661",
+  ],
+};
+
+export default FILES_TO_IGNORES;


### PR DESCRIPTION
The config added too much noise to the file `checkLinks.ts`. That file should only have high-level logic. That allows us to more cleanly split out the list between `SHOULD_BE_FIXED` and `EXPECTED` so that we know what is a legit problem and we're only punting on it.

No changes were made to the actual list.