### PR TITLE
Deduplicate error messages in link checker for same link in same file

### DIFF
--- a/scripts/lib/LinkChecker.test.ts
+++ b/scripts/lib/LinkChecker.test.ts
@@ -22,7 +22,12 @@ describe("Test the constructor of Link", () => {
       testLink.originFiles,
       testLink.isExternal,
     ];
-    const correct_values = ["/testpath", "", ["/testorigin.mdx"], false];
+    const correct_values = [
+      "/testpath",
+      "",
+      new Set(["/testorigin.mdx"]),
+      false,
+    ];
     expect(attributes).toEqual(correct_values);
   });
 
@@ -37,7 +42,7 @@ describe("Test the constructor of Link", () => {
     const correct_values = [
       "/testpath",
       "#testanchor",
-      ["/testorigin.mdx"],
+      new Set(["/testorigin.mdx"]),
       false,
     ];
     expect(attributes).toEqual(correct_values);
@@ -54,7 +59,7 @@ describe("Test the constructor of Link", () => {
     const correct_values = [
       "https://test.link.com",
       "",
-      ["/testorigin.mdx"],
+      new Set(["/testorigin.mdx"]),
       true,
     ];
     expect(attributes).toEqual(correct_values);
@@ -128,6 +133,8 @@ describe("Validate links", () => {
   test("Validate internal links with relative path and multiple origin files", async () => {
     let testLink = new Link("../testpath", [
       "docs/test/testorigin.mdx",
+      "docs/test/test2/testorigin.mdx",
+      // Duplicate of the above value to confirm we de-duplicate originFiles.
       "docs/test/test2/testorigin.mdx",
       "docs/test/test3/testorigin.mdx",
       "docs/test/test2/test4/testorigin.mdx",

--- a/scripts/lib/LinkChecker.ts
+++ b/scripts/lib/LinkChecker.ts
@@ -35,7 +35,7 @@ export class File {
 export class Link {
   readonly value: string;
   readonly anchor: string;
-  readonly originFiles: string[];
+  readonly originFiles: Set<string>;
   readonly isExternal: boolean;
 
   /**
@@ -46,7 +46,7 @@ export class Link {
     const splitLink = linkString.split("#", 2);
     this.value = splitLink[0];
     this.anchor = splitLink.length > 1 ? `#${splitLink[1]}` : "";
-    this.originFiles = originFiles;
+    this.originFiles = new Set(originFiles);
     this.isExternal = linkString.startsWith("http");
   }
 


### PR DESCRIPTION
Otherwise, we get a couple of duplicate error messages. This happens when the same file has the same bad link >1 times.