### PR TITLE
Fix API generation script

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -364,6 +364,7 @@ async function convertHtmlToMarkdown(
       src: img.src,
       dest: `${getRoot()}/public${img.dest}`,
     })),
+    htmlPath,
   );
 }
 

--- a/scripts/lib/downloadImages.ts
+++ b/scripts/lib/downloadImages.ts
@@ -17,23 +17,37 @@ import { createWriteStream } from "node:fs";
 import { finished } from "stream/promises";
 import { Readable } from "stream";
 import pMap from "p-map";
+import { startWebServer, closeWebServer } from "../lib/webServer";
 
 export async function downloadImages(
   images: Array<{ src: string; dest: string }>,
+  imagesPath: string,
 ) {
-  await pMap(
-    images,
-    async (img) => {
-      if (await pathExists(img.dest)) return;
-      const response = await fetch(img.src);
-      if (response.ok) {
-        await mkdirp(dirname(img.dest));
-        const stream = createWriteStream(img.dest);
-        await finished(Readable.fromWeb(response.body as any).pipe(stream));
-      } else {
-        console.log(`Error downloading ${img.src} to ${img.dest}`);
-      }
-    },
-    { concurrency: 4 },
+  const missingImages = images.filter(
+    async (img) => !(await pathExists(img.dest)),
   );
+
+  if (missingImages.length == 0) {
+    return;
+  }
+
+  await startWebServer(`${imagesPath}/artifact`, 8000);
+  try {
+    await pMap(
+      missingImages,
+      async (img) => {
+        const response = await fetch(img.src);
+        if (response.ok) {
+          await mkdirp(dirname(img.dest));
+          const stream = createWriteStream(img.dest);
+          await finished(Readable.fromWeb(response.body as any).pipe(stream));
+        } else {
+          console.log(`Error downloading ${img.src} to ${img.dest}`);
+        }
+      },
+      { concurrency: 4 },
+    );
+  } finally {
+    await closeWebServer(8000);
+  }
 }

--- a/scripts/lib/webServer.ts
+++ b/scripts/lib/webServer.ts
@@ -14,6 +14,17 @@ import { $ } from "zx";
 
 export async function startWebServer(directory: string, listenPort: number) {
   $`python3 -m http.server ${listenPort} -d ${directory} -b ::1 &`;
+
+  // Wait until the server is up and able to listen to the requests
+  while (true) {
+    try {
+      const response = await fetch(`http://localhost:${listenPort}`);
+      return;
+    } catch {
+      // Wait 5 ms for the next fetch
+      await new Promise((res) => setTimeout(res, 5));
+    }
+  }
 }
 
 export async function closeWebServer(listenPort: number) {


### PR DESCRIPTION
The API generation script is not downloading the images because we stopped the server after downloading the HTML sources and never started it again. This PR starts the server before downloading the images and adds validation for the server to be up. Without this validation, the script tries to download the images immediately and fails because the server doesn't have time to start. This validation wasn't necessary until now because we opened the server before downloading the CI artifact, giving enough time to avoid all problems.