### PR TITLE
Rewrite `./start` script to Python

### DIFF
--- a/start
+++ b/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env python3
 # This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
@@ -11,10 +11,34 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Keep this aligned with the Dockerfile at the root of the repository.
-docker run \
-  -v "$(pwd)"/docs:/home/node/app/docs \
-  -v "$(pwd)"/public/images:/home/node/app/packages/preview/public/images \
-  -p 3000:3000 \
-  -p 5001:5001 \
-  qiskit/documentation
+import subprocess
+from pathlib import Path
+
+PWD = Path(__file__).parent
+
+
+def main() -> None:
+    subprocess.run(
+        # Keep this aligned with the Dockerfile at the root of the repository.
+        [
+            "docker",
+            "run",
+            "-v",
+            f"{PWD}/docs:/home/node/app/docs",
+            "-v",
+            f"{PWD}/public/images:/home/node/app/packages/preview/public/images",
+            "-p",
+            "3000:3000",
+            "-p",
+            "5001:5001",
+            "qiskit/documentation",
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
In https://github.com/Qiskit/documentation/pull/541, we're going to need to add semi-complex logic to our `./start` script to dynamically discover every subfolder we have in `translations/`, then tell Docker to mount the folder as a volume. I'd much rather write that logic in Python than Bash.

This PR is prework so that https://github.com/Qiskit/documentation/pull/541 is a smaller PR. It makes no logic changes and should be a 1:1 mapping.