### PR TITLE
Refactor link checker to use FileBatch class

### DIFF
--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -14,9 +14,8 @@ import { globby } from "globby";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
-import { Link, File } from "../lib/links/LinkChecker";
-import FILES_TO_IGNORES from "../lib/links/ignores";
-import { getMarkdownAndAnchors, addLinksToMap } from "../lib/links/markdown";
+import { File } from "../lib/links/LinkChecker";
+import { FileBatch } from "../lib/links/FileBatch";
 
 const DOCS_GLOBS_TO_CHECK = [
   "docs/**/*.{ipynb,md,mdx}",
@@ -59,104 +58,21 @@ const readArgs = (): Arguments => {
     .parseSync();
 };
 
-/**
- * Process the markdown and Jupyter notebook files.
- *
- * filePathsToLoad is for files that we only need to load
- * so that we can determine if links from other files to that
- * file are valid. We need to determine all of its anchors.
- *
- * filePathsToCheck is for files that we will actually end up
- * checking. We determine its internal and external links. Other
- * files might link to these files, too, so we also determine
- * the valid anchors to make sure those links are correct.
- *
- * Returns a triplet:
- *   1. A list of `File` objects with their anchors. These represent
- *      the universe of valid internal links, other than any additional
- *      we may add in main() for e.g. images.
- *   2. A list of Link objects with internal links we will validate.
- *   3. A list of Link objects with external links we will validate.
- */
-async function processDocsFiles(
-  filePathsToLoad: string[],
-  filePathsToCheck: string[],
-): Promise<[File[], Link[], Link[]]> {
-  const files: File[] = [];
-  for (let filePath of filePathsToLoad) {
-    const [_, anchors] = await getMarkdownAndAnchors(filePath);
-    files.push(new File(filePath, anchors, false));
-  }
-
-  const linksToOriginFiles = new Map<string, string[]>();
-  for (const filePath of filePathsToCheck) {
-    const [markdown, anchors] = await getMarkdownAndAnchors(filePath);
-    files.push(new File(filePath, anchors, false));
-    await addLinksToMap(filePath, markdown, linksToOriginFiles);
-  }
-
-  const internalLinks: Link[] = [];
-  const externalLinks: Link[] = [];
-  for (let [linkPath, originFiles] of linksToOriginFiles) {
-    originFiles = originFiles.filter(
-      (originFile) =>
-        FILES_TO_IGNORES[originFile] == null ||
-        !FILES_TO_IGNORES[originFile].includes(linkPath),
-    );
-
-    if (originFiles.length > 0) {
-      const link = new Link(linkPath, originFiles);
-      link.isExternal ? externalLinks.push(link) : internalLinks.push(link);
-    }
-  }
-
-  return [files, internalLinks, externalLinks];
-}
-
 async function main() {
   const args = readArgs();
 
-  const docsToLoad = await globby(DOCS_GLOBS_TO_LOAD);
-  const docsToCheck = await globby(DOCS_GLOBS_TO_CHECK);
-
-  // Parse the files with links and get a list with all the links
-  // in all the files without duplications.
-  const [docsFiles, internalLinkList, externalLinkList] =
-    await processDocsFiles(docsToLoad, docsToCheck);
-
-  // Define extra files that we don't want to parse
+  const fileBatch = await FileBatch.fromGlobs(
+    DOCS_GLOBS_TO_LOAD,
+    DOCS_GLOBS_TO_CHECK,
+  );
   const otherFiles = [
     ...(await globby("{public,docs}/**/*.{png,jpg,gif,svg}")).map(
-      (fp) => new File(fp, [], false),
+      (fp) => new File(fp, []),
     ),
     ...SYNTHETIC_FILES.map((fp) => new File(fp, [], true)),
   ];
 
-  // Create an array with all the valid destinations for a link
-  const existingFiles = docsFiles.concat(otherFiles);
-
-  // Validate internal links
-  const results = await Promise.all(
-    internalLinkList.map((link) => link.checkLink(existingFiles)),
-  );
-
-  // Validate external links
-  // A for loop is used to reduce the risk of rate-limiting
-  if (args["external"]) {
-    for (let link of externalLinkList) {
-      results.push(await link.checkLink(existingFiles));
-    }
-  }
-
-  // Print the results
-  let allGood = true;
-  results.forEach((linkErrors) => {
-    linkErrors.forEach((errorMessage) => {
-      console.error(errorMessage);
-      allGood = false;
-    });
-  });
-
+  const allGood = await fileBatch.check(args.external, otherFiles);
   if (!allGood) {
     console.error("\nSome links appear broken 💔\n");
     process.exit(1);

--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -62,8 +62,8 @@ async function main() {
   const args = readArgs();
 
   const fileBatch = await FileBatch.fromGlobs(
-    DOCS_GLOBS_TO_LOAD,
     DOCS_GLOBS_TO_CHECK,
+    DOCS_GLOBS_TO_LOAD,
   );
   const otherFiles = [
     ...(await globby("{public,docs}/**/*.{png,jpg,gif,svg}")).map(

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -80,7 +80,7 @@ export class FileBatch {
 
   /**
    * Check that all links in this file batch are valid.
-   * 
+   *
    * Logs the results to the console and returns `true` if there were no issues.
    */
   async check(externalLinks: boolean, otherFiles: File[]): Promise<boolean> {

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -17,7 +17,16 @@ import FILES_TO_IGNORES from "./ignores";
 import { getMarkdownAndAnchors, addLinksToMap } from "./markdown";
 
 export class FileBatch {
+  /**
+   * Files whose links should be validated. These files will also be loaded
+   * into memory so that links from other files to these files are recognized.
+   */
   readonly toCheck: string[];
+  /**
+   * Files that may be linked to from other files, but who should not have their
+   * own links checked for validity. These files need to be loaded into memory
+   * so that links from other files to these files are recognized.
+   */
   readonly toLoad: string[];
 
   constructor(toCheck: string[], toLoad: string[]) {

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -1,0 +1,110 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2023.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { globby } from "globby";
+
+import { Link, File } from "./LinkChecker";
+import FILES_TO_IGNORES from "./ignores";
+import { getMarkdownAndAnchors, addLinksToMap } from "./markdown";
+
+export class FileBatch {
+  readonly toCheck: string[];
+  readonly toLoad: string[];
+
+  constructor(toCheck: string[], toLoad: string[]) {
+    this.toCheck = toCheck;
+    this.toLoad = toLoad;
+  }
+
+  static async fromGlobs(
+    toCheckGlobs: string[],
+    toLoadGlobs: string[],
+  ): Promise<FileBatch> {
+    const [toCheck, toLoad] = await Promise.all([
+      globby(toCheckGlobs),
+      globby(toLoadGlobs),
+    ]);
+    return new FileBatch(toCheck, toLoad);
+  }
+
+  /**
+   * Load and process the file batch.
+   *
+   * Returns a triplet:
+   *   1. A list of `File` objects with their anchors. These represent
+   *      the universe of valid internal links for this batch, other
+   *      than any additional we may add at check-time, e.g. images.
+   *   2. A list of Link objects with internal links we will validate.
+   *   3. A list of Link objects with external links we will validate.
+   */
+  async load(): Promise<[File[], Link[], Link[]]> {
+    const files: File[] = [];
+    for (let filePath of this.toLoad) {
+      const [_, anchors] = await getMarkdownAndAnchors(filePath);
+      files.push(new File(filePath, anchors));
+    }
+
+    const linksToOriginFiles = new Map<string, string[]>();
+    for (const filePath of this.toCheck) {
+      const [markdown, anchors] = await getMarkdownAndAnchors(filePath);
+      files.push(new File(filePath, anchors));
+      await addLinksToMap(filePath, markdown, linksToOriginFiles);
+    }
+
+    const internalLinks: Link[] = [];
+    const externalLinks: Link[] = [];
+    for (let [linkPath, originFiles] of linksToOriginFiles) {
+      originFiles = originFiles.filter(
+        (originFile) =>
+          FILES_TO_IGNORES[originFile] == null ||
+          !FILES_TO_IGNORES[originFile].includes(linkPath),
+      );
+
+      if (originFiles.length > 0) {
+        const link = new Link(linkPath, originFiles);
+        link.isExternal ? externalLinks.push(link) : internalLinks.push(link);
+      }
+    }
+
+    return [files, internalLinks, externalLinks];
+  }
+
+  /**
+   * Check that all links in this file batch are valid.
+   * 
+   * Logs the results to the console and returns `true` if there were no issues.
+   */
+  async check(externalLinks: boolean, otherFiles: File[]): Promise<boolean> {
+    const [docsFiles, internalLinkList, externalLinkList] = await this.load();
+    const existingFiles = docsFiles.concat(otherFiles);
+
+    const results = await Promise.all(
+      internalLinkList.map((link) => link.checkLink(existingFiles)),
+    );
+
+    if (externalLinks) {
+      // For loop reduces the risk of rate-limiting.
+      for (let link of externalLinkList) {
+        results.push(await link.checkLink(existingFiles));
+      }
+    }
+
+    let allGood = true;
+    results.forEach((linkErrors) => {
+      linkErrors.forEach((errorMessage) => {
+        console.error(errorMessage);
+        allGood = false;
+      });
+    });
+    return allGood;
+  }
+}

--- a/scripts/lib/links/LinkChecker.test.ts
+++ b/scripts/lib/links/LinkChecker.test.ts
@@ -69,14 +69,14 @@ describe("Test the constructor of Link", () => {
 describe("Validate links", () => {
   test("Validate existing internal links with absolute path", async () => {
     let testLink = new Link("/testpath", ["/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", [], false);
+    let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([]);
   });
 
   test("Validate non-existing internal links with absolute path", async () => {
     let testLink = new Link("/test-alternative-path", ["/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", [], false);
+    let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([
       "❌ /testorigin.mdx: Could not find link '/test-alternative-path'",
@@ -85,14 +85,14 @@ describe("Validate links", () => {
 
   test("Validate existing internal links with relative path", async () => {
     let testLink = new Link("../testpath", ["docs/test/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", [], false);
+    let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([]);
   });
 
   test("Validate non-existing internal links with relative path", async () => {
     let testLink = new Link("../testpath", ["docs/test1/test2/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", [], false);
+    let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([
       "❌ docs/test1/test2/testorigin.mdx: Could not find link '../testpath'",
@@ -106,8 +106,8 @@ describe("Validate links", () => {
       "docs/test/test3/testorigin.mdx",
       "docs/test/test2/test4/testorigin.mdx",
     ]);
-    let testFile1 = new File("docs/testpath.mdx", [], false);
-    let testFile2 = new File("docs/test/test2/testpath.mdx", [], false);
+    let testFile1 = new File("docs/testpath.mdx", []);
+    let testFile2 = new File("docs/test/test2/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
     expect(results).toEqual([]);
   });
@@ -119,8 +119,8 @@ describe("Validate links", () => {
       "docs/test/test3/testorigin.mdx",
       "docs/test/test2/test4/testorigin.mdx",
     ]);
-    let testFile1 = new File("docs/test/testpath.mdx", [], false);
-    let testFile2 = new File("docs/test2/test3/testpath.mdx", [], false);
+    let testFile1 = new File("docs/test/testpath.mdx", []);
+    let testFile2 = new File("docs/test2/test3/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
     expect(results).toEqual([
       "❌ docs/test/testorigin.mdx: Could not find link '/testpath' ❓ Did you mean '/test/testpath'?",
@@ -139,8 +139,8 @@ describe("Validate links", () => {
       "docs/test/test3/testorigin.mdx",
       "docs/test/test2/test4/testorigin.mdx",
     ]);
-    let testFile1 = new File("docs/testpath.mdx", [], false);
-    let testFile2 = new File("docs/test/test2/testpath.mdx", [], false);
+    let testFile1 = new File("docs/testpath.mdx", []);
+    let testFile2 = new File("docs/test/test2/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
     expect(results).toEqual([
       "❌ docs/test/test2/testorigin.mdx: Could not find link '../testpath'",
@@ -150,14 +150,14 @@ describe("Validate links", () => {
 
   test("Validate anchor of existing internal links with absolute path", async () => {
     let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", ["#test_anchor"], false);
+    let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([]);
   });
 
   test("Validate anchor of non-existing internal links with absolute path", async () => {
     let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
-    let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"], false);
+    let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([
       "❌ /testorigin.mdx: Could not find link '/testpath#test_anchor' ❓ Did you mean '/testpath#test_diff_anchor'?",
@@ -168,7 +168,7 @@ describe("Validate links", () => {
     let testLink = new Link("../testpath#test_anchor", [
       "docs/test/testorigin.mdx",
     ]);
-    let testFile = new File("docs/testpath.mdx", ["#test_anchor"], false);
+    let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([]);
   });
@@ -177,7 +177,7 @@ describe("Validate links", () => {
     let testLink = new Link("../testpath#test-anchor", [
       "docs/test/testorigin.mdx",
     ]);
-    let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"], false);
+    let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual([
       "❌ docs/test/testorigin.mdx: Could not find link '../testpath#test-anchor' ❓ Did you mean '/testpath#test_diff_anchor'?",

--- a/scripts/lib/links/LinkChecker.ts
+++ b/scripts/lib/links/LinkChecker.ts
@@ -25,7 +25,7 @@ export class File {
    *    path: Path to the file
    * anchors: Anchors available in the file
    */
-  constructor(path: string, anchors: string[], synthetic: boolean) {
+  constructor(path: string, anchors: string[], synthetic: boolean = false) {
     this.path = path;
     this.anchors = anchors;
     this.synthetic = synthetic;


### PR DESCRIPTION
In https://github.com/Qiskit/documentation/issues/495, we will start checking historical API docs. For performance, it's important that we don't load every single file in the project at once in memory. Instead, we want to operate in batches: e.g. check all of 0.44, then drop from memory and move on to 0.43.

This PR is a pre-factor to add a new `FileBatch` class. For now, we only have a single `FileBatch`, the same as before. This class still differentiates between files "to load" vs "to check", per https://github.com/Qiskit/documentation/pull/496.