### PR TITLE
Allow checking historical APIs with link checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ npm run check:links
 # Enable the validation of external links
 npm run check:links -- --external
 
-# By default, only the non-API docs are checked. You can add any of these
-# options to check API docs.
-npm run check:links -- --current-apis --qiskit-release-notes
+# By default, only the non-API docs are checked. You can add any of the
+# below arguments to also check API docs and/or Qiskit release notes.
+npm run check:links -- --current-apis --historical-apis --qiskit-release-notes
 
 # Or, run all the checks
 npm run check

--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+import { readdir } from "fs/promises";
+
 import { globby } from "globby";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";

--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -140,22 +140,16 @@ async function determineCurrentDocsFileBatch(
 async function determineHistoricalFileBatches(
   projectName: string,
 ): Promise<FileBatch[]> {
-  const versionIndexPaths = await globby(
-    `docs/api/${projectName}/[0-9]*/index.md`,
-  );
-  versionIndexPaths.sort();
+  const historicalFolders = (
+    await readdir(`docs/api/${projectName}`, { withFileTypes: true })
+  ).filter((file) => file.isDirectory() && file.name.match(/[0-9].*/));
 
   const result = [];
-  for (const indexPath of versionIndexPaths) {
-    const versionMatch = indexPath.match(/(\d+\.\d+)/);
-    if (versionMatch === null) {
-      throw new Error(`Failed to determine version from ${indexPath}`);
-    }
-
+  for (const folder of historicalFolders) {
     const fileBatch = await FileBatch.fromGlobs(
-      [indexPath.replace("index.md", "*")],
+      [`docs/api/${projectName}/${folder.name}/*`],
       [],
-      `${projectName} v${versionMatch[0]}`,
+      `${projectName} v${folder.name}`,
     );
     result.push(fileBatch);
   }

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -28,21 +28,27 @@ export class FileBatch {
    * so that links from other files to these files are recognized.
    */
   readonly toLoad: string[];
+  /**
+   * A short description of the batch to make logging more useful.
+   */
+  readonly description: string;
 
-  constructor(toCheck: string[], toLoad: string[]) {
+  constructor(toCheck: string[], toLoad: string[], description: string) {
     this.toCheck = toCheck;
     this.toLoad = toLoad;
+    this.description = description;
   }
 
   static async fromGlobs(
     toCheckGlobs: string[],
     toLoadGlobs: string[],
+    description: string,
   ): Promise<FileBatch> {
     const [toCheck, toLoad] = await Promise.all([
       globby(toCheckGlobs),
       globby(toLoadGlobs),
     ]);
-    return new FileBatch(toCheck, toLoad);
+    return new FileBatch(toCheck, toLoad, description);
   }
 
   /**
@@ -93,6 +99,8 @@ export class FileBatch {
    * Logs the results to the console and returns `true` if there were no issues.
    */
   async check(externalLinks: boolean, otherFiles: File[]): Promise<boolean> {
+    console.log(`\n\nChecking links for ${this.description}`);
+
     const [docsFiles, internalLinkList, externalLinkList] = await this.load();
     const existingFiles = docsFiles.concat(otherFiles);
 


### PR DESCRIPTION
This unblocks https://github.com/Qiskit/documentation/issues/495. We still have to actually fix the broken links, but we can at least now detect them.

To make the script more interactive, we now output a description of each file batch, like this:

```
Checking links for non-API docs


Checking links for qiskit-ibm-runtime v0.14
❌ docs/api/qiskit-ibm-runtime/0.14/ibm-runtime.md: Could not find link 'runtime_service' ❓ Did you mean '/api/qiskit-ibm-runtime/0.14/ibm-runtime'?
❌ docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.QiskitRuntimeService.md: Could not find link '/api/qiskit/providers_models'


Checking links for qiskit-ibm-runtime v0.15
❌ docs/api/qiskit-ibm-runtime/0.15/ibm-runtime.md: Could not find link 'runtime_service' ❓ Did you mean '/api/qiskit-ibm-runtime/0.15/ibm-runtime'?
❌ docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.QiskitRuntimeService.md: Could not find link '/api/qiskit/providers_models'
```

Note that to fix the broken links, we're going to need to set `toLoad` for some of the projects. For example, you can see in the above `qiskit-ibm-runtime` failures that they need to read in the file `/api/qiskit/providers_models`. I plan to address that in a follow up because we want to load the minimum amount of files possible to reduce memory usage, so I still want to see what we really need to load.