### PR TITLE
Check Runtime historical API docs for broken links

### DIFF
--- a/.github/workflows/external-link-checker.yml
+++ b/.github/workflows/external-link-checker.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Check external links
         run: >
           npm run check:links --
-            --current-apis
-            --qiskit-release-notes
-            --historical-apis
-            --skip-broken-historical
-            --external
+          --current-apis
+          --qiskit-release-notes
+          --historical-apis
+          --skip-broken-historical
+          --external

--- a/.github/workflows/external-link-checker.yml
+++ b/.github/workflows/external-link-checker.yml
@@ -32,4 +32,10 @@ jobs:
         run: npm ci
 
       - name: Check external links
-        run: npm run check:links -- --current-apis --qiskit-release-notes --external
+        run: |
+          npm run check:links -- \
+            --current-apis \
+            --qiskit-release-notes \
+            --historical-apis \
+            --skip-broken-historical \
+            --external

--- a/.github/workflows/external-link-checker.yml
+++ b/.github/workflows/external-link-checker.yml
@@ -32,10 +32,10 @@ jobs:
         run: npm ci
 
       - name: Check external links
-        run: |
-          npm run check:links -- \
-            --current-apis \
-            --qiskit-release-notes \
-            --historical-apis \
-            --skip-broken-historical \
+        run: >
+          npm run check:links --
+            --current-apis
+            --qiskit-release-notes
+            --historical-apis
+            --skip-broken-historical
             --external

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Link checker
         run: >
           npm run check:links --
-            --current-apis
-            --qiskit-release-notes
-            --historical-apis
-            --skip-broken-historical
+          --current-apis
+          --qiskit-release-notes
+          --historical-apis
+          --skip-broken-historical
       - name: Formatting
         run: npm run check:fmt
       - name: Typecheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,12 @@ jobs:
       - name: Spellcheck
         run: npm run check:spelling
       - name: Link checker
-        run: npm run check:links -- --current-apis --qiskit-release-notes
+        run: |
+          npm run check:links -- \
+            --current-apis \
+            --qiskit-release-notes \
+            --historical-apis \
+            --skip-broken-historical
       - name: Formatting
         run: npm run check:fmt
       - name: Typecheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Spellcheck
         run: npm run check:spelling
       - name: Link checker
-        run: |
-          npm run check:links -- \
-            --current-apis \
-            --qiskit-release-notes \
-            --historical-apis \
+        run: >
+          npm run check:links --
+            --current-apis
+            --qiskit-release-notes
+            --historical-apis
             --skip-broken-historical
       - name: Formatting
         run: npm run check:fmt

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ npm run check:links -- --external
 # below arguments to also check API docs and/or Qiskit release notes.
 npm run check:links -- --current-apis --historical-apis --qiskit-release-notes
 
+# However, `--historical-apis` currently has failing versions, so you may
+# want to add `--skip-broken-historical`.
+npm run check:links -- --historical-apis --skip-broken-historical
+
 # Or, run all the checks
 npm run check
 ```


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/495. We now will enforce in CI that historical API docs are valid for Runtime and Provider. To do this, this PR adds the `--skip-broken-historical` argument.

In a follow up, I want to try checking Qiskit docs, at least certain versions. But I'm waiting until we regenerate the docs with https://github.com/Qiskit/documentation/pull/552 applied because I suspect it will fix some issues.