### PR TITLE
Remove translations placeholder file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs
+translations

--- a/translations/placeholder.txt
+++ b/translations/placeholder.txt
@@ -1,2 +1,0 @@
-Remove me once actual translations exist. This is only so that the translations/ folder
-is saved with Git.


### PR DESCRIPTION
We now have actual translations under the folder `translations/ja`.

Also fixes our Prettier (autoformatter) config to ignore translations.