### PR TITLE
Fix release notes order

### DIFF
--- a/docs/api/qiskit/release-notes/0.11.md
+++ b/docs/api/qiskit/release-notes/0.11.md
@@ -5,6 +5,42 @@ description: New features and bug fixes
 
 # Qiskit 0.11 release notes
 
+## 0.11.1
+
+We have bumped up Qiskit micro version to 0.11.1 because IBM Q Provider has bumped its micro version as well.
+
+<span id="terra-0-8" />
+
+### Terra 0.8
+
+No Change
+
+<span id="aer-0-2" />
+
+### Aer 0.2
+
+No change
+
+<span id="ignis-0-1" />
+
+### Ignis 0.1
+
+No Change
+
+<span id="aqua-0-5" />
+
+### Aqua 0.5
+
+`qiskit-aqua` has been updated to `0.5.3` to fix code related to changes in how gates inverses are done.
+
+<span id="id569" />
+
+### IBM Q Provider 0.3
+
+The `IBMQProvider` has been updated to version `0.3.1` to fix backward compatibility issues and work with the default 10 job limit in single calls to the IBM Q API v2.
+
+<span id="qiskit-0-11" />
+
 ## 0.11
 
 We have bumped up Qiskit minor version to 0.11 because IBM Q Provider has bumped up its minor version too. On Aer, we have jumped from 0.2.1 to 0.2.3 because there was an issue detected right after releasing 0.2.2 and before Qiskit 0.11 went online.
@@ -104,38 +140,3 @@ backend_2 = provider_2.get_backend('ibmq_qasm_simulator')
 You can find more information and details in the [IBM Q Provider documentation](https://github.com/Qiskit/qiskit-ibmq-provider).
 
 <span id="qiskit-0-10" />
-## 0.11.1
-
-We have bumped up Qiskit micro version to 0.11.1 because IBM Q Provider has bumped its micro version as well.
-
-<span id="terra-0-8" />
-
-### Terra 0.8
-
-No Change
-
-<span id="aer-0-2" />
-
-### Aer 0.2
-
-No change
-
-<span id="ignis-0-1" />
-
-### Ignis 0.1
-
-No Change
-
-<span id="aqua-0-5" />
-
-### Aqua 0.5
-
-`qiskit-aqua` has been updated to `0.5.3` to fix code related to changes in how gates inverses are done.
-
-<span id="id569" />
-
-### IBM Q Provider 0.3
-
-The `IBMQProvider` has been updated to version `0.3.1` to fix backward compatibility issues and work with the default 10 job limit in single calls to the IBM Q API v2.
-
-<span id="qiskit-0-11" />

--- a/docs/api/qiskit/release-notes/0.18.md
+++ b/docs/api/qiskit/release-notes/0.18.md
@@ -5,6 +5,71 @@ description: New features and bug fixes
 
 # Qiskit 0.18 release notes
 
+## 0.18.3
+
+<span id="terra-0-13-0" />
+
+### Terra 0.13.0
+
+No Change
+
+<span id="id488" />
+
+### Aer 0.5.1
+
+<span id="release-notes-0-5-1-upgrade-notes" />
+
+<span id="id489" />
+
+#### Upgrade Notes
+
+*   Changes how transpilation passes are handled in the C++ Controller classes so that each pass must be explicitly called. This allows for greater customization on when each pass should be called, and with what parameters. In particular this enables setting different parameters for the gate fusion optimization pass depending on the QasmController simulation method.
+*   Add `gate_length_units` kwarg to `qiskit.providers.aer.noise.NoiseModel.from_device()` for specifying custom `gate_lengths` in the device noise model function to handle unit conversions for internal code.
+*   Add Controlled-Y (“cy”) gate to the Stabilizer simulator methods supported gateset.
+*   For Aer’s backend the jsonschema validation of input qobj objects from terra is now opt-in instead of being enabled by default. If you want to enable jsonschema validation of qobj set the `validate` kwarg on the `qiskit.providers.aer.QasmSimualtor.run()` method for the backend object to `True`.
+
+<span id="release-notes-0-5-1-bug-fixes" />
+
+<span id="id490" />
+
+#### Bug Fixes
+
+*   Remove “extended\_stabilizer” from the automatically selected simulation methods. This is needed as the extended stabilizer method is not exact and may give incorrect results for certain circuits unless the user knows how to optimize its configuration parameters.
+
+    The automatic method now only selects from “stabilizer”, “density\_matrix”, and “statevector” methods. If a non-Clifford circuit that is too large for the statevector method is executed an exception will be raised suggesting you could try explicitly using the “extended\_stabilizer” or “matrix\_product\_state” methods instead.
+
+*   Fixes Controller classes so that the ReduceBarrier transpilation pass is applied first. This prevents barrier instructions from preventing truncation of unused qubits if the only instruction defined on them was a barrier.
+
+*   Disables gate fusion for the matrix product state simulation method as this was causing issues with incorrect results being returned in some cases.
+
+*   Fix error in gate time unit conversion for device noise model with thermal relaxation errors and gate errors. The error probability the depolarizing error was being calculated with gate time in microseconds, while for thermal relaxation it was being calculated in nanoseconds. This resulted in no depolarizing error being applied as the incorrect units would make the device seem to be coherence limited.
+
+*   Fix bug in incorrect composition of QuantumErrors when the qubits of composed instructions differ.
+
+*   Fix issue where the “diagonal” gate is checked to be unitary with too high a tolerance. This was causing diagonals generated from Numpy functions to often fail the test.
+
+*   Fix remove-barrier circuit optimization pass to be applied before qubit trucation. This fixes an issue where barriers inserted by the Terra transpiler across otherwise inactive qubits would prevent them from being truncated.
+
+<span id="id491" />
+
+### Ignis 0.3.0
+
+No Change
+
+<span id="aqua-0-6-6" />
+
+### Aqua 0.6.6
+
+No Change
+
+<span id="ibm-q-provider-0-6-1" />
+
+### IBM Q Provider 0.6.1
+
+No Change
+
+<span id="qiskit-0-18-0" />
+
 ## 0.18.0
 
 <span id="release-notes-0-13-0" />
@@ -985,67 +1050,3 @@ No Change
 No Change
 
 <span id="qiskit-0-17-0" />
-## 0.18.3
-
-<span id="terra-0-13-0" />
-
-### Terra 0.13.0
-
-No Change
-
-<span id="id488" />
-
-### Aer 0.5.1
-
-<span id="release-notes-0-5-1-upgrade-notes" />
-
-<span id="id489" />
-
-#### Upgrade Notes
-
-*   Changes how transpilation passes are handled in the C++ Controller classes so that each pass must be explicitly called. This allows for greater customization on when each pass should be called, and with what parameters. In particular this enables setting different parameters for the gate fusion optimization pass depending on the QasmController simulation method.
-*   Add `gate_length_units` kwarg to `qiskit.providers.aer.noise.NoiseModel.from_device()` for specifying custom `gate_lengths` in the device noise model function to handle unit conversions for internal code.
-*   Add Controlled-Y (“cy”) gate to the Stabilizer simulator methods supported gateset.
-*   For Aer’s backend the jsonschema validation of input qobj objects from terra is now opt-in instead of being enabled by default. If you want to enable jsonschema validation of qobj set the `validate` kwarg on the `qiskit.providers.aer.QasmSimualtor.run()` method for the backend object to `True`.
-
-<span id="release-notes-0-5-1-bug-fixes" />
-
-<span id="id490" />
-
-#### Bug Fixes
-
-*   Remove “extended\_stabilizer” from the automatically selected simulation methods. This is needed as the extended stabilizer method is not exact and may give incorrect results for certain circuits unless the user knows how to optimize its configuration parameters.
-
-    The automatic method now only selects from “stabilizer”, “density\_matrix”, and “statevector” methods. If a non-Clifford circuit that is too large for the statevector method is executed an exception will be raised suggesting you could try explicitly using the “extended\_stabilizer” or “matrix\_product\_state” methods instead.
-
-*   Fixes Controller classes so that the ReduceBarrier transpilation pass is applied first. This prevents barrier instructions from preventing truncation of unused qubits if the only instruction defined on them was a barrier.
-
-*   Disables gate fusion for the matrix product state simulation method as this was causing issues with incorrect results being returned in some cases.
-
-*   Fix error in gate time unit conversion for device noise model with thermal relaxation errors and gate errors. The error probability the depolarizing error was being calculated with gate time in microseconds, while for thermal relaxation it was being calculated in nanoseconds. This resulted in no depolarizing error being applied as the incorrect units would make the device seem to be coherence limited.
-
-*   Fix bug in incorrect composition of QuantumErrors when the qubits of composed instructions differ.
-
-*   Fix issue where the “diagonal” gate is checked to be unitary with too high a tolerance. This was causing diagonals generated from Numpy functions to often fail the test.
-
-*   Fix remove-barrier circuit optimization pass to be applied before qubit trucation. This fixes an issue where barriers inserted by the Terra transpiler across otherwise inactive qubits would prevent them from being truncated.
-
-<span id="id491" />
-
-### Ignis 0.3.0
-
-No Change
-
-<span id="aqua-0-6-6" />
-
-### Aqua 0.6.6
-
-No Change
-
-<span id="ibm-q-provider-0-6-1" />
-
-### IBM Q Provider 0.6.1
-
-No Change
-
-<span id="qiskit-0-18-0" />

--- a/docs/api/qiskit/release-notes/0.19.md
+++ b/docs/api/qiskit/release-notes/0.19.md
@@ -5,6 +5,223 @@ description: New features and bug fixes
 
 # Qiskit 0.19 release notes
 
+## 0.19.6
+
+<span id="terra-0-14-2" />
+
+### Terra 0.14.2
+
+No Change
+
+<span id="aer-0-5-2" />
+
+### Aer 0.5.2
+
+No Change
+
+<span id="ignis-0-3-3" />
+
+### Ignis 0.3.3
+
+<span id="release-notes-0-3-3-upgrade-notes" />
+
+<span id="id446" />
+
+#### Upgrade Notes
+
+*   A new requirement [scikit-learn](https://scikit-learn.org/stable/) has been added to the requirements list. This dependency was added in the 0.3.0 release but wasn’t properly exposed as a dependency in that release. This would lead to an `ImportError` if the `qiskit.ignis.measurement.discriminator.iq_discriminators` module was imported. This is now correctly listed as a dependency so that `scikit-learn` will be installed with qiskit-ignis.
+
+<span id="release-notes-0-3-3-bug-fixes" />
+
+<span id="id447" />
+
+#### Bug Fixes
+
+*   Fixes an issue in qiskit-ignis 0.3.2 which would raise an `ImportError` when `qiskit.ignis.verification.tomography.fitters.process_fitter` was imported without `cvxpy` being installed.
+
+<span id="aqua-0-7-3" />
+
+### Aqua 0.7.3
+
+No Change
+
+<span id="ibm-q-provider-0-7-2" />
+
+### IBM Q Provider 0.7.2
+
+No Change
+
+<span id="qiskit-0-19-5" />
+
+## 0.19.5
+
+<span id="id448" />
+
+### Terra 0.14.2
+
+No Change
+
+<span id="id449" />
+
+### Aer 0.5.2
+
+No Change
+
+<span id="ignis-0-3-2" />
+
+### Ignis 0.3.2
+
+<span id="id450" />
+
+#### Bug Fixes
+
+*   The `qiskit.ignis.verification.TomographyFitter.fit()` method has improved detection logic for the default fitter. Previously, the `cvx` fitter method was used whenever [cvxpy](https://www.cvxpy.org/) was installed. However, it was possible to install cvxpy without an SDP solver that would work for the `cvx` fitter method. This logic has been reworked so that the `cvx` fitter method is only used if `cvxpy` is installed and an SDP solver is present that can be used. Otherwise, the `lstsq` fitter is used.
+*   Fixes an edge case in `qiskit.ignis.mitigation.measurement.fitters.MeasurementFitter.apply()` for input that has invalid or incorrect state labels that don’t match the calibration circuit. Previously, this would not error and just return an empty result. Instead now this case is correctly caught and a `QiskitError` exception is raised when using incorrect labels.
+
+<span id="id451" />
+
+### Aqua 0.7.3
+
+<span id="release-notes-0-7-3-upgrade-notes" />
+
+<span id="id452" />
+
+#### Upgrade Notes
+
+*   The [cvxpy](https://www.cvxpy.org/) dependency which is required for the svm classifier has been removed from the requirements list and made an optional dependency. This is because installing cvxpy is not seamless in every environment and often requires a compiler be installed to run. To use the svm classifier now you’ll need to install cvxpy by either running `pip install cvxpy<1.1.0` or to install it with aqua running `pip install qiskit-aqua[cvx]`.
+
+<span id="release-notes-0-7-3-bug-fixes" />
+
+<span id="id453" />
+
+#### Bug Fixes
+
+*   The `compose` method of the `CircuitOp` used `QuantumCircuit.combine` which has been changed to use `QuantumCircuit.compose`. Using combine leads to the problem that composing an operator with a `CircuitOp` based on a named register does not chain the operators but stacks them. E.g. composing `Z ^ 2` with a circuit based on a 2-qubit named register yielded a 4-qubit operator instead of a 2-qubit operator.
+*   The `MatrixOp.to_instruction` method previously returned an operator and not an instruction. This method has been updated to return an Instruction. Note that this only works if the operator primitive is unitary, otherwise an error is raised upon the construction of the instruction.
+*   The `__hash__` method of the `PauliOp` class used the `id()` method which prevents set comparisons to work as expected since they rely on hash tables and identical objects used to not have identical hashes. Now, the implementation uses a hash of the string representation inline with the implementation in the `Pauli` class.
+
+<span id="id454" />
+
+### IBM Q Provider 0.7.2
+
+No Change
+
+<span id="qiskit-0-19-4" />
+## 0.19.4
+
+<span id="id455" />
+
+### Terra 0.14.2
+
+<span id="release-notes-0-14-2-upgrade-notes" />
+
+<span id="id456" />
+
+#### Upgrade Notes
+
+*   The `circuit_to_gate` and `circuit_to_instruction` converters had previously automatically included the generated gate or instruction in the active `SessionEquivalenceLibrary`. These converters now accept an optional `equivalence_library` keyword argument to specify if and where the converted instances should be registered. The default behavior is not to register the converted instance.
+
+<span id="release-notes-0-14-2-bug-fixes" />
+
+<span id="id457" />
+
+#### Bug Fixes
+
+*   Implementations of the multi-controlled X Gate (`MCXGrayCode`, `MCXRecursive` and `MCXVChain`) have had their `name` properties changed to more accurately describe their implementation (`mcx_gray`, `mcx_recursive`, and `mcx_vchain` respectively.) Previously, these gates shared the name ```mcx` with ``MCXGate```, which caused these gates to be incorrectly transpiled and simulated.
+*   `ControlledGate` instances with a set `ctrl_state` were in some cases not being evaluated as equal, even if the compared gates were equivalent. This has been resolved.
+*   Fixed the SI unit conversion for `qiskit.pulse.SetFrequency`. The `SetFrequency` instruction should be in Hz on the frontend and has to be converted to GHz when `SetFrequency` is converted to `PulseQobjInstruction`.
+*   Open controls were implemented by modifying a gate's definition. However, when the gate already exists in the basis, this definition is not used, which yields incorrect circuits sent to a backend. This modifies the unroller to output the definition if it encounters a controlled gate with open controls.
+
+<span id="id458" />
+
+### Aer 0.5.2
+
+No Change
+
+<span id="ignis-0-3-0" />
+
+### Ignis 0.3.0
+
+No Change
+
+<span id="aqua-0-7-2" />
+
+### Aqua 0.7.2
+
+<span id="id459" />
+
+#### Prelude
+
+VQE expectation computation with Aer qasm\_simulator now defaults to a computation that has the expected shot noise behavior.
+
+<span id="id460" />
+
+#### Upgrade Notes
+
+*   [cvxpy](https://github.com/cvxgrp/cvxpy/) is now in the requirements list as a dependency for qiskit-aqua. It is used for the quadratic program solver which is used as part of the `qiskit.aqua.algorithms.QSVM`. Previously `cvxopt` was an optional dependency that needed to be installed to use this functionality. This is no longer required as cvxpy will be installed with qiskit-aqua.
+*   For state tomography run as part of `qiskit.aqua.algorithms.HHL` with a QASM backend the tomography fitter function `qiskit.ignis.verification.StateTomographyFitter.fit()` now gets called explicitly with the method set to `lstsq` to always use the least-squares fitting. Previously it would opportunistically try to use the `cvx` fitter if `cvxpy` were installed. But, the `cvx` fitter depends on a specifically configured `cvxpy` installation with an SDP solver installed as part of `cvxpy` which is not always present in an environment with `cvxpy` installed.
+*   The VQE expectation computation using qiskit-aer’s `qiskit.providers.aer.extensions.SnapshotExpectationValue` instruction is not enabled by default anymore. This was changed to be the default in 0.7.0 because it is significantly faster, but it led to unexpected ideal results without shot noise (see [#1013](https://github.com/Qiskit/qiskit-aqua/issues/1013) for more details). The default has now changed back to match user expectations. Using the faster expectation computation is now opt-in by setting the new `include_custom` kwarg to `True` on the `qiskit.aqua.algorithms.VQE` constructor.
+
+<span id="id462" />
+
+#### New Features
+
+*   A new kwarg `include_custom` has been added to the constructor for `qiskit.aqua.algorithms.VQE` and it’s subclasses (mainly `qiskit.aqua.algorithms.QAOA`). When set to true and the `expectation` kwarg is set to `None` (the default) this will enable the use of VQE expectation computation with Aer’s `qasm_simulator` `qiskit.providers.aer.extensions.SnapshotExpectationValue` instruction. The special Aer snapshot based computation is much faster but with the ideal output similar to state vector simulator.
+
+<span id="id463" />
+
+### IBM Q Provider 0.7.2
+
+No Change
+
+<span id="qiskit-0-19-3" />
+## 0.19.3
+
+<span id="terra-0-14-1" />
+
+### Terra 0.14.1
+
+No Change
+
+<span id="id464" />
+
+### Aer 0.5.2
+
+<span id="id465" />
+
+#### Bug Fixes
+
+*   Fixed bug with statevector and unitary simulators running a number of (parallel) shots equal to the number of CPU threads instead of only running a single shot.
+*   Fixes the “diagonal” qobj gate instructions being applied incorrectly in the density matrix Qasm Simulator method.
+*   Fixes bug where conditional gates were not being applied correctly on the density matrix simulation method.
+*   Fix bug in CZ gate and Z gate for “density\_matrix\_gpu” and “density\_matrix\_thrust” QasmSimulator methods.
+*   Fixes issue where memory requirements of simulation were not being checked on the QasmSimulator when using a non-automatic simulation method.
+*   Fixed a memory leak that effected the GPU simulator methods
+
+<span id="id466" />
+
+### Ignis 0.3.0
+
+No Change
+
+<span id="aqua-0-7-1" />
+
+### Aqua 0.7.1
+
+No Change
+
+<span id="id467" />
+
+### IBM Q Provider 0.7.2
+
+<span id="id468" />
+
+#### Bug Fixes
+
+*   `qiskit.provider.ibmq.IBMQBackend.jobs()` will now return the correct list of `IBMQJob` objects when the `status` kwarg is set to `'RUNNING'`. Fixes [#523](https://github.com/Qiskit/qiskit-ibmq-provider/issues/523)
+*   The package metadata has been updated to properly reflect the dependency on `qiskit-terra` >= 0.14.0. This dependency was implicitly added as part of the 0.7.0 release but was not reflected in the package requirements so it was previously possible to install `qiskit-ibmq-provider` with a version of `qiskit-terra` which was too old. Fixes [#677](https://github.com/Qiskit/qiskit-ibmq-provider/issues/677)
+
+<span id="qiskit-0-19-0" />
 ## 0.19.0
 
 <span id="terra-0-14-0" />
@@ -318,219 +535,3 @@ The ability of running algorithms using dictionaries as parameters as well as us
 *   Fixed an issue where `nest_asyncio.apply()` may raise an exception if there is no asyncio loop due to threading.
 
 <span id="qiskit-0-18-3" />
-## 0.19.3
-
-<span id="terra-0-14-1" />
-
-### Terra 0.14.1
-
-No Change
-
-<span id="id464" />
-
-### Aer 0.5.2
-
-<span id="id465" />
-
-#### Bug Fixes
-
-*   Fixed bug with statevector and unitary simulators running a number of (parallel) shots equal to the number of CPU threads instead of only running a single shot.
-*   Fixes the “diagonal” qobj gate instructions being applied incorrectly in the density matrix Qasm Simulator method.
-*   Fixes bug where conditional gates were not being applied correctly on the density matrix simulation method.
-*   Fix bug in CZ gate and Z gate for “density\_matrix\_gpu” and “density\_matrix\_thrust” QasmSimulator methods.
-*   Fixes issue where memory requirements of simulation were not being checked on the QasmSimulator when using a non-automatic simulation method.
-*   Fixed a memory leak that effected the GPU simulator methods
-
-<span id="id466" />
-
-### Ignis 0.3.0
-
-No Change
-
-<span id="aqua-0-7-1" />
-
-### Aqua 0.7.1
-
-No Change
-
-<span id="id467" />
-
-### IBM Q Provider 0.7.2
-
-<span id="id468" />
-
-#### Bug Fixes
-
-*   `qiskit.provider.ibmq.IBMQBackend.jobs()` will now return the correct list of `IBMQJob` objects when the `status` kwarg is set to `'RUNNING'`. Fixes [#523](https://github.com/Qiskit/qiskit-ibmq-provider/issues/523)
-*   The package metadata has been updated to properly reflect the dependency on `qiskit-terra` >= 0.14.0. This dependency was implicitly added as part of the 0.7.0 release but was not reflected in the package requirements so it was previously possible to install `qiskit-ibmq-provider` with a version of `qiskit-terra` which was too old. Fixes [#677](https://github.com/Qiskit/qiskit-ibmq-provider/issues/677)
-
-<span id="qiskit-0-19-0" />
-## 0.19.4
-
-<span id="id455" />
-
-### Terra 0.14.2
-
-<span id="release-notes-0-14-2-upgrade-notes" />
-
-<span id="id456" />
-
-#### Upgrade Notes
-
-*   The `circuit_to_gate` and `circuit_to_instruction` converters had previously automatically included the generated gate or instruction in the active `SessionEquivalenceLibrary`. These converters now accept an optional `equivalence_library` keyword argument to specify if and where the converted instances should be registered. The default behavior is not to register the converted instance.
-
-<span id="release-notes-0-14-2-bug-fixes" />
-
-<span id="id457" />
-
-#### Bug Fixes
-
-*   Implementations of the multi-controlled X Gate (`MCXGrayCode`, `MCXRecursive` and `MCXVChain`) have had their `name` properties changed to more accurately describe their implementation (`mcx_gray`, `mcx_recursive`, and `mcx_vchain` respectively.) Previously, these gates shared the name ```mcx` with ``MCXGate```, which caused these gates to be incorrectly transpiled and simulated.
-*   `ControlledGate` instances with a set `ctrl_state` were in some cases not being evaluated as equal, even if the compared gates were equivalent. This has been resolved.
-*   Fixed the SI unit conversion for `qiskit.pulse.SetFrequency`. The `SetFrequency` instruction should be in Hz on the frontend and has to be converted to GHz when `SetFrequency` is converted to `PulseQobjInstruction`.
-*   Open controls were implemented by modifying a gate's definition. However, when the gate already exists in the basis, this definition is not used, which yields incorrect circuits sent to a backend. This modifies the unroller to output the definition if it encounters a controlled gate with open controls.
-
-<span id="id458" />
-
-### Aer 0.5.2
-
-No Change
-
-<span id="ignis-0-3-0" />
-
-### Ignis 0.3.0
-
-No Change
-
-<span id="aqua-0-7-2" />
-
-### Aqua 0.7.2
-
-<span id="id459" />
-
-#### Prelude
-
-VQE expectation computation with Aer qasm\_simulator now defaults to a computation that has the expected shot noise behavior.
-
-<span id="id460" />
-
-#### Upgrade Notes
-
-*   [cvxpy](https://github.com/cvxgrp/cvxpy/) is now in the requirements list as a dependency for qiskit-aqua. It is used for the quadratic program solver which is used as part of the `qiskit.aqua.algorithms.QSVM`. Previously `cvxopt` was an optional dependency that needed to be installed to use this functionality. This is no longer required as cvxpy will be installed with qiskit-aqua.
-*   For state tomography run as part of `qiskit.aqua.algorithms.HHL` with a QASM backend the tomography fitter function `qiskit.ignis.verification.StateTomographyFitter.fit()` now gets called explicitly with the method set to `lstsq` to always use the least-squares fitting. Previously it would opportunistically try to use the `cvx` fitter if `cvxpy` were installed. But, the `cvx` fitter depends on a specifically configured `cvxpy` installation with an SDP solver installed as part of `cvxpy` which is not always present in an environment with `cvxpy` installed.
-*   The VQE expectation computation using qiskit-aer’s `qiskit.providers.aer.extensions.SnapshotExpectationValue` instruction is not enabled by default anymore. This was changed to be the default in 0.7.0 because it is significantly faster, but it led to unexpected ideal results without shot noise (see [#1013](https://github.com/Qiskit/qiskit-aqua/issues/1013) for more details). The default has now changed back to match user expectations. Using the faster expectation computation is now opt-in by setting the new `include_custom` kwarg to `True` on the `qiskit.aqua.algorithms.VQE` constructor.
-
-<span id="id462" />
-
-#### New Features
-
-*   A new kwarg `include_custom` has been added to the constructor for `qiskit.aqua.algorithms.VQE` and it’s subclasses (mainly `qiskit.aqua.algorithms.QAOA`). When set to true and the `expectation` kwarg is set to `None` (the default) this will enable the use of VQE expectation computation with Aer’s `qasm_simulator` `qiskit.providers.aer.extensions.SnapshotExpectationValue` instruction. The special Aer snapshot based computation is much faster but with the ideal output similar to state vector simulator.
-
-<span id="id463" />
-
-### IBM Q Provider 0.7.2
-
-No Change
-
-<span id="qiskit-0-19-3" />
-## 0.19.5
-
-<span id="id448" />
-
-### Terra 0.14.2
-
-No Change
-
-<span id="id449" />
-
-### Aer 0.5.2
-
-No Change
-
-<span id="ignis-0-3-2" />
-
-### Ignis 0.3.2
-
-<span id="id450" />
-
-#### Bug Fixes
-
-*   The `qiskit.ignis.verification.TomographyFitter.fit()` method has improved detection logic for the default fitter. Previously, the `cvx` fitter method was used whenever [cvxpy](https://www.cvxpy.org/) was installed. However, it was possible to install cvxpy without an SDP solver that would work for the `cvx` fitter method. This logic has been reworked so that the `cvx` fitter method is only used if `cvxpy` is installed and an SDP solver is present that can be used. Otherwise, the `lstsq` fitter is used.
-*   Fixes an edge case in `qiskit.ignis.mitigation.measurement.fitters.MeasurementFitter.apply()` for input that has invalid or incorrect state labels that don’t match the calibration circuit. Previously, this would not error and just return an empty result. Instead now this case is correctly caught and a `QiskitError` exception is raised when using incorrect labels.
-
-<span id="id451" />
-
-### Aqua 0.7.3
-
-<span id="release-notes-0-7-3-upgrade-notes" />
-
-<span id="id452" />
-
-#### Upgrade Notes
-
-*   The [cvxpy](https://www.cvxpy.org/) dependency which is required for the svm classifier has been removed from the requirements list and made an optional dependency. This is because installing cvxpy is not seamless in every environment and often requires a compiler be installed to run. To use the svm classifier now you’ll need to install cvxpy by either running `pip install cvxpy<1.1.0` or to install it with aqua running `pip install qiskit-aqua[cvx]`.
-
-<span id="release-notes-0-7-3-bug-fixes" />
-
-<span id="id453" />
-
-#### Bug Fixes
-
-*   The `compose` method of the `CircuitOp` used `QuantumCircuit.combine` which has been changed to use `QuantumCircuit.compose`. Using combine leads to the problem that composing an operator with a `CircuitOp` based on a named register does not chain the operators but stacks them. E.g. composing `Z ^ 2` with a circuit based on a 2-qubit named register yielded a 4-qubit operator instead of a 2-qubit operator.
-*   The `MatrixOp.to_instruction` method previously returned an operator and not an instruction. This method has been updated to return an Instruction. Note that this only works if the operator primitive is unitary, otherwise an error is raised upon the construction of the instruction.
-*   The `__hash__` method of the `PauliOp` class used the `id()` method which prevents set comparisons to work as expected since they rely on hash tables and identical objects used to not have identical hashes. Now, the implementation uses a hash of the string representation inline with the implementation in the `Pauli` class.
-
-<span id="id454" />
-
-### IBM Q Provider 0.7.2
-
-No Change
-
-<span id="qiskit-0-19-4" />
-## 0.19.6
-
-<span id="terra-0-14-2" />
-
-### Terra 0.14.2
-
-No Change
-
-<span id="aer-0-5-2" />
-
-### Aer 0.5.2
-
-No Change
-
-<span id="ignis-0-3-3" />
-
-### Ignis 0.3.3
-
-<span id="release-notes-0-3-3-upgrade-notes" />
-
-<span id="id446" />
-
-#### Upgrade Notes
-
-*   A new requirement [scikit-learn](https://scikit-learn.org/stable/) has been added to the requirements list. This dependency was added in the 0.3.0 release but wasn’t properly exposed as a dependency in that release. This would lead to an `ImportError` if the `qiskit.ignis.measurement.discriminator.iq_discriminators` module was imported. This is now correctly listed as a dependency so that `scikit-learn` will be installed with qiskit-ignis.
-
-<span id="release-notes-0-3-3-bug-fixes" />
-
-<span id="id447" />
-
-#### Bug Fixes
-
-*   Fixes an issue in qiskit-ignis 0.3.2 which would raise an `ImportError` when `qiskit.ignis.verification.tomography.fitters.process_fitter` was imported without `cvxpy` being installed.
-
-<span id="aqua-0-7-3" />
-
-### Aqua 0.7.3
-
-No Change
-
-<span id="ibm-q-provider-0-7-2" />
-
-### IBM Q Provider 0.7.2
-
-No Change
-
-<span id="qiskit-0-19-5" />

--- a/docs/api/qiskit/release-notes/0.20.md
+++ b/docs/api/qiskit/release-notes/0.20.md
@@ -5,6 +5,57 @@ description: New features and bug fixes
 
 # Qiskit 0.20 release notes
 
+## 0.20.1
+
+<span id="id405" />
+
+### Terra 0.15.2
+
+<span id="release-notes-0-15-2-bug-fixes" />
+
+<span id="id406" />
+
+#### Bug Fixes
+
+*   When accessing the `definition` attribute of a parameterized `Gate` instance, the generated `QuantumCircuit` had been generated with an invalid `ParameterTable`, such that reading from `QuantumCircuit.parameters` or calling `QuantumCircuit.bind_parameters` would incorrectly report the unbound parameters. This has been resolved.
+*   `SXGate().inverse()` had previously returned an ‘sx\_dg’ gate with a correct `definition` but incorrect `to_matrix`. This has been updated such that `SXGate().inverse()` returns an `SXdgGate()` and vice versa.
+*   `Instruction.inverse()`, when not overridden by a subclass, would in some cases return a `Gate` instance with an incorrect `to_matrix` method. The instances of incorrect `to_matrix` methods have been removed.
+*   For `C3XGate` with a non-zero `angle`, inverting the gate via `C3XGate.inverse()` had previously generated an incorrect inverse gate. This has been corrected.
+*   The `MCXGate` modes have been updated to return a gate of the same mode when calling `.inverse()`. This resolves an issue where in some cases, transpiling a circuit containing the inverse of an `MCXVChain` gate would raise an error.
+*   Previously, when creating a multiply controlled phase gate via `PhaseGate.control`, an `MCU1Gate` gate had been returned. This has been had corrected so that an `MCPhaseGate` is returned.
+*   Previously, attempting to decompose a circuit containing an `MCPhaseGate` would raise an error due to an inconsistency in the definition of the `MCPhaseGate`. This has been corrected.
+*   `QuantumCircuit.compose` and `DAGCircuit.compose` had, in some cases, incorrectly translated conditional gates if the input circuit contained more than one `ClassicalRegister`. This has been resolved.
+*   Fixed an issue when creating a [`qiskit.result.Counts`](/api/qiskit/qiskit.result.Counts "qiskit.result.Counts") object from an empty data dictionary. Now this will create an empty [`Counts`](/api/qiskit/qiskit.result.Counts "qiskit.result.Counts") object. The [`most_frequent()`](/api/qiskit/qiskit.result.Counts#most_frequent "qiskit.result.Counts.most_frequent") method is also updated to raise a more descriptive exception when the object is empty. Fixes [#5017](https://github.com/Qiskit/qiskit-terra/issues/5017)
+*   Extending circuits with differing registers updated the `qregs` and `cregs` properties accordingly, but not the `qubits` and `clbits` lists. As these are no longer generated from the registers but are cached lists, this lead to a discrepancy of registers and bits. This has been fixed and the `extend` method explicitly updates the cached bit lists.
+*   Fix bugs of the concrete implementations of meth:\~qiskit.circuit.ControlledGate.inverse method which do not preserve the `ctrl_state` parameter.
+*   A bug was fixed that caused long pulse schedules to throw a recursion error.
+
+<span id="id407" />
+
+### Aer 0.6.1
+
+No change
+
+<span id="id408" />
+
+### Ignis 0.4.0
+
+No change
+
+<span id="id409" />
+
+### Aqua 0.7.5
+
+No change
+
+<span id="ibm-q-provider-0-8-0" />
+
+### IBM Q Provider 0.8.0
+
+No change
+
+<span id="qiskit-0-20-0" />
+
 ## 0.20.0
 
 <span id="terra-0-15-1" />
@@ -835,53 +886,3 @@ The main change made in this release is a refactor of the Randomized Benchmarkin
 *   The package metadata has been updated to properly reflect the dependency on `qiskit-terra` >= 0.14.0. This dependency was implicitly added as part of the 0.7.0 release but was not reflected in the package requirements so it was previously possible to install `qiskit-ibmq-provider` with a version of `qiskit-terra` which was too old. Fixes [#677](https://github.com/Qiskit/qiskit-ibmq-provider/issues/677)
 
 <span id="qiskit-0-19-6" />
-## 0.20.1
-
-<span id="id405" />
-
-### Terra 0.15.2
-
-<span id="release-notes-0-15-2-bug-fixes" />
-
-<span id="id406" />
-
-#### Bug Fixes
-
-*   When accessing the `definition` attribute of a parameterized `Gate` instance, the generated `QuantumCircuit` had been generated with an invalid `ParameterTable`, such that reading from `QuantumCircuit.parameters` or calling `QuantumCircuit.bind_parameters` would incorrectly report the unbound parameters. This has been resolved.
-*   `SXGate().inverse()` had previously returned an ‘sx\_dg’ gate with a correct `definition` but incorrect `to_matrix`. This has been updated such that `SXGate().inverse()` returns an `SXdgGate()` and vice versa.
-*   `Instruction.inverse()`, when not overridden by a subclass, would in some cases return a `Gate` instance with an incorrect `to_matrix` method. The instances of incorrect `to_matrix` methods have been removed.
-*   For `C3XGate` with a non-zero `angle`, inverting the gate via `C3XGate.inverse()` had previously generated an incorrect inverse gate. This has been corrected.
-*   The `MCXGate` modes have been updated to return a gate of the same mode when calling `.inverse()`. This resolves an issue where in some cases, transpiling a circuit containing the inverse of an `MCXVChain` gate would raise an error.
-*   Previously, when creating a multiply controlled phase gate via `PhaseGate.control`, an `MCU1Gate` gate had been returned. This has been had corrected so that an `MCPhaseGate` is returned.
-*   Previously, attempting to decompose a circuit containing an `MCPhaseGate` would raise an error due to an inconsistency in the definition of the `MCPhaseGate`. This has been corrected.
-*   `QuantumCircuit.compose` and `DAGCircuit.compose` had, in some cases, incorrectly translated conditional gates if the input circuit contained more than one `ClassicalRegister`. This has been resolved.
-*   Fixed an issue when creating a [`qiskit.result.Counts`](/api/qiskit/qiskit.result.Counts "qiskit.result.Counts") object from an empty data dictionary. Now this will create an empty [`Counts`](/api/qiskit/qiskit.result.Counts "qiskit.result.Counts") object. The [`most_frequent()`](/api/qiskit/qiskit.result.Counts#most_frequent "qiskit.result.Counts.most_frequent") method is also updated to raise a more descriptive exception when the object is empty. Fixes [#5017](https://github.com/Qiskit/qiskit-terra/issues/5017)
-*   Extending circuits with differing registers updated the `qregs` and `cregs` properties accordingly, but not the `qubits` and `clbits` lists. As these are no longer generated from the registers but are cached lists, this lead to a discrepancy of registers and bits. This has been fixed and the `extend` method explicitly updates the cached bit lists.
-*   Fix bugs of the concrete implementations of meth:\~qiskit.circuit.ControlledGate.inverse method which do not preserve the `ctrl_state` parameter.
-*   A bug was fixed that caused long pulse schedules to throw a recursion error.
-
-<span id="id407" />
-
-### Aer 0.6.1
-
-No change
-
-<span id="id408" />
-
-### Ignis 0.4.0
-
-No change
-
-<span id="id409" />
-
-### Aqua 0.7.5
-
-No change
-
-<span id="ibm-q-provider-0-8-0" />
-
-### IBM Q Provider 0.8.0
-
-No change
-
-<span id="qiskit-0-20-0" />

--- a/docs/api/qiskit/release-notes/0.23.md
+++ b/docs/api/qiskit/release-notes/0.23.md
@@ -5,6 +5,436 @@ description: New features and bug fixes
 
 # Qiskit 0.23 release notes
 
+## 0.23.6
+
+<span id="id334" />
+
+### Terra 0.16.4
+
+No change
+
+<span id="aer-0-7-5" />
+
+### Aer 0.7.5
+
+<span id="release-notes-aer-0-7-5-prelude" />
+
+<span id="id335" />
+
+#### Prelude
+
+This release is a bugfix release that fixes compatibility in the precompiled binary wheel packages with numpy versions \< 1.20.0. The previous release 0.7.4 was building the binaries in a way that would require numpy 1.20.0 which has been resolved now, so the precompiled binary wheel packages will work with any numpy compatible version.
+
+<span id="id336" />
+
+### Ignis 0.5.2
+
+No change
+
+<span id="id337" />
+
+### Aqua 0.8.2
+
+No change
+
+<span id="ibm-q-provider-0-11-1" />
+
+### IBM Q Provider 0.11.1
+
+No change
+
+<span id="qiskit-0-23-5" />
+
+## 0.23.5
+
+<span id="id338" />
+
+### Terra 0.16.4
+
+<span id="release-notes-0-16-4-prelude" />
+
+<span id="id339" />
+
+#### Prelude
+
+This release is a bugfix release that primarily fixes compatibility with numpy 1.20.0. This numpy release deprecated their local aliases for Python’s numeric types (`np.int` -> `int`, `np.float` -> `float`, etc.) and the usage of these aliases in Qiskit resulted in a large number of deprecation warnings being emitted. This release fixes this so you can run Qiskit with numpy 1.20.0 without those deprecation warnings.
+
+<span id="aer-0-7-4" />
+
+### Aer 0.7.4
+
+<span id="release-notes-aer-0-7-4-bug-fixes" />
+
+<span id="id340" />
+
+#### Bug Fixes
+
+Fixes compatibility with numpy 1.20.0. This numpy release deprecated their local aliases for Python’s numeric types (`np.int` -> `int`, `np.float` -> `float`, etc.) and the usage of these aliases in Qiskit Aer resulted in a large number of deprecation warnings being emitted. This release fixes this so you can run Qiskit Aer with numpy 1.20.0 without those deprecation warnings.
+
+<span id="id341" />
+
+### Ignis 0.5.2
+
+<span id="release-notes-ignis-0-5-2-prelude" />
+
+<span id="id342" />
+
+#### Prelude
+
+This release is a bugfix release that primarily fixes compatibility with numpy 1.20.0. It is also the first release to include support for Python 3.9. Earlier releases (including 0.5.0 and 0.5.1) worked with Python 3.9 but did not indicate this in the package metadata, and there was no upstream testing for those releases. This release fixes that and was tested on Python 3.9 (in addition to 3.6, 3.7, and 3.8).
+
+<span id="release-notes-ignis-0-5-2-bug-fixes" />
+
+<span id="id343" />
+
+#### Bug Fixes
+
+*   [networkx](https://networkx.org/) is explicitly listed as a dependency now. It previously was an implicit dependency as it was required for the `qiskit.ignis.verification.topological_codes` module but was not correctly listed as a depdendency as qiskit-terra also requires networkx and is also a depdency of ignis so it would always be installed in practice. However, it is necessary to list it as a requirement for future releases of qiskit-terra that will not require networkx. It’s also important to correctly list the dependencies of ignis in case there were a future incompatibility between version requirements.
+
+<span id="id344" />
+
+### Aqua 0.8.2
+
+<span id="id345" />
+
+### IBM Q Provider 0.11.1
+
+No change
+
+<span id="qiskit-0-23-4" />
+## 0.23.4
+
+<span id="terra-0-16-3" />
+
+### Terra 0.16.3
+
+<span id="release-notes-0-16-3-bug-fixes" />
+
+<span id="id346" />
+
+#### Bug Fixes
+
+*   Fixed an issue introduced in 0.16.2 that would cause errors when running [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") on a circuit with a series of 1 qubit gates and a non-gate instruction that only operates on a qubit (e.g. `Reset`). Fixes [#5736](https://github.com/Qiskit/qiskit-terra/issues/5736)
+
+<span id="aer-0-7-3" />
+
+### Aer 0.7.3
+
+No change
+
+<span id="ignis-0-5-1" />
+
+### Ignis 0.5.1
+
+No change
+
+<span id="aqua-0-8-1" />
+
+### Aqua 0.8.1
+
+No change
+
+<span id="id347" />
+
+### IBM Q Provider 0.11.1
+
+No change
+
+<span id="qiskit-0-23-3" />
+## 0.23.3
+
+<span id="terra-0-16-2" />
+
+### Terra 0.16.2
+
+<span id="release-notes-0-16-2-new-features" />
+
+<span id="id348" />
+
+#### New Features
+
+*   Python 3.9 support has been added in this release. You can now run Qiskit Terra using Python 3.9.
+
+<span id="release-notes-0-16-2-upgrade-notes" />
+
+<span id="id349" />
+
+#### Upgrade Notes
+
+*   The class `MCXGrayCode` will now create a `C3XGate` if `num_ctrl_qubits` is 3 and a `C4XGate` if `num_ctrl_qubits` is 4. This is in addition to the previous functionality where for any of the modes of the :class:’qiskit.library.standard\_gates.x.MCXGate\`, if `num_ctrl_bits` is 1, a `CXGate` is created, and if 2, a `CCXGate` is created.
+
+<span id="release-notes-0-16-2-bug-fixes" />
+
+<span id="id350" />
+
+#### Bug Fixes
+
+*   Pulse [`Delay`](/api/qiskit/qiskit.pulse.instructions.Delay "qiskit.pulse.instructions.Delay") instructions are now explicitly assembled as [`PulseQobjInstruction`](/api/qiskit/qiskit.qobj.PulseQobjInstruction "qiskit.qobj.PulseQobjInstruction") objects included in the [`PulseQobj`](/api/qiskit/qiskit.qobj.PulseQobj "qiskit.qobj.PulseQobj") output from [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble").
+
+    Previously, we could ignore [`Delay`](/api/qiskit/qiskit.pulse.instructions.Delay "qiskit.pulse.instructions.Delay") instructions in a [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule") as part of [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") as the time was explicit in the [`PulseQobj`](/api/qiskit/qiskit.qobj.PulseQobj "qiskit.qobj.PulseQobj") objects. But, now with pulse gates, there are situations where we can schedule ONLY a delay, and not including the delay itself would remove the delay.
+
+*   Circuits with custom gate calibrations can now be scheduled with the transpiler without explicitly providing the durations of each circuit calibration.
+
+*   The [`BasisTranslator`](/api/qiskit/qiskit.transpiler.passes.BasisTranslator "qiskit.transpiler.passes.BasisTranslator") and [`Unroller`](/api/qiskit/qiskit.transpiler.passes.Unroller "qiskit.transpiler.passes.Unroller") passes, in some cases, had not been preserving the global phase of the circuit under transpilation. This has been fixed.
+
+*   A bug in [`qiskit.pulse.builder.frequency_offset()`](/api/qiskit/pulse#qiskit.pulse.builder.frequency_offset "qiskit.pulse.builder.frequency_offset") where when `compensate_phase` was set a factor of $2\pi$ was missing from the appended phase.
+
+*   Fix the global phase of the output of the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") method [`repeat()`](/api/qiskit/qiskit.circuit.QuantumCircuit#repeat "qiskit.circuit.QuantumCircuit.repeat"). If a circuit with global phase is appended to another circuit, the global phase is currently not propagated. Simulators rely on this, since the phase otherwise gets applied multiple times. This sets the global phase of [`repeat()`](/api/qiskit/qiskit.circuit.QuantumCircuit#repeat "qiskit.circuit.QuantumCircuit.repeat") to 0 before appending the repeated circuit instead of multiplying the existing phase times the number of repetitions.
+
+*   Fixes bug in [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") where multiplying by a certain non Python builtin Numpy scalar types returned incorrect values. Fixes [#5408](https://github.com/Qiskit/qiskit-terra/issues/5408)
+
+*   The definition of the Hellinger fidelity from has been corrected from the previous defition of $1-H(P,Q)$ to $[1-H(P,Q)^2]^2$ so that it is equal to the quantum state fidelity of P, Q as diagonal density matrices.
+
+*   Reduce the number of CX gates in the decomposition of the 3-controlled X gate, [`C3XGate`](/api/qiskit/qiskit.circuit.library.C3XGate "qiskit.circuit.library.C3XGate"). Compiled and optimized in the U CX basis, now only 14 CX and 16 U gates are used instead of 20 and 22, respectively.
+
+*   Fixes the issue wherein using Jupyter backend widget or [`qiskit.tools.backend_monitor()`](/api/qiskit/tools#qiskit.tools.backend_monitor "qiskit.tools.backend_monitor") would fail if the backend’s basis gates do not include the traditional u1, u2, and u3.
+
+*   When running [`qiskit.compiler.transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") on a list of circuits with a single element, the function used to return a circuit instead of a list. Now, when [`qiskit.compiler.transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") is called with a list, it will return a list even if that list has a single element. See [#5260](https://github.com/Qiskit/qiskit-terra/issues/5260).
+
+    ```python
+    from qiskit import *
+
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure_all()
+
+    transpiled = transpile([qc])
+    print(type(transpiled), len(transpiled))
+    ```
+
+    ```python
+    <class 'list'> 1
+    ```
+
+<span id="id351" />
+
+### Aer 0.7.3
+
+<span id="release-notes-aer-0-7-3-new-features" />
+
+<span id="id352" />
+
+#### New Features
+
+*   Python 3.9 support has been added in this release. You can now run Qiskit Aer using Python 3.9 without building from source.
+
+<span id="release-notes-aer-0-7-3-bug-fixes" />
+
+<span id="id353" />
+
+#### Bug Fixes
+
+*   Fixes issue with setting `QasmSimulator` basis gates when using `"method"` and `"noise_model"` options together, and when using them with a simulator constructed using `from_backend()`. Now the listed basis gates will be the intersection of gates supported by the backend configuration, simulation method, and noise model basis gates. If the intersection of the noise model basis gates and simulator basis gates is empty a warning will be logged.
+*   Fixes a bug that resulted in c\_if not working when the width of the conditional register was greater than 64. See [#1077](https://github.com/Qiskit/qiskit-aer/issues/1077).
+*   Fixes bug in `from_backend()` and `from_backend()` where `basis_gates` was set incorrectly for IBMQ devices with basis gate set `['id', 'rz', 'sx', 'x', 'cx']`. Now the noise model will always have the same basis gates as the backend basis gates regardless of whether those instructions have errors in the noise model or not.
+*   Fixes a bug when applying truncation in the matrix product state method of the QasmSimulator.
+
+<span id="id354" />
+
+### Ignis 0.5.1
+
+No change
+
+<span id="id355" />
+
+### Aqua 0.8.1
+
+No change
+
+<span id="id356" />
+
+### IBM Q Provider 0.11.1
+
+No change
+
+<span id="qiskit-0-23-2" />
+## 0.23.2
+
+<span id="terra-0-16-1" />
+
+### Terra 0.16.1
+
+No change
+
+<span id="aer-0-7-2" />
+
+### Aer 0.7.2
+
+<span id="release-notes-0-7-2-new-features" />
+
+<span id="id357" />
+
+#### New Features
+
+*   Add the CMake flag `DISABLE_CONAN` (default=\`\`OFF\`\`)s. When installing from source, setting this to `ON` allows bypassing the Conan package manager to find libraries that are already installed on your system. This is also available as an environment variable `DISABLE_CONAN`, which takes precedence over the CMake flag. This is not the official procedure to build AER. Thus, the user is responsible of providing all needed libraries and corresponding files to make them findable to CMake.
+
+<span id="release-notes-0-7-2-bug-fixes" />
+
+<span id="id358" />
+
+#### Bug Fixes
+
+*   Fixes a bug with nested OpenMP flag was being set to true when it shouldn’t be.
+
+<span id="id359" />
+
+### Ignis 0.5.1
+
+No change
+
+<span id="id360" />
+
+### Aqua 0.8.1
+
+No change
+
+<span id="id361" />
+
+### IBM Q Provider 0.11.1
+
+No change
+
+<span id="qiskit-0-23-1" />
+## 0.23.1
+
+<span id="release-notes-0-16-1" />
+
+<span id="id362" />
+
+### Terra 0.16.1
+
+<span id="release-notes-0-16-1-bug-fixes" />
+
+<span id="id363" />
+
+#### Bug Fixes
+
+*   Fixed an issue where an error was thrown in execute for valid circuits built with delays.
+*   The QASM definition of ‘c4x’ in qelib1.inc has been corrected to match the standard library definition for C4XGate.
+*   Fixes a bug in subtraction for quantum channels $A - B$ where $B$ was an [`Operator`](/api/qiskit/qiskit.quantum_info.Operator "qiskit.quantum_info.Operator") object. Negation was being applied to the matrix in the Operator representation which is not equivalent to negation in the quantum channel representation.
+*   Changes the way `_evolve_instruction()` access qubits to handle the case of an instruction with multiple registers.
+
+<span id="aer-0-7-1" />
+
+<span id="release-notes-aer-0-7-1" />
+
+### Aer 0.7.1
+
+<span id="release-notes-aer-0-7-1-upgrade-notes" />
+
+<span id="id364" />
+
+#### Upgrade Notes
+
+*   The minimum cmake version to build qiskit-aer has increased from 3.6 to 3.8. This change was necessary to enable fixing GPU version builds that support running on x86\_64 CPUs lacking AVX2 instructions.
+
+<span id="release-notes-aer-0-7-1-bug-fixes" />
+
+<span id="id365" />
+
+#### Bug Fixes
+
+*   qiskit-aer with GPU support will now work on systems with x86\_64 CPUs lacking AVX2 instructions. Previously, the GPU package would only run if the AVX2 instructions were available. Fixes [#1023](https://github.com/Qiskit/qiskit-aer/issues/1023)
+*   Fixes bug with `AerProvider` where options set on the returned backends using `set_options()` were stored in the provider and would persist for subsequent calls to `get_backend()` for the same named backend. Now every call to and `backends()` returns a new instance of the simulator backend that can be configured.
+*   Fixes bug in the error message returned when a circuit contains unsupported simulator instructions. Previously some supported instructions were also being listed in the error message along with the unsupported instructions.
+*   Fix bug where the “sx”\` gate [`SXGate`](/api/qiskit/qiskit.circuit.library.SXGate "qiskit.circuit.library.SXGate") was not listed as a supported gate in the C++ code, in StateOpSet of matrix\_product\_state.hp.
+*   Fix bug where `"csx"`, `"cu2"`, `"cu3"` were incorrectly listed as supported basis gates for the `"density_matrix"` method of the `QasmSimulator`.
+*   In MPS, apply\_kraus was operating directly on the input bits in the parameter qubits, instead of on the internal qubits. In the MPS algorithm, the qubits are constantly moving around so all operations should be applied to the internal qubits.
+*   When invoking MPS::sample\_measure, we need to first sort the qubits to the default ordering because this is the assumption in qasm\_controller.This is done by invoking the method move\_all\_qubits\_to\_sorted\_ordering. It was correct in sample\_measure\_using\_apply\_measure, but missing in sample\_measure\_using\_probabilities.
+
+<span id="release-notes-ignis-0-5-1" />
+
+<span id="id366" />
+
+### Ignis 0.5.1
+
+<span id="release-notes-ignis-0-5-1-bug-fixes" />
+
+<span id="id367" />
+
+#### Bug Fixes
+
+*   Fix the `"auto"` method of the `TomographyFitter`, `StateTomographyFitter`, and `ProcessTomographyFitter` to only use `"cvx"` if CVXPY is installed *and* a third-party SDP solver other than SCS is available. This is because the SCS solver has lower accuracy than other solver methods and often returns a density matrix or Choi-matrix that is not completely-positive and fails validation when used with the [`qiskit.quantum_info.state_fidelity()`](/api/qiskit/quantum_info#qiskit.quantum_info.state_fidelity "qiskit.quantum_info.state_fidelity") or [`qiskit.quantum_info.process_fidelity()`](/api/qiskit/quantum_info#qiskit.quantum_info.process_fidelity "qiskit.quantum_info.process_fidelity") functions.
+
+<span id="release-notes-aqua-0-8-1" />
+
+<span id="id368" />
+
+### Aqua 0.8.1
+
+<span id="id369" />
+
+### 0.8.1
+
+<span id="release-notes-aqua-0-8-1-new-features" />
+
+<span id="id370" />
+
+#### New Features
+
+*   A new algorithm has been added: the Born Openheimer Potential Energy surface for the calculation of potential energy surface along different degrees of freedom of the molecule. The algorithm is called `BOPESSampler`. It further provides functionalities of fitting the potential energy surface to an analytic function of predefined potentials.some details.
+
+<span id="release-notes-aqua-0-8-1-critical-issues" />
+
+#### Critical Issues
+
+*   Be aware that `initial_state` parameter in `QAOA` has now different implementation as a result of a bug fix. The previous implementation wrongly mixed the user provided `initial_state` with Hadamard gates. The issue is fixed now. No attention needed if your code does not make use of the user provided `initial_state` parameter.
+
+<span id="release-notes-aqua-0-8-1-bug-fixes" />
+
+<span id="id371" />
+
+#### Bug Fixes
+
+*   optimize\_svm method of qp\_solver would sometimes fail resulting in an error like this ValueError: cannot reshape array of size 1 into shape (200,1) This addresses the issue by adding an L2 norm parameter, lambda2, which defaults to 0.001 but can be changed via the QSVM algorithm, as needed, to facilitate convergence.
+*   A method `one_letter_symbol` has been removed from the `VarType` in the latest build of DOCplex making Aqua incompatible with this version. So instead of using this method an explicit type check of variable types has been introduced in the Aqua optimization module.
+*   :meth\`\~qiskit.aqua.operators.state\_fns.DictStateFn.sample()\` could only handle real amplitudes, but it is fixed to handle complex amplitudes. #1311 \<[https://github.com/Qiskit/qiskit-aqua/issues/1311](https://github.com/Qiskit/qiskit-aqua/issues/1311)> for more details.
+*   Trotter class did not use the reps argument in constructor. #1317 \<[https://github.com/Qiskit/qiskit-aqua/issues/1317](https://github.com/Qiskit/qiskit-aqua/issues/1317)> for more details.
+*   Raise an AquaError if :class\`qiskit.aqua.operators.converters.CircuitSampler\` samples an empty operator. #1321 \<[https://github.com/Qiskit/qiskit-aqua/issues/1321](https://github.com/Qiskit/qiskit-aqua/issues/1321)> for more details.
+*   `to_opflow()` returns a correct operator when coefficients are complex numbers. #1381 \<[https://github.com/Qiskit/qiskit-aqua/issues/1381](https://github.com/Qiskit/qiskit-aqua/issues/1381)> for more details.
+*   Let backend simulators validate NoiseModel support instead of restricting to Aer only in QuantumInstance.
+*   Correctly handle PassManager on QuantumInstance `transpile` method by calling its `run` method if it exists.
+*   A bug that mixes custom `initial_state` in `QAOA` with Hadamard gates has been fixed. This doesn’t change functionality of QAOA if no initial\_state is provided by the user. Attention should be taken if your implementation uses QAOA with cusom `initial_state` parameter as the optimization results might differ.
+*   Previously, setting seed\_simulator=0 in the QuantumInstance did not set any seed. This was only affecting the value 0. This has been fixed.
+
+>
+
+<span id="release-notes-ibmq-0-11-1" />
+
+<span id="id372" />
+
+### IBM Q Provider 0.11.1
+
+>
+
+<span id="release-notes-ibmq-0-11-1-new-features" />
+
+<span id="id373" />
+
+#### New Features
+
+*   `qiskit.providers.ibmq.experiment.Experiment` now has three additional attributes, hub, group, and project, that identify the provider used to create the experiment.
+*   Methods `qiskit.providers.ibmq.experiment.ExperimentService.experiments()` and `qiskit.providers.ibmq.experiment.ExperimentService.analysis_results()` now support a `limit` parameter that allows you to limit the number of experiments and analysis results returned.
+
+<span id="release-notes-ibmq-0-11-1-upgrade-notes" />
+
+<span id="id374" />
+
+#### Upgrade Notes
+
+*   A new parameter, `limit` is now the first parameter for both `qiskit.providers.ibmq.experiment.ExperimentService.experiments()` and `qiskit.providers.ibmq.experiment.ExperimentService.analysis_results()` methods. This `limit` has a default value of 10, meaning by deafult only 10 experiments and analysis results will be returned.
+
+<span id="release-notes-ibmq-0-11-1-bug-fixes" />
+
+<span id="id375" />
+
+#### Bug Fixes
+
+*   Fixes the issue wherein a job could be left in the `CREATING` state if job submit fails half-way through.
+*   Fixes the infinite loop raised when passing an `IBMQRandomService` instance to a child process.
+
+<span id="qiskit-0-23-0" />
 ## 0.23.0
 
 <span id="terra-0-16-0" />
@@ -1014,432 +1444,3 @@ VQE expectation computation with Aer qasm\_simulator now defaults to a computati
 *   Prior to this release, `websockets` 7.0 was used for Python 3.6. With this release, `websockets` 8.0 or above is required for all Python versions. The package requirements have been updated to reflect this.
 
 <span id="qiskit-0-22-0" />
-## 0.23.1
-
-<span id="release-notes-0-16-1" />
-
-<span id="id362" />
-
-### Terra 0.16.1
-
-<span id="release-notes-0-16-1-bug-fixes" />
-
-<span id="id363" />
-
-#### Bug Fixes
-
-*   Fixed an issue where an error was thrown in execute for valid circuits built with delays.
-*   The QASM definition of ‘c4x’ in qelib1.inc has been corrected to match the standard library definition for C4XGate.
-*   Fixes a bug in subtraction for quantum channels $A - B$ where $B$ was an [`Operator`](/api/qiskit/qiskit.quantum_info.Operator "qiskit.quantum_info.Operator") object. Negation was being applied to the matrix in the Operator representation which is not equivalent to negation in the quantum channel representation.
-*   Changes the way `_evolve_instruction()` access qubits to handle the case of an instruction with multiple registers.
-
-<span id="aer-0-7-1" />
-
-<span id="release-notes-aer-0-7-1" />
-
-### Aer 0.7.1
-
-<span id="release-notes-aer-0-7-1-upgrade-notes" />
-
-<span id="id364" />
-
-#### Upgrade Notes
-
-*   The minimum cmake version to build qiskit-aer has increased from 3.6 to 3.8. This change was necessary to enable fixing GPU version builds that support running on x86\_64 CPUs lacking AVX2 instructions.
-
-<span id="release-notes-aer-0-7-1-bug-fixes" />
-
-<span id="id365" />
-
-#### Bug Fixes
-
-*   qiskit-aer with GPU support will now work on systems with x86\_64 CPUs lacking AVX2 instructions. Previously, the GPU package would only run if the AVX2 instructions were available. Fixes [#1023](https://github.com/Qiskit/qiskit-aer/issues/1023)
-*   Fixes bug with `AerProvider` where options set on the returned backends using `set_options()` were stored in the provider and would persist for subsequent calls to `get_backend()` for the same named backend. Now every call to and `backends()` returns a new instance of the simulator backend that can be configured.
-*   Fixes bug in the error message returned when a circuit contains unsupported simulator instructions. Previously some supported instructions were also being listed in the error message along with the unsupported instructions.
-*   Fix bug where the “sx”\` gate [`SXGate`](/api/qiskit/qiskit.circuit.library.SXGate "qiskit.circuit.library.SXGate") was not listed as a supported gate in the C++ code, in StateOpSet of matrix\_product\_state.hp.
-*   Fix bug where `"csx"`, `"cu2"`, `"cu3"` were incorrectly listed as supported basis gates for the `"density_matrix"` method of the `QasmSimulator`.
-*   In MPS, apply\_kraus was operating directly on the input bits in the parameter qubits, instead of on the internal qubits. In the MPS algorithm, the qubits are constantly moving around so all operations should be applied to the internal qubits.
-*   When invoking MPS::sample\_measure, we need to first sort the qubits to the default ordering because this is the assumption in qasm\_controller.This is done by invoking the method move\_all\_qubits\_to\_sorted\_ordering. It was correct in sample\_measure\_using\_apply\_measure, but missing in sample\_measure\_using\_probabilities.
-
-<span id="release-notes-ignis-0-5-1" />
-
-<span id="id366" />
-
-### Ignis 0.5.1
-
-<span id="release-notes-ignis-0-5-1-bug-fixes" />
-
-<span id="id367" />
-
-#### Bug Fixes
-
-*   Fix the `"auto"` method of the `TomographyFitter`, `StateTomographyFitter`, and `ProcessTomographyFitter` to only use `"cvx"` if CVXPY is installed *and* a third-party SDP solver other than SCS is available. This is because the SCS solver has lower accuracy than other solver methods and often returns a density matrix or Choi-matrix that is not completely-positive and fails validation when used with the [`qiskit.quantum_info.state_fidelity()`](/api/qiskit/quantum_info#qiskit.quantum_info.state_fidelity "qiskit.quantum_info.state_fidelity") or [`qiskit.quantum_info.process_fidelity()`](/api/qiskit/quantum_info#qiskit.quantum_info.process_fidelity "qiskit.quantum_info.process_fidelity") functions.
-
-<span id="release-notes-aqua-0-8-1" />
-
-<span id="id368" />
-
-### Aqua 0.8.1
-
-<span id="id369" />
-
-### 0.8.1
-
-<span id="release-notes-aqua-0-8-1-new-features" />
-
-<span id="id370" />
-
-#### New Features
-
-*   A new algorithm has been added: the Born Openheimer Potential Energy surface for the calculation of potential energy surface along different degrees of freedom of the molecule. The algorithm is called `BOPESSampler`. It further provides functionalities of fitting the potential energy surface to an analytic function of predefined potentials.some details.
-
-<span id="release-notes-aqua-0-8-1-critical-issues" />
-
-#### Critical Issues
-
-*   Be aware that `initial_state` parameter in `QAOA` has now different implementation as a result of a bug fix. The previous implementation wrongly mixed the user provided `initial_state` with Hadamard gates. The issue is fixed now. No attention needed if your code does not make use of the user provided `initial_state` parameter.
-
-<span id="release-notes-aqua-0-8-1-bug-fixes" />
-
-<span id="id371" />
-
-#### Bug Fixes
-
-*   optimize\_svm method of qp\_solver would sometimes fail resulting in an error like this ValueError: cannot reshape array of size 1 into shape (200,1) This addresses the issue by adding an L2 norm parameter, lambda2, which defaults to 0.001 but can be changed via the QSVM algorithm, as needed, to facilitate convergence.
-*   A method `one_letter_symbol` has been removed from the `VarType` in the latest build of DOCplex making Aqua incompatible with this version. So instead of using this method an explicit type check of variable types has been introduced in the Aqua optimization module.
-*   :meth\`\~qiskit.aqua.operators.state\_fns.DictStateFn.sample()\` could only handle real amplitudes, but it is fixed to handle complex amplitudes. #1311 \<[https://github.com/Qiskit/qiskit-aqua/issues/1311](https://github.com/Qiskit/qiskit-aqua/issues/1311)> for more details.
-*   Trotter class did not use the reps argument in constructor. #1317 \<[https://github.com/Qiskit/qiskit-aqua/issues/1317](https://github.com/Qiskit/qiskit-aqua/issues/1317)> for more details.
-*   Raise an AquaError if :class\`qiskit.aqua.operators.converters.CircuitSampler\` samples an empty operator. #1321 \<[https://github.com/Qiskit/qiskit-aqua/issues/1321](https://github.com/Qiskit/qiskit-aqua/issues/1321)> for more details.
-*   `to_opflow()` returns a correct operator when coefficients are complex numbers. #1381 \<[https://github.com/Qiskit/qiskit-aqua/issues/1381](https://github.com/Qiskit/qiskit-aqua/issues/1381)> for more details.
-*   Let backend simulators validate NoiseModel support instead of restricting to Aer only in QuantumInstance.
-*   Correctly handle PassManager on QuantumInstance `transpile` method by calling its `run` method if it exists.
-*   A bug that mixes custom `initial_state` in `QAOA` with Hadamard gates has been fixed. This doesn’t change functionality of QAOA if no initial\_state is provided by the user. Attention should be taken if your implementation uses QAOA with cusom `initial_state` parameter as the optimization results might differ.
-*   Previously, setting seed\_simulator=0 in the QuantumInstance did not set any seed. This was only affecting the value 0. This has been fixed.
-
->
-
-<span id="release-notes-ibmq-0-11-1" />
-
-<span id="id372" />
-
-### IBM Q Provider 0.11.1
-
->
-
-<span id="release-notes-ibmq-0-11-1-new-features" />
-
-<span id="id373" />
-
-#### New Features
-
-*   `qiskit.providers.ibmq.experiment.Experiment` now has three additional attributes, hub, group, and project, that identify the provider used to create the experiment.
-*   Methods `qiskit.providers.ibmq.experiment.ExperimentService.experiments()` and `qiskit.providers.ibmq.experiment.ExperimentService.analysis_results()` now support a `limit` parameter that allows you to limit the number of experiments and analysis results returned.
-
-<span id="release-notes-ibmq-0-11-1-upgrade-notes" />
-
-<span id="id374" />
-
-#### Upgrade Notes
-
-*   A new parameter, `limit` is now the first parameter for both `qiskit.providers.ibmq.experiment.ExperimentService.experiments()` and `qiskit.providers.ibmq.experiment.ExperimentService.analysis_results()` methods. This `limit` has a default value of 10, meaning by deafult only 10 experiments and analysis results will be returned.
-
-<span id="release-notes-ibmq-0-11-1-bug-fixes" />
-
-<span id="id375" />
-
-#### Bug Fixes
-
-*   Fixes the issue wherein a job could be left in the `CREATING` state if job submit fails half-way through.
-*   Fixes the infinite loop raised when passing an `IBMQRandomService` instance to a child process.
-
-<span id="qiskit-0-23-0" />
-## 0.23.2
-
-<span id="terra-0-16-1" />
-
-### Terra 0.16.1
-
-No change
-
-<span id="aer-0-7-2" />
-
-### Aer 0.7.2
-
-<span id="release-notes-0-7-2-new-features" />
-
-<span id="id357" />
-
-#### New Features
-
-*   Add the CMake flag `DISABLE_CONAN` (default=\`\`OFF\`\`)s. When installing from source, setting this to `ON` allows bypassing the Conan package manager to find libraries that are already installed on your system. This is also available as an environment variable `DISABLE_CONAN`, which takes precedence over the CMake flag. This is not the official procedure to build AER. Thus, the user is responsible of providing all needed libraries and corresponding files to make them findable to CMake.
-
-<span id="release-notes-0-7-2-bug-fixes" />
-
-<span id="id358" />
-
-#### Bug Fixes
-
-*   Fixes a bug with nested OpenMP flag was being set to true when it shouldn’t be.
-
-<span id="id359" />
-
-### Ignis 0.5.1
-
-No change
-
-<span id="id360" />
-
-### Aqua 0.8.1
-
-No change
-
-<span id="id361" />
-
-### IBM Q Provider 0.11.1
-
-No change
-
-<span id="qiskit-0-23-1" />
-## 0.23.3
-
-<span id="terra-0-16-2" />
-
-### Terra 0.16.2
-
-<span id="release-notes-0-16-2-new-features" />
-
-<span id="id348" />
-
-#### New Features
-
-*   Python 3.9 support has been added in this release. You can now run Qiskit Terra using Python 3.9.
-
-<span id="release-notes-0-16-2-upgrade-notes" />
-
-<span id="id349" />
-
-#### Upgrade Notes
-
-*   The class `MCXGrayCode` will now create a `C3XGate` if `num_ctrl_qubits` is 3 and a `C4XGate` if `num_ctrl_qubits` is 4. This is in addition to the previous functionality where for any of the modes of the :class:’qiskit.library.standard\_gates.x.MCXGate\`, if `num_ctrl_bits` is 1, a `CXGate` is created, and if 2, a `CCXGate` is created.
-
-<span id="release-notes-0-16-2-bug-fixes" />
-
-<span id="id350" />
-
-#### Bug Fixes
-
-*   Pulse [`Delay`](/api/qiskit/qiskit.pulse.instructions.Delay "qiskit.pulse.instructions.Delay") instructions are now explicitly assembled as [`PulseQobjInstruction`](/api/qiskit/qiskit.qobj.PulseQobjInstruction "qiskit.qobj.PulseQobjInstruction") objects included in the [`PulseQobj`](/api/qiskit/qiskit.qobj.PulseQobj "qiskit.qobj.PulseQobj") output from [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble").
-
-    Previously, we could ignore [`Delay`](/api/qiskit/qiskit.pulse.instructions.Delay "qiskit.pulse.instructions.Delay") instructions in a [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule") as part of [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") as the time was explicit in the [`PulseQobj`](/api/qiskit/qiskit.qobj.PulseQobj "qiskit.qobj.PulseQobj") objects. But, now with pulse gates, there are situations where we can schedule ONLY a delay, and not including the delay itself would remove the delay.
-
-*   Circuits with custom gate calibrations can now be scheduled with the transpiler without explicitly providing the durations of each circuit calibration.
-
-*   The [`BasisTranslator`](/api/qiskit/qiskit.transpiler.passes.BasisTranslator "qiskit.transpiler.passes.BasisTranslator") and [`Unroller`](/api/qiskit/qiskit.transpiler.passes.Unroller "qiskit.transpiler.passes.Unroller") passes, in some cases, had not been preserving the global phase of the circuit under transpilation. This has been fixed.
-
-*   A bug in [`qiskit.pulse.builder.frequency_offset()`](/api/qiskit/pulse#qiskit.pulse.builder.frequency_offset "qiskit.pulse.builder.frequency_offset") where when `compensate_phase` was set a factor of $2\pi$ was missing from the appended phase.
-
-*   Fix the global phase of the output of the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") method [`repeat()`](/api/qiskit/qiskit.circuit.QuantumCircuit#repeat "qiskit.circuit.QuantumCircuit.repeat"). If a circuit with global phase is appended to another circuit, the global phase is currently not propagated. Simulators rely on this, since the phase otherwise gets applied multiple times. This sets the global phase of [`repeat()`](/api/qiskit/qiskit.circuit.QuantumCircuit#repeat "qiskit.circuit.QuantumCircuit.repeat") to 0 before appending the repeated circuit instead of multiplying the existing phase times the number of repetitions.
-
-*   Fixes bug in [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") where multiplying by a certain non Python builtin Numpy scalar types returned incorrect values. Fixes [#5408](https://github.com/Qiskit/qiskit-terra/issues/5408)
-
-*   The definition of the Hellinger fidelity from has been corrected from the previous defition of $1-H(P,Q)$ to $[1-H(P,Q)^2]^2$ so that it is equal to the quantum state fidelity of P, Q as diagonal density matrices.
-
-*   Reduce the number of CX gates in the decomposition of the 3-controlled X gate, [`C3XGate`](/api/qiskit/qiskit.circuit.library.C3XGate "qiskit.circuit.library.C3XGate"). Compiled and optimized in the U CX basis, now only 14 CX and 16 U gates are used instead of 20 and 22, respectively.
-
-*   Fixes the issue wherein using Jupyter backend widget or [`qiskit.tools.backend_monitor()`](/api/qiskit/tools#qiskit.tools.backend_monitor "qiskit.tools.backend_monitor") would fail if the backend’s basis gates do not include the traditional u1, u2, and u3.
-
-*   When running [`qiskit.compiler.transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") on a list of circuits with a single element, the function used to return a circuit instead of a list. Now, when [`qiskit.compiler.transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") is called with a list, it will return a list even if that list has a single element. See [#5260](https://github.com/Qiskit/qiskit-terra/issues/5260).
-
-    ```python
-    from qiskit import *
-
-    qc = QuantumCircuit(2)
-    qc.h(0)
-    qc.cx(0, 1)
-    qc.measure_all()
-
-    transpiled = transpile([qc])
-    print(type(transpiled), len(transpiled))
-    ```
-
-    ```python
-    <class 'list'> 1
-    ```
-
-<span id="id351" />
-
-### Aer 0.7.3
-
-<span id="release-notes-aer-0-7-3-new-features" />
-
-<span id="id352" />
-
-#### New Features
-
-*   Python 3.9 support has been added in this release. You can now run Qiskit Aer using Python 3.9 without building from source.
-
-<span id="release-notes-aer-0-7-3-bug-fixes" />
-
-<span id="id353" />
-
-#### Bug Fixes
-
-*   Fixes issue with setting `QasmSimulator` basis gates when using `"method"` and `"noise_model"` options together, and when using them with a simulator constructed using `from_backend()`. Now the listed basis gates will be the intersection of gates supported by the backend configuration, simulation method, and noise model basis gates. If the intersection of the noise model basis gates and simulator basis gates is empty a warning will be logged.
-*   Fixes a bug that resulted in c\_if not working when the width of the conditional register was greater than 64. See [#1077](https://github.com/Qiskit/qiskit-aer/issues/1077).
-*   Fixes bug in `from_backend()` and `from_backend()` where `basis_gates` was set incorrectly for IBMQ devices with basis gate set `['id', 'rz', 'sx', 'x', 'cx']`. Now the noise model will always have the same basis gates as the backend basis gates regardless of whether those instructions have errors in the noise model or not.
-*   Fixes a bug when applying truncation in the matrix product state method of the QasmSimulator.
-
-<span id="id354" />
-
-### Ignis 0.5.1
-
-No change
-
-<span id="id355" />
-
-### Aqua 0.8.1
-
-No change
-
-<span id="id356" />
-
-### IBM Q Provider 0.11.1
-
-No change
-
-<span id="qiskit-0-23-2" />
-## 0.23.4
-
-<span id="terra-0-16-3" />
-
-### Terra 0.16.3
-
-<span id="release-notes-0-16-3-bug-fixes" />
-
-<span id="id346" />
-
-#### Bug Fixes
-
-*   Fixed an issue introduced in 0.16.2 that would cause errors when running [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") on a circuit with a series of 1 qubit gates and a non-gate instruction that only operates on a qubit (e.g. `Reset`). Fixes [#5736](https://github.com/Qiskit/qiskit-terra/issues/5736)
-
-<span id="aer-0-7-3" />
-
-### Aer 0.7.3
-
-No change
-
-<span id="ignis-0-5-1" />
-
-### Ignis 0.5.1
-
-No change
-
-<span id="aqua-0-8-1" />
-
-### Aqua 0.8.1
-
-No change
-
-<span id="id347" />
-
-### IBM Q Provider 0.11.1
-
-No change
-
-<span id="qiskit-0-23-3" />
-## 0.23.5
-
-<span id="id338" />
-
-### Terra 0.16.4
-
-<span id="release-notes-0-16-4-prelude" />
-
-<span id="id339" />
-
-#### Prelude
-
-This release is a bugfix release that primarily fixes compatibility with numpy 1.20.0. This numpy release deprecated their local aliases for Python’s numeric types (`np.int` -> `int`, `np.float` -> `float`, etc.) and the usage of these aliases in Qiskit resulted in a large number of deprecation warnings being emitted. This release fixes this so you can run Qiskit with numpy 1.20.0 without those deprecation warnings.
-
-<span id="aer-0-7-4" />
-
-### Aer 0.7.4
-
-<span id="release-notes-aer-0-7-4-bug-fixes" />
-
-<span id="id340" />
-
-#### Bug Fixes
-
-Fixes compatibility with numpy 1.20.0. This numpy release deprecated their local aliases for Python’s numeric types (`np.int` -> `int`, `np.float` -> `float`, etc.) and the usage of these aliases in Qiskit Aer resulted in a large number of deprecation warnings being emitted. This release fixes this so you can run Qiskit Aer with numpy 1.20.0 without those deprecation warnings.
-
-<span id="id341" />
-
-### Ignis 0.5.2
-
-<span id="release-notes-ignis-0-5-2-prelude" />
-
-<span id="id342" />
-
-#### Prelude
-
-This release is a bugfix release that primarily fixes compatibility with numpy 1.20.0. It is also the first release to include support for Python 3.9. Earlier releases (including 0.5.0 and 0.5.1) worked with Python 3.9 but did not indicate this in the package metadata, and there was no upstream testing for those releases. This release fixes that and was tested on Python 3.9 (in addition to 3.6, 3.7, and 3.8).
-
-<span id="release-notes-ignis-0-5-2-bug-fixes" />
-
-<span id="id343" />
-
-#### Bug Fixes
-
-*   [networkx](https://networkx.org/) is explicitly listed as a dependency now. It previously was an implicit dependency as it was required for the `qiskit.ignis.verification.topological_codes` module but was not correctly listed as a depdendency as qiskit-terra also requires networkx and is also a depdency of ignis so it would always be installed in practice. However, it is necessary to list it as a requirement for future releases of qiskit-terra that will not require networkx. It’s also important to correctly list the dependencies of ignis in case there were a future incompatibility between version requirements.
-
-<span id="id344" />
-
-### Aqua 0.8.2
-
-<span id="id345" />
-
-### IBM Q Provider 0.11.1
-
-No change
-
-<span id="qiskit-0-23-4" />
-## 0.23.6
-
-<span id="id334" />
-
-### Terra 0.16.4
-
-No change
-
-<span id="aer-0-7-5" />
-
-### Aer 0.7.5
-
-<span id="release-notes-aer-0-7-5-prelude" />
-
-<span id="id335" />
-
-#### Prelude
-
-This release is a bugfix release that fixes compatibility in the precompiled binary wheel packages with numpy versions \< 1.20.0. The previous release 0.7.4 was building the binaries in a way that would require numpy 1.20.0 which has been resolved now, so the precompiled binary wheel packages will work with any numpy compatible version.
-
-<span id="id336" />
-
-### Ignis 0.5.2
-
-No change
-
-<span id="id337" />
-
-### Aqua 0.8.2
-
-No change
-
-<span id="ibm-q-provider-0-11-1" />
-
-### IBM Q Provider 0.11.1
-
-No change
-
-<span id="qiskit-0-23-5" />

--- a/docs/api/qiskit/release-notes/0.24.md
+++ b/docs/api/qiskit/release-notes/0.24.md
@@ -5,6 +5,46 @@ description: New features and bug fixes
 
 # Qiskit 0.24 release notes
 
+## 0.24.1
+
+<span id="terra-0-16-4" />
+
+### Terra 0.16.4
+
+No change
+
+<span id="aer-0-7-6" />
+
+### Aer 0.7.6
+
+No change
+
+<span id="ignis-0-5-2" />
+
+### Ignis 0.5.2
+
+No change
+
+<span id="aqua-0-8-2" />
+
+### Aqua 0.8.2
+
+No change
+
+<span id="id320" />
+
+### IBM Q Provider 0.12.2
+
+<span id="release-notes-ibmq-0-12-2-new-features" />
+
+<span id="id321" />
+
+#### Upgrade Notes
+
+*   `qiskit.providers.ibmq.IBMQBackend.defaults()` now returns the pulse defaults for the backend if the backend supports pulse. However, your provider may not support pulse even if the backend does. The `open_pulse` flag in backend configuration indicates whether the provider supports it.
+
+<span id="qiskit-0-24-0" />
+
 ## 0.24.0
 
 <span id="id322" />
@@ -164,42 +204,3 @@ No change
 *   Fixes the issue wherein a `TypeError` is raised if the server returns an error code but the response data is not in the expected format.
 
 <span id="qiskit-0-23-6" />
-## 0.24.1
-
-<span id="terra-0-16-4" />
-
-### Terra 0.16.4
-
-No change
-
-<span id="aer-0-7-6" />
-
-### Aer 0.7.6
-
-No change
-
-<span id="ignis-0-5-2" />
-
-### Ignis 0.5.2
-
-No change
-
-<span id="aqua-0-8-2" />
-
-### Aqua 0.8.2
-
-No change
-
-<span id="id320" />
-
-### IBM Q Provider 0.12.2
-
-<span id="release-notes-ibmq-0-12-2-new-features" />
-
-<span id="id321" />
-
-#### Upgrade Notes
-
-*   `qiskit.providers.ibmq.IBMQBackend.defaults()` now returns the pulse defaults for the backend if the backend supports pulse. However, your provider may not support pulse even if the backend does. The `open_pulse` flag in backend configuration indicates whether the provider supports it.
-
-<span id="qiskit-0-24-0" />

--- a/docs/api/qiskit/release-notes/0.25.md
+++ b/docs/api/qiskit/release-notes/0.25.md
@@ -5,6 +5,239 @@ description: New features and bug fixes
 
 # Qiskit 0.25 release notes
 
+## 0.25.4
+
+<span id="terra-0-17-2" />
+
+<span id="release-notes-0-17-2" />
+
+### Terra 0.17.2
+
+<span id="release-notes-0-17-2-prelude" />
+
+<span id="id276" />
+
+#### Prelude
+
+This is a bugfix release that fixes several issues from the 0.17.1 release. Most importantly this release fixes compatibility for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running on backends that are based on the [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") abstract class. This fixes all the algorithms and applications built on [`qiskit.algorithms`](/api/qiskit/algorithms#module-qiskit.algorithms "qiskit.algorithms") or [`qiskit.opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow") when running on newer backends.
+
+<span id="release-notes-0-17-2-bug-fixes" />
+
+<span id="id277" />
+
+#### Bug Fixes
+
+*   Fixed an issue with the [`BasisTranslator`](/api/qiskit/qiskit.transpiler.passes.BasisTranslator "qiskit.transpiler.passes.BasisTranslator") transpiler pass which in some cases would translate gates already in the target basis. This would potentially result in both longer execution time and less optimal results. Fixed [#6085](https://github.com/Qiskit/qiskit-terra/issues/6085)
+*   Fixed an issue in the `SPSA` when the optimizer was initialized with a callback function via the `callback` kwarg would potentially cause an error to be raised.
+*   Fixed an issue in the [`qiskit.quantum_info.Statevector.expectation_value()`](/api/qiskit/qiskit.quantum_info.Statevector#expectation_value "qiskit.quantum_info.Statevector.expectation_value") and ```qiskit.quantum_info.DensityMatrix.expectation_value`methods where the ``qargs`()``` kwarg was ignored if the operator was a [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") or [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") operator object. Fixed [#6303](https://github.com/Qiskit/qiskit-terra/issues/6303)
+*   Fixed an issue in the [`qiskit.quantum_info.Pauli.evolve()`](/api/qiskit/qiskit.quantum_info.Pauli#evolve "qiskit.quantum_info.Pauli.evolve") method which could have resulted in the incorrect Pauli being returned when evolving by a [`CZGate`](/api/qiskit/qiskit.circuit.library.CZGate "qiskit.circuit.library.CZGate"), [`CYGate`](/api/qiskit/qiskit.circuit.library.CYGate "qiskit.circuit.library.CYGate"), or a [`SwapGate`](/api/qiskit/qiskit.circuit.library.SwapGate "qiskit.circuit.library.SwapGate") gate.
+*   Fixed an issue in the `qiskit.opflow.SparseVectorStateFn.to_dict_fn()` method, which previously had at most one entry for the all zero state due to an index error.
+*   Fixed an issue in the `qiskit.opflow.SparseVectorStateFn.equals()` method so that is properly returning `True` or `False` instead of a sparse vector comparison of the single elements.
+*   Fixes an issue in the [`Statevector`](/api/qiskit/qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") and [`DensityMatrix`](/api/qiskit/qiskit.quantum_info.DensityMatrix "qiskit.quantum_info.DensityMatrix") probability methods [`qiskit.quantum_info.Statevector.probabilities()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities "qiskit.quantum_info.Statevector.probabilities"), [`qiskit.quantum_info.Statevector.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities_dict "qiskit.quantum_info.Statevector.probabilities_dict"), [`qiskit.quantum_info.DensityMatrix.probabilities()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities "qiskit.quantum_info.DensityMatrix.probabilities"), [`qiskit.quantum_info.DensityMatrix.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities_dict "qiskit.quantum_info.DensityMatrix.probabilities_dict") where the returned probabilities could have incorrect ordering for certain values of the `qargs` kwarg. Fixed [#6320](https://github.com/Qiskit/qiskit-terra/issues/6320)
+*   Fixed an issue where the `TaperedPauliSumOp` class did not support the multiplication with [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") object and also did not have a necessary `assign_parameters()` method for working with [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") objects. Fixed [#6127](https://github.com/Qiskit/qiskit-terra/issues/6127)
+*   Fixed compatibility for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running on backends that are based on the [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") abstract class. Fixed [#6280](https://github.com/Qiskit/qiskit-terra/issues/6280)
+
+<span id="id278" />
+
+### Aer 0.8.2
+
+No change
+
+<span id="id279" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="id280" />
+
+### Aqua 0.9.1
+
+No change
+
+<span id="ibm-q-provider-0-12-3" />
+
+### IBM Q Provider 0.12.3
+
+No change
+
+<span id="qiskit-0-25-3" />
+
+## 0.25.3
+
+<span id="terra-0-17-1" />
+
+### Terra 0.17.1
+
+No change
+
+<span id="release-notes-aer-0-8-2" />
+
+<span id="id281" />
+
+### Aer 0.8.2
+
+<span id="release-notes-aer-0-8-2-known-issues" />
+
+<span id="id282" />
+
+#### Known Issues
+
+*   The `SaveExpectationValue` and `SaveExpectationValueVariance` have been disabled for the extended\_stabilizer method of the `QasmSimulator` and `AerSimulator` due to returning the incorrect value for certain Pauli operator components. Refer to #1227 \<[https://github.com/Qiskit/qiskit-aer/issues/1227](https://github.com/Qiskit/qiskit-aer/issues/1227)> for more information and examples.
+
+<span id="release-notes-aer-0-8-2-bug-fixes" />
+
+<span id="id283" />
+
+#### Bug Fixes
+
+*   Fixes performance issue with how the `basis_gates` configuration attribute was set. Previously there were unintended side-effects to the backend class which could cause repeated simulation runtime to incrementally increase. Refer to #1229 \<[https://github.com/Qiskit/qiskit-aer/issues/1229](https://github.com/Qiskit/qiskit-aer/issues/1229)> for more information and examples.
+*   Fixes a bug with the `"multiplexer"` simulator instruction where the order of target and control qubits was reversed to the order in the Qiskit instruction.
+*   Fixes a bug introduced in 0.8.0 where GPU simulations would allocate unneeded host memory in addition to the GPU memory.
+*   Fixes a bug in the `stabilizer` simulator method of the `QasmSimulator` and `AerSimulator` where the expectation value for the `save_expectation_value` and `snapshot_expectation_value` could have the wrong sign for certain `Y` Pauli’s.
+
+<span id="id284" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="id285" />
+
+### Aqua 0.9.1
+
+No change
+
+<span id="id286" />
+
+### IBM Q Provider 0.12.3
+
+No change
+
+<span id="qiskit-0-25-2" />
+## 0.25.2
+
+<span id="id287" />
+
+### Terra 0.17.1
+
+No change
+
+<span id="aer-0-8-1" />
+
+### Aer 0.8.1
+
+No change
+
+<span id="id288" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="id289" />
+
+### Aqua 0.9.1
+
+No change
+
+<span id="id290" />
+
+### IBM Q Provider 0.12.3
+
+<span id="release-notes-ibmq-0-12-3-other-notes" />
+
+<span id="id291" />
+
+#### Other Notes
+
+*   The `qiskit.providers.ibmq.experiment.analysis_result.AnalysisResult` `fit` attribute is now optional.
+
+<span id="qiskit-0-25-1" />
+## 0.25.1
+
+<span id="release-notes-0-17-1" />
+
+<span id="id292" />
+
+### Terra 0.17.1
+
+<span id="release-notes-0-17-1-prelude" />
+
+<span id="id293" />
+
+#### Prelude
+
+This is a bugfix release that fixes several issues from the 0.17.0 release. Most importantly this release fixes the incorrectly constructed sdist package for the 0.17.0 release which was not actually buildable and was blocking installation on platforms without precompiled binaries available.
+
+<span id="release-notes-0-17-1-bug-fixes" />
+
+<span id="id294" />
+
+#### Bug Fixes
+
+*   Fixed an issue where the [`global_phase`](/api/qiskit/qiskit.circuit.QuantumCircuit#global_phase "qiskit.circuit.QuantumCircuit.global_phase") attribute would not be preserved in the output [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") object when the [`qiskit.circuit.QuantumCircuit.reverse_bits()`](/api/qiskit/qiskit.circuit.QuantumCircuit#reverse_bits "qiskit.circuit.QuantumCircuit.reverse_bits") method was called. For example:
+
+    ```python
+    import math
+    from qiskit import QuantumCircuit
+
+    qc = QuantumCircuit(3, 2, global_phase=math.pi)
+    qc.h(0)
+    qc.s(1)
+    qc.cx(0, 1)
+    qc.measure(0, 1)
+    qc.x(0)
+    qc.y(1)
+
+    reversed = qc.reverse_bits()
+    print(reversed.global_phase)
+    ```
+
+    will now correctly print $\pi$.
+
+*   Fixed an issue where the transpiler pass [`Unroller`](/api/qiskit/qiskit.transpiler.passes.Unroller "qiskit.transpiler.passes.Unroller") didn’t preserve global phase in case of nested instructions with one rule in their definition. Fixed [#6134](https://github.com/Qiskit/qiskit-terra/issues/6134)
+
+*   Fixed an issue where the `parameter` attribute of a [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") object built from a `UnitaryGate` was not being set to the unitary matrix of the `UnitaryGate` object. Previously, `control()` was building a [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") with the `parameter` attribute set to the controlled version of `UnitaryGate` matrix. This would lead to a modification of the `parameter` of the base `UnitaryGate` object and subsequent calls to [`inverse()`](/api/qiskit/qiskit.circuit.ControlledGate#inverse "qiskit.circuit.ControlledGate.inverse") was creating the inverse of a double-controlled `UnitaryGate`. Fixed [#5750](https://github.com/Qiskit/qiskit-terra/issues/5750)
+
+*   Fixed an issue with the preset pass managers [`level_0_pass_manager`](/api/qiskit/transpiler_preset#qiskit.transpiler.preset_passmanagers.level_0_pass_manager "qiskit.transpiler.preset_passmanagers.level_0_pass_manager") and [`level_1_pass_manager`](/api/qiskit/transpiler_preset#qiskit.transpiler.preset_passmanagers.level_1_pass_manager "qiskit.transpiler.preset_passmanagers.level_1_pass_manager") (which corresponds to `optimization_level` 0 and 1 for [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile")) where in some cases they would produce circuits not in the requested basis.
+
+*   Fix a bug where using [`SPSA`](/api/qiskit/qiskit.algorithms.optimizers.SPSA "qiskit.algorithms.optimizers.SPSA") with automatic calibration of the learning rate and perturbation (i.e. `learning_rate` and `perturbation` are `None` in the initializer), stores the calibration for all future optimizations. Instead, the calibration should be done for each new objective function.
+
+<span id="aer-release-notes-0-8-1" />
+
+<span id="id295" />
+
+### Aer 0.8.1
+
+<span id="aer-release-notes-0-8-1-bug-fixes" />
+
+<span id="id296" />
+
+#### Bug Fixes
+
+*   Fixed an issue with use of the `matrix_product_state` method of the `AerSimulator` and `QasmSimulator` simulators when running a noisy simulation with Kraus errors. Previously, the matrix product state simulation method would not propogate changes to neighboring qubits after applying the Kraus matrix. This has been fixed so the output from the simulation is correct. Fixed [#1184](https://github.com/Qiskit/qiskit-aer/issues/1184) and [#1205](https://github.com/Qiskit/qiskit-aer/issues/1205)
+*   Fixed an issue where the `qiskit.extensions.Initialize` instruction would disable measurement sampling optimization for the `statevector` and `matrix_product_state` simulation methods of the `AerSimulator` and `QasmSimulator` simulators, even when it was the first circuit instruction or applied to all qubits and hence deterministic. Fixed [#1210](https://github.com/Qiskit/qiskit-aer/issues/1210)
+*   Fix an issue with the `SaveStatevector` and `SnapshotStatevector` instructions when used with the `extended_stabilizer` simulation method of the `AerSimulator` and `QasmSimulator` simulators where it would return an unnormalized statevector. Fixed [#1196](https://github.com/Qiskit/qiskit-aer/issues/1210)
+*   The `matrix_product_state` simulation method now has support for it’s previously missing set state instruction, `qiskit.providers.aer.library.SetMatrixProductState`, which enables setting the state of a simulation in a circuit.
+
+<span id="id297" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="id298" />
+
+### Aqua 0.9.1
+
+<span id="ibm-q-provider-0-12-2" />
+
+### IBM Q Provider 0.12.2
+
+No change
+
+<span id="qiskit-0-25-0" />
 ## 0.25.0
 
 This release officially deprecates the Qiskit Aqua project. Accordingly, in a future release the `qiskit-aqua` package will be removed from the Qiskit metapackage, which means in that future release `pip install qiskit` will no longer include `qiskit-aqua`. The application modules that are provided by qiskit-aqua have been split into several new packages: `qiskit-optimization`, `qiskit-nature`, `qiskit-machine-learning`, and `qiskit-finance`. These packages can be installed by themselves (via the standard pip install command, e.g. `pip install qiskit-nature`) or with the rest of the Qiskit metapackage as optional extras (e.g. `pip install 'qiskit[finance,optimization]'` or `pip install 'qiskit[all]'` The core algorithms and the operator flow now exist as part of qiskit-terra at [`qiskit.algorithms`](/api/qiskit/algorithms#module-qiskit.algorithms "qiskit.algorithms") and [`qiskit.opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow"). Depending on your existing usage of Aqua you should either use the application packages or the new modules in Qiskit Terra. For more details on how to migrate from Qiskit Aqua, you can refer to the [migration guide](https://github.com/Qiskit/qiskit-aqua/blob/main/README.md#migration-guide).
@@ -1476,235 +1709,3 @@ For more details on how to migrate from using Qiskit Aqua, you can refer to the 
 No change
 
 <span id="qiskit-0-24-1" />
-## 0.25.1
-
-<span id="release-notes-0-17-1" />
-
-<span id="id292" />
-
-### Terra 0.17.1
-
-<span id="release-notes-0-17-1-prelude" />
-
-<span id="id293" />
-
-#### Prelude
-
-This is a bugfix release that fixes several issues from the 0.17.0 release. Most importantly this release fixes the incorrectly constructed sdist package for the 0.17.0 release which was not actually buildable and was blocking installation on platforms without precompiled binaries available.
-
-<span id="release-notes-0-17-1-bug-fixes" />
-
-<span id="id294" />
-
-#### Bug Fixes
-
-*   Fixed an issue where the [`global_phase`](/api/qiskit/qiskit.circuit.QuantumCircuit#global_phase "qiskit.circuit.QuantumCircuit.global_phase") attribute would not be preserved in the output [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") object when the [`qiskit.circuit.QuantumCircuit.reverse_bits()`](/api/qiskit/qiskit.circuit.QuantumCircuit#reverse_bits "qiskit.circuit.QuantumCircuit.reverse_bits") method was called. For example:
-
-    ```python
-    import math
-    from qiskit import QuantumCircuit
-
-    qc = QuantumCircuit(3, 2, global_phase=math.pi)
-    qc.h(0)
-    qc.s(1)
-    qc.cx(0, 1)
-    qc.measure(0, 1)
-    qc.x(0)
-    qc.y(1)
-
-    reversed = qc.reverse_bits()
-    print(reversed.global_phase)
-    ```
-
-    will now correctly print $\pi$.
-
-*   Fixed an issue where the transpiler pass [`Unroller`](/api/qiskit/qiskit.transpiler.passes.Unroller "qiskit.transpiler.passes.Unroller") didn’t preserve global phase in case of nested instructions with one rule in their definition. Fixed [#6134](https://github.com/Qiskit/qiskit-terra/issues/6134)
-
-*   Fixed an issue where the `parameter` attribute of a [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") object built from a `UnitaryGate` was not being set to the unitary matrix of the `UnitaryGate` object. Previously, `control()` was building a [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") with the `parameter` attribute set to the controlled version of `UnitaryGate` matrix. This would lead to a modification of the `parameter` of the base `UnitaryGate` object and subsequent calls to [`inverse()`](/api/qiskit/qiskit.circuit.ControlledGate#inverse "qiskit.circuit.ControlledGate.inverse") was creating the inverse of a double-controlled `UnitaryGate`. Fixed [#5750](https://github.com/Qiskit/qiskit-terra/issues/5750)
-
-*   Fixed an issue with the preset pass managers [`level_0_pass_manager`](/api/qiskit/transpiler_preset#qiskit.transpiler.preset_passmanagers.level_0_pass_manager "qiskit.transpiler.preset_passmanagers.level_0_pass_manager") and [`level_1_pass_manager`](/api/qiskit/transpiler_preset#qiskit.transpiler.preset_passmanagers.level_1_pass_manager "qiskit.transpiler.preset_passmanagers.level_1_pass_manager") (which corresponds to `optimization_level` 0 and 1 for [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile")) where in some cases they would produce circuits not in the requested basis.
-
-*   Fix a bug where using [`SPSA`](/api/qiskit/qiskit.algorithms.optimizers.SPSA "qiskit.algorithms.optimizers.SPSA") with automatic calibration of the learning rate and perturbation (i.e. `learning_rate` and `perturbation` are `None` in the initializer), stores the calibration for all future optimizations. Instead, the calibration should be done for each new objective function.
-
-<span id="aer-release-notes-0-8-1" />
-
-<span id="id295" />
-
-### Aer 0.8.1
-
-<span id="aer-release-notes-0-8-1-bug-fixes" />
-
-<span id="id296" />
-
-#### Bug Fixes
-
-*   Fixed an issue with use of the `matrix_product_state` method of the `AerSimulator` and `QasmSimulator` simulators when running a noisy simulation with Kraus errors. Previously, the matrix product state simulation method would not propogate changes to neighboring qubits after applying the Kraus matrix. This has been fixed so the output from the simulation is correct. Fixed [#1184](https://github.com/Qiskit/qiskit-aer/issues/1184) and [#1205](https://github.com/Qiskit/qiskit-aer/issues/1205)
-*   Fixed an issue where the `qiskit.extensions.Initialize` instruction would disable measurement sampling optimization for the `statevector` and `matrix_product_state` simulation methods of the `AerSimulator` and `QasmSimulator` simulators, even when it was the first circuit instruction or applied to all qubits and hence deterministic. Fixed [#1210](https://github.com/Qiskit/qiskit-aer/issues/1210)
-*   Fix an issue with the `SaveStatevector` and `SnapshotStatevector` instructions when used with the `extended_stabilizer` simulation method of the `AerSimulator` and `QasmSimulator` simulators where it would return an unnormalized statevector. Fixed [#1196](https://github.com/Qiskit/qiskit-aer/issues/1210)
-*   The `matrix_product_state` simulation method now has support for it’s previously missing set state instruction, `qiskit.providers.aer.library.SetMatrixProductState`, which enables setting the state of a simulation in a circuit.
-
-<span id="id297" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="id298" />
-
-### Aqua 0.9.1
-
-<span id="ibm-q-provider-0-12-2" />
-
-### IBM Q Provider 0.12.2
-
-No change
-
-<span id="qiskit-0-25-0" />
-## 0.25.2
-
-<span id="id287" />
-
-### Terra 0.17.1
-
-No change
-
-<span id="aer-0-8-1" />
-
-### Aer 0.8.1
-
-No change
-
-<span id="id288" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="id289" />
-
-### Aqua 0.9.1
-
-No change
-
-<span id="id290" />
-
-### IBM Q Provider 0.12.3
-
-<span id="release-notes-ibmq-0-12-3-other-notes" />
-
-<span id="id291" />
-
-#### Other Notes
-
-*   The `qiskit.providers.ibmq.experiment.analysis_result.AnalysisResult` `fit` attribute is now optional.
-
-<span id="qiskit-0-25-1" />
-## 0.25.3
-
-<span id="terra-0-17-1" />
-
-### Terra 0.17.1
-
-No change
-
-<span id="release-notes-aer-0-8-2" />
-
-<span id="id281" />
-
-### Aer 0.8.2
-
-<span id="release-notes-aer-0-8-2-known-issues" />
-
-<span id="id282" />
-
-#### Known Issues
-
-*   The `SaveExpectationValue` and `SaveExpectationValueVariance` have been disabled for the extended\_stabilizer method of the `QasmSimulator` and `AerSimulator` due to returning the incorrect value for certain Pauli operator components. Refer to #1227 \<[https://github.com/Qiskit/qiskit-aer/issues/1227](https://github.com/Qiskit/qiskit-aer/issues/1227)> for more information and examples.
-
-<span id="release-notes-aer-0-8-2-bug-fixes" />
-
-<span id="id283" />
-
-#### Bug Fixes
-
-*   Fixes performance issue with how the `basis_gates` configuration attribute was set. Previously there were unintended side-effects to the backend class which could cause repeated simulation runtime to incrementally increase. Refer to #1229 \<[https://github.com/Qiskit/qiskit-aer/issues/1229](https://github.com/Qiskit/qiskit-aer/issues/1229)> for more information and examples.
-*   Fixes a bug with the `"multiplexer"` simulator instruction where the order of target and control qubits was reversed to the order in the Qiskit instruction.
-*   Fixes a bug introduced in 0.8.0 where GPU simulations would allocate unneeded host memory in addition to the GPU memory.
-*   Fixes a bug in the `stabilizer` simulator method of the `QasmSimulator` and `AerSimulator` where the expectation value for the `save_expectation_value` and `snapshot_expectation_value` could have the wrong sign for certain `Y` Pauli’s.
-
-<span id="id284" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="id285" />
-
-### Aqua 0.9.1
-
-No change
-
-<span id="id286" />
-
-### IBM Q Provider 0.12.3
-
-No change
-
-<span id="qiskit-0-25-2" />
-## 0.25.4
-
-<span id="terra-0-17-2" />
-
-<span id="release-notes-0-17-2" />
-
-### Terra 0.17.2
-
-<span id="release-notes-0-17-2-prelude" />
-
-<span id="id276" />
-
-#### Prelude
-
-This is a bugfix release that fixes several issues from the 0.17.1 release. Most importantly this release fixes compatibility for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running on backends that are based on the [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") abstract class. This fixes all the algorithms and applications built on [`qiskit.algorithms`](/api/qiskit/algorithms#module-qiskit.algorithms "qiskit.algorithms") or [`qiskit.opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow") when running on newer backends.
-
-<span id="release-notes-0-17-2-bug-fixes" />
-
-<span id="id277" />
-
-#### Bug Fixes
-
-*   Fixed an issue with the [`BasisTranslator`](/api/qiskit/qiskit.transpiler.passes.BasisTranslator "qiskit.transpiler.passes.BasisTranslator") transpiler pass which in some cases would translate gates already in the target basis. This would potentially result in both longer execution time and less optimal results. Fixed [#6085](https://github.com/Qiskit/qiskit-terra/issues/6085)
-*   Fixed an issue in the `SPSA` when the optimizer was initialized with a callback function via the `callback` kwarg would potentially cause an error to be raised.
-*   Fixed an issue in the [`qiskit.quantum_info.Statevector.expectation_value()`](/api/qiskit/qiskit.quantum_info.Statevector#expectation_value "qiskit.quantum_info.Statevector.expectation_value") and ```qiskit.quantum_info.DensityMatrix.expectation_value`methods where the ``qargs`()``` kwarg was ignored if the operator was a [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") or [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") operator object. Fixed [#6303](https://github.com/Qiskit/qiskit-terra/issues/6303)
-*   Fixed an issue in the [`qiskit.quantum_info.Pauli.evolve()`](/api/qiskit/qiskit.quantum_info.Pauli#evolve "qiskit.quantum_info.Pauli.evolve") method which could have resulted in the incorrect Pauli being returned when evolving by a [`CZGate`](/api/qiskit/qiskit.circuit.library.CZGate "qiskit.circuit.library.CZGate"), [`CYGate`](/api/qiskit/qiskit.circuit.library.CYGate "qiskit.circuit.library.CYGate"), or a [`SwapGate`](/api/qiskit/qiskit.circuit.library.SwapGate "qiskit.circuit.library.SwapGate") gate.
-*   Fixed an issue in the `qiskit.opflow.SparseVectorStateFn.to_dict_fn()` method, which previously had at most one entry for the all zero state due to an index error.
-*   Fixed an issue in the `qiskit.opflow.SparseVectorStateFn.equals()` method so that is properly returning `True` or `False` instead of a sparse vector comparison of the single elements.
-*   Fixes an issue in the [`Statevector`](/api/qiskit/qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") and [`DensityMatrix`](/api/qiskit/qiskit.quantum_info.DensityMatrix "qiskit.quantum_info.DensityMatrix") probability methods [`qiskit.quantum_info.Statevector.probabilities()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities "qiskit.quantum_info.Statevector.probabilities"), [`qiskit.quantum_info.Statevector.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities_dict "qiskit.quantum_info.Statevector.probabilities_dict"), [`qiskit.quantum_info.DensityMatrix.probabilities()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities "qiskit.quantum_info.DensityMatrix.probabilities"), [`qiskit.quantum_info.DensityMatrix.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities_dict "qiskit.quantum_info.DensityMatrix.probabilities_dict") where the returned probabilities could have incorrect ordering for certain values of the `qargs` kwarg. Fixed [#6320](https://github.com/Qiskit/qiskit-terra/issues/6320)
-*   Fixed an issue where the `TaperedPauliSumOp` class did not support the multiplication with [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") object and also did not have a necessary `assign_parameters()` method for working with [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") objects. Fixed [#6127](https://github.com/Qiskit/qiskit-terra/issues/6127)
-*   Fixed compatibility for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running on backends that are based on the [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") abstract class. Fixed [#6280](https://github.com/Qiskit/qiskit-terra/issues/6280)
-
-<span id="id278" />
-
-### Aer 0.8.2
-
-No change
-
-<span id="id279" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="id280" />
-
-### Aqua 0.9.1
-
-No change
-
-<span id="ibm-q-provider-0-12-3" />
-
-### IBM Q Provider 0.12.3
-
-No change
-
-<span id="qiskit-0-25-3" />

--- a/docs/api/qiskit/release-notes/0.26.md
+++ b/docs/api/qiskit/release-notes/0.26.md
@@ -5,6 +5,48 @@ description: New features and bug fixes
 
 # Qiskit 0.26 release notes
 
+## 0.26.1
+
+<span id="release-notes-0-17-4" />
+
+<span id="id260" />
+
+### Terra 0.17.4
+
+<span id="release-notes-0-17-4-bug-fixes" />
+
+<span id="id261" />
+
+#### Bug Fixes
+
+*   Fixed an issue with the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") with [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") backends with the `` `max_experiments `` attribute set to a value less than the number of circuits to run. Previously the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") would not correctly split the circuits to run into separate jobs, which has been corrected.
+
+<span id="id262" />
+
+### Aer 0.8.2
+
+No change
+
+<span id="id263" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="aqua-0-9-1" />
+
+### Aqua 0.9.1
+
+No change
+
+<span id="ibm-q-provider-0-13-1" />
+
+### IBM Q Provider 0.13.1
+
+No change
+
+<span id="qiskit-0-26-0" />
+
 ## 0.26.0
 
 <span id="terra-0-17-3" />
@@ -134,44 +176,3 @@ Note that Qiskit Runtime is currently in private beta for select account but wil
 *   The `qiskit.providers.ibmq.experiment.analysis_result.AnalysisResult` `fit` attribute is now optional.
 
 <span id="qiskit-0-25-4" />
-## 0.26.1
-
-<span id="release-notes-0-17-4" />
-
-<span id="id260" />
-
-### Terra 0.17.4
-
-<span id="release-notes-0-17-4-bug-fixes" />
-
-<span id="id261" />
-
-#### Bug Fixes
-
-*   Fixed an issue with the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") with [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") backends with the `` `max_experiments `` attribute set to a value less than the number of circuits to run. Previously the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") would not correctly split the circuits to run into separate jobs, which has been corrected.
-
-<span id="id262" />
-
-### Aer 0.8.2
-
-No change
-
-<span id="id263" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="aqua-0-9-1" />
-
-### Aqua 0.9.1
-
-No change
-
-<span id="ibm-q-provider-0-13-1" />
-
-### IBM Q Provider 0.13.1
-
-No change
-
-<span id="qiskit-0-26-0" />

--- a/docs/api/qiskit/release-notes/0.29.md
+++ b/docs/api/qiskit/release-notes/0.29.md
@@ -5,6 +5,57 @@ description: New features and bug fixes
 
 # Qiskit 0.29 release notes
 
+## 0.29.1
+
+<span id="release-notes-0-18-2" />
+
+<span id="id227" />
+
+### Terra 0.18.2
+
+<span id="release-notes-0-18-2-bug-fixes" />
+
+<span id="id228" />
+
+#### Bug Fixes
+
+*   Fixed an issue with the [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") function when called with the `backend` kwarg set and the `parametric_pulses` kwarg was set to an empty list the output qobj would contain the `parametric_pulses` setting from the given backend’s [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration") instead of the expected empty list. Fixed [#6898](https://github.com/Qiskit/qiskit-terra/issues/6898)
+*   The Matplotlib circuit drawer will no longer duplicate drawings when using `ipykernel>=6.0.0`. Fixes [#6889](https://github.com/Qiskit/qiskit-terra/issues/6889).
+
+<span id="aer-0-8-2" />
+
+### Aer 0.8.2
+
+No change
+
+<span id="id229" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="release-notes-aqua-0-9-5" />
+
+<span id="id230" />
+
+### Aqua 0.9.5
+
+<span id="release-notes-aqua-0-9-5-bug-fixes" />
+
+<span id="id231" />
+
+#### Bug Fixes
+
+*   Fixed a handling error in the Yahoo provider when only one ticker is entered. Added exception error if no ticker is entered. Limit yfinance to >=0.1.62 as previous versions have a JSON decoder error.
+
+<span id="id232" />
+
+### IBM Q Provider 0.16.0
+
+No change
+
+<span id="qiskit-0-29-0" />
+
 ## 0.29.0
 
 <span id="terra-0-18-1" />
@@ -94,53 +145,3 @@ No change
 *   `qiskit.providers.ibmq.IBMQBackend.run()` no longer accepts validate\_qobj as a parameter. If you were relying on this schema validation you should pull the schemas from the [Qiskit/ibm-quantum-schemas](https://github.com/Qiskit/ibm-quantum-schemas) and directly validate your payloads with that.
 
 <span id="qiskit-0-28-0" />
-## 0.29.1
-
-<span id="release-notes-0-18-2" />
-
-<span id="id227" />
-
-### Terra 0.18.2
-
-<span id="release-notes-0-18-2-bug-fixes" />
-
-<span id="id228" />
-
-#### Bug Fixes
-
-*   Fixed an issue with the [`assemble()`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") function when called with the `backend` kwarg set and the `parametric_pulses` kwarg was set to an empty list the output qobj would contain the `parametric_pulses` setting from the given backend’s [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration") instead of the expected empty list. Fixed [#6898](https://github.com/Qiskit/qiskit-terra/issues/6898)
-*   The Matplotlib circuit drawer will no longer duplicate drawings when using `ipykernel>=6.0.0`. Fixes [#6889](https://github.com/Qiskit/qiskit-terra/issues/6889).
-
-<span id="aer-0-8-2" />
-
-### Aer 0.8.2
-
-No change
-
-<span id="id229" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="release-notes-aqua-0-9-5" />
-
-<span id="id230" />
-
-### Aqua 0.9.5
-
-<span id="release-notes-aqua-0-9-5-bug-fixes" />
-
-<span id="id231" />
-
-#### Bug Fixes
-
-*   Fixed a handling error in the Yahoo provider when only one ticker is entered. Added exception error if no ticker is entered. Limit yfinance to >=0.1.62 as previous versions have a JSON decoder error.
-
-<span id="id232" />
-
-### IBM Q Provider 0.16.0
-
-No change
-
-<span id="qiskit-0-29-0" />

--- a/docs/api/qiskit/release-notes/0.30.md
+++ b/docs/api/qiskit/release-notes/0.30.md
@@ -5,6 +5,56 @@ description: New features and bug fixes
 
 # Qiskit 0.30 release notes
 
+## 0.30.1
+
+<span id="release-notes-0-18-3" />
+
+<span id="id211" />
+
+### Terra 0.18.3
+
+<span id="id212" />
+
+#### Prelude
+
+This bugfix release fixes a few minor issues in 0.18, including a performance regression in [`assemble`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") when dealing with executing [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects on pulse-enabled backends.
+
+<span id="release-notes-0-18-3-bug-fixes" />
+
+<span id="id213" />
+
+#### Bug Fixes
+
+*   Fixed [#7004](https://github.com/Qiskit/qiskit-terra/issues/7004) where `AttributeError` was raised when executing [`ScheduleBlock`](/api/qiskit/qiskit.pulse.ScheduleBlock "qiskit.pulse.ScheduleBlock") on a pulse backend. These blocks are now correctly treated as pulse jobs, like [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule").
+*   Fixed an issue causing an error when binding a complex parameter value to an operator’s coefficient. Casts to `float` in [`PrimitiveOp`](/api/qiskit/qiskit.opflow.primitive_ops.PrimitiveOp "qiskit.opflow.primitive_ops.PrimitiveOp") were generalized to casts to `complex` if necessary, but will remain `float` if there is no imaginary component. Fixes [#6976](https://github.com/Qiskit/qiskit-terra/issues/6976).
+*   Update the 1-qubit gate errors in [`plot_error_map`](/api/qiskit/qiskit.visualization.plot_error_map "qiskit.visualization.plot_error_map") to use the sx gate instead of the u2 gate, consistent with IBMQ backends.
+
+<span id="aer-0-9-0" />
+
+### Aer 0.9.0
+
+No change
+
+<span id="id214" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="id215" />
+
+### Aqua 0.9.5
+
+No change
+
+<span id="ibm-q-provider-0-16-0" />
+
+### IBM Q Provider 0.16.0
+
+No change
+
+<span id="qiskit-0-30-0" />
+
 ## 0.30.0
 
 <span id="terra-0-18-2" />
@@ -170,52 +220,3 @@ No change
 No change
 
 <span id="qiskit-0-29-1" />
-## 0.30.1
-
-<span id="release-notes-0-18-3" />
-
-<span id="id211" />
-
-### Terra 0.18.3
-
-<span id="id212" />
-
-#### Prelude
-
-This bugfix release fixes a few minor issues in 0.18, including a performance regression in [`assemble`](/api/qiskit/compiler#qiskit.compiler.assemble "qiskit.compiler.assemble") when dealing with executing [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects on pulse-enabled backends.
-
-<span id="release-notes-0-18-3-bug-fixes" />
-
-<span id="id213" />
-
-#### Bug Fixes
-
-*   Fixed [#7004](https://github.com/Qiskit/qiskit-terra/issues/7004) where `AttributeError` was raised when executing [`ScheduleBlock`](/api/qiskit/qiskit.pulse.ScheduleBlock "qiskit.pulse.ScheduleBlock") on a pulse backend. These blocks are now correctly treated as pulse jobs, like [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule").
-*   Fixed an issue causing an error when binding a complex parameter value to an operator’s coefficient. Casts to `float` in [`PrimitiveOp`](/api/qiskit/qiskit.opflow.primitive_ops.PrimitiveOp "qiskit.opflow.primitive_ops.PrimitiveOp") were generalized to casts to `complex` if necessary, but will remain `float` if there is no imaginary component. Fixes [#6976](https://github.com/Qiskit/qiskit-terra/issues/6976).
-*   Update the 1-qubit gate errors in [`plot_error_map`](/api/qiskit/qiskit.visualization.plot_error_map "qiskit.visualization.plot_error_map") to use the sx gate instead of the u2 gate, consistent with IBMQ backends.
-
-<span id="aer-0-9-0" />
-
-### Aer 0.9.0
-
-No change
-
-<span id="id214" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="id215" />
-
-### Aqua 0.9.5
-
-No change
-
-<span id="ibm-q-provider-0-16-0" />
-
-### IBM Q Provider 0.16.0
-
-No change
-
-<span id="qiskit-0-30-0" />

--- a/docs/api/qiskit/release-notes/0.32.md
+++ b/docs/api/qiskit/release-notes/0.32.md
@@ -5,6 +5,48 @@ description: New features and bug fixes
 
 # Qiskit 0.32 release notes
 
+## 0.32.1
+
+<span id="terra-0-18-3" />
+
+### Terra 0.18.3
+
+No change
+
+<span id="id193" />
+
+### Aer 0.9.1
+
+No change
+
+<span id="ignis-0-6-0" />
+
+### Ignis 0.6.0
+
+No change
+
+<span id="aqua-0-9-5" />
+
+### Aqua 0.9.5
+
+No change
+
+<span id="ibm-q-provider-0-18-1" />
+
+<span id="release-notes-0-18-1-ibmq" />
+
+### IBM Q Provider 0.18.1
+
+<span id="release-notes-0-18-1-ibmq-bug-fixes" />
+
+<span id="id194" />
+
+#### Bug Fixes
+
+*   Fixes [#209](https://github.com/Qiskit-Partners/qiskit-ibm/issues/209) where the websocket connection kept timing out when streaming results for a runtime job, due to inactivity, when the job is in a pending state for a long time.
+
+<span id="qiskit-0-32-0" />
+
 ## 0.32.0
 
 <span id="id195" />
@@ -72,44 +114,3 @@ No change
 *   Fixes the issue wherein a runtime job result cannot be retrieved multiple times if the result contains a numpy array.
 
 <span id="qiskit-0-31-0" />
-## 0.32.1
-
-<span id="terra-0-18-3" />
-
-### Terra 0.18.3
-
-No change
-
-<span id="id193" />
-
-### Aer 0.9.1
-
-No change
-
-<span id="ignis-0-6-0" />
-
-### Ignis 0.6.0
-
-No change
-
-<span id="aqua-0-9-5" />
-
-### Aqua 0.9.5
-
-No change
-
-<span id="ibm-q-provider-0-18-1" />
-
-<span id="release-notes-0-18-1-ibmq" />
-
-### IBM Q Provider 0.18.1
-
-<span id="release-notes-0-18-1-ibmq-bug-fixes" />
-
-<span id="id194" />
-
-#### Bug Fixes
-
-*   Fixes [#209](https://github.com/Qiskit-Partners/qiskit-ibm/issues/209) where the websocket connection kept timing out when streaming results for a runtime job, due to inactivity, when the job is in a pending state for a long time.
-
-<span id="qiskit-0-32-0" />

--- a/docs/api/qiskit/release-notes/0.33.md
+++ b/docs/api/qiskit/release-notes/0.33.md
@@ -5,6 +5,138 @@ description: New features and bug fixes
 
 # Qiskit 0.33 release notes
 
+## 0.33.1
+
+<span id="release-notes-0-19-1-terra" />
+
+<span id="id172" />
+
+### Terra 0.19.1
+
+<span id="release-notes-0-19-1-terra-prelude" />
+
+<span id="id173" />
+
+#### Prelude
+
+Qiskit Terra 0.19.1 is a bugfix release, solving some issues in 0.19.0 concerning circuits constructed by the control-flow builder interface, conditional gates and QPY serialisation of newer Terra objects.
+
+<span id="release-notes-0-19-1-terra-deprecation-notes" />
+
+<span id="id174" />
+
+#### Deprecation Notes
+
+*   The loose functions `qiskit.circuit.measure.measure()` and `qiskit.circuit.reset.reset()` are deprecated, and will be removed in a future release. Instead, you should access these as methods on [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit"):
+
+    ```python
+    from qiskit import QuantumCircuit
+    circuit = QuantumCircuit(1, 1)
+
+    # Replace this deprecated form ...
+    from qiskit.circuit.measure import measure
+    measure(circuit, 0, 0)
+
+    # ... with either of the next two lines:
+    circuit.measure(0, 0)
+    QuantumCircuit.measure(circuit, 0, 0)
+    ```
+
+<span id="release-notes-0-19-1-terra-bug-fixes" />
+
+<span id="id175" />
+
+#### Bug Fixes
+
+*   Fixed an error in the circuit conversion functions [`circuit_to_gate()`](/api/qiskit/converters#qiskit.converters.circuit_to_gate "qiskit.converters.circuit_to_gate") and [`circuit_to_instruction()`](/api/qiskit/converters#qiskit.converters.circuit_to_instruction "qiskit.converters.circuit_to_instruction") (and their associated circuit methods [`QuantumCircuit.to_gate()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_gate "qiskit.circuit.QuantumCircuit.to_gate") and [`QuantumCircuit.to_instruction()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_instruction "qiskit.circuit.QuantumCircuit.to_instruction")) when acting on a circuit with registerless bits, or bits in more than one register. Previously, the number of bits necessary for the created gate or instruction would be calculated incorrectly, often causing an exception during the conversion.
+
+*   Fixed an issue where calling [`QuantumCircuit.copy()`](/api/qiskit/qiskit.circuit.QuantumCircuit#copy "qiskit.circuit.QuantumCircuit.copy") on the “body” circuits of a control-flow operation created with the builder interface would raise an error. For example, this was previously an error, but will now return successfully:
+
+    ```python
+    from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+    qreg = QuantumRegister(4)
+    creg = ClassicalRegister(1)
+    circ = QuantumCircuit(qreg, creg)
+
+    with circ.if_test((creg, 0)):
+        circ.h(0)
+
+    if_else_instruction, _, _ = circ.data[0]
+    true_body = if_else_instruction.params[0]
+    true_body.copy()
+    ```
+
+*   The control-flow builder interface now supports using [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister")s as conditions in nested control-flow scopes. Previously, doing this would not raise an error immediately, but the internal circuit blocks would not have the correct registers defined, and so later logic that worked with the inner blocks would fail.
+
+    For example, previously the drawers would fail when trying to draw an inner block conditioned on a classical register, whereas now it will succeed, such as in this example:
+
+    ```python
+    from qiskit import QuantumCircuit
+    from qiskit.circuit import QuantumRegister, ClassicalRegister
+
+    qreg = QuantumRegister(4)
+    creg = ClassicalRegister(1)
+    circ = QuantumCircuit(qreg, creg)
+
+    with circ.for_loop(range(10)) as a:
+        circ.ry(a, 0)
+        with circ.if_test((creg, 1)):
+            circ.break_loop()
+
+    print(circ.draw(cregbundle=False))
+    print(circ.data[0][0].blocks[0].draw(cregbundle=False))
+    ```
+
+*   Fixed `qpy_serialization` support for serializing [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects that are using [`ParameterVector`](/api/qiskit/qiskit.circuit.ParameterVector "qiskit.circuit.ParameterVector") or `ParameterVectorElement` as parameters. Previously, a `ParameterVectorElement` parameter was just treated as a [`Parameter`](/api/qiskit/qiskit.circuit.Parameter "qiskit.circuit.Parameter") for QPY serialization which meant the [`ParameterVector`](/api/qiskit/qiskit.circuit.ParameterVector "qiskit.circuit.ParameterVector") context was lost in QPY and the output order of [`parameters`](/api/qiskit/qiskit.circuit.QuantumCircuit#parameters "qiskit.circuit.QuantumCircuit.parameters") could be incorrect.
+
+    To fix this issue a new QPY format version, [Version 3](/api/qiskit/qpy#qpy-version-3), was required. This new format version includes a representation of the `ParameterVectorElement` class which is described in the `qpy_serialization` documentation at [PARAMETER\_VECTOR\_ELEMENT](/api/qiskit/qpy#qpy-param-vector).
+
+*   Fixed the `qpy_serialization` support for serializing a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") object. Previously, the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") was treated as a custom gate for serialization and would be deserialized as a [`Gate`](/api/qiskit/qiskit.circuit.Gate "qiskit.circuit.Gate") object that had the same definition and name as the original [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"). However, this would lose the original state from the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"). This has been fixed so that starting in this release a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") in the circuit will be preserved 1:1 across QPY serialization now. The only limitation with this is that it does not support custom [`EvolutionSynthesis`](/api/qiskit/qiskit.synthesis.EvolutionSynthesis "qiskit.synthesis.EvolutionSynthesis") classes. Only the classes available from [`qiskit.synthesis`](/api/qiskit/synthesis#module-qiskit.synthesis "qiskit.synthesis") can be used with a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") for qpy serialization.
+
+    To fix this issue a new QPY format version, [Version 3](/api/qiskit/qpy#qpy-version-3), was required. This new format version includes a representation of the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") class which is described in the `qpy_serialization` documentation at [PAULI\_EVOLUTION](/api/qiskit/qpy#pauli-evo-qpy).
+
+*   Two loose functions `qiskit.circuit.measure.measure()` and `qiskit.circuit.reset.reset()` were accidentally removed without a deprecation period. They have been reinstated, but are marked as deprecated in favour of the methods [`QuantumCircuit.measure()`](/api/qiskit/qiskit.circuit.QuantumCircuit#measure "qiskit.circuit.QuantumCircuit.measure") and [`QuantumCircuit.reset()`](/api/qiskit/qiskit.circuit.QuantumCircuit#reset "qiskit.circuit.QuantumCircuit.reset"), respectively, and will be removed in a future release.
+
+<span id="release-notes-0-19-1-terra-other-notes" />
+
+<span id="id176" />
+
+#### Other Notes
+
+*   The new control-flow builder interface uses various context managers and helper objects to do its work. These should not be considered part of the public API, and are liable to be changed and removed without warning. The *usage* of the builder interface has stability guarantees, in the sense that the behaviour described by [`QuantumCircuit.for_loop()`](/api/qiskit/qiskit.circuit.QuantumCircuit#for_loop "qiskit.circuit.QuantumCircuit.for_loop"), [`while_loop()`](/api/qiskit/qiskit.circuit.QuantumCircuit#while_loop "qiskit.circuit.QuantumCircuit.while_loop") and [`if_test()`](/api/qiskit/qiskit.circuit.QuantumCircuit#if_test "qiskit.circuit.QuantumCircuit.if_test") for the builder interface are subject to the standard deprecation policies, but the actual objects used to effect this are not. You should not rely on the objects (such as `IfContext` or `ControlFlowBuilderBlock`) existing in their current locations, or having any methods or attributes attached to them.
+
+    This was not previously clear in the 0.19.0 release. All such objects now have a warning in their documentation strings making this explicit. It is likely in the future that their locations and backing implementations will become quite different.
+
+<span id="aer-0-9-1" />
+
+### Aer 0.9.1
+
+No change
+
+<span id="id177" />
+
+### Ignis 0.7.0
+
+No change
+
+<span id="ibm-q-provider-0-18-2" />
+
+<span id="release-notes-0-18-2-ibmq" />
+
+### IBM Q Provider 0.18.2
+
+<span id="release-notes-0-18-2-ibmq-bug-fixes" />
+
+<span id="id178" />
+
+#### Bug Fixes
+
+*   Fix delivered in [#1065](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1065) for the issue where job kept crashing when `Parameter` was passed in circuit metadata.
+*   Fix delivered in [#1094](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1094) for the issue wherein `qiskit.providers.ibmq.runtime.RuntimeEncoder` does an extra decompose() if the circuit being serialized is a `BlueprintCircuit`.
+
+<span id="qiskit-0-33-0" />
+
 ## 0.33.0
 
 This release officially marks the end of support for the Qiskit Aqua project in Qiskit. It was originally deprecated in the 0.25.0 release and as was documented in that release the `qiskit-aqua` package has been removed from the Qiskit metapackage, which means `pip install qiskit` will no longer include `qiskit-aqua`. However, because of limitations in python packaging we cannot automatically remove a pre-existing install of `qiskit-aqua` when upgrading a previous version of Qiskit to this release (or a future release) with `pip install -U qiskit`. If you are upgrading from a previous version it’s recommended that you manually uninstall Qiskit Aqua with `pip uninstall qiskit-aqua` or install in a fresh python environment.
@@ -1323,134 +1455,3 @@ This release deprecates the Qiskit Ignis project, it has been supersceded by the
     [https://github.com/Qiskit/qiskit-ignis#migration-guide](https://github.com/Qiskit/qiskit-ignis#migration-guide)
 
 <span id="qiskit-0-32-1" />
-## 0.33.1
-
-<span id="release-notes-0-19-1-terra" />
-
-<span id="id172" />
-
-### Terra 0.19.1
-
-<span id="release-notes-0-19-1-terra-prelude" />
-
-<span id="id173" />
-
-#### Prelude
-
-Qiskit Terra 0.19.1 is a bugfix release, solving some issues in 0.19.0 concerning circuits constructed by the control-flow builder interface, conditional gates and QPY serialisation of newer Terra objects.
-
-<span id="release-notes-0-19-1-terra-deprecation-notes" />
-
-<span id="id174" />
-
-#### Deprecation Notes
-
-*   The loose functions `qiskit.circuit.measure.measure()` and `qiskit.circuit.reset.reset()` are deprecated, and will be removed in a future release. Instead, you should access these as methods on [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit"):
-
-    ```python
-    from qiskit import QuantumCircuit
-    circuit = QuantumCircuit(1, 1)
-
-    # Replace this deprecated form ...
-    from qiskit.circuit.measure import measure
-    measure(circuit, 0, 0)
-
-    # ... with either of the next two lines:
-    circuit.measure(0, 0)
-    QuantumCircuit.measure(circuit, 0, 0)
-    ```
-
-<span id="release-notes-0-19-1-terra-bug-fixes" />
-
-<span id="id175" />
-
-#### Bug Fixes
-
-*   Fixed an error in the circuit conversion functions [`circuit_to_gate()`](/api/qiskit/converters#qiskit.converters.circuit_to_gate "qiskit.converters.circuit_to_gate") and [`circuit_to_instruction()`](/api/qiskit/converters#qiskit.converters.circuit_to_instruction "qiskit.converters.circuit_to_instruction") (and their associated circuit methods [`QuantumCircuit.to_gate()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_gate "qiskit.circuit.QuantumCircuit.to_gate") and [`QuantumCircuit.to_instruction()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_instruction "qiskit.circuit.QuantumCircuit.to_instruction")) when acting on a circuit with registerless bits, or bits in more than one register. Previously, the number of bits necessary for the created gate or instruction would be calculated incorrectly, often causing an exception during the conversion.
-
-*   Fixed an issue where calling [`QuantumCircuit.copy()`](/api/qiskit/qiskit.circuit.QuantumCircuit#copy "qiskit.circuit.QuantumCircuit.copy") on the “body” circuits of a control-flow operation created with the builder interface would raise an error. For example, this was previously an error, but will now return successfully:
-
-    ```python
-    from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
-
-    qreg = QuantumRegister(4)
-    creg = ClassicalRegister(1)
-    circ = QuantumCircuit(qreg, creg)
-
-    with circ.if_test((creg, 0)):
-        circ.h(0)
-
-    if_else_instruction, _, _ = circ.data[0]
-    true_body = if_else_instruction.params[0]
-    true_body.copy()
-    ```
-
-*   The control-flow builder interface now supports using [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister")s as conditions in nested control-flow scopes. Previously, doing this would not raise an error immediately, but the internal circuit blocks would not have the correct registers defined, and so later logic that worked with the inner blocks would fail.
-
-    For example, previously the drawers would fail when trying to draw an inner block conditioned on a classical register, whereas now it will succeed, such as in this example:
-
-    ```python
-    from qiskit import QuantumCircuit
-    from qiskit.circuit import QuantumRegister, ClassicalRegister
-
-    qreg = QuantumRegister(4)
-    creg = ClassicalRegister(1)
-    circ = QuantumCircuit(qreg, creg)
-
-    with circ.for_loop(range(10)) as a:
-        circ.ry(a, 0)
-        with circ.if_test((creg, 1)):
-            circ.break_loop()
-
-    print(circ.draw(cregbundle=False))
-    print(circ.data[0][0].blocks[0].draw(cregbundle=False))
-    ```
-
-*   Fixed `qpy_serialization` support for serializing [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects that are using [`ParameterVector`](/api/qiskit/qiskit.circuit.ParameterVector "qiskit.circuit.ParameterVector") or `ParameterVectorElement` as parameters. Previously, a `ParameterVectorElement` parameter was just treated as a [`Parameter`](/api/qiskit/qiskit.circuit.Parameter "qiskit.circuit.Parameter") for QPY serialization which meant the [`ParameterVector`](/api/qiskit/qiskit.circuit.ParameterVector "qiskit.circuit.ParameterVector") context was lost in QPY and the output order of [`parameters`](/api/qiskit/qiskit.circuit.QuantumCircuit#parameters "qiskit.circuit.QuantumCircuit.parameters") could be incorrect.
-
-    To fix this issue a new QPY format version, [Version 3](/api/qiskit/qpy#qpy-version-3), was required. This new format version includes a representation of the `ParameterVectorElement` class which is described in the `qpy_serialization` documentation at [PARAMETER\_VECTOR\_ELEMENT](/api/qiskit/qpy#qpy-param-vector).
-
-*   Fixed the `qpy_serialization` support for serializing a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") object. Previously, the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") was treated as a custom gate for serialization and would be deserialized as a [`Gate`](/api/qiskit/qiskit.circuit.Gate "qiskit.circuit.Gate") object that had the same definition and name as the original [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"). However, this would lose the original state from the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"). This has been fixed so that starting in this release a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") in the circuit will be preserved 1:1 across QPY serialization now. The only limitation with this is that it does not support custom [`EvolutionSynthesis`](/api/qiskit/qiskit.synthesis.EvolutionSynthesis "qiskit.synthesis.EvolutionSynthesis") classes. Only the classes available from [`qiskit.synthesis`](/api/qiskit/synthesis#module-qiskit.synthesis "qiskit.synthesis") can be used with a [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") for qpy serialization.
-
-    To fix this issue a new QPY format version, [Version 3](/api/qiskit/qpy#qpy-version-3), was required. This new format version includes a representation of the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate") class which is described in the `qpy_serialization` documentation at [PAULI\_EVOLUTION](/api/qiskit/qpy#pauli-evo-qpy).
-
-*   Two loose functions `qiskit.circuit.measure.measure()` and `qiskit.circuit.reset.reset()` were accidentally removed without a deprecation period. They have been reinstated, but are marked as deprecated in favour of the methods [`QuantumCircuit.measure()`](/api/qiskit/qiskit.circuit.QuantumCircuit#measure "qiskit.circuit.QuantumCircuit.measure") and [`QuantumCircuit.reset()`](/api/qiskit/qiskit.circuit.QuantumCircuit#reset "qiskit.circuit.QuantumCircuit.reset"), respectively, and will be removed in a future release.
-
-<span id="release-notes-0-19-1-terra-other-notes" />
-
-<span id="id176" />
-
-#### Other Notes
-
-*   The new control-flow builder interface uses various context managers and helper objects to do its work. These should not be considered part of the public API, and are liable to be changed and removed without warning. The *usage* of the builder interface has stability guarantees, in the sense that the behaviour described by [`QuantumCircuit.for_loop()`](/api/qiskit/qiskit.circuit.QuantumCircuit#for_loop "qiskit.circuit.QuantumCircuit.for_loop"), [`while_loop()`](/api/qiskit/qiskit.circuit.QuantumCircuit#while_loop "qiskit.circuit.QuantumCircuit.while_loop") and [`if_test()`](/api/qiskit/qiskit.circuit.QuantumCircuit#if_test "qiskit.circuit.QuantumCircuit.if_test") for the builder interface are subject to the standard deprecation policies, but the actual objects used to effect this are not. You should not rely on the objects (such as `IfContext` or `ControlFlowBuilderBlock`) existing in their current locations, or having any methods or attributes attached to them.
-
-    This was not previously clear in the 0.19.0 release. All such objects now have a warning in their documentation strings making this explicit. It is likely in the future that their locations and backing implementations will become quite different.
-
-<span id="aer-0-9-1" />
-
-### Aer 0.9.1
-
-No change
-
-<span id="id177" />
-
-### Ignis 0.7.0
-
-No change
-
-<span id="ibm-q-provider-0-18-2" />
-
-<span id="release-notes-0-18-2-ibmq" />
-
-### IBM Q Provider 0.18.2
-
-<span id="release-notes-0-18-2-ibmq-bug-fixes" />
-
-<span id="id178" />
-
-#### Bug Fixes
-
-*   Fix delivered in [#1065](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1065) for the issue where job kept crashing when `Parameter` was passed in circuit metadata.
-*   Fix delivered in [#1094](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1094) for the issue wherein `qiskit.providers.ibmq.runtime.RuntimeEncoder` does an extra decompose() if the circuit being serialized is a `BlueprintCircuit`.
-
-<span id="qiskit-0-33-0" />

--- a/docs/api/qiskit/release-notes/0.34.md
+++ b/docs/api/qiskit/release-notes/0.34.md
@@ -5,6 +5,298 @@ description: New features and bug fixes
 
 # Qiskit 0.34 release notes
 
+## 0.34.2
+
+<span id="terra-0-19-2" />
+
+<span id="release-notes-0-19-2" />
+
+### Terra 0.19.2
+
+<span id="release-notes-0-19-2-prelude" />
+
+<span id="id148" />
+
+#### Prelude
+
+Qiskit Terra 0.19.2 is predominantly a bugfix release, but also now comes with wheels built for Python 3.10 on all major platforms.
+
+<span id="release-notes-0-19-2-new-features" />
+
+<span id="id149" />
+
+#### New Features
+
+*   Added support for running with Python 3.10. This includes publishing precompiled binaries to PyPI for Python 3.10 on supported platforms.
+
+<span id="release-notes-0-19-2-upgrade-notes" />
+
+<span id="id150" />
+
+#### Upgrade Notes
+
+*   Starting from Python 3.10, Qiskit Terra will have reduced support for 32-bit platforms. These are Linux i686 and 32-bit Windows. These platforms with Python 3.10 are now at Tier 3 instead of Tier 2 support (per the tiers defined in: [https://qiskit.org/documentation/getting\_started.html#platform-support](https://qiskit.org/documentation/getting_started.html#platform-support)) This is because the upstream dependencies Numpy and Scipy have dropped support for them. Qiskit will still publish precompiled binaries for these platforms, but we’re unable to test the packages prior to publishing, and you will need a C/C++ compiler so that `pip` can build their dependencies from source. If you’re using one of these platforms, we recommended that you use Python 3.7, 3.8, or 3.9.
+
+<span id="release-notes-0-19-2-bug-fixes" />
+
+<span id="id151" />
+
+#### Bug Fixes
+
+*   Fixed a bug where the [`CVaRMeasurement`](/api/qiskit/qiskit.opflow.state_fns.CVaRMeasurement "qiskit.opflow.state_fns.CVaRMeasurement") attempted to convert a [`PauliSumOp`](/api/qiskit/qiskit.opflow.primitive_ops.PauliSumOp "qiskit.opflow.primitive_ops.PauliSumOp") to a dense matrix to check whether it were diagonal. For large operators (> 16 qubits) this computation was extremely expensive and raised an error if not explicitly enabled using `qiskit.utils.algorithm_globals.massive = True`. The check is now efficient even for large numbers of qubits.
+
+*   [`DAGCircuit.draw()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#draw "qiskit.dagcircuit.DAGCircuit.draw") and the associated function [`dag_drawer()`](/api/qiskit/qiskit.visualization.dag_drawer "qiskit.visualization.dag_drawer") will now show a more useful error message when the provided filename is not valid.
+
+*   [`QuantumCircuit.add_register()`](/api/qiskit/qiskit.circuit.QuantumCircuit#add_register "qiskit.circuit.QuantumCircuit.add_register") will no longer cause duplicate [`AncillaQubit`](/api/qiskit/qiskit.circuit.AncillaQubit "qiskit.circuit.AncillaQubit") references in a circuit when given an [`AncillaRegister`](/api/qiskit/qiskit.circuit.AncillaRegister "qiskit.circuit.AncillaRegister") whose bits are already present.
+
+*   Fixed conversion of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit")s with classical conditions on single, registerless [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") s to [`Instruction`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction")s when using the [`circuit_to_instruction()`](/api/qiskit/converters#qiskit.converters.circuit_to_instruction "qiskit.converters.circuit_to_instruction") function or the [`QuantumCircuit.to_instruction()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_instruction "qiskit.circuit.QuantumCircuit.to_instruction") method. For example, the following will now work:
+
+    ```python
+    from qiskit.circuit import QuantumCircuit, Qubit, Clbit
+
+    qc = QuantumCircuit([Qubit(), Clbit()])
+    qc.h(0).c_if(qc.clbits[0], 0)
+    qc.to_instruction()
+    ```
+
+*   Registers will now correctly reject duplicate bits. Fixed [#7446](https://github.com/Qiskit/qiskit-terra/issues/7446).
+
+*   The `FakeOpenPulse2Q` mock backend now has T2 times and readout errors stored for its qubits. These are arbitrary values, approximately consistent with real backends at the time of its creation.
+
+*   Fix the qubit order of 2-qubit evolutions in the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"), if used with a product formula synthesis. For instance, before, the evolution of `IIZ + IZI + IZZ`
+
+    ```python
+    from qiskit.circuit.library import PauliEvolutionGate
+    from qiskit.opflow import I, Z
+    operator = (I ^ I ^ Z) + (I ^ Z ^ I) + (I ^ Z ^ Z)
+    print(PauliEvolutionGate(operator).definition.decompose())
+    ```
+
+    produced
+
+    ```python
+         ┌───────┐
+    q_0: ┤ Rz(2) ├────────
+         ├───────┤
+    q_1: ┤ Rz(2) ├─■──────
+         └───────┘ │ZZ(2)
+    q_2: ──────────■──────
+    ```
+
+    whereas now it correctly yields
+
+    ```python
+         ┌───────┐
+    q_0: ┤ Rz(2) ├─■──────
+         ├───────┤ │ZZ(2)
+    q_1: ┤ Rz(2) ├─■──────
+         └───────┘
+    q_2: ─────────────────
+    ```
+
+*   Fixed a problem in the `latex` and `mpl` circuit drawers when register names with multiple underscores in the name did not display correctly.
+
+*   Negative numbers in array outputs from the drawers will now appear as decimal numbers instead of fractions with huge numerators and denominators. Like positive numbers, they will still be fractions if the ratio is between small numbers.
+
+*   Fixed an issue with the [`Target.get_non_global_operation_names()`](/api/qiskit/qiskit.transpiler.Target#get_non_global_operation_names "qiskit.transpiler.Target.get_non_global_operation_names") method when running on a target incorrectly raising an exception on targets with ideal global operations. Previously, if this method was called on a target that contained any ideal globally defined operations, where the instruction properties are set to `None`, this method would raise an exception instead of treating that instruction as global.
+
+*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function where it could fail when being passed a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object directly with the `target` kwarg.
+
+*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function where it could fail when the `backend` argument was a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") or a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") via the `target` kwarg that contained ideal globally defined operations.
+
+*   Fixed an issue where plotting Bloch spheres could cause an `AttributeError` to be raised in Jupyter or when trying to crop figures down to size with Matplotlib 3.3 or 3.4 (but not 3.5). For example, the following code would previously crash with a message:
+
+    ```python
+    AttributeError: 'Arrow3D' object has no attribute '_path2d'
+    ```
+
+    but will now succeed with all current supported versions of Matplotlib:
+
+    ```python
+    from qiskit.visualization import plot_bloch_vector
+    plot_bloch_vector([0, 1, 0]).savefig("tmp.png", bbox_inches='tight')
+    ```
+
+*   Fixed a bug in [`PauliSumOp.permute()`](/api/qiskit/qiskit.opflow.primitive_ops.PauliSumOp#permute "qiskit.opflow.primitive_ops.PauliSumOp.permute") where the object on which the method is called was permuted in-place, instead of returning a permuted copy. This bug only occured for permutations that left the number of qubits in the operator unchanged.
+
+*   Fixed the `PauliEvolutionGate.inverse()` method, which previously computed the inverse by inverting the evolution time. This was only the correct inverse if the operator was evolved exactly. In particular, this led to the inverse of Trotterization-based time evolutions being incorrect.
+
+*   The [`QuantumInstance.execute()`](/api/qiskit/qiskit.utils.QuantumInstance#execute "qiskit.utils.QuantumInstance.execute") method will no longer mutate its input if it is given a list of circuits.
+
+*   Fixed QPY serialisation of custom instructions which had an explicit no-op definition. Previously these would be written and subsequently read the same way as if they were opaque gates (with no given definition). They will now correctly round-trip an empty definition. For example, the following will now be correct:
+
+    ```python
+    import io
+    from qiskit.circuit import Instruction, QuantumCircuit, qpy_serialization
+
+    # This instruction is explicitly defined as a one-qubit gate with no
+    # operations.
+    empty = QuantumCircuit(1, name="empty").to_instruction()
+    # This instruction will perform some operations that are only known
+    # by the hardware backend.
+    opaque = Instruction("opaque", 1, 0, [])
+
+    circuit = QuantumCircuit(2)
+    circuit.append(empty, [0], [])
+    circuit.append(opaque, [1], [])
+
+    qpy_file = io.BytesIO()
+    qpy_serialization.dump(circuit, qpy_file)
+    qpy_file.seek(0)
+    new_circuit = qpy_serialization.load(qpy_file)[0]
+
+    # Previously both instructions in `new_circuit` would now be opaque, but
+    # there is now a correct distinction.
+    circuit == new_circuit
+    ```
+
+*   Added a missing [`BackendV2.provider`](/api/qiskit/qiskit.providers.BackendV2#provider "qiskit.providers.BackendV2.provider") attribute to implementations of the [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") abstract class. Previously, [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backends could be initialized with a provider but that was not accessible to users.
+
+*   Fixed support for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend. Previously, attempting to use a [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") would have resulted in an error.
+
+*   Fixed a bug in [`VQE`](/api/qiskit/qiskit.algorithms.VQE "qiskit.algorithms.VQE") where the parameters of the ansatz were still explicitly ASCII-sorted by their name if the ansatz was resized. This led to a mismatched order of the optimized values in the `optimal_point` attribute of the result object.
+
+    In particular, this bug occurred if no ansatz was set by the user and the VQE chose a default with 11 or more free parameters.
+
+*   Stopped the parser in [`QuantumCircuit.from_qasm_str()`](/api/qiskit/qiskit.circuit.QuantumCircuit#from_qasm_str "qiskit.circuit.QuantumCircuit.from_qasm_str") and [`from_qasm_file()`](/api/qiskit/qiskit.circuit.QuantumCircuit#from_qasm_file "qiskit.circuit.QuantumCircuit.from_qasm_file") from accepting OpenQASM programs that identified themselves as being from a language version other than 2.0. This parser is only for OpenQASM 2.0; support for imported circuits from OpenQASM 3.0 will be added in an upcoming release.
+
+*   Fixed QPY serialization of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects that contained control flow instructions. Previously if you attempted to serialize a circuit containing [`IfElseOp`](/api/qiskit/qiskit.circuit.IfElseOp "qiskit.circuit.IfElseOp"), [`WhileLoopOp`](/api/qiskit/qiskit.circuit.WhileLoopOp "qiskit.circuit.WhileLoopOp"), or [`ForLoopOp`](/api/qiskit/qiskit.circuit.ForLoopOp "qiskit.circuit.ForLoopOp") the serialization would fail. Fixed [#7583](https://github.com/Qiskit/qiskit-terra/issues/7583).
+
+*   Fixed QPY serialization of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") containing subsets of bits from a [`QuantumRegister`](/api/qiskit/qiskit.circuit.QuantumRegister "qiskit.circuit.QuantumRegister") or [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister"). Previously if you tried to serialize a circuit like this it would incorrectly treat these bits as standalone [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") or [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") without having a register set. For example, if you try to serialize a circuit like:
+
+    ```python
+    import io
+    from qiskit import QuantumCircuit, QuantumRegister
+    from qiskit.circuit.qpy_serialization import load, dump
+
+    qr = QuantumRegister(2)
+    qc = QuantumCircuit([qr[0]])
+    qc.x(0)
+    with open('file.qpy', 'wb') as fd:
+        dump(qc, fd)
+    ```
+
+    when that circuit is loaded now the registers will be correctly populated fully even though the circuit only contains a subset of the bits from the register.
+
+*   [`QFT`](/api/qiskit/qiskit.circuit.library.QFT "qiskit.circuit.library.QFT") will now warn if it is instantiated or built with settings that will cause it to lose precision, rather than raising an `OverflowError`. This can happen if the number of qubits is very large (slightly over 1000) without the approximation degree being similarly large. The circuit will now build successfully, but some angles might be indistinguishable from zero, due to limitations in double-precision floating-point numbers.
+
+<span id="release-notes-aer-0-10-3" />
+
+<span id="id152" />
+
+### Aer 0.10.3
+
+<span id="release-notes-aer-0-10-3-prelude" />
+
+<span id="id153" />
+
+#### Prelude
+
+Qiskit Aer 0.10.3 is mainly a bugfix release, fixing several bugs that have been discovered since the 0.10.2 release. Howver, this release also introduces support for running with Python 3.10 including precompiled binary wheels on all major platforms. This release also includes precompiled binary wheels for arm64 on macOS.
+
+<span id="release-notes-aer-0-10-3-new-features" />
+
+<span id="id154" />
+
+#### New Features
+
+*   Added support for running with Python 3.10. This includes publishing precompiled binaries to PyPI for Python 3.10 on supported platforms.
+
+*   Added support for M1 macOS systems. Precompiled binaries for supported Python versions >=3.8 on arm64 macOS will now be published on PyPI for this and future releases.
+
+<span id="release-notes-aer-0-10-3-upgrade-notes" />
+
+<span id="id155" />
+
+#### Upgrade Notes
+
+*   Qiskit Aer no longer fully supports 32 bit platforms on Python >= 3.10. These are Linux i686 and 32-bit Windows. These platforms with Python 3.10 are now at Tier 3 instead of Tier 2 support (per the tiers defined in: [https://qiskit.org/documentation/getting\_started.html#platform-support](https://qiskit.org/documentation/getting_started.html#platform-support)) This is because the upstream dependencies Numpy and Scipy have dropped support for them. Qiskit will still publish precompiled binaries for these platforms, but we’re unable to test the packages prior to publishing, and you will need a C/C++ compiler so that `pip` can build their dependencies from source. If you’re using one of these platforms, we recommended that you use Python 3.7, 3.8, or 3.9.
+
+<span id="release-notes-aer-0-10-3-bug-fixes" />
+
+<span id="id156" />
+
+#### Bug Fixes
+
+*   Fixes a bug in `RelaxationNoisePass` where instruction durations were always assumed to be in *dt* time units, regardless of the actual unit of the isntruction. Now unit conversion is correctly handled for all instruction duration units.
+
+    See [#1453](https://github.com/Qiskit/qiskit-aer/issues/1453) for details.
+
+*   Fixes an issue with `LocalNoisePass` for noise functions that return a [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") for the noise op. These were appended to the DAG as an opaque circuit instruction that must be unrolled to be simulated. This fix composes them so that the cirucit instructions are added to the new DAG and can be simulated without additional unrolling if all circuit instructions are supported by the simulator.
+
+    See [#1447](https://github.com/Qiskit/qiskit-aer/issues/1447) for details.
+
+*   Multi-threaded transpilations to generate diagonal gates will now work correctly if the number of gates of a circuit exceeds `fusion_parallelization_threshold`. Previously, different threads would occasionally fuse the same element into multiple blocks, causing incorrect results.
+
+*   Fixes a bug with truncation of circuits in parameterized Qobjs. Previously parameters of parameterized QObj could be wrongly resolved if unused qubits of their circuits were truncated, because indices of the parameters were not updated after the instructions on unmeasured qubits were removed.
+
+    See [#1427](https://github.com/Qiskit/qiskit-aer/issues/1427) for details.
+
+<span id="id157" />
+
+### Ignis 0.7.0
+
+No change
+
+<span id="id158" />
+
+### IBM Q Provider 0.18.3
+
+No change
+
+<span id="qiskit-0-34-1" />
+
+## 0.34.1
+
+<span id="terra-0-19-1" />
+
+### Terra 0.19.1
+
+No change
+
+<span id="aer-0-10-2" />
+
+<span id="release-notes-0-10-2-aer" />
+
+### Aer 0.10.2
+
+<span id="release-notes-0-10-2-aer-bug-fixes" />
+
+<span id="id159" />
+
+#### Bug Fixes
+
+*   Fixed simulation of `for` loops where the loop parameter was not used in the body of the loop. For example, previously this code would fail, but will now succeed:
+
+    ```python
+    import qiskit
+    from qiskit.providers.aer import AerSimulator
+
+    qc = qiskit.QuantumCircuit(2)
+    with qc.for_loop(range(4)) as i:
+        qc.h(0)
+        qc.cx(0, 1)
+
+    AerSimulator(method="statevector").run(qc)
+    ```
+
+*   Fixes a bug in `QuantumError.to_dict()` where N-qubit circuit instructions where the assembled instruction always applied to qubits `[0, ..., N-1]` rather than the instruction qubits. This bug also affected device and fake backend noise models.
+
+    See [Issue 1415](https://github.com/Qiskit/qiskit-aer/issues/1415) for details.
+
+<span id="id160" />
+
+### Ignis 0.7.0
+
+No change
+
+<span id="id161" />
+
+### IBM Q Provider 0.18.3
+
+No change
+
+<span id="qiskit-0-34-0" />
 ## 0.34.0
 
 Qiskit 0.34.0 includes a point release of Qiskit Aer: version 0.10.1, which patches performance regressions in version 0.10.0 that were discovered immediately post-release. See below for the release notes for both Qiskit Aer 0.10.0 and 0.10.1.
@@ -272,294 +564,3 @@ No change
 *   Fix delivered in [#1100](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1100) for an issue with JSON encoding and decoding when using `ParameterExpression`s in conjunction with Qiskit Terra 0.19.1 and above. Previously, the `Parameter` instances reconstructed from the JSON output would have different unique identifiers, causing them to seem unequal to the input. They will now have the correct backing identities.
 
 <span id="qiskit-0-33-1" />
-## 0.34.1
-
-<span id="terra-0-19-1" />
-
-### Terra 0.19.1
-
-No change
-
-<span id="aer-0-10-2" />
-
-<span id="release-notes-0-10-2-aer" />
-
-### Aer 0.10.2
-
-<span id="release-notes-0-10-2-aer-bug-fixes" />
-
-<span id="id159" />
-
-#### Bug Fixes
-
-*   Fixed simulation of `for` loops where the loop parameter was not used in the body of the loop. For example, previously this code would fail, but will now succeed:
-
-    ```python
-    import qiskit
-    from qiskit.providers.aer import AerSimulator
-
-    qc = qiskit.QuantumCircuit(2)
-    with qc.for_loop(range(4)) as i:
-        qc.h(0)
-        qc.cx(0, 1)
-
-    AerSimulator(method="statevector").run(qc)
-    ```
-
-*   Fixes a bug in `QuantumError.to_dict()` where N-qubit circuit instructions where the assembled instruction always applied to qubits `[0, ..., N-1]` rather than the instruction qubits. This bug also affected device and fake backend noise models.
-
-    See [Issue 1415](https://github.com/Qiskit/qiskit-aer/issues/1415) for details.
-
-<span id="id160" />
-
-### Ignis 0.7.0
-
-No change
-
-<span id="id161" />
-
-### IBM Q Provider 0.18.3
-
-No change
-
-<span id="qiskit-0-34-0" />
-## 0.34.2
-
-<span id="terra-0-19-2" />
-
-<span id="release-notes-0-19-2" />
-
-### Terra 0.19.2
-
-<span id="release-notes-0-19-2-prelude" />
-
-<span id="id148" />
-
-#### Prelude
-
-Qiskit Terra 0.19.2 is predominantly a bugfix release, but also now comes with wheels built for Python 3.10 on all major platforms.
-
-<span id="release-notes-0-19-2-new-features" />
-
-<span id="id149" />
-
-#### New Features
-
-*   Added support for running with Python 3.10. This includes publishing precompiled binaries to PyPI for Python 3.10 on supported platforms.
-
-<span id="release-notes-0-19-2-upgrade-notes" />
-
-<span id="id150" />
-
-#### Upgrade Notes
-
-*   Starting from Python 3.10, Qiskit Terra will have reduced support for 32-bit platforms. These are Linux i686 and 32-bit Windows. These platforms with Python 3.10 are now at Tier 3 instead of Tier 2 support (per the tiers defined in: [https://qiskit.org/documentation/getting\_started.html#platform-support](https://qiskit.org/documentation/getting_started.html#platform-support)) This is because the upstream dependencies Numpy and Scipy have dropped support for them. Qiskit will still publish precompiled binaries for these platforms, but we’re unable to test the packages prior to publishing, and you will need a C/C++ compiler so that `pip` can build their dependencies from source. If you’re using one of these platforms, we recommended that you use Python 3.7, 3.8, or 3.9.
-
-<span id="release-notes-0-19-2-bug-fixes" />
-
-<span id="id151" />
-
-#### Bug Fixes
-
-*   Fixed a bug where the [`CVaRMeasurement`](/api/qiskit/qiskit.opflow.state_fns.CVaRMeasurement "qiskit.opflow.state_fns.CVaRMeasurement") attempted to convert a [`PauliSumOp`](/api/qiskit/qiskit.opflow.primitive_ops.PauliSumOp "qiskit.opflow.primitive_ops.PauliSumOp") to a dense matrix to check whether it were diagonal. For large operators (> 16 qubits) this computation was extremely expensive and raised an error if not explicitly enabled using `qiskit.utils.algorithm_globals.massive = True`. The check is now efficient even for large numbers of qubits.
-
-*   [`DAGCircuit.draw()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#draw "qiskit.dagcircuit.DAGCircuit.draw") and the associated function [`dag_drawer()`](/api/qiskit/qiskit.visualization.dag_drawer "qiskit.visualization.dag_drawer") will now show a more useful error message when the provided filename is not valid.
-
-*   [`QuantumCircuit.add_register()`](/api/qiskit/qiskit.circuit.QuantumCircuit#add_register "qiskit.circuit.QuantumCircuit.add_register") will no longer cause duplicate [`AncillaQubit`](/api/qiskit/qiskit.circuit.AncillaQubit "qiskit.circuit.AncillaQubit") references in a circuit when given an [`AncillaRegister`](/api/qiskit/qiskit.circuit.AncillaRegister "qiskit.circuit.AncillaRegister") whose bits are already present.
-
-*   Fixed conversion of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit")s with classical conditions on single, registerless [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") s to [`Instruction`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction")s when using the [`circuit_to_instruction()`](/api/qiskit/converters#qiskit.converters.circuit_to_instruction "qiskit.converters.circuit_to_instruction") function or the [`QuantumCircuit.to_instruction()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_instruction "qiskit.circuit.QuantumCircuit.to_instruction") method. For example, the following will now work:
-
-    ```python
-    from qiskit.circuit import QuantumCircuit, Qubit, Clbit
-
-    qc = QuantumCircuit([Qubit(), Clbit()])
-    qc.h(0).c_if(qc.clbits[0], 0)
-    qc.to_instruction()
-    ```
-
-*   Registers will now correctly reject duplicate bits. Fixed [#7446](https://github.com/Qiskit/qiskit-terra/issues/7446).
-
-*   The `FakeOpenPulse2Q` mock backend now has T2 times and readout errors stored for its qubits. These are arbitrary values, approximately consistent with real backends at the time of its creation.
-
-*   Fix the qubit order of 2-qubit evolutions in the [`PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate "qiskit.circuit.library.PauliEvolutionGate"), if used with a product formula synthesis. For instance, before, the evolution of `IIZ + IZI + IZZ`
-
-    ```python
-    from qiskit.circuit.library import PauliEvolutionGate
-    from qiskit.opflow import I, Z
-    operator = (I ^ I ^ Z) + (I ^ Z ^ I) + (I ^ Z ^ Z)
-    print(PauliEvolutionGate(operator).definition.decompose())
-    ```
-
-    produced
-
-    ```python
-         ┌───────┐
-    q_0: ┤ Rz(2) ├────────
-         ├───────┤
-    q_1: ┤ Rz(2) ├─■──────
-         └───────┘ │ZZ(2)
-    q_2: ──────────■──────
-    ```
-
-    whereas now it correctly yields
-
-    ```python
-         ┌───────┐
-    q_0: ┤ Rz(2) ├─■──────
-         ├───────┤ │ZZ(2)
-    q_1: ┤ Rz(2) ├─■──────
-         └───────┘
-    q_2: ─────────────────
-    ```
-
-*   Fixed a problem in the `latex` and `mpl` circuit drawers when register names with multiple underscores in the name did not display correctly.
-
-*   Negative numbers in array outputs from the drawers will now appear as decimal numbers instead of fractions with huge numerators and denominators. Like positive numbers, they will still be fractions if the ratio is between small numbers.
-
-*   Fixed an issue with the [`Target.get_non_global_operation_names()`](/api/qiskit/qiskit.transpiler.Target#get_non_global_operation_names "qiskit.transpiler.Target.get_non_global_operation_names") method when running on a target incorrectly raising an exception on targets with ideal global operations. Previously, if this method was called on a target that contained any ideal globally defined operations, where the instruction properties are set to `None`, this method would raise an exception instead of treating that instruction as global.
-
-*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function where it could fail when being passed a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object directly with the `target` kwarg.
-
-*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function where it could fail when the `backend` argument was a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") or a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") via the `target` kwarg that contained ideal globally defined operations.
-
-*   Fixed an issue where plotting Bloch spheres could cause an `AttributeError` to be raised in Jupyter or when trying to crop figures down to size with Matplotlib 3.3 or 3.4 (but not 3.5). For example, the following code would previously crash with a message:
-
-    ```python
-    AttributeError: 'Arrow3D' object has no attribute '_path2d'
-    ```
-
-    but will now succeed with all current supported versions of Matplotlib:
-
-    ```python
-    from qiskit.visualization import plot_bloch_vector
-    plot_bloch_vector([0, 1, 0]).savefig("tmp.png", bbox_inches='tight')
-    ```
-
-*   Fixed a bug in [`PauliSumOp.permute()`](/api/qiskit/qiskit.opflow.primitive_ops.PauliSumOp#permute "qiskit.opflow.primitive_ops.PauliSumOp.permute") where the object on which the method is called was permuted in-place, instead of returning a permuted copy. This bug only occured for permutations that left the number of qubits in the operator unchanged.
-
-*   Fixed the `PauliEvolutionGate.inverse()` method, which previously computed the inverse by inverting the evolution time. This was only the correct inverse if the operator was evolved exactly. In particular, this led to the inverse of Trotterization-based time evolutions being incorrect.
-
-*   The [`QuantumInstance.execute()`](/api/qiskit/qiskit.utils.QuantumInstance#execute "qiskit.utils.QuantumInstance.execute") method will no longer mutate its input if it is given a list of circuits.
-
-*   Fixed QPY serialisation of custom instructions which had an explicit no-op definition. Previously these would be written and subsequently read the same way as if they were opaque gates (with no given definition). They will now correctly round-trip an empty definition. For example, the following will now be correct:
-
-    ```python
-    import io
-    from qiskit.circuit import Instruction, QuantumCircuit, qpy_serialization
-
-    # This instruction is explicitly defined as a one-qubit gate with no
-    # operations.
-    empty = QuantumCircuit(1, name="empty").to_instruction()
-    # This instruction will perform some operations that are only known
-    # by the hardware backend.
-    opaque = Instruction("opaque", 1, 0, [])
-
-    circuit = QuantumCircuit(2)
-    circuit.append(empty, [0], [])
-    circuit.append(opaque, [1], [])
-
-    qpy_file = io.BytesIO()
-    qpy_serialization.dump(circuit, qpy_file)
-    qpy_file.seek(0)
-    new_circuit = qpy_serialization.load(qpy_file)[0]
-
-    # Previously both instructions in `new_circuit` would now be opaque, but
-    # there is now a correct distinction.
-    circuit == new_circuit
-    ```
-
-*   Added a missing [`BackendV2.provider`](/api/qiskit/qiskit.providers.BackendV2#provider "qiskit.providers.BackendV2.provider") attribute to implementations of the [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") abstract class. Previously, [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backends could be initialized with a provider but that was not accessible to users.
-
-*   Fixed support for the [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class when running with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend. Previously, attempting to use a [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") would have resulted in an error.
-
-*   Fixed a bug in [`VQE`](/api/qiskit/qiskit.algorithms.VQE "qiskit.algorithms.VQE") where the parameters of the ansatz were still explicitly ASCII-sorted by their name if the ansatz was resized. This led to a mismatched order of the optimized values in the `optimal_point` attribute of the result object.
-
-    In particular, this bug occurred if no ansatz was set by the user and the VQE chose a default with 11 or more free parameters.
-
-*   Stopped the parser in [`QuantumCircuit.from_qasm_str()`](/api/qiskit/qiskit.circuit.QuantumCircuit#from_qasm_str "qiskit.circuit.QuantumCircuit.from_qasm_str") and [`from_qasm_file()`](/api/qiskit/qiskit.circuit.QuantumCircuit#from_qasm_file "qiskit.circuit.QuantumCircuit.from_qasm_file") from accepting OpenQASM programs that identified themselves as being from a language version other than 2.0. This parser is only for OpenQASM 2.0; support for imported circuits from OpenQASM 3.0 will be added in an upcoming release.
-
-*   Fixed QPY serialization of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects that contained control flow instructions. Previously if you attempted to serialize a circuit containing [`IfElseOp`](/api/qiskit/qiskit.circuit.IfElseOp "qiskit.circuit.IfElseOp"), [`WhileLoopOp`](/api/qiskit/qiskit.circuit.WhileLoopOp "qiskit.circuit.WhileLoopOp"), or [`ForLoopOp`](/api/qiskit/qiskit.circuit.ForLoopOp "qiskit.circuit.ForLoopOp") the serialization would fail. Fixed [#7583](https://github.com/Qiskit/qiskit-terra/issues/7583).
-
-*   Fixed QPY serialization of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") containing subsets of bits from a [`QuantumRegister`](/api/qiskit/qiskit.circuit.QuantumRegister "qiskit.circuit.QuantumRegister") or [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister"). Previously if you tried to serialize a circuit like this it would incorrectly treat these bits as standalone [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") or [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") without having a register set. For example, if you try to serialize a circuit like:
-
-    ```python
-    import io
-    from qiskit import QuantumCircuit, QuantumRegister
-    from qiskit.circuit.qpy_serialization import load, dump
-
-    qr = QuantumRegister(2)
-    qc = QuantumCircuit([qr[0]])
-    qc.x(0)
-    with open('file.qpy', 'wb') as fd:
-        dump(qc, fd)
-    ```
-
-    when that circuit is loaded now the registers will be correctly populated fully even though the circuit only contains a subset of the bits from the register.
-
-*   [`QFT`](/api/qiskit/qiskit.circuit.library.QFT "qiskit.circuit.library.QFT") will now warn if it is instantiated or built with settings that will cause it to lose precision, rather than raising an `OverflowError`. This can happen if the number of qubits is very large (slightly over 1000) without the approximation degree being similarly large. The circuit will now build successfully, but some angles might be indistinguishable from zero, due to limitations in double-precision floating-point numbers.
-
-<span id="release-notes-aer-0-10-3" />
-
-<span id="id152" />
-
-### Aer 0.10.3
-
-<span id="release-notes-aer-0-10-3-prelude" />
-
-<span id="id153" />
-
-#### Prelude
-
-Qiskit Aer 0.10.3 is mainly a bugfix release, fixing several bugs that have been discovered since the 0.10.2 release. Howver, this release also introduces support for running with Python 3.10 including precompiled binary wheels on all major platforms. This release also includes precompiled binary wheels for arm64 on macOS.
-
-<span id="release-notes-aer-0-10-3-new-features" />
-
-<span id="id154" />
-
-#### New Features
-
-*   Added support for running with Python 3.10. This includes publishing precompiled binaries to PyPI for Python 3.10 on supported platforms.
-
-*   Added support for M1 macOS systems. Precompiled binaries for supported Python versions >=3.8 on arm64 macOS will now be published on PyPI for this and future releases.
-
-<span id="release-notes-aer-0-10-3-upgrade-notes" />
-
-<span id="id155" />
-
-#### Upgrade Notes
-
-*   Qiskit Aer no longer fully supports 32 bit platforms on Python >= 3.10. These are Linux i686 and 32-bit Windows. These platforms with Python 3.10 are now at Tier 3 instead of Tier 2 support (per the tiers defined in: [https://qiskit.org/documentation/getting\_started.html#platform-support](https://qiskit.org/documentation/getting_started.html#platform-support)) This is because the upstream dependencies Numpy and Scipy have dropped support for them. Qiskit will still publish precompiled binaries for these platforms, but we’re unable to test the packages prior to publishing, and you will need a C/C++ compiler so that `pip` can build their dependencies from source. If you’re using one of these platforms, we recommended that you use Python 3.7, 3.8, or 3.9.
-
-<span id="release-notes-aer-0-10-3-bug-fixes" />
-
-<span id="id156" />
-
-#### Bug Fixes
-
-*   Fixes a bug in `RelaxationNoisePass` where instruction durations were always assumed to be in *dt* time units, regardless of the actual unit of the isntruction. Now unit conversion is correctly handled for all instruction duration units.
-
-    See [#1453](https://github.com/Qiskit/qiskit-aer/issues/1453) for details.
-
-*   Fixes an issue with `LocalNoisePass` for noise functions that return a [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") for the noise op. These were appended to the DAG as an opaque circuit instruction that must be unrolled to be simulated. This fix composes them so that the cirucit instructions are added to the new DAG and can be simulated without additional unrolling if all circuit instructions are supported by the simulator.
-
-    See [#1447](https://github.com/Qiskit/qiskit-aer/issues/1447) for details.
-
-*   Multi-threaded transpilations to generate diagonal gates will now work correctly if the number of gates of a circuit exceeds `fusion_parallelization_threshold`. Previously, different threads would occasionally fuse the same element into multiple blocks, causing incorrect results.
-
-*   Fixes a bug with truncation of circuits in parameterized Qobjs. Previously parameters of parameterized QObj could be wrongly resolved if unused qubits of their circuits were truncated, because indices of the parameters were not updated after the instructions on unmeasured qubits were removed.
-
-    See [#1427](https://github.com/Qiskit/qiskit-aer/issues/1427) for details.
-
-<span id="id157" />
-
-### Ignis 0.7.0
-
-No change
-
-<span id="id158" />
-
-### IBM Q Provider 0.18.3
-
-No change
-
-<span id="qiskit-0-34-1" />

--- a/docs/api/qiskit/release-notes/0.36.md
+++ b/docs/api/qiskit/release-notes/0.36.md
@@ -5,6 +5,155 @@ description: New features and bug fixes
 
 # Qiskit 0.36 release notes
 
+## 0.36.2
+
+<span id="terra-0-20-2" />
+
+<span id="release-notes-terra-0-20-2" />
+
+### Terra 0.20.2
+
+<span id="release-notes-terra-0-20-2-prelude" />
+
+<span id="id121" />
+
+#### Prelude
+
+Qiskit Terra 0.20.2 is a bugfix release, addressing some minor issues identified since the last patch release.
+
+<span id="release-notes-terra-0-20-2-bug-fixes" />
+
+<span id="id122" />
+
+#### Bug Fixes
+
+*   Fixed an issue with [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2")-based fake backend classes from the `qiskit.providers.fake_provider` module such as `FakeMontrealV2`, where the values for the [`dtm`](/api/qiskit/qiskit.providers.BackendV2#dtm "qiskit.providers.BackendV2.dtm") and [`dt`](/api/qiskit/qiskit.providers.BackendV2#dt "qiskit.providers.BackendV2.dt") attributes and the associated attribute [`Target.dt`](/api/qiskit/qiskit.transpiler.Target#dt "qiskit.transpiler.Target.dt") would not be properly converted to seconds. This would cause issues when using these fake backends with scheduling. See [#8018](https://github.com/Qiskit/qiskit-terra/issues/8018).
+
+*   [`marginal_counts()`](/api/qiskit/result#qiskit.result.marginal_counts "qiskit.result.marginal_counts") will now succeed when asked to marginalize memory with an `indices` parameter containing non-zero elements. Previously, shots whose hexadecimal result representation was sufficiently small could raise a `ValueError`. See [#8044](https://github.com/Qiskit/qiskit-terra/issues/8044).
+
+*   The OpenQASM 3 exporter ([`qiskit.qasm3`](/api/qiskit/qasm3#module-qiskit.qasm3 "qiskit.qasm3")) will now output `input` or `output` declarations before gate declarations. This is more consistent with the current reference ANTLR grammar from the OpenQASM 3 team. See [#7964](https://github.com/Qiskit/qiskit-terra/issues/7964).
+
+*   Fixed a bug in the [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") transpiler pass where the scaled cross-resonance pulse amplitude could appear to be parametrized even after assignment. This could cause the pulse visualization tools to use the parametrized format instead of the expected numeric one. See [#8031](https://github.com/Qiskit/qiskit-terra/pull/8031).
+
+*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function when run with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2")-based backend and setting the `scheduling_method` keyword argument. Previously, the function would not correctly process the default durations of the instructions supported by the backend which would lead to an error.
+
+*   Fixed a bug in the [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") transpiler pass that was causing pulses to sometimes be constructed with incorrect durations. See [#7994](https://github.com/Qiskit/qiskit-terra/issues/7994).
+
+*   The [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler pass, used in [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") when `routing_method="sabre"` is set, will no longer sporadically drop classically conditioned gates and their successors from circuits during the routing phase of transpilation. See [#8040](https://github.com/Qiskit/qiskit-terra/issues/8040).
+
+*   [`Statevector`](/api/qiskit/qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") will now allow direct iteration through its values (such as `for coefficient in statevector`) and correctly report its length under `len`. Previously it would try and and access out-of-bounds data and raise a [`QiskitError`](/api/qiskit/exceptions#qiskit.exceptions.QiskitError "qiskit.exceptions.QiskitError"). See [#8039](https://github.com/Qiskit/qiskit-terra/issues/8039).
+
+<span id="id123" />
+
+### Aer 0.10.4
+
+No change
+
+<span id="ignis-0-7-1" />
+
+<span id="release-notes-ignis-0-7-1" />
+
+### Ignis 0.7.1
+
+<span id="release-notes-ignis-0-7-1-prelude" />
+
+<span id="id124" />
+
+#### Prelude
+
+This is a bugfix release that primarily fixes a packaging issue that was causing the `docs/` directory, which contains the source files used to build the qiskit-ignis documentation, to get included in the Python package.
+
+<span id="ibm-q-provider-0-19-1" />
+
+### IBM Q Provider 0.19.1
+
+No change
+
+<span id="qiskit-0-36-1" />
+
+## 0.36.1
+
+<span id="terra-0-20-1" />
+
+### Terra 0.20.1
+
+<span id="release-notes-terra-0-20-1-prelude" />
+
+<span id="id125" />
+
+#### Prelude
+
+Qiskit Terra 0.20.1 is a bugfix release resolving issues identified in release 0.20.0.
+
+<span id="release-notes-terra-0-20-1-known-issues" />
+
+<span id="id126" />
+
+#### Known Issues
+
+*   QPY deserialization with the [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load") function of a directly instantiated [`UCPauliRotGate`](/api/qiskit/qiskit.circuit.library.UCPauliRotGate "qiskit.circuit.library.UCPauliRotGate") object in a circuit will fail because the rotation axis argument to the class isn’t stored in a standard place. To workaround this you can instead use the subclasses: [`UCRXGate`](/api/qiskit/qiskit.circuit.library.UCRXGate "qiskit.circuit.library.UCRXGate"), [`UCRYGate`](/api/qiskit/qiskit.circuit.library.UCRYGate "qiskit.circuit.library.UCRYGate"), or [`UCRZGate`](/api/qiskit/qiskit.circuit.library.UCRZGate "qiskit.circuit.library.UCRZGate") (based on whether you’re using a rotation axis of `"X"`, `"Y"`, or `"Z"` respectively) which embeds the rotation axis in the class constructor and will work correctly in QPY.
+
+*   Since its original introduction in Qiskit Terra 0.20, [`XXPlusYYGate`](/api/qiskit/qiskit.circuit.library.XXPlusYYGate "qiskit.circuit.library.XXPlusYYGate") has used a negative angle convention compared to all other rotation gates. In Qiskit Terra 0.21, this will be corrected to be consistent with the other rotation gates. This does not affect any other rotation gates, nor [`XXMinusYYGate`](/api/qiskit/qiskit.circuit.library.XXMinusYYGate "qiskit.circuit.library.XXMinusYYGate").
+
+<span id="release-notes-terra-0-20-1-bug-fixes" />
+
+<span id="id127" />
+
+#### Bug Fixes
+
+*   Fixed [`Clifford`](/api/qiskit/qiskit.quantum_info.Clifford "qiskit.quantum_info.Clifford"), [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") and [`CNOTDihedral`](/api/qiskit/qiskit.quantum_info.CNOTDihedral "qiskit.quantum_info.CNOTDihedral") operator initialization from compatible circuits that contain [`Delay`](/api/qiskit/qiskit.circuit.Delay "qiskit.circuit.Delay") instructions. These instructions are treated as identities when converting to operators.
+
+*   Fixed an issue where the [`eval_observables()`](/api/qiskit/algorithms#qiskit.algorithms.eval_observables "qiskit.algorithms.eval_observables") function would raise an error if its `quantum_state` argument was of type `StateFn`. `eval_observables` now correctly supports all input types denoted by its type hints.
+
+*   Fixed an issue with the visualization function [`dag_drawer()`](/api/qiskit/qiskit.visualization.dag_drawer "qiskit.visualization.dag_drawer") and method [`DAGCircuit.draw()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#draw "qiskit.dagcircuit.DAGCircuit.draw") where previously the drawer would fail when attempting to generate a visualization for a [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "qiskit.dagcircuit.DAGCircuit") object that contained a [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") or [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") which wasn’t part of a `QuantumRegister` or `ClassicalRegister`. Fixed [#7915](https://github.com/Qiskit/qiskit-terra/issues/7915).
+
+*   Fixed parameter validation for class `Drag`. Previously, it was not sensitive to large beta values with negative signs, which may have resulted in waveform samples with a maximum value exceeding the amplitude limit of 1.0.
+
+*   The [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class used by many algorithms (like `VQE`) was hard-coding the value for a sleep while it looped waiting for the job status to be updated. It now respects the configured sleep value as set per the `wait` attribute in the initializer of [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance").
+
+*   Fixed an issue with the [`schedule`](/api/qiskit/compiler#qiskit.compiler.schedule "qiskit.compiler.schedule") function where callers specifying a `list` of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects with a single entry would incorrectly be returned a single [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule") object instead of a `list`.
+
+*   Fixed an issue with the `plot_error_map` visualization function which prevented it from working when run with a backend that had readout error defined in the provided backend’s [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "qiskit.providers.models.BackendProperties") or when running with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend. Fixed [#7879](https://github.com/Qiskit/qiskit-terra/issues/7879).
+
+*   Fixed a bug that could result in exponential runtime and nontermination when a [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") instance is given to method `init_observables()`.
+
+*   Fixed [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap"), and by extension [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") with `optimization_level=3`, occasionally re-ordering measurements invalidly. Previously, if two measurements wrote to the same classical bit, [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") could (depending on the coupling map) re-order them to produce a non-equivalent circuit. This behaviour was stochastic, so may not have appeared reliably. Fixed [#7950](https://github.com/Qiskit/qiskit-terra/issues/7950)
+
+*   The [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler pass, and by extension [`SabreLayout`](/api/qiskit/qiskit.transpiler.passes.SabreLayout "qiskit.transpiler.passes.SabreLayout") and [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") at `optimization_level=3`, now has an escape mechanism to guarantee that it can never get stuck in an infinite loop. Certain inputs previously could, with a great amount of bad luck, get stuck in a stable local minimum of the search space and the pass would never make further progress. It will now force a series of swaps that allow the routing to continue if it detects it has not made progress recently. Fixed [#7707](https://github.com/Qiskit/qiskit-terra/issues/7707).
+
+*   Fixed an issue with QPY deserialization via the [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load") function of the [`UCRXGate`](/api/qiskit/qiskit.circuit.library.UCRXGate "qiskit.circuit.library.UCRXGate"), [`UCRYGate`](/api/qiskit/qiskit.circuit.library.UCRYGate "qiskit.circuit.library.UCRYGate"), and [`UCRZGate`](/api/qiskit/qiskit.circuit.library.UCRZGate "qiskit.circuit.library.UCRZGate") classes. Previously, a QPY file that contained any of these gates would error when trying to load the file. Fixed [#7847](https://github.com/Qiskit/qiskit-terra/issues/7847).
+
+<span id="id128" />
+
+### Aer 0.10.4
+
+No change
+
+<span id="ignis-0-7-0" />
+
+### Ignis 0.7.0
+
+No change
+
+<span id="id129" />
+
+### IBM Q Provider 0.19.1
+
+<span id="release-notes-0-19-1-ibmq" />
+
+<span id="id130" />
+
+### 0.19.1
+
+<span id="release-notes-0-19-1-ibmq-bug-fixes" />
+
+<span id="id131" />
+
+#### Bug Fixes
+
+*   PR [#1129](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1129) updates `least_busy()` method to no longer support BaseBackend as a valid input or output type since it has been long deprecated in qiskit-terra and has recently been removed.
+
+<span id="qiskit-0-36-0" />
 ## 0.36.0
 
 <span id="terra-0-20-0" />
@@ -97,151 +246,3 @@ No change
 *   Fixes issue [#74](https://github.com/Qiskit/qiskit-ibm-provider/issues/74) where numpy ndarrays with object types could not be serialized. `qiskit.providers.ibmq.runtime.RuntimeEncoder` and `qiskit.providers.ibmq.runtime.RuntimeDecoder` have been updated to handle these ndarrays.
 
 <span id="qiskit-0-35-0" />
-## 0.36.1
-
-<span id="terra-0-20-1" />
-
-### Terra 0.20.1
-
-<span id="release-notes-terra-0-20-1-prelude" />
-
-<span id="id125" />
-
-#### Prelude
-
-Qiskit Terra 0.20.1 is a bugfix release resolving issues identified in release 0.20.0.
-
-<span id="release-notes-terra-0-20-1-known-issues" />
-
-<span id="id126" />
-
-#### Known Issues
-
-*   QPY deserialization with the [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load") function of a directly instantiated [`UCPauliRotGate`](/api/qiskit/qiskit.circuit.library.UCPauliRotGate "qiskit.circuit.library.UCPauliRotGate") object in a circuit will fail because the rotation axis argument to the class isn’t stored in a standard place. To workaround this you can instead use the subclasses: [`UCRXGate`](/api/qiskit/qiskit.circuit.library.UCRXGate "qiskit.circuit.library.UCRXGate"), [`UCRYGate`](/api/qiskit/qiskit.circuit.library.UCRYGate "qiskit.circuit.library.UCRYGate"), or [`UCRZGate`](/api/qiskit/qiskit.circuit.library.UCRZGate "qiskit.circuit.library.UCRZGate") (based on whether you’re using a rotation axis of `"X"`, `"Y"`, or `"Z"` respectively) which embeds the rotation axis in the class constructor and will work correctly in QPY.
-
-*   Since its original introduction in Qiskit Terra 0.20, [`XXPlusYYGate`](/api/qiskit/qiskit.circuit.library.XXPlusYYGate "qiskit.circuit.library.XXPlusYYGate") has used a negative angle convention compared to all other rotation gates. In Qiskit Terra 0.21, this will be corrected to be consistent with the other rotation gates. This does not affect any other rotation gates, nor [`XXMinusYYGate`](/api/qiskit/qiskit.circuit.library.XXMinusYYGate "qiskit.circuit.library.XXMinusYYGate").
-
-<span id="release-notes-terra-0-20-1-bug-fixes" />
-
-<span id="id127" />
-
-#### Bug Fixes
-
-*   Fixed [`Clifford`](/api/qiskit/qiskit.quantum_info.Clifford "qiskit.quantum_info.Clifford"), [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") and [`CNOTDihedral`](/api/qiskit/qiskit.quantum_info.CNOTDihedral "qiskit.quantum_info.CNOTDihedral") operator initialization from compatible circuits that contain [`Delay`](/api/qiskit/qiskit.circuit.Delay "qiskit.circuit.Delay") instructions. These instructions are treated as identities when converting to operators.
-
-*   Fixed an issue where the [`eval_observables()`](/api/qiskit/algorithms#qiskit.algorithms.eval_observables "qiskit.algorithms.eval_observables") function would raise an error if its `quantum_state` argument was of type `StateFn`. `eval_observables` now correctly supports all input types denoted by its type hints.
-
-*   Fixed an issue with the visualization function [`dag_drawer()`](/api/qiskit/qiskit.visualization.dag_drawer "qiskit.visualization.dag_drawer") and method [`DAGCircuit.draw()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#draw "qiskit.dagcircuit.DAGCircuit.draw") where previously the drawer would fail when attempting to generate a visualization for a [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "qiskit.dagcircuit.DAGCircuit") object that contained a [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") or [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") which wasn’t part of a `QuantumRegister` or `ClassicalRegister`. Fixed [#7915](https://github.com/Qiskit/qiskit-terra/issues/7915).
-
-*   Fixed parameter validation for class `Drag`. Previously, it was not sensitive to large beta values with negative signs, which may have resulted in waveform samples with a maximum value exceeding the amplitude limit of 1.0.
-
-*   The [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") class used by many algorithms (like `VQE`) was hard-coding the value for a sleep while it looped waiting for the job status to be updated. It now respects the configured sleep value as set per the `wait` attribute in the initializer of [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance").
-
-*   Fixed an issue with the [`schedule`](/api/qiskit/compiler#qiskit.compiler.schedule "qiskit.compiler.schedule") function where callers specifying a `list` of [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") objects with a single entry would incorrectly be returned a single [`Schedule`](/api/qiskit/qiskit.pulse.Schedule "qiskit.pulse.Schedule") object instead of a `list`.
-
-*   Fixed an issue with the `plot_error_map` visualization function which prevented it from working when run with a backend that had readout error defined in the provided backend’s [`BackendProperties`](/api/qiskit/qiskit.providers.models.BackendProperties "qiskit.providers.models.BackendProperties") or when running with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend. Fixed [#7879](https://github.com/Qiskit/qiskit-terra/issues/7879).
-
-*   Fixed a bug that could result in exponential runtime and nontermination when a [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli "qiskit.quantum_info.Pauli") instance is given to method `init_observables()`.
-
-*   Fixed [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap"), and by extension [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") with `optimization_level=3`, occasionally re-ordering measurements invalidly. Previously, if two measurements wrote to the same classical bit, [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") could (depending on the coupling map) re-order them to produce a non-equivalent circuit. This behaviour was stochastic, so may not have appeared reliably. Fixed [#7950](https://github.com/Qiskit/qiskit-terra/issues/7950)
-
-*   The [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler pass, and by extension [`SabreLayout`](/api/qiskit/qiskit.transpiler.passes.SabreLayout "qiskit.transpiler.passes.SabreLayout") and [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") at `optimization_level=3`, now has an escape mechanism to guarantee that it can never get stuck in an infinite loop. Certain inputs previously could, with a great amount of bad luck, get stuck in a stable local minimum of the search space and the pass would never make further progress. It will now force a series of swaps that allow the routing to continue if it detects it has not made progress recently. Fixed [#7707](https://github.com/Qiskit/qiskit-terra/issues/7707).
-
-*   Fixed an issue with QPY deserialization via the [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load") function of the [`UCRXGate`](/api/qiskit/qiskit.circuit.library.UCRXGate "qiskit.circuit.library.UCRXGate"), [`UCRYGate`](/api/qiskit/qiskit.circuit.library.UCRYGate "qiskit.circuit.library.UCRYGate"), and [`UCRZGate`](/api/qiskit/qiskit.circuit.library.UCRZGate "qiskit.circuit.library.UCRZGate") classes. Previously, a QPY file that contained any of these gates would error when trying to load the file. Fixed [#7847](https://github.com/Qiskit/qiskit-terra/issues/7847).
-
-<span id="id128" />
-
-### Aer 0.10.4
-
-No change
-
-<span id="ignis-0-7-0" />
-
-### Ignis 0.7.0
-
-No change
-
-<span id="id129" />
-
-### IBM Q Provider 0.19.1
-
-<span id="release-notes-0-19-1-ibmq" />
-
-<span id="id130" />
-
-### 0.19.1
-
-<span id="release-notes-0-19-1-ibmq-bug-fixes" />
-
-<span id="id131" />
-
-#### Bug Fixes
-
-*   PR [#1129](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1129) updates `least_busy()` method to no longer support BaseBackend as a valid input or output type since it has been long deprecated in qiskit-terra and has recently been removed.
-
-<span id="qiskit-0-36-0" />
-## 0.36.2
-
-<span id="terra-0-20-2" />
-
-<span id="release-notes-terra-0-20-2" />
-
-### Terra 0.20.2
-
-<span id="release-notes-terra-0-20-2-prelude" />
-
-<span id="id121" />
-
-#### Prelude
-
-Qiskit Terra 0.20.2 is a bugfix release, addressing some minor issues identified since the last patch release.
-
-<span id="release-notes-terra-0-20-2-bug-fixes" />
-
-<span id="id122" />
-
-#### Bug Fixes
-
-*   Fixed an issue with [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2")-based fake backend classes from the `qiskit.providers.fake_provider` module such as `FakeMontrealV2`, where the values for the [`dtm`](/api/qiskit/qiskit.providers.BackendV2#dtm "qiskit.providers.BackendV2.dtm") and [`dt`](/api/qiskit/qiskit.providers.BackendV2#dt "qiskit.providers.BackendV2.dt") attributes and the associated attribute [`Target.dt`](/api/qiskit/qiskit.transpiler.Target#dt "qiskit.transpiler.Target.dt") would not be properly converted to seconds. This would cause issues when using these fake backends with scheduling. See [#8018](https://github.com/Qiskit/qiskit-terra/issues/8018).
-
-*   [`marginal_counts()`](/api/qiskit/result#qiskit.result.marginal_counts "qiskit.result.marginal_counts") will now succeed when asked to marginalize memory with an `indices` parameter containing non-zero elements. Previously, shots whose hexadecimal result representation was sufficiently small could raise a `ValueError`. See [#8044](https://github.com/Qiskit/qiskit-terra/issues/8044).
-
-*   The OpenQASM 3 exporter ([`qiskit.qasm3`](/api/qiskit/qasm3#module-qiskit.qasm3 "qiskit.qasm3")) will now output `input` or `output` declarations before gate declarations. This is more consistent with the current reference ANTLR grammar from the OpenQASM 3 team. See [#7964](https://github.com/Qiskit/qiskit-terra/issues/7964).
-
-*   Fixed a bug in the [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") transpiler pass where the scaled cross-resonance pulse amplitude could appear to be parametrized even after assignment. This could cause the pulse visualization tools to use the parametrized format instead of the expected numeric one. See [#8031](https://github.com/Qiskit/qiskit-terra/pull/8031).
-
-*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") function when run with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2")-based backend and setting the `scheduling_method` keyword argument. Previously, the function would not correctly process the default durations of the instructions supported by the backend which would lead to an error.
-
-*   Fixed a bug in the [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") transpiler pass that was causing pulses to sometimes be constructed with incorrect durations. See [#7994](https://github.com/Qiskit/qiskit-terra/issues/7994).
-
-*   The [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler pass, used in [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") when `routing_method="sabre"` is set, will no longer sporadically drop classically conditioned gates and their successors from circuits during the routing phase of transpilation. See [#8040](https://github.com/Qiskit/qiskit-terra/issues/8040).
-
-*   [`Statevector`](/api/qiskit/qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") will now allow direct iteration through its values (such as `for coefficient in statevector`) and correctly report its length under `len`. Previously it would try and and access out-of-bounds data and raise a [`QiskitError`](/api/qiskit/exceptions#qiskit.exceptions.QiskitError "qiskit.exceptions.QiskitError"). See [#8039](https://github.com/Qiskit/qiskit-terra/issues/8039).
-
-<span id="id123" />
-
-### Aer 0.10.4
-
-No change
-
-<span id="ignis-0-7-1" />
-
-<span id="release-notes-ignis-0-7-1" />
-
-### Ignis 0.7.1
-
-<span id="release-notes-ignis-0-7-1-prelude" />
-
-<span id="id124" />
-
-#### Prelude
-
-This is a bugfix release that primarily fixes a packaging issue that was causing the `docs/` directory, which contains the source files used to build the qiskit-ignis documentation, to get included in the Python package.
-
-<span id="ibm-q-provider-0-19-1" />
-
-### IBM Q Provider 0.19.1
-
-No change
-
-<span id="qiskit-0-36-1" />

--- a/docs/api/qiskit/release-notes/0.37.md
+++ b/docs/api/qiskit/release-notes/0.37.md
@@ -5,6 +5,165 @@ description: New features and bug fixes
 
 # Qiskit 0.37 release notes
 
+## 0.37.2
+
+<span id="release-notes-terra-0-21-2" />
+
+<span id="id106" />
+
+### Terra 0.21.2
+
+<span id="release-notes-terra-0-21-2-prelude" />
+
+<span id="id107" />
+
+#### Prelude
+
+Qiskit Terra 0.21.2 is a primarily a bugfix release, and also comes with several improved documentation pages.
+
+<span id="release-notes-terra-0-21-2-bug-fixes" />
+
+<span id="id108" />
+
+#### Bug Fixes
+
+*   `aer_simulator_statevector_gpu` will now be recognized correctly as statevector method in some function when using Qiskit Aer’s GPU simulators in [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") and other algorithm runners.
+
+*   Fixed the [`UCGate.inverse()`](/api/qiskit/qiskit.circuit.library.UCGate#inverse "qiskit.circuit.library.UCGate.inverse") method which previously did not invert the global phase.
+
+*   [`QuantumCircuit.compose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#compose "qiskit.circuit.QuantumCircuit.compose") will now function correctly when used with the `inplace=True` argument within control-flow builder contexts. Previously the instructions would be added outside the control-flow scope. Fixed [#8433](https://github.com/Qiskit/qiskit-terra/issues/8433).
+
+*   Fixed a bug where a bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") was not identified as real if `symengine` was installed and the bound expression was not a plain `1j`. For example:
+
+    ```python
+    from qiskit.circuit import Parameter
+
+    x = Parameter("x")
+    expr = 1j * x
+    bound = expr.bind({x: 2})
+    print(bound.is_real())  # used to be True, but is now False
+    ```
+
+*   Fixed QPY serialisation and deserialisation of [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") with open controls (*i.e.* those whose `ctrl_state` is not all ones). Fixed [#8549](https://github.com/Qiskit/qiskit-terra/issues/8549).
+
+*   All fake backends in `qiskit.providers.fake_provider.backends` have been updated to return the corresponding pulse channel objects with the method call of `drive_channel()`, `measure_channel()`, `acquire_channel()`, `control_channel()`.
+
+*   Fixed support for running `Z2Symmetries.taper()` on larger problems. Previously, the method would require a large amount of memory which would typically cause failures for larger problem. As a side effect of this fix the performance has significantly improved.
+
+<span id="aer-0-10-4" />
+
+### Aer 0.10.4
+
+No change
+
+<span id="id109" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-37-1" />
+
+## 0.37.1
+
+<span id="terra-0-21-1" />
+
+<span id="release-notes-terra-0-21-1" />
+
+### Terra 0.21.1
+
+<span id="release-notes-terra-0-21-1-bug-fixes" />
+
+<span id="id110" />
+
+#### Bug Fixes
+
+*   Fixed an issue in [`QuantumCircuit.decompose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#decompose "qiskit.circuit.QuantumCircuit.decompose") method when passing in a list of `Gate` classes for the `gates_to_decompose` argument. If any gates in the circuit had a label set this argument wouldn’t be handled correctly and caused the output decomposition to incorrectly skip gates explicitly in the `gates_to_decompose` list.
+
+*   Fix [`to_instruction()`](/api/qiskit/qiskit.opflow.evolutions.EvolvedOp#to_instruction "qiskit.opflow.evolutions.EvolvedOp.to_instruction") which previously tried to create a [`UnitaryGate`](/api/qiskit/qiskit.circuit.library.UnitaryGate "qiskit.circuit.library.UnitaryGate") without exponentiating the operator to evolve. Since this operator is generally not unitary, this raised an error (and if the operator would have been unitary by chance, it would not have been the expected result).
+
+    Now calling [`to_instruction()`](/api/qiskit/qiskit.opflow.evolutions.EvolvedOp#to_instruction "qiskit.opflow.evolutions.EvolvedOp.to_instruction") correctly produces a gate that implements the time evolution of the operator it holds:
+
+    ```python
+    >>> from qiskit.opflow import EvolvedOp, X
+    >>> op = EvolvedOp(0.5 * X)
+    >>> op.to_instruction()
+    Instruction(
+        name='unitary', num_qubits=1, num_clbits=0,
+        params=[array([[0.87758256+0.j, 0.-0.47942554j], [0.-0.47942554j, 0.87758256+0.j]])]
+    )
+    ```
+
+*   Fixed an issue with the [`marginal_distribution()`](/api/qiskit/result#qiskit.result.marginal_distribution "qiskit.result.marginal_distribution") function: when a numpy array was passed in for the `indices` argument the function would raise an error. Fixed [#8283](https://github.com/Qiskit/qiskit-terra/issues/8283)
+
+*   Previously it was not possible to adjoint a [`CircuitStateFn`](/api/qiskit/qiskit.opflow.state_fns.CircuitStateFn "qiskit.opflow.state_fns.CircuitStateFn") that has been constructed from a [`VectorStateFn`](/api/qiskit/qiskit.opflow.state_fns.VectorStateFn "qiskit.opflow.state_fns.VectorStateFn"). That’s because the statevector has been converted to a circuit with the `Initialize` instruction, which is not unitary. This problem is now fixed by instead using the [`StatePreparation`](/api/qiskit/qiskit.circuit.library.StatePreparation "qiskit.circuit.library.StatePreparation") instruction, which can be used since the state is assumed to start out in the all 0 state.
+
+    For example we can now do:
+
+    ```python
+    from qiskit import QuantumCircuit
+    from qiskit.opflow import StateFn
+
+    left = StateFn([0, 1])
+    left_circuit = left.to_circuit_op().primitive
+
+    right_circuit = QuantumCircuit(1)
+    right_circuit.x(0)
+
+    overlap = left_circuit.inverse().compose(right_circuit)  # this line raised an error before!
+    ```
+
+*   Fix a bug in the [`Optimizer`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer "qiskit.algorithms.optimizers.Optimizer") classes where re-constructing a new optimizer instance from a previously exisiting [`settings`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer#settings "qiskit.algorithms.optimizers.Optimizer.settings") reset both the new and previous optimizer settings to the defaults. This notably led to a bug if [`Optimizer`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer "qiskit.algorithms.optimizers.Optimizer") objects were send as input to Qiskit Runtime programs.
+
+    Now optimizer objects are correctly reconstructed:
+
+    ```python
+    >>> from qiskit.algorithms.optimizers import COBYLA
+    >>> original = COBYLA(maxiter=1)
+    >>> reconstructed = COBYLA(**original.settings)
+    >>> reconstructed._options["maxiter"]
+    1  # used to be 1000!
+    ```
+
+*   Fixed an issue where the `limit_amplitude` argument on an individual [`SymbolicPulse`](/api/qiskit/qiskit.pulse.library.SymbolicPulse "qiskit.pulse.library.SymbolicPulse") or [`Waveform`](/api/qiskit/qiskit.pulse.library.Waveform "qiskit.pulse.library.Waveform") instance was not properly reflected by parameter validation. In addition, QPY schedule [`dump()`](/api/qiskit/qpy#qiskit.qpy.dump "qiskit.qpy.dump") has been fixed to correctly store the `limit_amplitude` value tied to the instance, rather than saving the global class variable.
+
+*   Fix the pairwise entanglement structure for [`NLocal`](/api/qiskit/qiskit.circuit.library.NLocal "qiskit.circuit.library.NLocal") circuits. This led to a bug in the [`ZZFeatureMap`](/api/qiskit/qiskit.circuit.library.ZZFeatureMap "qiskit.circuit.library.ZZFeatureMap"), where using `entanglement="pairwise"` raised an error. Now it correctly produces the desired feature map:
+
+    ```python
+    from qiskit.circuit.library import ZZFeatureMap
+    encoding = ZZFeatureMap(4, entanglement="pairwise", reps=1)
+    print(encoding.decompose().draw())
+    ```
+
+    The above prints:
+
+    ```python
+         ┌───┐┌─────────────┐
+    q_0: ┤ H ├┤ P(2.0*x[0]) ├──■────────────────────────────────────■────────────────────────────────────────────
+         ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐
+    q_1: ┤ H ├┤ P(2.0*x[1]) ├┤ X ├┤ P(2.0*(π - x[0])*(π - x[1])) ├┤ X ├──■────────────────────────────────────■──
+         ├───┤├─────────────┤└───┘└──────────────────────────────┘└───┘┌─┴─┐┌──────────────────────────────┐┌─┴─┐
+    q_2: ┤ H ├┤ P(2.0*x[2]) ├──■────────────────────────────────────■──┤ X ├┤ P(2.0*(π - x[1])*(π - x[2])) ├┤ X ├
+         ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐└───┘└──────────────────────────────┘└───┘
+    q_3: ┤ H ├┤ P(2.0*x[3]) ├┤ X ├┤ P(2.0*(π - x[2])*(π - x[3])) ├┤ X ├──────────────────────────────────────────
+         └───┘└─────────────┘└───┘└──────────────────────────────┘└───┘
+    ```
+
+*   Fixed an issue in handling the global phase of the [`UCGate`](/api/qiskit/qiskit.circuit.library.UCGate "qiskit.circuit.library.UCGate") class.
+
+<span id="id111" />
+
+### Aer 0.10.4
+
+No change
+
+<span id="id112" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-37-0" />
 ## 0.37.0
 
 This release officially marks the end of support for the Qiskit Ignis project from Qiskit. It was originally deprecated in the 0.33.0 release and as was documented in that release the `qiskit-ignis` package has been removed from the Qiskit metapackage, which means in that future release `pip install qiskit` will no longer include `qiskit-ignis`. However, note because of limitations in python packaging we cannot automatically remove a pre-existing install of `qiskit-ignis`. If you are upgrading from a previous version it’s recommended that you manually uninstall Qiskit Ignis with `pip uninstall qiskit-ignis` or install the metapackage in a fresh python environment.
@@ -490,161 +649,3 @@ No change
 *   `threading.currentThread` and `notifyAll` were deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023). PR [#1133](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1133) replaces them with `threading.current_thread`, `notify_all` added in Python 2.6 (October 2008).
 
 <span id="qiskit-0-36-2" />
-## 0.37.1
-
-<span id="terra-0-21-1" />
-
-<span id="release-notes-terra-0-21-1" />
-
-### Terra 0.21.1
-
-<span id="release-notes-terra-0-21-1-bug-fixes" />
-
-<span id="id110" />
-
-#### Bug Fixes
-
-*   Fixed an issue in [`QuantumCircuit.decompose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#decompose "qiskit.circuit.QuantumCircuit.decompose") method when passing in a list of `Gate` classes for the `gates_to_decompose` argument. If any gates in the circuit had a label set this argument wouldn’t be handled correctly and caused the output decomposition to incorrectly skip gates explicitly in the `gates_to_decompose` list.
-
-*   Fix [`to_instruction()`](/api/qiskit/qiskit.opflow.evolutions.EvolvedOp#to_instruction "qiskit.opflow.evolutions.EvolvedOp.to_instruction") which previously tried to create a [`UnitaryGate`](/api/qiskit/qiskit.circuit.library.UnitaryGate "qiskit.circuit.library.UnitaryGate") without exponentiating the operator to evolve. Since this operator is generally not unitary, this raised an error (and if the operator would have been unitary by chance, it would not have been the expected result).
-
-    Now calling [`to_instruction()`](/api/qiskit/qiskit.opflow.evolutions.EvolvedOp#to_instruction "qiskit.opflow.evolutions.EvolvedOp.to_instruction") correctly produces a gate that implements the time evolution of the operator it holds:
-
-    ```python
-    >>> from qiskit.opflow import EvolvedOp, X
-    >>> op = EvolvedOp(0.5 * X)
-    >>> op.to_instruction()
-    Instruction(
-        name='unitary', num_qubits=1, num_clbits=0,
-        params=[array([[0.87758256+0.j, 0.-0.47942554j], [0.-0.47942554j, 0.87758256+0.j]])]
-    )
-    ```
-
-*   Fixed an issue with the [`marginal_distribution()`](/api/qiskit/result#qiskit.result.marginal_distribution "qiskit.result.marginal_distribution") function: when a numpy array was passed in for the `indices` argument the function would raise an error. Fixed [#8283](https://github.com/Qiskit/qiskit-terra/issues/8283)
-
-*   Previously it was not possible to adjoint a [`CircuitStateFn`](/api/qiskit/qiskit.opflow.state_fns.CircuitStateFn "qiskit.opflow.state_fns.CircuitStateFn") that has been constructed from a [`VectorStateFn`](/api/qiskit/qiskit.opflow.state_fns.VectorStateFn "qiskit.opflow.state_fns.VectorStateFn"). That’s because the statevector has been converted to a circuit with the `Initialize` instruction, which is not unitary. This problem is now fixed by instead using the [`StatePreparation`](/api/qiskit/qiskit.circuit.library.StatePreparation "qiskit.circuit.library.StatePreparation") instruction, which can be used since the state is assumed to start out in the all 0 state.
-
-    For example we can now do:
-
-    ```python
-    from qiskit import QuantumCircuit
-    from qiskit.opflow import StateFn
-
-    left = StateFn([0, 1])
-    left_circuit = left.to_circuit_op().primitive
-
-    right_circuit = QuantumCircuit(1)
-    right_circuit.x(0)
-
-    overlap = left_circuit.inverse().compose(right_circuit)  # this line raised an error before!
-    ```
-
-*   Fix a bug in the [`Optimizer`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer "qiskit.algorithms.optimizers.Optimizer") classes where re-constructing a new optimizer instance from a previously exisiting [`settings`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer#settings "qiskit.algorithms.optimizers.Optimizer.settings") reset both the new and previous optimizer settings to the defaults. This notably led to a bug if [`Optimizer`](/api/qiskit/qiskit.algorithms.optimizers.Optimizer "qiskit.algorithms.optimizers.Optimizer") objects were send as input to Qiskit Runtime programs.
-
-    Now optimizer objects are correctly reconstructed:
-
-    ```python
-    >>> from qiskit.algorithms.optimizers import COBYLA
-    >>> original = COBYLA(maxiter=1)
-    >>> reconstructed = COBYLA(**original.settings)
-    >>> reconstructed._options["maxiter"]
-    1  # used to be 1000!
-    ```
-
-*   Fixed an issue where the `limit_amplitude` argument on an individual [`SymbolicPulse`](/api/qiskit/qiskit.pulse.library.SymbolicPulse "qiskit.pulse.library.SymbolicPulse") or [`Waveform`](/api/qiskit/qiskit.pulse.library.Waveform "qiskit.pulse.library.Waveform") instance was not properly reflected by parameter validation. In addition, QPY schedule [`dump()`](/api/qiskit/qpy#qiskit.qpy.dump "qiskit.qpy.dump") has been fixed to correctly store the `limit_amplitude` value tied to the instance, rather than saving the global class variable.
-
-*   Fix the pairwise entanglement structure for [`NLocal`](/api/qiskit/qiskit.circuit.library.NLocal "qiskit.circuit.library.NLocal") circuits. This led to a bug in the [`ZZFeatureMap`](/api/qiskit/qiskit.circuit.library.ZZFeatureMap "qiskit.circuit.library.ZZFeatureMap"), where using `entanglement="pairwise"` raised an error. Now it correctly produces the desired feature map:
-
-    ```python
-    from qiskit.circuit.library import ZZFeatureMap
-    encoding = ZZFeatureMap(4, entanglement="pairwise", reps=1)
-    print(encoding.decompose().draw())
-    ```
-
-    The above prints:
-
-    ```python
-         ┌───┐┌─────────────┐
-    q_0: ┤ H ├┤ P(2.0*x[0]) ├──■────────────────────────────────────■────────────────────────────────────────────
-         ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐
-    q_1: ┤ H ├┤ P(2.0*x[1]) ├┤ X ├┤ P(2.0*(π - x[0])*(π - x[1])) ├┤ X ├──■────────────────────────────────────■──
-         ├───┤├─────────────┤└───┘└──────────────────────────────┘└───┘┌─┴─┐┌──────────────────────────────┐┌─┴─┐
-    q_2: ┤ H ├┤ P(2.0*x[2]) ├──■────────────────────────────────────■──┤ X ├┤ P(2.0*(π - x[1])*(π - x[2])) ├┤ X ├
-         ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐└───┘└──────────────────────────────┘└───┘
-    q_3: ┤ H ├┤ P(2.0*x[3]) ├┤ X ├┤ P(2.0*(π - x[2])*(π - x[3])) ├┤ X ├──────────────────────────────────────────
-         └───┘└─────────────┘└───┘└──────────────────────────────┘└───┘
-    ```
-
-*   Fixed an issue in handling the global phase of the [`UCGate`](/api/qiskit/qiskit.circuit.library.UCGate "qiskit.circuit.library.UCGate") class.
-
-<span id="id111" />
-
-### Aer 0.10.4
-
-No change
-
-<span id="id112" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-37-0" />
-## 0.37.2
-
-<span id="release-notes-terra-0-21-2" />
-
-<span id="id106" />
-
-### Terra 0.21.2
-
-<span id="release-notes-terra-0-21-2-prelude" />
-
-<span id="id107" />
-
-#### Prelude
-
-Qiskit Terra 0.21.2 is a primarily a bugfix release, and also comes with several improved documentation pages.
-
-<span id="release-notes-terra-0-21-2-bug-fixes" />
-
-<span id="id108" />
-
-#### Bug Fixes
-
-*   `aer_simulator_statevector_gpu` will now be recognized correctly as statevector method in some function when using Qiskit Aer’s GPU simulators in [`QuantumInstance`](/api/qiskit/qiskit.utils.QuantumInstance "qiskit.utils.QuantumInstance") and other algorithm runners.
-
-*   Fixed the [`UCGate.inverse()`](/api/qiskit/qiskit.circuit.library.UCGate#inverse "qiskit.circuit.library.UCGate.inverse") method which previously did not invert the global phase.
-
-*   [`QuantumCircuit.compose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#compose "qiskit.circuit.QuantumCircuit.compose") will now function correctly when used with the `inplace=True` argument within control-flow builder contexts. Previously the instructions would be added outside the control-flow scope. Fixed [#8433](https://github.com/Qiskit/qiskit-terra/issues/8433).
-
-*   Fixed a bug where a bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") was not identified as real if `symengine` was installed and the bound expression was not a plain `1j`. For example:
-
-    ```python
-    from qiskit.circuit import Parameter
-
-    x = Parameter("x")
-    expr = 1j * x
-    bound = expr.bind({x: 2})
-    print(bound.is_real())  # used to be True, but is now False
-    ```
-
-*   Fixed QPY serialisation and deserialisation of [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") with open controls (*i.e.* those whose `ctrl_state` is not all ones). Fixed [#8549](https://github.com/Qiskit/qiskit-terra/issues/8549).
-
-*   All fake backends in `qiskit.providers.fake_provider.backends` have been updated to return the corresponding pulse channel objects with the method call of `drive_channel()`, `measure_channel()`, `acquire_channel()`, `control_channel()`.
-
-*   Fixed support for running `Z2Symmetries.taper()` on larger problems. Previously, the method would require a large amount of memory which would typically cause failures for larger problem. As a side effect of this fix the performance has significantly improved.
-
-<span id="aer-0-10-4" />
-
-### Aer 0.10.4
-
-No change
-
-<span id="id109" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-37-1" />

--- a/docs/api/qiskit/release-notes/0.39.md
+++ b/docs/api/qiskit/release-notes/0.39.md
@@ -5,6 +5,364 @@ description: New features and bug fixes
 
 # Qiskit 0.39 release notes
 
+## 0.39.5
+
+<span id="terra-0-22-4" />
+
+<span id="release-notes-terra-0-22-4" />
+
+### Terra 0.22.4
+
+<span id="release-notes-terra-0-22-4-prelude" />
+
+<span id="id70" />
+
+#### Prelude
+
+Qiskit Terra 0.22.4 is a minor bugfix release, fixing some bugs identified in the 0.22 series.
+
+<span id="release-notes-terra-0-22-4-bug-fixes" />
+
+<span id="id71" />
+
+#### Bug Fixes
+
+*   Fixed a bug in [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") that raised an error if its [`run()`](/api/qiskit/qiskit.primitives.BackendSampler#run "qiskit.primitives.BackendSampler.run") method was called two times sequentially.
+
+*   Fixed two bugs in the [`ComposedOp`](/api/qiskit/qiskit.opflow.list_ops.ComposedOp "qiskit.opflow.list_ops.ComposedOp") where the [`ComposedOp.to_matrix()`](/api/qiskit/qiskit.opflow.list_ops.ComposedOp#to_matrix "qiskit.opflow.list_ops.ComposedOp.to_matrix") method did not provide the correct results for compositions with [`StateFn`](/api/qiskit/qiskit.opflow.state_fns.StateFn "qiskit.opflow.state_fns.StateFn") and for compositions with a global coefficient. Fixed [#9283](https://github.com/Qiskit/qiskit-terra/issues/9283).
+
+*   Fixed the problem in which primitives, [`Sampler`](/api/qiskit/qiskit.primitives.Sampler "qiskit.primitives.Sampler") and [`Estimator`](/api/qiskit/qiskit.primitives.Estimator "qiskit.primitives.Estimator"), did not work when passed a circuit with `numpy.ndarray` as a parameter.
+
+*   Fixed a bug in [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") where the `aggregation` argument did not have an effect. Now the aggregation function and, with it, the CVaR expectation value can correctly be specified.
+
+*   Fixed a performance bug where [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") evaluated the energies of eigenstates in a slow manner.
+
+*   Fixed the autoevaluation of the beta parameters in [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD"), added support for [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") inputs, and fixed the energy evaluation function to leverage the asynchronous execution of primitives, by only retrieving the job results after both jobs have been submitted.
+
+*   Fixed an issue with the [`Statevector.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities_dict "qiskit.quantum_info.Statevector.probabilities_dict") and [`DensityMatrix.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities_dict "qiskit.quantum_info.DensityMatrix.probabilities_dict") methods where they would return incorrect results for non-qubit systems when the `qargs` argument was specified. Fixed [#9210](https://github.com/Qiskit/qiskit-terra/issues/9210)
+
+*   Fixed handling of some `classmethod`s by [`wrap_method()`](/api/qiskit/utils#qiskit.utils.wrap_method "qiskit.utils.wrap_method") in Python 3.11. Previously, in Python 3.11, `wrap_method` would wrap the unbound function associated with the `classmethod` and then fail when invoked because the class object usually bound to the `classmethod` was not passed to the function. Starting in Python 3.11.1, this issue affected `QiskitTestCase`, preventing it from being imported by other test code. Fixed [#9291](https://github.com/Qiskit/qiskit-terra/issues/9291).
+
+<span id="id72" />
+
+### Aer 0.11.2
+
+No change
+
+<span id="id73" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-39-4" />
+
+## 0.39.4
+
+<span id="terra-0-22-3" />
+
+### Terra 0.22.3
+
+No change
+
+<span id="release-notes-aer-0-11-2" />
+
+<span id="id74" />
+
+### Aer 0.11.2
+
+<span id="release-notes-aer-0-11-2-new-features" />
+
+<span id="id75" />
+
+#### New Features
+
+*   Added support for running Qiskit Aer with Python 3.11 support.
+
+<span id="release-notes-aer-0-11-2-known-issues" />
+
+<span id="id76" />
+
+#### Known Issues
+
+*   Fix two bugs in AerStatevector. AerStatevector uses mc\* instructions, which are not enabled in matrix\_product\_state method. This commit changes AerStatevector not to use MC\* and use H, X, Y, Z, U and CX. AerStatevector also failed if an instruction is decomposed to empty QuantumCircuit. This commit allows such instruction.
+
+<span id="release-notes-aer-0-11-2-bug-fixes" />
+
+<span id="id77" />
+
+#### Bug Fixes
+
+*   Fixed support in the `AerSimulator.from_backend()` method for instantiating an `AerSimulator` instance from an a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") object. Previously, attempting to use `AerSimulator.from_backend()` with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") object would have raised an `AerError` saying this wasn’t supported.
+
+*   Fixes a bug where `NoiseModel.from_backend()` with a `BackendV2` object may generate a noise model with excessive `QuantumError` s on non-Gate instructions while, for example, only `ReadoutError` s should be sufficient for measures. This commit updates `NoiseModel.from_backend()` with a `BackendV2` object so that it returns the same noise model as that called with the corresponding `BackendV1` object. That is, the resulting noise model does not contain any `QuantumError` s on measures and it may contain only thermal relaxation errors on other non-gate instructions such as resets. Note that it still contains `ReadoutError` s on measures.
+
+*   Fixed a bug in `NoiseModel.from_backend()` where using the `temperature` kwarg with a non-default value would incorrectly compute the excited state population for the specified temperature. Previously, there was an additional factor of 2 in the Boltzman distribution calculation leading to an incorrect smaller value for the excited state population.
+
+*   Fixed incorrect logic in the control-flow compiler that could allow unrelated instructions to appear “inside” control-flow bodies during execution, causing incorrect results. For example, previously:
+
+    ```python
+    from qiskit import QuantumCircuit
+    from qiskit_aer import AerSimulator
+
+    backend = AerSimulator(method="statevector")
+
+    circuit = QuantumCircuit(3, 3)
+    circuit.measure(0, 0)
+    circuit.measure(1, 1)
+
+    with circuit.if_test((0, True)):
+        with circuit.if_test((1, False)):
+            circuit.x(2)
+
+    with circuit.if_test((0, False)):
+        with circuit.if_test((1, True)):
+            circuit.x(2)
+
+    circuit.measure(range(3), range(3))
+    print(backend.run(circuit, method=method, shots=100).result())
+    ```
+
+    would print `{'010': 100}` as the nested control-flow operations would accidentally jump over the first X gate on qubit 2, which should have been executed.
+
+*   Fixes a bug where `NoiseModel.from_backend()` prints verbose warnings when supplying a backend that reports un-physical device parameters such as T2 > 2 \* T1 due to statistical errors in their estimation. This commit removes such warnings because they are not actionable for users in the sense that there are no means other than truncating them to the theoretical bounds as done within `noise.device` module. See [Issue 1631](https://github.com/Qiskit/qiskit-aer/issues/1631) for details of the fixed bug.
+
+*   This is fix for GPU statevector simulator. Chunk distribution tried to allocate all free memory on GPU, but this causes memory allocation error. So this fix allocates 80 percent of free memory. Also this fixes size of matrix buffer when noise sampling is applied.
+
+*   This is a fix of AerState running with cache blocking. AerState wrongly configured transpiler of Aer for cache blocking, and then its algorithm to swap qubits worked wrongly. This fix corrects AerState to use this transpiler. More specifically, After the transpilation, a swapped qubit map is recoverd to the original map when using AerState. This fix is necessary for AerStatevector to use multiple-GPUs.
+
+*   This is fix for AerStatevector. It was not possible to create an AerStatevector instance directly from terra’s Statevector. This fix allows a Statevector as AerStatevector’s input.
+
+*   [`SamplerResult.quasi_dists`](/api/qiskit/qiskit.primitives.SamplerResult#quasi_dists "qiskit.primitives.SamplerResult.quasi_dists") contain the data about the number of qubits. `QuasiDistribution.binary_probabilities()` returns bitstrings with correct length.
+
+*   Previously seed is not initialized in AerStatevector and then sampled results are always same. With this commit, a seed is initialized for each sampling and sampled results can be vary.
+
+<span id="id78" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-39-3" />
+## 0.39.3
+
+<span id="release-notes-terra-0-22-3" />
+
+<span id="id79" />
+
+### Terra 0.22.3
+
+<span id="release-notes-terra-0-22-3-prelude" />
+
+<span id="id80" />
+
+#### Prelude
+
+Qiskit Terra 0.22.3 is a minor bugfix release, fixing some further bugs in the 0.22 series.
+
+<span id="release-notes-terra-0-22-3-bug-fixes" />
+
+<span id="id81" />
+
+#### Bug Fixes
+
+*   `AdaptVQE` now correctly indicates that it supports auxiliary operators.
+
+*   The circuit drawers ([`QuantumCircuit.draw()`](/api/qiskit/qiskit.circuit.QuantumCircuit#draw "qiskit.circuit.QuantumCircuit.draw") and [`circuit_drawer()`](/api/qiskit/qiskit.visualization.circuit_drawer "qiskit.visualization.circuit_drawer")) will no longer emit a warning about the `cregbundle` parameter when using the default arguments, if the content of the circuit requires all bits to be drawn individually. This was most likely to appear when trying to draw circuits with new-style control-flow operations.
+
+*   Fixed a bug causing [`QNSPSA`](/api/qiskit/qiskit.algorithms.optimizers.QNSPSA "qiskit.algorithms.optimizers.QNSPSA") to fail when `max_evals_grouped` was set to a value larger than 1.
+
+*   Fixed an issue with the [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") pass which would cause the output of multiple runs of the pass without the `seed` argument specified to reuse the same random number generator seed between runs instead of using different seeds. This previously caused identical results to be returned between runs even when no `seed` was specified.
+
+*   Fixed an issue with the primitive classes, [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator"), where instances were not able to be serialized with `pickle`. In general these classes are not guaranteed to be serializable as [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") and [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instances are not required to be serializable (and often are not), but the class definitions of [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") no longer prevent the use of `pickle`.
+
+*   The `pulse.Instruction.draw()` method will now succeed, as before. This method is deprecated with no replacement planned, but it should still work for the period of deprecation.
+
+<span id="aer-0-11-1" />
+
+### Aer 0.11.1
+
+No change
+
+<span id="id82" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-39-2" />
+## 0.39.2
+
+<span id="terra-0-22-2" />
+
+<span id="release-notes-terra-0-22-2" />
+
+### Terra 0.22.2
+
+<span id="release-notes-terra-0-22-2-prelude" />
+
+<span id="id83" />
+
+#### Prelude
+
+Qiskit Terra 0.22.2 is a minor bugfix release, and marks the first official support for Python 3.11.
+
+<span id="release-notes-terra-0-22-2-bug-fixes" />
+
+<span id="id84" />
+
+#### Bug Fixes
+
+*   Fixed an issue with the backend primitive classes [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") which prevented running with a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instance that does not have a `max_experiments` field set in its [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration").
+
+*   Fixed a bug in the [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") pass when transpiling for backends with a defined [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target"), where the interaction graph would be built incorrectly. This could result in excessive runtimes due to the graph being far more complex than necessary.
+
+*   The Pulse expression parser should no longer periodically hang when called from Jupyter notebooks. This is achieved by avoiding an internal `deepycopy` of a recursive object that seemed to be particularly difficult for the memoization to evaluate.
+
+<span id="id85" />
+
+### Aer 0.11.1
+
+No change
+
+<span id="id86" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-39-1" />
+## 0.39.1
+
+<span id="terra-0-22-1" />
+
+<span id="release-notes-0-22-1" />
+
+### Terra 0.22.1
+
+<span id="release-notes-0-22-1-prelude" />
+
+<span id="id87" />
+
+#### Prelude
+
+Qiskit Terra 0.22.1 is a bugfix release, addressing some minor issues identified since the 0.22.0 release.
+
+<span id="release-notes-0-22-1-deprecation-notes" />
+
+<span id="id88" />
+
+#### Deprecation Notes
+
+*   The `pauli_list` kwarg of [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") has been deprecated as [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") now always returns a [`PauliList`](/api/qiskit/qiskit.quantum_info.PauliList "qiskit.quantum_info.PauliList"). This argument was removed prematurely from Qiskit Terra 0.22.0 which broke compatibility for users that were leveraging the `pauli_list``argument. Now, the argument has been restored but will emit a ``DeprecationWarning` when used. If used it has no effect because since Qiskit Terra 0.22.0 a [`PauliList`](/api/qiskit/qiskit.quantum_info.PauliList "qiskit.quantum_info.PauliList") is always returned.
+
+<span id="release-notes-0-22-1-bug-fixes" />
+
+<span id="id89" />
+
+#### Bug Fixes
+
+*   Fixed the [`BarrierBeforeFinalMeasurements`](/api/qiskit/qiskit.transpiler.passes.BarrierBeforeFinalMeasurements "qiskit.transpiler.passes.BarrierBeforeFinalMeasurements") transpiler pass when there are conditions on loose [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s immediately before the final measurement layer. Previously, this would fail claiming that the bit was not present in an internal temporary circuit. Fixed [#8923](https://github.com/Qiskit/qiskit-terra/issues/8923)
+
+*   The equality checkers for [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") and [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "qiskit.dagcircuit.DAGCircuit") (with objects of the same type) will now correctly handle conditions on single bits. Previously, these would produce false negatives for equality, as the bits would use “exact” equality checks instead of the “semantic” checks the rest of the properties of circuit instructions get.
+
+*   Fixed handling of classical bits in [`StochasticSwap`](/api/qiskit/qiskit.transpiler.passes.StochasticSwap "qiskit.transpiler.passes.StochasticSwap") with control flow. Previously, control-flow operations would be expanded to contain all the classical bits in the outer circuit and not contracted again, leading to a mismatch between the numbers of clbits the instruction reported needing and the actual number supplied to it. Fixed [#8903](https://github.com/Qiskit/qiskit-terra/issues/8903)
+
+*   Fixed handling of globally defined instructions for the [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") class. Previously, two methods, [`operations_for_qargs()`](/api/qiskit/qiskit.transpiler.Target#operations_for_qargs "qiskit.transpiler.Target.operations_for_qargs") and [`operation_names_for_qargs()`](/api/qiskit/qiskit.transpiler.Target#operation_names_for_qargs "qiskit.transpiler.Target.operation_names_for_qargs") would ignore/incorrectly handle any globally defined ideal operations present in the target. For example:
+
+    ```python
+    from qiskit.transpiler import Target
+    from qiskit.circuit.library import CXGate
+
+    target = Target(num_qubits=5)
+    target.add_instruction(CXGate())
+    names = target.operation_names_for_qargs((1, 2))
+    ops = target.operations_for_qargs((1, 2))
+    ```
+
+    will now return `{"cx"}` for `names` and `[CXGate()]` for `ops` instead of raising a `KeyError` or an empty return.
+
+*   Fixed an issue in the [`Target.add_instruction()`](/api/qiskit/qiskit.transpiler.Target#add_instruction "qiskit.transpiler.Target.add_instruction") method where it would previously have accepted an argument with an invalid number of qubits as part of the `properties` argument. For example:
+
+    ```python
+    from qiskit.transpiler import Target
+    from qiskit.circuit.library import CXGate
+
+    target = Target()
+    target.add_instruction(CXGate(), {(0, 1, 2): None})
+    ```
+
+    This will now correctly raise a `TranspilerError` instead of causing runtime issues when interacting with the target. Fixed [#8914](https://github.com/Qiskit/qiskit-terra/issues/8914)
+
+*   Fixed an issue with the [`plot_state_hinton()`](/api/qiskit/qiskit.visualization.plot_state_hinton "qiskit.visualization.plot_state_hinton") visualization function which would result in a misplaced axis that was offset from the actual plot. Fixed #8446 \<[https://github.com/Qiskit/qiskit-terra/issues/8446](https://github.com/Qiskit/qiskit-terra/issues/8446)>
+
+*   Fixed the output of the [`plot_state_hinton()`](/api/qiskit/qiskit.visualization.plot_state_hinton "qiskit.visualization.plot_state_hinton") function so that the state labels are ordered ordered correctly, and the image matches up with the natural matrix ordering. Fixed [#8324](https://github.com/Qiskit/qiskit-terra/issues/8324)
+
+*   Fixed an issue with the primitive classes, [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") when running on backends that have a limited number of circuits in each job. Not all backends support an unlimited batch size (most hardware backends do not) and previously the backend primitive classes would have potentially incorrectly sent more circuits than the backend supported. This has been corrected so that [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") will chunk the circuits into multiple jobs if the backend has a limited number of circuits per job.
+
+*   Fixed an issue with the [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") class where previously setting a run option named `monitor` to a value that evaluated as `True` would have incorrectly triggered a job monitor that only worked on backends from the `qiskit-ibmq-provider` package. This has been removed so that you can use a `monitor` run option if needed without causing any issues.
+
+*   Fixed an issue with the [`Target.build_coupling_map()`](/api/qiskit/qiskit.transpiler.Target#build_coupling_map "qiskit.transpiler.Target.build_coupling_map") method where it would incorrectly return `None` for a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object with a mix of ideal globally available instructions and instructions that have qubit constraints. Now in such cases the [`Target.build_coupling_map()`](/api/qiskit/qiskit.transpiler.Target#build_coupling_map "qiskit.transpiler.Target.build_coupling_map") will return a coupling map for the constrained instruction (unless it’s a 2 qubit operation which will return `None` because globally there is no connectivity constraint). Fixed [#8971](https://github.com/Qiskit/qiskit-terra/issues/8971)
+
+*   Fixed an issue with the [`Target.qargs`](/api/qiskit/qiskit.transpiler.Target#qargs "qiskit.transpiler.Target.qargs") attribute where it would incorrectly return `None` for a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object that contained any globally available ideal instruction.
+
+*   Fixed the premature removal of the `pauli_list` keyword argument of the [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") function which broke existing code using the `pauli_list=True` future compatibility path on upgrade to Qiskit Terra 0.22.0. This keyword argument has been added back to the function and is now deprecated and will be removed in a future release.
+
+*   Fixed an issue in QPY serialization ([`dump()`](/api/qiskit/qpy#qiskit.qpy.dump "qiskit.qpy.dump")) when a custom [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") subclass that overloaded the `_define()` method to provide a custom definition for the operation. Previously, this case of operation was not serialized correctly because it wasn’t accounting for using the potentially `_define()` method to provide a definition. Fixes [#8794](https://github.com/Qiskit/qiskit-terra/issues/8794)
+
+*   QPY deserialisation will no longer add extra [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") instances to the circuit if there are both loose [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s in the circuit and more [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit")s than [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s.
+
+*   QPY deserialisation will no longer add registers named q and c if the input circuit contained only loose bits.
+
+*   Fixed the [`SparsePauliOp.dot()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#dot "qiskit.quantum_info.SparsePauliOp.dot") method when run on two operators with real coefficients. To fix this, the dtype that `SparsePauliOp` can take is restricted to `np.complex128` and `object`. Fixed [#8992](https://github.com/Qiskit/qiskit-terra/issues/8992)
+
+*   Fixed an issue in the [`circuit_drawer()`](/api/qiskit/qiskit.visualization.circuit_drawer "qiskit.visualization.circuit_drawer") function and `QuantumCircuit.draw()` method where the only built-in style for the `mpl` output that was usable was `default`. If another built-in style, such as `iqx`, were used then a warning about the style not being found would be emitted and the drawer would fall back to use the `default` style. Fixed [#8991](https://github.com/Qiskit/qiskit-terra/issues/8991)
+
+*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") where it would previously fail with a `TypeError` if a custom [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object was passed in via the `target` argument and a list of multiple circuits were specified for the `circuits` argument.
+
+*   Fixed an issue with [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") when targeting a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") (either directly via the `target` argument or via a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") instance from the `backend` argument) that contained an ideal [`Measure`](/api/qiskit/qiskit.circuit.library.Measure "qiskit.circuit.library.Measure") instruction (one that does not have any properties defined). Previously this would raise an exception trying to parse the target. Fixed [#8969](https://github.com/Qiskit/qiskit-terra/issues/8969)
+
+*   Fixed an issue with the [`VF2Layout`](/api/qiskit/qiskit.transpiler.passes.VF2Layout "qiskit.transpiler.passes.VF2Layout") pass where it would error when running with a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") that had instructions that were missing error rates. This has been corrected so in such cases the lack of an error rate will be treated as an ideal implementation and if no error rates are present it will just select the first matching layout. Fixed [#8970](https://github.com/Qiskit/qiskit-terra/issues/8970)
+
+*   Fixed an issue with the [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") pass where it would error when running with a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") that had instructions that were missing. In such cases the lack of an error rate will be treated as an ideal implementation of the operation.
+
+*   Fixed an issue with the [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") class if more than `k=2` eigenvalues were computed. Previously this would fail due to an internal type mismatch, but now runs as expected. Fixed [#8982](https://github.com/Qiskit/qiskit-terra/issues/8982)
+
+*   Fixed a performance bug where the new primitive-based variational algorithms [`minimum_eigensolvers.VQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.VQE "qiskit.algorithms.minimum_eigensolvers.VQE"), [`eigensolvers.VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") and [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") did not batch energy evaluations per default, which resulted in a significant slowdown if a hardware backend was used.
+
+*   Zero-operand gates and instructions will now work with [`circuit_to_gate()`](/api/qiskit/converters#qiskit.converters.circuit_to_gate "qiskit.converters.circuit_to_gate"), [`QuantumCircuit.to_gate()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_gate "qiskit.circuit.QuantumCircuit.to_gate"), [`Gate.control()`](/api/qiskit/qiskit.circuit.Gate#control "qiskit.circuit.Gate.control"), and the construction of an [`Operator`](/api/qiskit/qiskit.quantum_info.Operator "qiskit.quantum_info.Operator") from a [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") containing zero-operand instructions. This edge case is occasionally useful in creating global-phase gates as part of larger compound instructions, though for many uses, [`QuantumCircuit.global_phase`](/api/qiskit/qiskit.circuit.QuantumCircuit#global_phase "qiskit.circuit.QuantumCircuit.global_phase") may be more appropriate.
+
+*   Fixes issue where [`Statevector.evolve()`](/api/qiskit/qiskit.quantum_info.Statevector#evolve "qiskit.quantum_info.Statevector.evolve") and [`DensityMatrix.evolve()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#evolve "qiskit.quantum_info.DensityMatrix.evolve") would raise an exeception for nested subsystem evolution for non-qubit subsystems. Fixes [issue #8897](https://github.com/Qiskit/qiskit-terra/issues/8897)
+
+*   Fixes bug in [`Statevector.evolve()`](/api/qiskit/qiskit.quantum_info.Statevector#evolve "qiskit.quantum_info.Statevector.evolve") where subsystem evolution will return the incorrect value in certain cases where there are 2 or more than non-evolved subsystems with different subsystem dimensions. Fixes [issue #8899](https://github.com/Qiskit/qiskit-terra/issues/8899)
+
+<span id="release-notes-aer-0-11-1" />
+
+<span id="id90" />
+
+### Aer 0.11.1
+
+<span id="release-notes-aer-0-11-1-bug-fixes" />
+
+<span id="id91" />
+
+#### Bug Fixes
+
+*   Fixed a potential build error when trying to use CMake 3.18 or newer and building qiskit-aer with GPU support enabled. Since CMake 3.18 or later when building with CUDA the `CMAKE_CUDA_ARCHITECTURES` was required to be set with the architecture value for the target GPU. This has been corrected so that setting `AER_CUDA_ARCH` will be used if this was not set.
+
+*   Fixes a bug in the handling of instructions with clbits in `LocalNoisePass`. Previously, it was accidentally erasing clbits of instructions (e.g. measures) to which the noise is applied in the case of `method="append"`.
+
+*   Fixed the performance overhead of the Sampler class when running with identical circuits on multiple executions. This was accomplished by skipping/caching the transpilation of these identical circuits on subsequent executions.
+
+*   Fixed compatibility of the [`Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html#qiskit_aer.primitives.Sampler "(in Qiskit Aer v0.13.0)") and `Estimator` primitive classes with qiskit-terra 0.22.0 release. In qiskit-terra 0.22.0 breaking API changes were made to the abstract interface which broke compatibility with these classes, this has been addressed so that [`Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html#qiskit_aer.primitives.Sampler "(in Qiskit Aer v0.13.0)") and `Estimator` can now be used with qiskit-terra >= 0.22.0.
+
+<span id="id92" />
+
+### IBM Q Provider 0.19.2
+
+No change
+
+<span id="qiskit-0-39-0" />
 ## 0.39.0
 
 This release also officially deprecates the Qiskit Aer project as part of the Qiskit metapackage. This means that in a future release `pip install qiskit` will no longer include `qiskit-aer`. If you’re currently installing or listing `qiskit` as a dependency to get Aer you should upgrade this to explicitly list `qiskit-aer` as well.
@@ -1157,360 +1515,3 @@ No change
 No change
 
 <span id="qiskit-0-38-0" />
-## 0.39.1
-
-<span id="terra-0-22-1" />
-
-<span id="release-notes-0-22-1" />
-
-### Terra 0.22.1
-
-<span id="release-notes-0-22-1-prelude" />
-
-<span id="id87" />
-
-#### Prelude
-
-Qiskit Terra 0.22.1 is a bugfix release, addressing some minor issues identified since the 0.22.0 release.
-
-<span id="release-notes-0-22-1-deprecation-notes" />
-
-<span id="id88" />
-
-#### Deprecation Notes
-
-*   The `pauli_list` kwarg of [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") has been deprecated as [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") now always returns a [`PauliList`](/api/qiskit/qiskit.quantum_info.PauliList "qiskit.quantum_info.PauliList"). This argument was removed prematurely from Qiskit Terra 0.22.0 which broke compatibility for users that were leveraging the `pauli_list``argument. Now, the argument has been restored but will emit a ``DeprecationWarning` when used. If used it has no effect because since Qiskit Terra 0.22.0 a [`PauliList`](/api/qiskit/qiskit.quantum_info.PauliList "qiskit.quantum_info.PauliList") is always returned.
-
-<span id="release-notes-0-22-1-bug-fixes" />
-
-<span id="id89" />
-
-#### Bug Fixes
-
-*   Fixed the [`BarrierBeforeFinalMeasurements`](/api/qiskit/qiskit.transpiler.passes.BarrierBeforeFinalMeasurements "qiskit.transpiler.passes.BarrierBeforeFinalMeasurements") transpiler pass when there are conditions on loose [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s immediately before the final measurement layer. Previously, this would fail claiming that the bit was not present in an internal temporary circuit. Fixed [#8923](https://github.com/Qiskit/qiskit-terra/issues/8923)
-
-*   The equality checkers for [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") and [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "qiskit.dagcircuit.DAGCircuit") (with objects of the same type) will now correctly handle conditions on single bits. Previously, these would produce false negatives for equality, as the bits would use “exact” equality checks instead of the “semantic” checks the rest of the properties of circuit instructions get.
-
-*   Fixed handling of classical bits in [`StochasticSwap`](/api/qiskit/qiskit.transpiler.passes.StochasticSwap "qiskit.transpiler.passes.StochasticSwap") with control flow. Previously, control-flow operations would be expanded to contain all the classical bits in the outer circuit and not contracted again, leading to a mismatch between the numbers of clbits the instruction reported needing and the actual number supplied to it. Fixed [#8903](https://github.com/Qiskit/qiskit-terra/issues/8903)
-
-*   Fixed handling of globally defined instructions for the [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") class. Previously, two methods, [`operations_for_qargs()`](/api/qiskit/qiskit.transpiler.Target#operations_for_qargs "qiskit.transpiler.Target.operations_for_qargs") and [`operation_names_for_qargs()`](/api/qiskit/qiskit.transpiler.Target#operation_names_for_qargs "qiskit.transpiler.Target.operation_names_for_qargs") would ignore/incorrectly handle any globally defined ideal operations present in the target. For example:
-
-    ```python
-    from qiskit.transpiler import Target
-    from qiskit.circuit.library import CXGate
-
-    target = Target(num_qubits=5)
-    target.add_instruction(CXGate())
-    names = target.operation_names_for_qargs((1, 2))
-    ops = target.operations_for_qargs((1, 2))
-    ```
-
-    will now return `{"cx"}` for `names` and `[CXGate()]` for `ops` instead of raising a `KeyError` or an empty return.
-
-*   Fixed an issue in the [`Target.add_instruction()`](/api/qiskit/qiskit.transpiler.Target#add_instruction "qiskit.transpiler.Target.add_instruction") method where it would previously have accepted an argument with an invalid number of qubits as part of the `properties` argument. For example:
-
-    ```python
-    from qiskit.transpiler import Target
-    from qiskit.circuit.library import CXGate
-
-    target = Target()
-    target.add_instruction(CXGate(), {(0, 1, 2): None})
-    ```
-
-    This will now correctly raise a `TranspilerError` instead of causing runtime issues when interacting with the target. Fixed [#8914](https://github.com/Qiskit/qiskit-terra/issues/8914)
-
-*   Fixed an issue with the [`plot_state_hinton()`](/api/qiskit/qiskit.visualization.plot_state_hinton "qiskit.visualization.plot_state_hinton") visualization function which would result in a misplaced axis that was offset from the actual plot. Fixed #8446 \<[https://github.com/Qiskit/qiskit-terra/issues/8446](https://github.com/Qiskit/qiskit-terra/issues/8446)>
-
-*   Fixed the output of the [`plot_state_hinton()`](/api/qiskit/qiskit.visualization.plot_state_hinton "qiskit.visualization.plot_state_hinton") function so that the state labels are ordered ordered correctly, and the image matches up with the natural matrix ordering. Fixed [#8324](https://github.com/Qiskit/qiskit-terra/issues/8324)
-
-*   Fixed an issue with the primitive classes, [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") when running on backends that have a limited number of circuits in each job. Not all backends support an unlimited batch size (most hardware backends do not) and previously the backend primitive classes would have potentially incorrectly sent more circuits than the backend supported. This has been corrected so that [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") will chunk the circuits into multiple jobs if the backend has a limited number of circuits per job.
-
-*   Fixed an issue with the [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") class where previously setting a run option named `monitor` to a value that evaluated as `True` would have incorrectly triggered a job monitor that only worked on backends from the `qiskit-ibmq-provider` package. This has been removed so that you can use a `monitor` run option if needed without causing any issues.
-
-*   Fixed an issue with the [`Target.build_coupling_map()`](/api/qiskit/qiskit.transpiler.Target#build_coupling_map "qiskit.transpiler.Target.build_coupling_map") method where it would incorrectly return `None` for a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object with a mix of ideal globally available instructions and instructions that have qubit constraints. Now in such cases the [`Target.build_coupling_map()`](/api/qiskit/qiskit.transpiler.Target#build_coupling_map "qiskit.transpiler.Target.build_coupling_map") will return a coupling map for the constrained instruction (unless it’s a 2 qubit operation which will return `None` because globally there is no connectivity constraint). Fixed [#8971](https://github.com/Qiskit/qiskit-terra/issues/8971)
-
-*   Fixed an issue with the [`Target.qargs`](/api/qiskit/qiskit.transpiler.Target#qargs "qiskit.transpiler.Target.qargs") attribute where it would incorrectly return `None` for a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object that contained any globally available ideal instruction.
-
-*   Fixed the premature removal of the `pauli_list` keyword argument of the [`pauli_basis()`](/api/qiskit/qiskit.quantum_info.pauli_basis "qiskit.quantum_info.pauli_basis") function which broke existing code using the `pauli_list=True` future compatibility path on upgrade to Qiskit Terra 0.22.0. This keyword argument has been added back to the function and is now deprecated and will be removed in a future release.
-
-*   Fixed an issue in QPY serialization ([`dump()`](/api/qiskit/qpy#qiskit.qpy.dump "qiskit.qpy.dump")) when a custom [`ControlledGate`](/api/qiskit/qiskit.circuit.ControlledGate "qiskit.circuit.ControlledGate") subclass that overloaded the `_define()` method to provide a custom definition for the operation. Previously, this case of operation was not serialized correctly because it wasn’t accounting for using the potentially `_define()` method to provide a definition. Fixes [#8794](https://github.com/Qiskit/qiskit-terra/issues/8794)
-
-*   QPY deserialisation will no longer add extra [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") instances to the circuit if there are both loose [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s in the circuit and more [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit")s than [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s.
-
-*   QPY deserialisation will no longer add registers named q and c if the input circuit contained only loose bits.
-
-*   Fixed the [`SparsePauliOp.dot()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#dot "qiskit.quantum_info.SparsePauliOp.dot") method when run on two operators with real coefficients. To fix this, the dtype that `SparsePauliOp` can take is restricted to `np.complex128` and `object`. Fixed [#8992](https://github.com/Qiskit/qiskit-terra/issues/8992)
-
-*   Fixed an issue in the [`circuit_drawer()`](/api/qiskit/qiskit.visualization.circuit_drawer "qiskit.visualization.circuit_drawer") function and `QuantumCircuit.draw()` method where the only built-in style for the `mpl` output that was usable was `default`. If another built-in style, such as `iqx`, were used then a warning about the style not being found would be emitted and the drawer would fall back to use the `default` style. Fixed [#8991](https://github.com/Qiskit/qiskit-terra/issues/8991)
-
-*   Fixed an issue with the [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") where it would previously fail with a `TypeError` if a custom [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") object was passed in via the `target` argument and a list of multiple circuits were specified for the `circuits` argument.
-
-*   Fixed an issue with [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") when targeting a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") (either directly via the `target` argument or via a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") instance from the `backend` argument) that contained an ideal [`Measure`](/api/qiskit/qiskit.circuit.library.Measure "qiskit.circuit.library.Measure") instruction (one that does not have any properties defined). Previously this would raise an exception trying to parse the target. Fixed [#8969](https://github.com/Qiskit/qiskit-terra/issues/8969)
-
-*   Fixed an issue with the [`VF2Layout`](/api/qiskit/qiskit.transpiler.passes.VF2Layout "qiskit.transpiler.passes.VF2Layout") pass where it would error when running with a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") that had instructions that were missing error rates. This has been corrected so in such cases the lack of an error rate will be treated as an ideal implementation and if no error rates are present it will just select the first matching layout. Fixed [#8970](https://github.com/Qiskit/qiskit-terra/issues/8970)
-
-*   Fixed an issue with the [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") pass where it would error when running with a [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target") that had instructions that were missing. In such cases the lack of an error rate will be treated as an ideal implementation of the operation.
-
-*   Fixed an issue with the [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") class if more than `k=2` eigenvalues were computed. Previously this would fail due to an internal type mismatch, but now runs as expected. Fixed [#8982](https://github.com/Qiskit/qiskit-terra/issues/8982)
-
-*   Fixed a performance bug where the new primitive-based variational algorithms [`minimum_eigensolvers.VQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.VQE "qiskit.algorithms.minimum_eigensolvers.VQE"), [`eigensolvers.VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") and [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") did not batch energy evaluations per default, which resulted in a significant slowdown if a hardware backend was used.
-
-*   Zero-operand gates and instructions will now work with [`circuit_to_gate()`](/api/qiskit/converters#qiskit.converters.circuit_to_gate "qiskit.converters.circuit_to_gate"), [`QuantumCircuit.to_gate()`](/api/qiskit/qiskit.circuit.QuantumCircuit#to_gate "qiskit.circuit.QuantumCircuit.to_gate"), [`Gate.control()`](/api/qiskit/qiskit.circuit.Gate#control "qiskit.circuit.Gate.control"), and the construction of an [`Operator`](/api/qiskit/qiskit.quantum_info.Operator "qiskit.quantum_info.Operator") from a [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") containing zero-operand instructions. This edge case is occasionally useful in creating global-phase gates as part of larger compound instructions, though for many uses, [`QuantumCircuit.global_phase`](/api/qiskit/qiskit.circuit.QuantumCircuit#global_phase "qiskit.circuit.QuantumCircuit.global_phase") may be more appropriate.
-
-*   Fixes issue where [`Statevector.evolve()`](/api/qiskit/qiskit.quantum_info.Statevector#evolve "qiskit.quantum_info.Statevector.evolve") and [`DensityMatrix.evolve()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#evolve "qiskit.quantum_info.DensityMatrix.evolve") would raise an exeception for nested subsystem evolution for non-qubit subsystems. Fixes [issue #8897](https://github.com/Qiskit/qiskit-terra/issues/8897)
-
-*   Fixes bug in [`Statevector.evolve()`](/api/qiskit/qiskit.quantum_info.Statevector#evolve "qiskit.quantum_info.Statevector.evolve") where subsystem evolution will return the incorrect value in certain cases where there are 2 or more than non-evolved subsystems with different subsystem dimensions. Fixes [issue #8899](https://github.com/Qiskit/qiskit-terra/issues/8899)
-
-<span id="release-notes-aer-0-11-1" />
-
-<span id="id90" />
-
-### Aer 0.11.1
-
-<span id="release-notes-aer-0-11-1-bug-fixes" />
-
-<span id="id91" />
-
-#### Bug Fixes
-
-*   Fixed a potential build error when trying to use CMake 3.18 or newer and building qiskit-aer with GPU support enabled. Since CMake 3.18 or later when building with CUDA the `CMAKE_CUDA_ARCHITECTURES` was required to be set with the architecture value for the target GPU. This has been corrected so that setting `AER_CUDA_ARCH` will be used if this was not set.
-
-*   Fixes a bug in the handling of instructions with clbits in `LocalNoisePass`. Previously, it was accidentally erasing clbits of instructions (e.g. measures) to which the noise is applied in the case of `method="append"`.
-
-*   Fixed the performance overhead of the Sampler class when running with identical circuits on multiple executions. This was accomplished by skipping/caching the transpilation of these identical circuits on subsequent executions.
-
-*   Fixed compatibility of the [`Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html#qiskit_aer.primitives.Sampler "(in Qiskit Aer v0.13.0)") and `Estimator` primitive classes with qiskit-terra 0.22.0 release. In qiskit-terra 0.22.0 breaking API changes were made to the abstract interface which broke compatibility with these classes, this has been addressed so that [`Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html#qiskit_aer.primitives.Sampler "(in Qiskit Aer v0.13.0)") and `Estimator` can now be used with qiskit-terra >= 0.22.0.
-
-<span id="id92" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-39-0" />
-## 0.39.2
-
-<span id="terra-0-22-2" />
-
-<span id="release-notes-terra-0-22-2" />
-
-### Terra 0.22.2
-
-<span id="release-notes-terra-0-22-2-prelude" />
-
-<span id="id83" />
-
-#### Prelude
-
-Qiskit Terra 0.22.2 is a minor bugfix release, and marks the first official support for Python 3.11.
-
-<span id="release-notes-terra-0-22-2-bug-fixes" />
-
-<span id="id84" />
-
-#### Bug Fixes
-
-*   Fixed an issue with the backend primitive classes [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") which prevented running with a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instance that does not have a `max_experiments` field set in its [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration").
-
-*   Fixed a bug in the [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") pass when transpiling for backends with a defined [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target"), where the interaction graph would be built incorrectly. This could result in excessive runtimes due to the graph being far more complex than necessary.
-
-*   The Pulse expression parser should no longer periodically hang when called from Jupyter notebooks. This is achieved by avoiding an internal `deepycopy` of a recursive object that seemed to be particularly difficult for the memoization to evaluate.
-
-<span id="id85" />
-
-### Aer 0.11.1
-
-No change
-
-<span id="id86" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-39-1" />
-## 0.39.3
-
-<span id="release-notes-terra-0-22-3" />
-
-<span id="id79" />
-
-### Terra 0.22.3
-
-<span id="release-notes-terra-0-22-3-prelude" />
-
-<span id="id80" />
-
-#### Prelude
-
-Qiskit Terra 0.22.3 is a minor bugfix release, fixing some further bugs in the 0.22 series.
-
-<span id="release-notes-terra-0-22-3-bug-fixes" />
-
-<span id="id81" />
-
-#### Bug Fixes
-
-*   `AdaptVQE` now correctly indicates that it supports auxiliary operators.
-
-*   The circuit drawers ([`QuantumCircuit.draw()`](/api/qiskit/qiskit.circuit.QuantumCircuit#draw "qiskit.circuit.QuantumCircuit.draw") and [`circuit_drawer()`](/api/qiskit/qiskit.visualization.circuit_drawer "qiskit.visualization.circuit_drawer")) will no longer emit a warning about the `cregbundle` parameter when using the default arguments, if the content of the circuit requires all bits to be drawn individually. This was most likely to appear when trying to draw circuits with new-style control-flow operations.
-
-*   Fixed a bug causing [`QNSPSA`](/api/qiskit/qiskit.algorithms.optimizers.QNSPSA "qiskit.algorithms.optimizers.QNSPSA") to fail when `max_evals_grouped` was set to a value larger than 1.
-
-*   Fixed an issue with the [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") pass which would cause the output of multiple runs of the pass without the `seed` argument specified to reuse the same random number generator seed between runs instead of using different seeds. This previously caused identical results to be returned between runs even when no `seed` was specified.
-
-*   Fixed an issue with the primitive classes, [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator"), where instances were not able to be serialized with `pickle`. In general these classes are not guaranteed to be serializable as [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") and [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instances are not required to be serializable (and often are not), but the class definitions of [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") no longer prevent the use of `pickle`.
-
-*   The `pulse.Instruction.draw()` method will now succeed, as before. This method is deprecated with no replacement planned, but it should still work for the period of deprecation.
-
-<span id="aer-0-11-1" />
-
-### Aer 0.11.1
-
-No change
-
-<span id="id82" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-39-2" />
-## 0.39.4
-
-<span id="terra-0-22-3" />
-
-### Terra 0.22.3
-
-No change
-
-<span id="release-notes-aer-0-11-2" />
-
-<span id="id74" />
-
-### Aer 0.11.2
-
-<span id="release-notes-aer-0-11-2-new-features" />
-
-<span id="id75" />
-
-#### New Features
-
-*   Added support for running Qiskit Aer with Python 3.11 support.
-
-<span id="release-notes-aer-0-11-2-known-issues" />
-
-<span id="id76" />
-
-#### Known Issues
-
-*   Fix two bugs in AerStatevector. AerStatevector uses mc\* instructions, which are not enabled in matrix\_product\_state method. This commit changes AerStatevector not to use MC\* and use H, X, Y, Z, U and CX. AerStatevector also failed if an instruction is decomposed to empty QuantumCircuit. This commit allows such instruction.
-
-<span id="release-notes-aer-0-11-2-bug-fixes" />
-
-<span id="id77" />
-
-#### Bug Fixes
-
-*   Fixed support in the `AerSimulator.from_backend()` method for instantiating an `AerSimulator` instance from an a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") object. Previously, attempting to use `AerSimulator.from_backend()` with a [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") object would have raised an `AerError` saying this wasn’t supported.
-
-*   Fixes a bug where `NoiseModel.from_backend()` with a `BackendV2` object may generate a noise model with excessive `QuantumError` s on non-Gate instructions while, for example, only `ReadoutError` s should be sufficient for measures. This commit updates `NoiseModel.from_backend()` with a `BackendV2` object so that it returns the same noise model as that called with the corresponding `BackendV1` object. That is, the resulting noise model does not contain any `QuantumError` s on measures and it may contain only thermal relaxation errors on other non-gate instructions such as resets. Note that it still contains `ReadoutError` s on measures.
-
-*   Fixed a bug in `NoiseModel.from_backend()` where using the `temperature` kwarg with a non-default value would incorrectly compute the excited state population for the specified temperature. Previously, there was an additional factor of 2 in the Boltzman distribution calculation leading to an incorrect smaller value for the excited state population.
-
-*   Fixed incorrect logic in the control-flow compiler that could allow unrelated instructions to appear “inside” control-flow bodies during execution, causing incorrect results. For example, previously:
-
-    ```python
-    from qiskit import QuantumCircuit
-    from qiskit_aer import AerSimulator
-
-    backend = AerSimulator(method="statevector")
-
-    circuit = QuantumCircuit(3, 3)
-    circuit.measure(0, 0)
-    circuit.measure(1, 1)
-
-    with circuit.if_test((0, True)):
-        with circuit.if_test((1, False)):
-            circuit.x(2)
-
-    with circuit.if_test((0, False)):
-        with circuit.if_test((1, True)):
-            circuit.x(2)
-
-    circuit.measure(range(3), range(3))
-    print(backend.run(circuit, method=method, shots=100).result())
-    ```
-
-    would print `{'010': 100}` as the nested control-flow operations would accidentally jump over the first X gate on qubit 2, which should have been executed.
-
-*   Fixes a bug where `NoiseModel.from_backend()` prints verbose warnings when supplying a backend that reports un-physical device parameters such as T2 > 2 \* T1 due to statistical errors in their estimation. This commit removes such warnings because they are not actionable for users in the sense that there are no means other than truncating them to the theoretical bounds as done within `noise.device` module. See [Issue 1631](https://github.com/Qiskit/qiskit-aer/issues/1631) for details of the fixed bug.
-
-*   This is fix for GPU statevector simulator. Chunk distribution tried to allocate all free memory on GPU, but this causes memory allocation error. So this fix allocates 80 percent of free memory. Also this fixes size of matrix buffer when noise sampling is applied.
-
-*   This is a fix of AerState running with cache blocking. AerState wrongly configured transpiler of Aer for cache blocking, and then its algorithm to swap qubits worked wrongly. This fix corrects AerState to use this transpiler. More specifically, After the transpilation, a swapped qubit map is recoverd to the original map when using AerState. This fix is necessary for AerStatevector to use multiple-GPUs.
-
-*   This is fix for AerStatevector. It was not possible to create an AerStatevector instance directly from terra’s Statevector. This fix allows a Statevector as AerStatevector’s input.
-
-*   [`SamplerResult.quasi_dists`](/api/qiskit/qiskit.primitives.SamplerResult#quasi_dists "qiskit.primitives.SamplerResult.quasi_dists") contain the data about the number of qubits. `QuasiDistribution.binary_probabilities()` returns bitstrings with correct length.
-
-*   Previously seed is not initialized in AerStatevector and then sampled results are always same. With this commit, a seed is initialized for each sampling and sampled results can be vary.
-
-<span id="id78" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-39-3" />
-## 0.39.5
-
-<span id="terra-0-22-4" />
-
-<span id="release-notes-terra-0-22-4" />
-
-### Terra 0.22.4
-
-<span id="release-notes-terra-0-22-4-prelude" />
-
-<span id="id70" />
-
-#### Prelude
-
-Qiskit Terra 0.22.4 is a minor bugfix release, fixing some bugs identified in the 0.22 series.
-
-<span id="release-notes-terra-0-22-4-bug-fixes" />
-
-<span id="id71" />
-
-#### Bug Fixes
-
-*   Fixed a bug in [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") that raised an error if its [`run()`](/api/qiskit/qiskit.primitives.BackendSampler#run "qiskit.primitives.BackendSampler.run") method was called two times sequentially.
-
-*   Fixed two bugs in the [`ComposedOp`](/api/qiskit/qiskit.opflow.list_ops.ComposedOp "qiskit.opflow.list_ops.ComposedOp") where the [`ComposedOp.to_matrix()`](/api/qiskit/qiskit.opflow.list_ops.ComposedOp#to_matrix "qiskit.opflow.list_ops.ComposedOp.to_matrix") method did not provide the correct results for compositions with [`StateFn`](/api/qiskit/qiskit.opflow.state_fns.StateFn "qiskit.opflow.state_fns.StateFn") and for compositions with a global coefficient. Fixed [#9283](https://github.com/Qiskit/qiskit-terra/issues/9283).
-
-*   Fixed the problem in which primitives, [`Sampler`](/api/qiskit/qiskit.primitives.Sampler "qiskit.primitives.Sampler") and [`Estimator`](/api/qiskit/qiskit.primitives.Estimator "qiskit.primitives.Estimator"), did not work when passed a circuit with `numpy.ndarray` as a parameter.
-
-*   Fixed a bug in [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") where the `aggregation` argument did not have an effect. Now the aggregation function and, with it, the CVaR expectation value can correctly be specified.
-
-*   Fixed a performance bug where [`SamplingVQE`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.SamplingVQE "qiskit.algorithms.minimum_eigensolvers.SamplingVQE") evaluated the energies of eigenstates in a slow manner.
-
-*   Fixed the autoevaluation of the beta parameters in [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD"), added support for [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp") inputs, and fixed the energy evaluation function to leverage the asynchronous execution of primitives, by only retrieving the job results after both jobs have been submitted.
-
-*   Fixed an issue with the [`Statevector.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.Statevector#probabilities_dict "qiskit.quantum_info.Statevector.probabilities_dict") and [`DensityMatrix.probabilities_dict()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#probabilities_dict "qiskit.quantum_info.DensityMatrix.probabilities_dict") methods where they would return incorrect results for non-qubit systems when the `qargs` argument was specified. Fixed [#9210](https://github.com/Qiskit/qiskit-terra/issues/9210)
-
-*   Fixed handling of some `classmethod`s by [`wrap_method()`](/api/qiskit/utils#qiskit.utils.wrap_method "qiskit.utils.wrap_method") in Python 3.11. Previously, in Python 3.11, `wrap_method` would wrap the unbound function associated with the `classmethod` and then fail when invoked because the class object usually bound to the `classmethod` was not passed to the function. Starting in Python 3.11.1, this issue affected `QiskitTestCase`, preventing it from being imported by other test code. Fixed [#9291](https://github.com/Qiskit/qiskit-terra/issues/9291).
-
-<span id="id72" />
-
-### Aer 0.11.2
-
-No change
-
-<span id="id73" />
-
-### IBM Q Provider 0.19.2
-
-No change
-
-<span id="qiskit-0-39-4" />

--- a/docs/api/qiskit/release-notes/0.41.md
+++ b/docs/api/qiskit/release-notes/0.41.md
@@ -5,6 +5,68 @@ description: New features and bug fixes
 
 # Qiskit 0.41 release notes
 
+## 0.41.1
+
+<span id="release-notes-terra-0-23-2" />
+
+<span id="id55" />
+
+### Terra 0.23.2
+
+<span id="release-notes-terra-0-23-2-prelude" />
+
+<span id="id56" />
+
+#### Prelude
+
+The Qiskit Terra 0.23.2 patch release fixes further bugs identified in the 0.23 series.
+
+<span id="release-notes-terra-0-23-2-bug-fixes" />
+
+<span id="id57" />
+
+#### Bug Fixes
+
+*   Add the following Clifford gates, that already exist in the circuit library, to the [`Clifford`](/api/qiskit/qiskit.quantum_info.Clifford "qiskit.quantum_info.Clifford") class: [`SXGate`](/api/qiskit/qiskit.circuit.library.SXGate "qiskit.circuit.library.SXGate"), [`SXdgGate`](/api/qiskit/qiskit.circuit.library.SXdgGate "qiskit.circuit.library.SXdgGate"), [`CYGate`](/api/qiskit/qiskit.circuit.library.CYGate "qiskit.circuit.library.CYGate"), [`DCXGate`](/api/qiskit/qiskit.circuit.library.DCXGate "qiskit.circuit.library.DCXGate"), [`iSwapGate`](/api/qiskit/qiskit.circuit.library.iSwapGate "qiskit.circuit.library.iSwapGate") and [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate").
+
+*   Add a decomposition of an [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate") into Clifford gates (up to a global phase) to the standard equivalence library.
+
+*   Fixed an issue with the [`BackendV2Converter`](/api/qiskit/qiskit.providers.BackendV2Converter "qiskit.providers.BackendV2Converter") class when wrapping a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1")-based simulator. It would error if either the `online_date` field in the [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration") for the simulator was not present or if the simulator backend supported ideal implementations of gates that involve more than 1 qubit. Fixed [#9562](https://github.com/Qiskit/qiskit-terra/issues/9562).
+
+*   Fixed an incorrect return value of the method `BackendV2Converter.meas_map()` that had returned the backend `dt` instead.
+
+*   Fixed missing return values from the methods [`BackendV2Converter.drive_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#drive_channel "qiskit.providers.BackendV2Converter.drive_channel"), [`measure_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#measure_channel "qiskit.providers.BackendV2Converter.measure_channel"), [`acquire_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#acquire_channel "qiskit.providers.BackendV2Converter.acquire_channel") and [`control_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#control_channel "qiskit.providers.BackendV2Converter.control_channel").
+
+*   The deprecated [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") and [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") properties [`register`](/api/qiskit/qiskit.circuit.Qubit#register "qiskit.circuit.Qubit.register") and [`index`](/api/qiskit/qiskit.circuit.Qubit#index "qiskit.circuit.Qubit.index") will now be correctly round-tripped by QPY ([`qiskit.qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy")) in all valid usages of [`QuantumRegister`](/api/qiskit/qiskit.circuit.QuantumRegister "qiskit.circuit.QuantumRegister") and [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister"). In earlier releases in the Terra 0.23 series, this information would be lost. In versions before 0.23.0, this information was partially reconstructed but could be incorrect or produce invalid circuits for certain register configurations.
+
+    The correct way to retrieve the index of a bit within a circuit, and any registers in that circuit the bit is contained within is to call [`QuantumCircuit.find_bit()`](/api/qiskit/qiskit.circuit.QuantumCircuit#find_bit "qiskit.circuit.QuantumCircuit.find_bit"). This method will return the correct information in all versions of Terra since its addition in version 0.19.
+
+*   Fixed an issue with the [`InstructionScheduleMap.has_custom_gate()`](/api/qiskit/qiskit.pulse.InstructionScheduleMap#has_custom_gate "qiskit.pulse.InstructionScheduleMap.has_custom_gate") method, where it would always return `True` when the [`InstructionScheduleMap`](/api/qiskit/qiskit.pulse.InstructionScheduleMap "qiskit.pulse.InstructionScheduleMap") object was created by [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target"). Fixed [#9595](https://github.com/Qiskit/qiskit-terra/issues/9595).
+
+*   Fixed a bug in the NumPy-based eigensolvers ([`NumPyMinimumEigensolver`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver") / [`NumPyEigensolver`](/api/qiskit/qiskit.algorithms.eigensolvers.NumPyEigensolver "qiskit.algorithms.eigensolvers.NumPyEigensolver")) and in the SciPy-based time evolvers ([`SciPyRealEvolver`](/api/qiskit/qiskit.algorithms.SciPyRealEvolver "qiskit.algorithms.SciPyRealEvolver") / [`SciPyImaginaryEvolver`](/api/qiskit/qiskit.algorithms.SciPyImaginaryEvolver "qiskit.algorithms.SciPyImaginaryEvolver")), where operators that support conversion to sparse matrices, such as [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp"), were converted to dense matrices anyways.
+
+*   Fixed a bug in [`generate_basic_approximations()`](/api/qiskit/synthesis#qiskit.synthesis.generate_basic_approximations "qiskit.synthesis.generate_basic_approximations") where the inverse of the [`SdgGate`](/api/qiskit/qiskit.circuit.library.SdgGate "qiskit.circuit.library.SdgGate") was not correctly recognized as [`SGate`](/api/qiskit/qiskit.circuit.library.SGate "qiskit.circuit.library.SGate"). Fixed [#9585](https://github.com/Qiskit/qiskit-terra/issues/9585).
+
+*   Fixed a bug in the [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") algorithm where the energy evaluation function could not process batches of parameters, making it incompatible with optimizers with `max_evals_grouped>1`. Fixed [#9500](https://github.com/Qiskit/qiskit-terra/issues/9500).
+
+*   Fixed bug in [`QNSPSA`](/api/qiskit/qiskit.algorithms.optimizers.QNSPSA "qiskit.algorithms.optimizers.QNSPSA") which raised a type error when the computed fidelities happened to be of type `int` but the perturbation was of type `float`.
+
+<span id="aer-0-11-2" />
+
+### Aer 0.11.2
+
+No change
+
+<span id="ibm-q-provider-0-20-1" />
+
+<span id="release-notes-ibmq-0-20-1" />
+
+### IBM Q Provider 0.20.1
+
+Since `qiskit-ibmq-provider` is now deprecated, the dependencies have been bumped and fixed to the latest working versions. There was an issue with the latest version of the `requests-ntlm` package which caused some end to end tests to fail.
+
+<span id="qiskit-0-41-0" />
+
 ## 0.41.0
 
 <span id="terra-0-23-1" />
@@ -82,64 +144,3 @@ for links to the migration guides for moving from `qiskit-ibmq-provider` to its 
 *   Calls to run a quantum circuit with `dynamic=True` now raise an error that asks the user to install the new `qiskit-ibm-provider`.
 
 <span id="qiskit-0-40-0" />
-## 0.41.1
-
-<span id="release-notes-terra-0-23-2" />
-
-<span id="id55" />
-
-### Terra 0.23.2
-
-<span id="release-notes-terra-0-23-2-prelude" />
-
-<span id="id56" />
-
-#### Prelude
-
-The Qiskit Terra 0.23.2 patch release fixes further bugs identified in the 0.23 series.
-
-<span id="release-notes-terra-0-23-2-bug-fixes" />
-
-<span id="id57" />
-
-#### Bug Fixes
-
-*   Add the following Clifford gates, that already exist in the circuit library, to the [`Clifford`](/api/qiskit/qiskit.quantum_info.Clifford "qiskit.quantum_info.Clifford") class: [`SXGate`](/api/qiskit/qiskit.circuit.library.SXGate "qiskit.circuit.library.SXGate"), [`SXdgGate`](/api/qiskit/qiskit.circuit.library.SXdgGate "qiskit.circuit.library.SXdgGate"), [`CYGate`](/api/qiskit/qiskit.circuit.library.CYGate "qiskit.circuit.library.CYGate"), [`DCXGate`](/api/qiskit/qiskit.circuit.library.DCXGate "qiskit.circuit.library.DCXGate"), [`iSwapGate`](/api/qiskit/qiskit.circuit.library.iSwapGate "qiskit.circuit.library.iSwapGate") and [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate").
-
-*   Add a decomposition of an [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate") into Clifford gates (up to a global phase) to the standard equivalence library.
-
-*   Fixed an issue with the [`BackendV2Converter`](/api/qiskit/qiskit.providers.BackendV2Converter "qiskit.providers.BackendV2Converter") class when wrapping a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1")-based simulator. It would error if either the `online_date` field in the [`BackendConfiguration`](/api/qiskit/qiskit.providers.models.BackendConfiguration "qiskit.providers.models.BackendConfiguration") for the simulator was not present or if the simulator backend supported ideal implementations of gates that involve more than 1 qubit. Fixed [#9562](https://github.com/Qiskit/qiskit-terra/issues/9562).
-
-*   Fixed an incorrect return value of the method `BackendV2Converter.meas_map()` that had returned the backend `dt` instead.
-
-*   Fixed missing return values from the methods [`BackendV2Converter.drive_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#drive_channel "qiskit.providers.BackendV2Converter.drive_channel"), [`measure_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#measure_channel "qiskit.providers.BackendV2Converter.measure_channel"), [`acquire_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#acquire_channel "qiskit.providers.BackendV2Converter.acquire_channel") and [`control_channel()`](/api/qiskit/qiskit.providers.BackendV2Converter#control_channel "qiskit.providers.BackendV2Converter.control_channel").
-
-*   The deprecated [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit") and [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit") properties [`register`](/api/qiskit/qiskit.circuit.Qubit#register "qiskit.circuit.Qubit.register") and [`index`](/api/qiskit/qiskit.circuit.Qubit#index "qiskit.circuit.Qubit.index") will now be correctly round-tripped by QPY ([`qiskit.qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy")) in all valid usages of [`QuantumRegister`](/api/qiskit/qiskit.circuit.QuantumRegister "qiskit.circuit.QuantumRegister") and [`ClassicalRegister`](/api/qiskit/qiskit.circuit.ClassicalRegister "qiskit.circuit.ClassicalRegister"). In earlier releases in the Terra 0.23 series, this information would be lost. In versions before 0.23.0, this information was partially reconstructed but could be incorrect or produce invalid circuits for certain register configurations.
-
-    The correct way to retrieve the index of a bit within a circuit, and any registers in that circuit the bit is contained within is to call [`QuantumCircuit.find_bit()`](/api/qiskit/qiskit.circuit.QuantumCircuit#find_bit "qiskit.circuit.QuantumCircuit.find_bit"). This method will return the correct information in all versions of Terra since its addition in version 0.19.
-
-*   Fixed an issue with the [`InstructionScheduleMap.has_custom_gate()`](/api/qiskit/qiskit.pulse.InstructionScheduleMap#has_custom_gate "qiskit.pulse.InstructionScheduleMap.has_custom_gate") method, where it would always return `True` when the [`InstructionScheduleMap`](/api/qiskit/qiskit.pulse.InstructionScheduleMap "qiskit.pulse.InstructionScheduleMap") object was created by [`Target`](/api/qiskit/qiskit.transpiler.Target "qiskit.transpiler.Target"). Fixed [#9595](https://github.com/Qiskit/qiskit-terra/issues/9595).
-
-*   Fixed a bug in the NumPy-based eigensolvers ([`NumPyMinimumEigensolver`](/api/qiskit/qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver") / [`NumPyEigensolver`](/api/qiskit/qiskit.algorithms.eigensolvers.NumPyEigensolver "qiskit.algorithms.eigensolvers.NumPyEigensolver")) and in the SciPy-based time evolvers ([`SciPyRealEvolver`](/api/qiskit/qiskit.algorithms.SciPyRealEvolver "qiskit.algorithms.SciPyRealEvolver") / [`SciPyImaginaryEvolver`](/api/qiskit/qiskit.algorithms.SciPyImaginaryEvolver "qiskit.algorithms.SciPyImaginaryEvolver")), where operators that support conversion to sparse matrices, such as [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp "qiskit.quantum_info.SparsePauliOp"), were converted to dense matrices anyways.
-
-*   Fixed a bug in [`generate_basic_approximations()`](/api/qiskit/synthesis#qiskit.synthesis.generate_basic_approximations "qiskit.synthesis.generate_basic_approximations") where the inverse of the [`SdgGate`](/api/qiskit/qiskit.circuit.library.SdgGate "qiskit.circuit.library.SdgGate") was not correctly recognized as [`SGate`](/api/qiskit/qiskit.circuit.library.SGate "qiskit.circuit.library.SGate"). Fixed [#9585](https://github.com/Qiskit/qiskit-terra/issues/9585).
-
-*   Fixed a bug in the [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") algorithm where the energy evaluation function could not process batches of parameters, making it incompatible with optimizers with `max_evals_grouped>1`. Fixed [#9500](https://github.com/Qiskit/qiskit-terra/issues/9500).
-
-*   Fixed bug in [`QNSPSA`](/api/qiskit/qiskit.algorithms.optimizers.QNSPSA "qiskit.algorithms.optimizers.QNSPSA") which raised a type error when the computed fidelities happened to be of type `int` but the perturbation was of type `float`.
-
-<span id="aer-0-11-2" />
-
-### Aer 0.11.2
-
-No change
-
-<span id="ibm-q-provider-0-20-1" />
-
-<span id="release-notes-ibmq-0-20-1" />
-
-### IBM Q Provider 0.20.1
-
-Since `qiskit-ibmq-provider` is now deprecated, the dependencies have been bumped and fixed to the latest working versions. There was an issue with the latest version of the `requests-ntlm` package which caused some end to end tests to fail.
-
-<span id="qiskit-0-41-0" />

--- a/docs/api/qiskit/release-notes/0.42.md
+++ b/docs/api/qiskit/release-notes/0.42.md
@@ -5,6 +5,72 @@ description: New features and bug fixes
 
 # Qiskit 0.42 release notes
 
+## 0.42.1
+
+<span id="terra-0-23-3" />
+
+<span id="release-notes-terra-0-23-3" />
+
+### Terra 0.23.3
+
+<span id="release-notes-terra-0-23-3-prelude" />
+
+<span id="id43" />
+
+#### Prelude
+
+Qiskit Terra 0.23.3 is a minor bugfix release.
+
+<span id="release-notes-terra-0-23-3-bug-fixes" />
+
+<span id="id44" />
+
+#### Bug Fixes
+
+*   Fixes a bug in the [`Optimize1qGatesDecomposition`](/api/qiskit/qiskit.transpiler.passes.Optimize1qGatesDecomposition "qiskit.transpiler.passes.Optimize1qGatesDecomposition") transformation pass where the score for substitutions was wrongly calculated when the gate errors are zero.
+
+*   The method [`ECRGate.inverse()`](/api/qiskit/qiskit.circuit.library.ECRGate#inverse "qiskit.circuit.library.ECRGate.inverse") now returns another [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate") instance rather than a custom gate, since it is self inverse.
+
+*   Clip probabilities in the `QuantumState.probabilities()` and `QuantumState.probabilities_dict()` methods to the interval `[0, 1]`. This fixes roundoff errors where probabilities could e.g. be larger than 1, leading to errors in the shot emulation of the sampler. Fixed [#9761](https://github.com/Qiskit/qiskit-terra/issues/9761).
+
+*   Fixed a bug in the [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") where the binary probability bitstrings were truncated to the minimal number of bits required to represent the largest outcome as integer. That means that if e.g. `{"0001": 1.0}` was measured, the result was truncated to `{"1": 1.0}`.
+
+*   Fixed an issue with the [`PassManagerConfig.from_backend()`](/api/qiskit/qiskit.transpiler.PassManagerConfig#from_backend "qiskit.transpiler.PassManagerConfig.from_backend") constructor method when it was used with a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") based simulator backend. For some simulator backends which did not populate some optional fields the constructor would error. Fixed [#9265](https://github.com/Qiskit/qiskit-terra/issues/9265) and [#8546](https://github.com/Qiskit/qiskit-terra/issues/8546)
+
+*   Fixed the [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") to run successfully with a custom `bound_pass_manager`. Previously, the execution for single circuits with a `bound_pass_manager` would raise a `ValueError` because a list was not returned in one of the steps.
+
+*   The [`GateDirection`](/api/qiskit/qiskit.transpiler.passes.GateDirection "qiskit.transpiler.passes.GateDirection") transpiler pass will no longer reject gates that have been given explicit calibrations, but do not exist in the generic coupling map or target.
+
+*   Fixed an issue with the [`CommutationChecker`](/api/qiskit/qiskit.circuit.CommutationChecker "qiskit.circuit.CommutationChecker") class where it would attempt to internally allocate an array for $2^{n}$ qubits when it only needed an array to represent $n$ qubits. This could cause an excessive amount of memory for wide gates, for example a 4 qubit gate would require 32 gigabytes instead of 2 kilobytes. Fixed [#9197](https://github.com/Qiskit/qiskit-terra/issues/9197)
+
+*   Getting empty calibration from [`InstructionProperties`](/api/qiskit/qiskit.transpiler.InstructionProperties "qiskit.transpiler.InstructionProperties") raises AttributeError has been fixed. Now it returns `None`.
+
+*   Fixed [`qasm()`](/api/qiskit/qiskit.circuit.QuantumCircuit#qasm "qiskit.circuit.QuantumCircuit.qasm") so that it appends `;` after `reset` instruction.
+
+*   Register and parameter names will now be escaped during the OpenQASM 3 export ([`qasm3.dumps()`](/api/qiskit/qasm3#qiskit.qasm3.dumps "qiskit.qasm3.dumps")) if they are not already valid identifiers. Fixed [#9658](https://github.com/Qiskit/qiskit-terra/issues/9658).
+
+*   QPY (using [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load")) will now correctly deserialize [`StatePreparation`](/api/qiskit/qiskit.circuit.library.StatePreparation "qiskit.circuit.library.StatePreparation") instructions. Previously, QPY would error when attempting to load a file containing one. Fixed [#8297](https://github.com/Qiskit/qiskit-terra/issues/8297).
+
+*   Fixed a bug in [`random_circuit()`](/api/qiskit/circuit#qiskit.circuit.random.random_circuit "qiskit.circuit.random.random_circuit") with 64 or more qubits and `conditional=True`, where the resulting circuit could have an incorrectly typed value in its condition, causing a variety of failures during transpilation or other circuit operations. Fixed [#9649](https://github.com/Qiskit/qiskit-terra/issues/9649).
+
+*   Fixed an issue with the [`OneQubitEulerDecomposer`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer "qiskit.quantum_info.OneQubitEulerDecomposer") class’s methods [`angles()`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer#angles "qiskit.quantum_info.OneQubitEulerDecomposer.angles") and [`angles_and_phase()`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer#angles_and_phase "qiskit.quantum_info.OneQubitEulerDecomposer.angles_and_phase") would error if the input matrix was of a dtype other than `complex`/`np.cdouble`. In earlier releases this worked fine but this stopped working in Qiskit Terra 0.23.0 when the internals of [`OneQubitEulerDecomposer`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer "qiskit.quantum_info.OneQubitEulerDecomposer") were re-written in Rust. Fixed [#9827](https://github.com/Qiskit/qiskit-terra/issues/9827)
+
+*   The Qiskit gates [`CCZGate`](/api/qiskit/qiskit.circuit.library.CCZGate "qiskit.circuit.library.CCZGate"), [`CSGate`](/api/qiskit/qiskit.circuit.library.CSGate "qiskit.circuit.library.CSGate"), [`CSdgGate`](/api/qiskit/qiskit.circuit.library.CSdgGate "qiskit.circuit.library.CSdgGate") are not defined in `qelib1.inc` and, therefore, when dump as OpenQASM 2.0, their definition should be inserted in the file. Fixes [#9559](https://github.com/Qiskit/qiskit-terra/issues/9559), [#9721](https://github.com/Qiskit/qiskit-terra/issues/9721), and [#9722](https://github.com/Qiskit/qiskit-terra/issues/9722).
+
+<span id="id45" />
+
+### Aer 0.12.0
+
+No change
+
+<span id="id46" />
+
+### IBM Q Provider 0.20.2
+
+No change
+
+<span id="qiskit-0-42-0" />
+
 ## 0.42.0
 
 <span id="terra-0-23-2" />
@@ -183,68 +249,3 @@ The Qiskit Aer 0.12.0 release highlights are:
 This release removes the overly restrictive version constraints set in the requirements for the package added in 0.20.1. For the 0.20.1 the only dependency that was intended to have a version cap was the `requests-ntlm` package as its new release was the only dependency which currently has an incompatibility with `qiskit-ibmq-provider`. The other version caps which were added as part of 0.20.1 were causing installation issues in several environments because it made the `qiskit-ibmq-provider` package incompatible with the dependency versions used in other packages.
 
 <span id="qiskit-0-41-1" />
-## 0.42.1
-
-<span id="terra-0-23-3" />
-
-<span id="release-notes-terra-0-23-3" />
-
-### Terra 0.23.3
-
-<span id="release-notes-terra-0-23-3-prelude" />
-
-<span id="id43" />
-
-#### Prelude
-
-Qiskit Terra 0.23.3 is a minor bugfix release.
-
-<span id="release-notes-terra-0-23-3-bug-fixes" />
-
-<span id="id44" />
-
-#### Bug Fixes
-
-*   Fixes a bug in the [`Optimize1qGatesDecomposition`](/api/qiskit/qiskit.transpiler.passes.Optimize1qGatesDecomposition "qiskit.transpiler.passes.Optimize1qGatesDecomposition") transformation pass where the score for substitutions was wrongly calculated when the gate errors are zero.
-
-*   The method [`ECRGate.inverse()`](/api/qiskit/qiskit.circuit.library.ECRGate#inverse "qiskit.circuit.library.ECRGate.inverse") now returns another [`ECRGate`](/api/qiskit/qiskit.circuit.library.ECRGate "qiskit.circuit.library.ECRGate") instance rather than a custom gate, since it is self inverse.
-
-*   Clip probabilities in the `QuantumState.probabilities()` and `QuantumState.probabilities_dict()` methods to the interval `[0, 1]`. This fixes roundoff errors where probabilities could e.g. be larger than 1, leading to errors in the shot emulation of the sampler. Fixed [#9761](https://github.com/Qiskit/qiskit-terra/issues/9761).
-
-*   Fixed a bug in the [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") where the binary probability bitstrings were truncated to the minimal number of bits required to represent the largest outcome as integer. That means that if e.g. `{"0001": 1.0}` was measured, the result was truncated to `{"1": 1.0}`.
-
-*   Fixed an issue with the [`PassManagerConfig.from_backend()`](/api/qiskit/qiskit.transpiler.PassManagerConfig#from_backend "qiskit.transpiler.PassManagerConfig.from_backend") constructor method when it was used with a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") based simulator backend. For some simulator backends which did not populate some optional fields the constructor would error. Fixed [#9265](https://github.com/Qiskit/qiskit-terra/issues/9265) and [#8546](https://github.com/Qiskit/qiskit-terra/issues/8546)
-
-*   Fixed the [`BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler "qiskit.primitives.BackendSampler") and [`BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator "qiskit.primitives.BackendEstimator") to run successfully with a custom `bound_pass_manager`. Previously, the execution for single circuits with a `bound_pass_manager` would raise a `ValueError` because a list was not returned in one of the steps.
-
-*   The [`GateDirection`](/api/qiskit/qiskit.transpiler.passes.GateDirection "qiskit.transpiler.passes.GateDirection") transpiler pass will no longer reject gates that have been given explicit calibrations, but do not exist in the generic coupling map or target.
-
-*   Fixed an issue with the [`CommutationChecker`](/api/qiskit/qiskit.circuit.CommutationChecker "qiskit.circuit.CommutationChecker") class where it would attempt to internally allocate an array for $2^{n}$ qubits when it only needed an array to represent $n$ qubits. This could cause an excessive amount of memory for wide gates, for example a 4 qubit gate would require 32 gigabytes instead of 2 kilobytes. Fixed [#9197](https://github.com/Qiskit/qiskit-terra/issues/9197)
-
-*   Getting empty calibration from [`InstructionProperties`](/api/qiskit/qiskit.transpiler.InstructionProperties "qiskit.transpiler.InstructionProperties") raises AttributeError has been fixed. Now it returns `None`.
-
-*   Fixed [`qasm()`](/api/qiskit/qiskit.circuit.QuantumCircuit#qasm "qiskit.circuit.QuantumCircuit.qasm") so that it appends `;` after `reset` instruction.
-
-*   Register and parameter names will now be escaped during the OpenQASM 3 export ([`qasm3.dumps()`](/api/qiskit/qasm3#qiskit.qasm3.dumps "qiskit.qasm3.dumps")) if they are not already valid identifiers. Fixed [#9658](https://github.com/Qiskit/qiskit-terra/issues/9658).
-
-*   QPY (using [`qpy.load()`](/api/qiskit/qpy#qiskit.qpy.load "qiskit.qpy.load")) will now correctly deserialize [`StatePreparation`](/api/qiskit/qiskit.circuit.library.StatePreparation "qiskit.circuit.library.StatePreparation") instructions. Previously, QPY would error when attempting to load a file containing one. Fixed [#8297](https://github.com/Qiskit/qiskit-terra/issues/8297).
-
-*   Fixed a bug in [`random_circuit()`](/api/qiskit/circuit#qiskit.circuit.random.random_circuit "qiskit.circuit.random.random_circuit") with 64 or more qubits and `conditional=True`, where the resulting circuit could have an incorrectly typed value in its condition, causing a variety of failures during transpilation or other circuit operations. Fixed [#9649](https://github.com/Qiskit/qiskit-terra/issues/9649).
-
-*   Fixed an issue with the [`OneQubitEulerDecomposer`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer "qiskit.quantum_info.OneQubitEulerDecomposer") class’s methods [`angles()`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer#angles "qiskit.quantum_info.OneQubitEulerDecomposer.angles") and [`angles_and_phase()`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer#angles_and_phase "qiskit.quantum_info.OneQubitEulerDecomposer.angles_and_phase") would error if the input matrix was of a dtype other than `complex`/`np.cdouble`. In earlier releases this worked fine but this stopped working in Qiskit Terra 0.23.0 when the internals of [`OneQubitEulerDecomposer`](/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer "qiskit.quantum_info.OneQubitEulerDecomposer") were re-written in Rust. Fixed [#9827](https://github.com/Qiskit/qiskit-terra/issues/9827)
-
-*   The Qiskit gates [`CCZGate`](/api/qiskit/qiskit.circuit.library.CCZGate "qiskit.circuit.library.CCZGate"), [`CSGate`](/api/qiskit/qiskit.circuit.library.CSGate "qiskit.circuit.library.CSGate"), [`CSdgGate`](/api/qiskit/qiskit.circuit.library.CSdgGate "qiskit.circuit.library.CSdgGate") are not defined in `qelib1.inc` and, therefore, when dump as OpenQASM 2.0, their definition should be inserted in the file. Fixes [#9559](https://github.com/Qiskit/qiskit-terra/issues/9559), [#9721](https://github.com/Qiskit/qiskit-terra/issues/9721), and [#9722](https://github.com/Qiskit/qiskit-terra/issues/9722).
-
-<span id="id45" />
-
-### Aer 0.12.0
-
-No change
-
-<span id="id46" />
-
-### IBM Q Provider 0.20.2
-
-No change
-
-<span id="qiskit-0-42-0" />

--- a/docs/api/qiskit/release-notes/0.43.md
+++ b/docs/api/qiskit/release-notes/0.43.md
@@ -5,6 +5,296 @@ description: New features and bug fixes
 
 # Qiskit 0.43 release notes
 
+## 0.43.3
+
+<span id="terra-0-24-2" />
+
+### Terra 0.24.2
+
+<span id="release-notes-0-24-2-prelude" />
+
+<span id="id4" />
+
+#### Prelude
+
+Qiskit Terra 0.24.2 is a bugfix release, addressing some minor issues identified since the 0.24.1 release.
+
+<span id="release-notes-0-24-2-upgrade-notes" />
+
+<span id="id5" />
+
+#### Upgrade Notes
+
+*   The QPY format version emitted by `dump` has increased to 8. This new format version adds support for serializing the [`QuantumCircuit.layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribute.
+
+<span id="release-notes-0-24-2-bug-fixes" />
+
+<span id="id6" />
+
+#### Bug Fixes
+
+*   Fixed the deserialization of [`DiagonalGate`](/api/qiskit/qiskit.circuit.library.DiagonalGate "qiskit.circuit.library.DiagonalGate") instances through QPY. Fixed [#10364](https://github.com/Qiskit/qiskit-terra/issues/10364)
+
+*   Fixed an issue with the `qs_decomposition()` function, which does quantum Shannon decomposition, when it was called on trivial numeric unitaries that do not benefit from this decomposition, an unexpected error was raised. This error has been fixed so that such unitaries are detected and the equivalent circuit is returned. Fixed [#10036](https://github.com/Qiskit/qiskit-terra/issues/10036)
+
+*   Fixed an issue in the the [`BasicSwap`](/api/qiskit/qiskit.transpiler.passes.BasicSwap "qiskit.transpiler.passes.BasicSwap") class that prevented the [`BasicSwap.run()`](/api/qiskit/qiskit.transpiler.passes.BasicSwap#run "qiskit.transpiler.passes.BasicSwap.run") method from functioning if the `fake_run` keyword argument was set to `True` when the class was instantiated. Fixed [#10147](https://github.com/Qiskit/qiskit-terra/issues/10147)
+
+*   Fixed an issue with copying circuits with new-style [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s and [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit")s (bits without registers) where references to these bits from the containing circuit could be broken, causing issues with serialization and circuit visualization. Fixed [#10409](https://github.com/Qiskit/qiskit-terra/issues/10409)
+
+*   The [`CheckMap`](/api/qiskit/qiskit.transpiler.passes.CheckMap "qiskit.transpiler.passes.CheckMap") transpiler pass will no longer spuriously error when dealing with nested conditional structures created by the control-flow builder interface. See [#10394](https://github.com/Qiskit/qiskit-terra/issues/10394).
+
+*   Fixed an failure of the [Pulse Builder](/api/qiskit/pulse#pulse-builder) when the context is initialized with [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2").
+
+*   Fixed the output of pulse [`measure()`](/api/qiskit/pulse#qiskit.pulse.builder.measure "qiskit.pulse.builder.measure") and [`measure_all()`](/api/qiskit/pulse#qiskit.pulse.builder.measure_all "qiskit.pulse.builder.measure_all") when functions are called with the [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend.
+
+*   Fixed the dimensions of the output density matrix from [`DensityMatrix.partial_transpose()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#partial_transpose "qiskit.quantum_info.DensityMatrix.partial_transpose") so they match the dimensions of the corresponding input density matrix.
+
+*   Importing [`qiskit.primitives`](/api/qiskit/primitives#module-qiskit.primitives "qiskit.primitives") will no longer cause deprecation warnings stemming from the deprecated [`qiskit.opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow") module. These warnings would have been hidden to users by the default Python filters, but triggered the eager import of [`opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow"), which meant that a subsequent import by a user would not trigger the warnings. Fixed [#10245](https://github.com/Qiskit/qiskit-terra/issues/10245)
+
+*   Fixed the OpenQASM 2 output of [`QuantumCircuit.qasm()`](/api/qiskit/qiskit.circuit.QuantumCircuit#qasm "qiskit.circuit.QuantumCircuit.qasm") when a custom gate object contained a gate with the same name. Ideally this shouldn’t happen for most gates, but complex algorithmic operations like the [`GroverOperator`](/api/qiskit/qiskit.circuit.library.GroverOperator "qiskit.circuit.library.GroverOperator") class could produce such structures accidentally. See [#10162](https://github.com/Qiskit/qiskit-terra/issues/10162).
+
+*   Fixed a regression in the LaTeX drawer of [`QuantumCircuit.draw()`](/api/qiskit/qiskit.circuit.QuantumCircuit#draw "qiskit.circuit.QuantumCircuit.draw") when temporary files are placed on a separate filesystem to the working directory. See [#10211](https://github.com/Qiskit/qiskit-terra/issues/10211).
+
+*   Fixed an issue with [`UnitarySynthesis`](/api/qiskit/qiskit.transpiler.passes.UnitarySynthesis "qiskit.transpiler.passes.UnitarySynthesis") when using the `target` parameter where circuits with control flow were not properly mapped to the target.
+
+*   Fixed bug in [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") where `result.optimal_values` was a copy of `result.optimal_points`. It now returns the corresponding values. Fixed [#10263](https://github.com/Qiskit/qiskit-terra/issues/10263)
+
+*   Improved the error messages returned when an attempt to convert a fully bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") into a concrete `float` or `int` failed, for example because the expression was naturally a complex number. Fixed [#9187](https://github.com/Qiskit/qiskit-terra/issues/9187)
+
+*   Fixed `float` conversions for [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") values which had, at some point in their construction history, an imaginary component that had subsequently been cancelled. When using Sympy as a backend, these conversions would usually already have worked. When using Symengine as the backend, these conversions would often fail with type errors, despite the result having been symbolically evaluated to be real, and [`ParameterExpression.is_real()`](/api/qiskit/qiskit.circuit.ParameterExpression#is_real "qiskit.circuit.ParameterExpression.is_real") being true. Fixed [#10191](https://github.com/Qiskit/qiskit-terra/issues/10191)
+
+*   Fixed the [`qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy") serialization of [`QuantumCircuit.layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribue. Previously, the [`layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribute would have been dropped when serializing a circuit to QPY. Fixed [#10112](https://github.com/Qiskit/qiskit-terra/issues/10112)
+
+<span id="aer-0-12-2" />
+
+<span id="release-notes-aer-0-12-2" />
+
+### Aer 0.12.2
+
+<span id="release-notes-aer-0-12-2-prelude" />
+
+<span id="id7" />
+
+#### Prelude
+
+Qiskit Aer 0.12.2 is the second patch release to 0.12.0. This fixes some bugs that have been discovered since the release of 0.12.1.
+
+<span id="release-notes-aer-0-12-2-upgrade-notes" />
+
+<span id="id8" />
+
+#### Upgrade Notes
+
+*   Qiskit Aer now requires CUDA version for GPU simulator to 11.2 or higher. Previously, CUDA 10.1 was the minimum supported version. This change was necessary because of changes in the upstream CUDA ecosystem, including cuQuantum support. To support users running with different versions of CUDA there is now a separate package available for running with CUDA 11: `qiskit-aer-gpu-cu11` and using the `qiskit-aer-gpu` package now requires CUDA 12. If you’re an existing user of the `qiskit-aer-gpu` package and want to use CUDA 11 you will need to run:
+
+    ```python
+    pip uninstall qiskit-aer-gpu && pip install -U qiskit-aer-gpu-cu11
+    ```
+
+    to go from the previously CUDA 10.x compatible `qiskit-aer-gpu` package’s releases to upgrade to the new CUDA 11 compatible package. If you’re running CUDA 12 locally already you can upgrade the `qiskit-aer-gpu` package as normal.
+
+<span id="release-notes-aer-0-12-2-bug-fixes" />
+
+<span id="id9" />
+
+#### Bug Fixes
+
+*   If a circuit has conditional and parameters, the circuit was not be correctly simulated because parameter bindings of Aer used wrong positions to apply parameters. This is from a lack of consideration of bfunc operations injected by conditional. With this commit, parameters are set to correct positions with consideration of injected bfun operations.
+
+*   Parameters for global phases were not correctly set in #1814. [https://github.com/Qiskit/qiskit-aer/pull/1814](https://github.com/Qiskit/qiskit-aer/pull/1814) Parameter values for global phases were copied to a template circuit and not to actual circuits to be simulated. This commit correctly copies parameter values to circuits to be simulated.
+
+*   Results of `backend.run()` were not serializable because they include `AerCircuit`s. This commit makes the results serializable by removing `AerCircuit`s from metadata.
+
+*   :meth:`QuantumCircuit.save_statevector()` does not work if the circuit is generated from OpenQASM3 text because its quantum registers have duplicated qubit instances. With this commit, :meth:`QuantumCircuit.save_statevector()` uses :data:`QuantumCircuit.qubits` to get qubits to be saved.
+
+<span id="ibm-q-provider-0-20-2" />
+
+### IBM Q Provider 0.20.2
+
+No change.
+
+<span id="qiskit-0-43-2" />
+
+## 0.43.2
+
+As a reminder, [Qiskit Aer](https://qiskit.org/ecosystem/aer/)’s inclusion in the `qiskit` package is deprecated. The next minor version of Qiskit Aer (0.13) will not be included in any release of the `qiskit` package, and you should immediately begin installing Aer separately by:
+
+```python
+pip install qiskit-aer
+```
+
+and importing it as:
+
+```python
+import qiskit_aer
+```
+
+Starting from Qiskit 0.44, the command `pip install qiskit` will no longer install Qiskit Aer, or the obsolete IBM Q Provider that has already been replaced by the new [IBM Provider](../../qiskit-ibm-provider).
+
+<span id="terra-0-24-1" />
+
+<span id="release-notes-0-24-2" />
+
+### Terra 0.24.1
+
+No change
+
+<span id="aer-0-12-1" />
+
+### Aer 0.12.1
+
+<span id="release-notes-aer-0-12-1-prelude" />
+
+<span id="id10" />
+
+#### Prelude
+
+Qiskit Aer 0.12.1 is the first patch release to 0.12.0. This fixes some bugs that have been discovered since the release of 0.12.0.
+
+<span id="release-notes-aer-0-12-1-known-issues" />
+
+<span id="id11" />
+
+#### Known Issues
+
+*   Fix a bug that returns wrong expectation values in `Estimator` when `abelian_grouping=True`.
+
+<span id="release-notes-aer-0-12-1-upgrade-notes" />
+
+<span id="id12" />
+
+#### Upgrade Notes
+
+*   Improved performance when the same circuits and multiple parameters are passed to [`Estimator`](/api/qiskit/qiskit.primitives.Estimator "qiskit.primitives.Estimator") with `approximation=True`.
+
+<span id="release-notes-aer-0-12-1-deprecation-notes" />
+
+<span id="id13" />
+
+#### Deprecation Notes
+
+*   Options of meth:\~.AerSimulator.run need to use correct types.
+
+<span id="release-notes-aer-0-12-1-bug-fixes" />
+
+<span id="id14" />
+
+#### Bug Fixes
+
+*   Performance regression due to introduction of `AER::Config` is fixed. This class has many fields but is frequently copied in `AER::Transpile::CircuitOptimization`. Originally `json_t` (former class for configuration) was also frequently copied but it does have entries in most cases and then this copy overhead is not a problem. With this fix, `AER::Transpile::CircuitOptimization` does not copy `AER::Config`.
+
+*   When BLAS calls are failed, because omp threads do not handle exceptions, Aer crashes without any error messages. This fix is for omp threads to catch exceptions correctly and then rethrow them outside of omp loops.
+
+*   Previously, parameters for gates are not validate in C++. If parameters are shorter than expected (due to custom gate), segmentaion faults are thrown. This commit adds checks whether parameter lenght is expceted. This commit will fix issues reported in #1612. [https://github.com/Qiskit/qiskit-aer/issues/1612](https://github.com/Qiskit/qiskit-aer/issues/1612)
+
+*   Since 0.12.0, parameter values in circuits are temporarily replaced with constant values and parameter values are assigned in C++ library. Therefore, if parameter\_binds is specified, simulator returns results with the constnat values as paramter values. With this commit, Aer raises an error if parameter\_binds is not specified though circuits have parameters.
+
+*   Available devices and methods are no longer queried when importing Aer.
+
+*   Previously `AerSimulator` modifies circuit metadata to maintain consistency between input and output of simulation with side effect of unexpected view of metadata from applicatiln in simiulation. This fix avoids using circuit metadata to maintain consistency internaly and then always provides consistent view of metadata to application.
+
+*   Fixed a bug where the variance in metadata in EstimatorResult was complex and now returns float.
+
+*   Fixed a build break to compile Qiskit Aer with cuQuautum support (AER\_ENABLE\_CUQUANTUM=true). This change does not affect build for CPU and normal GPU binaries.
+
+*   Fixed a bug in `from_backend()` that raised an error when the backend has no T1 and T2 values (i.e. None) for a qubit in its qubit properties. This commit updates `NoiseModel.from_backend()` and `basic_device_gate_errors()` so that they add an identity `QuantumError` (i.e. effectively no thermal relaxation error) to a qubit with no T1 and T2 values for all gates acting on qubits including the qubit. Fixed [#1779](https://github.com/Qiskit/qiskit-aer/issues/1779) and [#1815](https://github.com/Qiskit/qiskit-aer/issues/1815).
+
+*   Fix an issue even if the number of qubits is set by a coupling map or device’s configuration, when the simulation method is configured, the number of qubits is overwritten in accordance with the method. Fixed [#1769](https://github.com/Qiskit/qiskit-aer/issues/1769)
+
+*   This is fix for library path setting in CMakeLists.txt for cuQuantum SDK. Because the latest cuQuantum includes libraries for CUDA 11.x and 12.x, this fix uses CUDA version returned from FindCUDA to the path of libraries of cuQuantum and cuTENSOR.
+
+*   This is fix for static link libraries of cuQuantum when building with CUQUANTUM\_STATIC=true.
+
+*   MPI parallelization was not enabled since we have not used qobj. This fix sets the number of processes and MPI rank correctly.
+
+*   `AerCircuit` is created from a circuit by iterating its operations while skipping barrier instructions. However, skipping barrier instructions make wrong positionings of parameter bindings. This fix adds `barrier()` and keeps parametr bindings correct.
+
+*   Aer still supports Qobj as an argument of `run()` though it was deprecated. However, since 0.12.0, it always fails if no `run_options` is specified. This fix enables simulation of Qobj without `run_options`.
+
+*   Since 0.12.0, `AerConfig` is used for simulation configuration while performing strict type checking for arguments of meth:\~.AerSimulator.run. This commit adds casting if argument types are not expected.
+
+*   :meth:`QuantumCircuit.initialize()` with int value was not processed correctly as reported in #1821 \<[https://github.com/Qiskit/qiskit-aer/issues/1821](https://github.com/Qiskit/qiskit-aer/issues/1821)>. This commit enables such initialization by decomposing initialize instructions.
+
+*   [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") supports parameterization for its global\_phase. However, Aer has not allowed such parameterization and failed when transpiler generates parameterized global phases. This commit supports parameterization of global\_phase and resolve issues related to [https://github.com/Qiskit/qiskit-aer/issues/1795](https://github.com/Qiskit/qiskit-aer/issues/1795), [https://github.com/Qiskit/qiskit-aer/issues/1781](https://github.com/Qiskit/qiskit-aer/issues/1781), and [https://github.com/Qiskit/qiskit-aer/issues/1798](https://github.com/Qiskit/qiskit-aer/issues/1798).
+
+*   Aer will now use `omp_set_max_active_levels()` instead of the deprecated `omp_set_nested()` when compiled against recent versions of OpenMP.
+
+<span id="id15" />
+
+### IBM Q Provider 0.20.2
+
+No change.
+
+<span id="qiskit-0-43-1" />
+## 0.43.1
+
+<span id="release-notes-terra-0-24-1" />
+
+<span id="id16" />
+
+### Terra 0.24.1
+
+<span id="release-notes-terra-0-24-1-prelude" />
+
+<span id="id17" />
+
+#### Prelude
+
+Qiskit Terra 0.24.1 is the first patch release to 0.24.0. This fixes some bugs that have been discovered since the release of 0.24.0.
+
+<span id="release-notes-terra-0-24-1-upgrade-notes" />
+
+<span id="id18" />
+
+#### Upgrade Notes
+
+*   Changed [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters") to bind assigned integer and float values directly into the parameters of [`Instruction`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction") instances in the circuit rather than binding the values wrapped within a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression"). This change should have little user impact as `float(QuantumCircuit.data[i].operation.params[j])` still produces a `float` (and is the only way to access the value of a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression")). Also, [`Instruction()`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction") parameters could already be `float` as well as a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression"), so code dealing with instruction parameters should already handle both cases. The most likely chance for user impact is in code that uses `isinstance` to check for [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") and behaves differently depending on the result. Additionally, qpy serializes the numeric value in a bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") at a different precision than a `float` (see also the related bug fix note about [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters")).
+
+<span id="release-notes-terra-0-24-1-bug-fixes" />
+
+<span id="id19" />
+
+#### Bug Fixes
+
+*   Updated [`plot_gate_map()`](/api/qiskit/qiskit.visualization.plot_gate_map "qiskit.visualization.plot_gate_map"), [`plot_error_map()`](/api/qiskit/qiskit.visualization.plot_error_map "qiskit.visualization.plot_error_map"), and [`plot_circuit_layout()`](/api/qiskit/qiskit.visualization.plot_circuit_layout "qiskit.visualization.plot_circuit_layout") to support 433 qubit heavy-hex coupling maps. This allows coupling map visualizations for IBM Quantum’s `ibm_seattle` backend.
+
+*   Changed the binding of numeric values with [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters") to avoid a mismatch between the values of circuit instruction parameters and corresponding parameter keys in the circuit’s calibration dictionary. Fixed [#9764](https://github.com/Qiskit/qiskit-terra/issues/9764) and [#10166](https://github.com/Qiskit/qiskit-terra/issues/10166). See also the related upgrade note regarding [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters").
+
+*   Fixed a bug in `BlockCollapser` where classical bits were ignored when collapsing a block of nodes.
+
+*   Fixed a bug in [`replace_block_with_op()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#replace_block_with_op "qiskit.dagcircuit.DAGCircuit.replace_block_with_op") and [`replace_block_with_op()`](/api/qiskit/qiskit.dagcircuit.DAGDependency#replace_block_with_op "qiskit.dagcircuit.DAGDependency.replace_block_with_op") that led to ignoring classical bits.
+
+*   Fixed a bug in [`QuantumCircuit.compose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#compose "qiskit.circuit.QuantumCircuit.compose") where the `SwitchCaseOp.target` attribute in the subcircuit was not correctly mapped to a register in the base circuit.
+
+*   Fix a bug in [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") where calling calibration with wrong parameters would crash instead of raising an exception.
+
+*   Fixed an issue with the [`BooleanExpression.from_dimacs_file()`](/api/qiskit/qiskit.circuit.classicalfunction.BooleanExpression#from_dimacs_file "qiskit.circuit.classicalfunction.BooleanExpression.from_dimacs_file") constructor method where the exception type raised when tweedledum wasn’t installed was not the expected `MissingOptionalLibrary`. Fixed [#10079](https://github.com/Qiskit/qiskit-terra/issues/10079)
+
+*   Using `initial_layout` in calls to [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") will no longer error if the circuit contains qubits not in any registers, or qubits that exist in more than one register. See [#10125](https://github.com/Qiskit/qiskit-terra/issues/10125).
+
+*   Fixed the gate decomposition of multi-controlled Z rotation gates added via [`QuantumCircuit.mcrz()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcrz "qiskit.circuit.QuantumCircuit.mcrz"). Previously, this method implemented a multi-controlled phase gate, which has a relative phase difference to the Z rotation. To obtain the previous [`QuantumCircuit.mcrz()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcrz "qiskit.circuit.QuantumCircuit.mcrz") behaviour, use [`QuantumCircuit.mcp()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcp "qiskit.circuit.QuantumCircuit.mcp").
+
+*   Fixed an issue with the [`PassManagerConfig.from_backend()`](/api/qiskit/qiskit.transpiler.PassManagerConfig#from_backend "qiskit.transpiler.PassManagerConfig.from_backend") constructor when building a [`PassManagerConfig`](/api/qiskit/qiskit.transpiler.PassManagerConfig "qiskit.transpiler.PassManagerConfig") object from a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instance that didn’t have a coupling map attribute defined. Previously, the constructor would incorrectly create a [`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap "qiskit.transpiler.CouplingMap") object with 0 qubits instead of using `None`. Fixed [#10171](https://github.com/Qiskit/qiskit-terra/issues/10171)
+
+*   Fixes a bug introduced in Qiskit 0.24.0 where numeric rotation angles were no longer substituted for symbolic ones before preparing for two-qubit synthesis. This caused an exception to be raised because the synthesis routines require numberic matrices.
+
+*   Fix a bug in which running [`Optimize1qGatesDecomposition`](/api/qiskit/qiskit.transpiler.passes.Optimize1qGatesDecomposition "qiskit.transpiler.passes.Optimize1qGatesDecomposition") in parallel would raise an error due to OneQubitGateErrorMap not being picklable.
+
+*   Fix a bug in the [`VF2Layout`](/api/qiskit/qiskit.transpiler.passes.VF2Layout "qiskit.transpiler.passes.VF2Layout") and [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") passes where the passes were failing to account for the 1 qubit error component when evaluating a potential layout.
+
+<span id="aer-0-12-0" />
+
+### Aer 0.12.0
+
+No change
+
+<span id="id22" />
+
+### IBM Q Provider 0.20.2
+
+No change
+
+<span id="qiskit-0-43-0" />
 ## 0.43.0
 
 <span id="terra-0-24-0" />
@@ -791,292 +1081,3 @@ No change
 No change
 
 <span id="qiskit-0-42-1" />
-## 0.43.1
-
-<span id="release-notes-terra-0-24-1" />
-
-<span id="id16" />
-
-### Terra 0.24.1
-
-<span id="release-notes-terra-0-24-1-prelude" />
-
-<span id="id17" />
-
-#### Prelude
-
-Qiskit Terra 0.24.1 is the first patch release to 0.24.0. This fixes some bugs that have been discovered since the release of 0.24.0.
-
-<span id="release-notes-terra-0-24-1-upgrade-notes" />
-
-<span id="id18" />
-
-#### Upgrade Notes
-
-*   Changed [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters") to bind assigned integer and float values directly into the parameters of [`Instruction`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction") instances in the circuit rather than binding the values wrapped within a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression"). This change should have little user impact as `float(QuantumCircuit.data[i].operation.params[j])` still produces a `float` (and is the only way to access the value of a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression")). Also, [`Instruction()`](/api/qiskit/qiskit.circuit.Instruction "qiskit.circuit.Instruction") parameters could already be `float` as well as a [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression"), so code dealing with instruction parameters should already handle both cases. The most likely chance for user impact is in code that uses `isinstance` to check for [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") and behaves differently depending on the result. Additionally, qpy serializes the numeric value in a bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") at a different precision than a `float` (see also the related bug fix note about [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters")).
-
-<span id="release-notes-terra-0-24-1-bug-fixes" />
-
-<span id="id19" />
-
-#### Bug Fixes
-
-*   Updated [`plot_gate_map()`](/api/qiskit/qiskit.visualization.plot_gate_map "qiskit.visualization.plot_gate_map"), [`plot_error_map()`](/api/qiskit/qiskit.visualization.plot_error_map "qiskit.visualization.plot_error_map"), and [`plot_circuit_layout()`](/api/qiskit/qiskit.visualization.plot_circuit_layout "qiskit.visualization.plot_circuit_layout") to support 433 qubit heavy-hex coupling maps. This allows coupling map visualizations for IBM Quantum’s `ibm_seattle` backend.
-
-*   Changed the binding of numeric values with [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters") to avoid a mismatch between the values of circuit instruction parameters and corresponding parameter keys in the circuit’s calibration dictionary. Fixed [#9764](https://github.com/Qiskit/qiskit-terra/issues/9764) and [#10166](https://github.com/Qiskit/qiskit-terra/issues/10166). See also the related upgrade note regarding [`QuantumCircuit.assign_parameters()`](/api/qiskit/qiskit.circuit.QuantumCircuit#assign_parameters "qiskit.circuit.QuantumCircuit.assign_parameters").
-
-*   Fixed a bug in `BlockCollapser` where classical bits were ignored when collapsing a block of nodes.
-
-*   Fixed a bug in [`replace_block_with_op()`](/api/qiskit/qiskit.dagcircuit.DAGCircuit#replace_block_with_op "qiskit.dagcircuit.DAGCircuit.replace_block_with_op") and [`replace_block_with_op()`](/api/qiskit/qiskit.dagcircuit.DAGDependency#replace_block_with_op "qiskit.dagcircuit.DAGDependency.replace_block_with_op") that led to ignoring classical bits.
-
-*   Fixed a bug in [`QuantumCircuit.compose()`](/api/qiskit/qiskit.circuit.QuantumCircuit#compose "qiskit.circuit.QuantumCircuit.compose") where the `SwitchCaseOp.target` attribute in the subcircuit was not correctly mapped to a register in the base circuit.
-
-*   Fix a bug in [`RZXCalibrationBuilder`](/api/qiskit/qiskit.transpiler.passes.RZXCalibrationBuilder "qiskit.transpiler.passes.RZXCalibrationBuilder") where calling calibration with wrong parameters would crash instead of raising an exception.
-
-*   Fixed an issue with the [`BooleanExpression.from_dimacs_file()`](/api/qiskit/qiskit.circuit.classicalfunction.BooleanExpression#from_dimacs_file "qiskit.circuit.classicalfunction.BooleanExpression.from_dimacs_file") constructor method where the exception type raised when tweedledum wasn’t installed was not the expected `MissingOptionalLibrary`. Fixed [#10079](https://github.com/Qiskit/qiskit-terra/issues/10079)
-
-*   Using `initial_layout` in calls to [`transpile()`](/api/qiskit/compiler#qiskit.compiler.transpile "qiskit.compiler.transpile") will no longer error if the circuit contains qubits not in any registers, or qubits that exist in more than one register. See [#10125](https://github.com/Qiskit/qiskit-terra/issues/10125).
-
-*   Fixed the gate decomposition of multi-controlled Z rotation gates added via [`QuantumCircuit.mcrz()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcrz "qiskit.circuit.QuantumCircuit.mcrz"). Previously, this method implemented a multi-controlled phase gate, which has a relative phase difference to the Z rotation. To obtain the previous [`QuantumCircuit.mcrz()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcrz "qiskit.circuit.QuantumCircuit.mcrz") behaviour, use [`QuantumCircuit.mcp()`](/api/qiskit/qiskit.circuit.QuantumCircuit#mcp "qiskit.circuit.QuantumCircuit.mcp").
-
-*   Fixed an issue with the [`PassManagerConfig.from_backend()`](/api/qiskit/qiskit.transpiler.PassManagerConfig#from_backend "qiskit.transpiler.PassManagerConfig.from_backend") constructor when building a [`PassManagerConfig`](/api/qiskit/qiskit.transpiler.PassManagerConfig "qiskit.transpiler.PassManagerConfig") object from a [`BackendV1`](/api/qiskit/qiskit.providers.BackendV1 "qiskit.providers.BackendV1") instance that didn’t have a coupling map attribute defined. Previously, the constructor would incorrectly create a [`CouplingMap`](/api/qiskit/qiskit.transpiler.CouplingMap "qiskit.transpiler.CouplingMap") object with 0 qubits instead of using `None`. Fixed [#10171](https://github.com/Qiskit/qiskit-terra/issues/10171)
-
-*   Fixes a bug introduced in Qiskit 0.24.0 where numeric rotation angles were no longer substituted for symbolic ones before preparing for two-qubit synthesis. This caused an exception to be raised because the synthesis routines require numberic matrices.
-
-*   Fix a bug in which running [`Optimize1qGatesDecomposition`](/api/qiskit/qiskit.transpiler.passes.Optimize1qGatesDecomposition "qiskit.transpiler.passes.Optimize1qGatesDecomposition") in parallel would raise an error due to OneQubitGateErrorMap not being picklable.
-
-*   Fix a bug in the [`VF2Layout`](/api/qiskit/qiskit.transpiler.passes.VF2Layout "qiskit.transpiler.passes.VF2Layout") and [`VF2PostLayout`](/api/qiskit/qiskit.transpiler.passes.VF2PostLayout "qiskit.transpiler.passes.VF2PostLayout") passes where the passes were failing to account for the 1 qubit error component when evaluating a potential layout.
-
-<span id="aer-0-12-0" />
-
-### Aer 0.12.0
-
-No change
-
-<span id="id22" />
-
-### IBM Q Provider 0.20.2
-
-No change
-
-<span id="qiskit-0-43-0" />
-## 0.43.2
-
-As a reminder, [Qiskit Aer](https://qiskit.org/ecosystem/aer/)’s inclusion in the `qiskit` package is deprecated. The next minor version of Qiskit Aer (0.13) will not be included in any release of the `qiskit` package, and you should immediately begin installing Aer separately by:
-
-```python
-pip install qiskit-aer
-```
-
-and importing it as:
-
-```python
-import qiskit_aer
-```
-
-Starting from Qiskit 0.44, the command `pip install qiskit` will no longer install Qiskit Aer, or the obsolete IBM Q Provider that has already been replaced by the new [IBM Provider](../../qiskit-ibm-provider).
-
-<span id="terra-0-24-1" />
-
-<span id="release-notes-0-24-2" />
-
-### Terra 0.24.1
-
-No change
-
-<span id="aer-0-12-1" />
-
-### Aer 0.12.1
-
-<span id="release-notes-aer-0-12-1-prelude" />
-
-<span id="id10" />
-
-#### Prelude
-
-Qiskit Aer 0.12.1 is the first patch release to 0.12.0. This fixes some bugs that have been discovered since the release of 0.12.0.
-
-<span id="release-notes-aer-0-12-1-known-issues" />
-
-<span id="id11" />
-
-#### Known Issues
-
-*   Fix a bug that returns wrong expectation values in `Estimator` when `abelian_grouping=True`.
-
-<span id="release-notes-aer-0-12-1-upgrade-notes" />
-
-<span id="id12" />
-
-#### Upgrade Notes
-
-*   Improved performance when the same circuits and multiple parameters are passed to [`Estimator`](/api/qiskit/qiskit.primitives.Estimator "qiskit.primitives.Estimator") with `approximation=True`.
-
-<span id="release-notes-aer-0-12-1-deprecation-notes" />
-
-<span id="id13" />
-
-#### Deprecation Notes
-
-*   Options of meth:\~.AerSimulator.run need to use correct types.
-
-<span id="release-notes-aer-0-12-1-bug-fixes" />
-
-<span id="id14" />
-
-#### Bug Fixes
-
-*   Performance regression due to introduction of `AER::Config` is fixed. This class has many fields but is frequently copied in `AER::Transpile::CircuitOptimization`. Originally `json_t` (former class for configuration) was also frequently copied but it does have entries in most cases and then this copy overhead is not a problem. With this fix, `AER::Transpile::CircuitOptimization` does not copy `AER::Config`.
-
-*   When BLAS calls are failed, because omp threads do not handle exceptions, Aer crashes without any error messages. This fix is for omp threads to catch exceptions correctly and then rethrow them outside of omp loops.
-
-*   Previously, parameters for gates are not validate in C++. If parameters are shorter than expected (due to custom gate), segmentaion faults are thrown. This commit adds checks whether parameter lenght is expceted. This commit will fix issues reported in #1612. [https://github.com/Qiskit/qiskit-aer/issues/1612](https://github.com/Qiskit/qiskit-aer/issues/1612)
-
-*   Since 0.12.0, parameter values in circuits are temporarily replaced with constant values and parameter values are assigned in C++ library. Therefore, if parameter\_binds is specified, simulator returns results with the constnat values as paramter values. With this commit, Aer raises an error if parameter\_binds is not specified though circuits have parameters.
-
-*   Available devices and methods are no longer queried when importing Aer.
-
-*   Previously `AerSimulator` modifies circuit metadata to maintain consistency between input and output of simulation with side effect of unexpected view of metadata from applicatiln in simiulation. This fix avoids using circuit metadata to maintain consistency internaly and then always provides consistent view of metadata to application.
-
-*   Fixed a bug where the variance in metadata in EstimatorResult was complex and now returns float.
-
-*   Fixed a build break to compile Qiskit Aer with cuQuautum support (AER\_ENABLE\_CUQUANTUM=true). This change does not affect build for CPU and normal GPU binaries.
-
-*   Fixed a bug in `from_backend()` that raised an error when the backend has no T1 and T2 values (i.e. None) for a qubit in its qubit properties. This commit updates `NoiseModel.from_backend()` and `basic_device_gate_errors()` so that they add an identity `QuantumError` (i.e. effectively no thermal relaxation error) to a qubit with no T1 and T2 values for all gates acting on qubits including the qubit. Fixed [#1779](https://github.com/Qiskit/qiskit-aer/issues/1779) and [#1815](https://github.com/Qiskit/qiskit-aer/issues/1815).
-
-*   Fix an issue even if the number of qubits is set by a coupling map or device’s configuration, when the simulation method is configured, the number of qubits is overwritten in accordance with the method. Fixed [#1769](https://github.com/Qiskit/qiskit-aer/issues/1769)
-
-*   This is fix for library path setting in CMakeLists.txt for cuQuantum SDK. Because the latest cuQuantum includes libraries for CUDA 11.x and 12.x, this fix uses CUDA version returned from FindCUDA to the path of libraries of cuQuantum and cuTENSOR.
-
-*   This is fix for static link libraries of cuQuantum when building with CUQUANTUM\_STATIC=true.
-
-*   MPI parallelization was not enabled since we have not used qobj. This fix sets the number of processes and MPI rank correctly.
-
-*   `AerCircuit` is created from a circuit by iterating its operations while skipping barrier instructions. However, skipping barrier instructions make wrong positionings of parameter bindings. This fix adds `barrier()` and keeps parametr bindings correct.
-
-*   Aer still supports Qobj as an argument of `run()` though it was deprecated. However, since 0.12.0, it always fails if no `run_options` is specified. This fix enables simulation of Qobj without `run_options`.
-
-*   Since 0.12.0, `AerConfig` is used for simulation configuration while performing strict type checking for arguments of meth:\~.AerSimulator.run. This commit adds casting if argument types are not expected.
-
-*   :meth:`QuantumCircuit.initialize()` with int value was not processed correctly as reported in #1821 \<[https://github.com/Qiskit/qiskit-aer/issues/1821](https://github.com/Qiskit/qiskit-aer/issues/1821)>. This commit enables such initialization by decomposing initialize instructions.
-
-*   [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit") supports parameterization for its global\_phase. However, Aer has not allowed such parameterization and failed when transpiler generates parameterized global phases. This commit supports parameterization of global\_phase and resolve issues related to [https://github.com/Qiskit/qiskit-aer/issues/1795](https://github.com/Qiskit/qiskit-aer/issues/1795), [https://github.com/Qiskit/qiskit-aer/issues/1781](https://github.com/Qiskit/qiskit-aer/issues/1781), and [https://github.com/Qiskit/qiskit-aer/issues/1798](https://github.com/Qiskit/qiskit-aer/issues/1798).
-
-*   Aer will now use `omp_set_max_active_levels()` instead of the deprecated `omp_set_nested()` when compiled against recent versions of OpenMP.
-
-<span id="id15" />
-
-### IBM Q Provider 0.20.2
-
-No change.
-
-<span id="qiskit-0-43-1" />
-## 0.43.3
-
-<span id="terra-0-24-2" />
-
-### Terra 0.24.2
-
-<span id="release-notes-0-24-2-prelude" />
-
-<span id="id4" />
-
-#### Prelude
-
-Qiskit Terra 0.24.2 is a bugfix release, addressing some minor issues identified since the 0.24.1 release.
-
-<span id="release-notes-0-24-2-upgrade-notes" />
-
-<span id="id5" />
-
-#### Upgrade Notes
-
-*   The QPY format version emitted by `dump` has increased to 8. This new format version adds support for serializing the [`QuantumCircuit.layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribute.
-
-<span id="release-notes-0-24-2-bug-fixes" />
-
-<span id="id6" />
-
-#### Bug Fixes
-
-*   Fixed the deserialization of [`DiagonalGate`](/api/qiskit/qiskit.circuit.library.DiagonalGate "qiskit.circuit.library.DiagonalGate") instances through QPY. Fixed [#10364](https://github.com/Qiskit/qiskit-terra/issues/10364)
-
-*   Fixed an issue with the `qs_decomposition()` function, which does quantum Shannon decomposition, when it was called on trivial numeric unitaries that do not benefit from this decomposition, an unexpected error was raised. This error has been fixed so that such unitaries are detected and the equivalent circuit is returned. Fixed [#10036](https://github.com/Qiskit/qiskit-terra/issues/10036)
-
-*   Fixed an issue in the the [`BasicSwap`](/api/qiskit/qiskit.transpiler.passes.BasicSwap "qiskit.transpiler.passes.BasicSwap") class that prevented the [`BasicSwap.run()`](/api/qiskit/qiskit.transpiler.passes.BasicSwap#run "qiskit.transpiler.passes.BasicSwap.run") method from functioning if the `fake_run` keyword argument was set to `True` when the class was instantiated. Fixed [#10147](https://github.com/Qiskit/qiskit-terra/issues/10147)
-
-*   Fixed an issue with copying circuits with new-style [`Clbit`](/api/qiskit/qiskit.circuit.Clbit "qiskit.circuit.Clbit")s and [`Qubit`](/api/qiskit/qiskit.circuit.Qubit "qiskit.circuit.Qubit")s (bits without registers) where references to these bits from the containing circuit could be broken, causing issues with serialization and circuit visualization. Fixed [#10409](https://github.com/Qiskit/qiskit-terra/issues/10409)
-
-*   The [`CheckMap`](/api/qiskit/qiskit.transpiler.passes.CheckMap "qiskit.transpiler.passes.CheckMap") transpiler pass will no longer spuriously error when dealing with nested conditional structures created by the control-flow builder interface. See [#10394](https://github.com/Qiskit/qiskit-terra/issues/10394).
-
-*   Fixed an failure of the [Pulse Builder](/api/qiskit/pulse#pulse-builder) when the context is initialized with [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2").
-
-*   Fixed the output of pulse [`measure()`](/api/qiskit/pulse#qiskit.pulse.builder.measure "qiskit.pulse.builder.measure") and [`measure_all()`](/api/qiskit/pulse#qiskit.pulse.builder.measure_all "qiskit.pulse.builder.measure_all") when functions are called with the [`BackendV2`](/api/qiskit/qiskit.providers.BackendV2 "qiskit.providers.BackendV2") backend.
-
-*   Fixed the dimensions of the output density matrix from [`DensityMatrix.partial_transpose()`](/api/qiskit/qiskit.quantum_info.DensityMatrix#partial_transpose "qiskit.quantum_info.DensityMatrix.partial_transpose") so they match the dimensions of the corresponding input density matrix.
-
-*   Importing [`qiskit.primitives`](/api/qiskit/primitives#module-qiskit.primitives "qiskit.primitives") will no longer cause deprecation warnings stemming from the deprecated [`qiskit.opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow") module. These warnings would have been hidden to users by the default Python filters, but triggered the eager import of [`opflow`](/api/qiskit/opflow#module-qiskit.opflow "qiskit.opflow"), which meant that a subsequent import by a user would not trigger the warnings. Fixed [#10245](https://github.com/Qiskit/qiskit-terra/issues/10245)
-
-*   Fixed the OpenQASM 2 output of [`QuantumCircuit.qasm()`](/api/qiskit/qiskit.circuit.QuantumCircuit#qasm "qiskit.circuit.QuantumCircuit.qasm") when a custom gate object contained a gate with the same name. Ideally this shouldn’t happen for most gates, but complex algorithmic operations like the [`GroverOperator`](/api/qiskit/qiskit.circuit.library.GroverOperator "qiskit.circuit.library.GroverOperator") class could produce such structures accidentally. See [#10162](https://github.com/Qiskit/qiskit-terra/issues/10162).
-
-*   Fixed a regression in the LaTeX drawer of [`QuantumCircuit.draw()`](/api/qiskit/qiskit.circuit.QuantumCircuit#draw "qiskit.circuit.QuantumCircuit.draw") when temporary files are placed on a separate filesystem to the working directory. See [#10211](https://github.com/Qiskit/qiskit-terra/issues/10211).
-
-*   Fixed an issue with [`UnitarySynthesis`](/api/qiskit/qiskit.transpiler.passes.UnitarySynthesis "qiskit.transpiler.passes.UnitarySynthesis") when using the `target` parameter where circuits with control flow were not properly mapped to the target.
-
-*   Fixed bug in [`VQD`](/api/qiskit/qiskit.algorithms.eigensolvers.VQD "qiskit.algorithms.eigensolvers.VQD") where `result.optimal_values` was a copy of `result.optimal_points`. It now returns the corresponding values. Fixed [#10263](https://github.com/Qiskit/qiskit-terra/issues/10263)
-
-*   Improved the error messages returned when an attempt to convert a fully bound [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") into a concrete `float` or `int` failed, for example because the expression was naturally a complex number. Fixed [#9187](https://github.com/Qiskit/qiskit-terra/issues/9187)
-
-*   Fixed `float` conversions for [`ParameterExpression`](/api/qiskit/qiskit.circuit.ParameterExpression "qiskit.circuit.ParameterExpression") values which had, at some point in their construction history, an imaginary component that had subsequently been cancelled. When using Sympy as a backend, these conversions would usually already have worked. When using Symengine as the backend, these conversions would often fail with type errors, despite the result having been symbolically evaluated to be real, and [`ParameterExpression.is_real()`](/api/qiskit/qiskit.circuit.ParameterExpression#is_real "qiskit.circuit.ParameterExpression.is_real") being true. Fixed [#10191](https://github.com/Qiskit/qiskit-terra/issues/10191)
-
-*   Fixed the [`qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy") serialization of [`QuantumCircuit.layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribue. Previously, the [`layout`](/api/qiskit/qiskit.circuit.QuantumCircuit#layout "qiskit.circuit.QuantumCircuit.layout") attribute would have been dropped when serializing a circuit to QPY. Fixed [#10112](https://github.com/Qiskit/qiskit-terra/issues/10112)
-
-<span id="aer-0-12-2" />
-
-<span id="release-notes-aer-0-12-2" />
-
-### Aer 0.12.2
-
-<span id="release-notes-aer-0-12-2-prelude" />
-
-<span id="id7" />
-
-#### Prelude
-
-Qiskit Aer 0.12.2 is the second patch release to 0.12.0. This fixes some bugs that have been discovered since the release of 0.12.1.
-
-<span id="release-notes-aer-0-12-2-upgrade-notes" />
-
-<span id="id8" />
-
-#### Upgrade Notes
-
-*   Qiskit Aer now requires CUDA version for GPU simulator to 11.2 or higher. Previously, CUDA 10.1 was the minimum supported version. This change was necessary because of changes in the upstream CUDA ecosystem, including cuQuantum support. To support users running with different versions of CUDA there is now a separate package available for running with CUDA 11: `qiskit-aer-gpu-cu11` and using the `qiskit-aer-gpu` package now requires CUDA 12. If you’re an existing user of the `qiskit-aer-gpu` package and want to use CUDA 11 you will need to run:
-
-    ```python
-    pip uninstall qiskit-aer-gpu && pip install -U qiskit-aer-gpu-cu11
-    ```
-
-    to go from the previously CUDA 10.x compatible `qiskit-aer-gpu` package’s releases to upgrade to the new CUDA 11 compatible package. If you’re running CUDA 12 locally already you can upgrade the `qiskit-aer-gpu` package as normal.
-
-<span id="release-notes-aer-0-12-2-bug-fixes" />
-
-<span id="id9" />
-
-#### Bug Fixes
-
-*   If a circuit has conditional and parameters, the circuit was not be correctly simulated because parameter bindings of Aer used wrong positions to apply parameters. This is from a lack of consideration of bfunc operations injected by conditional. With this commit, parameters are set to correct positions with consideration of injected bfun operations.
-
-*   Parameters for global phases were not correctly set in #1814. [https://github.com/Qiskit/qiskit-aer/pull/1814](https://github.com/Qiskit/qiskit-aer/pull/1814) Parameter values for global phases were copied to a template circuit and not to actual circuits to be simulated. This commit correctly copies parameter values to circuits to be simulated.
-
-*   Results of `backend.run()` were not serializable because they include `AerCircuit`s. This commit makes the results serializable by removing `AerCircuit`s from metadata.
-
-*   :meth:`QuantumCircuit.save_statevector()` does not work if the circuit is generated from OpenQASM3 text because its quantum registers have duplicated qubit instances. With this commit, :meth:`QuantumCircuit.save_statevector()` uses :data:`QuantumCircuit.qubits` to get qubits to be saved.
-
-<span id="ibm-q-provider-0-20-2" />
-
-### IBM Q Provider 0.20.2
-
-No change.
-
-<span id="qiskit-0-43-2" />

--- a/docs/api/qiskit/release-notes/0.44.md
+++ b/docs/api/qiskit/release-notes/0.44.md
@@ -116,6 +116,73 @@ This table tracks the meta-package versions and the version of each legacy Qiski
   For the `0.7.0`, `0.7.1`, and `0.7.2` meta-package releases the meta-package versioning strategy was not formalized yet.
 </Admonition>
 
+## 0.44.1
+
+<span id="terra-0-25-1" />
+
+<span id="release-notes-0-25-1" />
+
+### Terra 0.25.1
+
+<span id="release-notes-0-25-1-prelude" />
+
+#### Prelude
+
+Qiskit Terra 0.25.1 is a bugfix release, addressing some issues identified since the 0.25.1 release.
+
+<span id="release-notes-0-25-1-bug-fixes" />
+
+#### Bug Fixes
+
+*   Fixed a bug in QPY serialization ([`qiskit.qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy")) where multiple controlled custom gates in a circuit could result in an invalid QPY file that could not be parsed. Fixed [#9746](https://github.com/Qiskit/qiskit-terra/issues/9746).
+
+*   Fixed [#9363](https://github.com/Qiskit/qiskit-terra/issues/9363). by labeling the non-registerless synthesis in the order that Tweedledum returns. For example, compare this example before and after the fix:
+
+    ```python
+    from qiskit.circuit import QuantumCircuit
+    from qiskit.circuit.classicalfunction import BooleanExpression
+
+    boolean_exp = BooleanExpression.from_dimacs_file("simple_v3_c2.cnf")
+    circuit = QuantumCircuit(boolean_exp.num_qubits)
+    circuit.append(boolean_exp, range(boolean_exp.num_qubits))
+    circuit.draw("text")
+
+    from qiskit.circuit.classicalfunction import classical_function
+    from qiskit.circuit.classicalfunction.types import Int1
+
+    @classical_function
+    def grover_oracle(a: Int1, b: Int1, c: Int1) -> Int1:
+        return (a and b and not c)
+
+    quantum_circuit = grover_oracle.synth(registerless=False)
+    print(quantum_circuit.draw())
+    ```
+
+    Which would print
+
+    ```python
+         Before             After
+
+         c: ──■──           a: ──■──
+              │                  │
+         b: ──■──           b: ──■──
+              │                  │
+         a: ──o──           c: ──o──
+            ┌─┴─┐              ┌─┴─┐
+    return: ┤ X ├      return: ┤ X ├
+            └───┘              └───┘
+    ```
+
+*   Fixed `plot_state_paulivec()`, which previously damped the state coefficients by a factor of $2^n$, where $n$ is the number of qubits. Now the bar graph correctly displays the coefficients as $\mathrm{Tr}(\sigma\rho)$, where $\rho$ is the state to be plotted and $\sigma$ iterates over all possible tensor products of single-qubit Paulis.
+
+*   Angles in the OpenQASM 2 exporter (`QuantumCircuit.qasm()`) will now always include a decimal point, for example in the case of `1.e-5`. This is required by a strict interpretation of the floating-point-literal specification in OpenQASM 2. Qiskit’s OpenQASM 2 parser ([`qasm2.load()`](/api/qiskit/qasm2#qiskit.qasm2.load "qiskit.qasm2.load") and [`loads()`](/api/qiskit/qasm2#qiskit.qasm2.loads "qiskit.qasm2.loads")) is more permissive by default, and will allow `1e-5` without the decimal point unless in `strict` mode.
+
+*   The setter for [`SparsePauliOp.paulis`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#paulis "qiskit.quantum_info.SparsePauliOp.paulis") will now correctly reject attempts to set the attribute with incorrectly shaped data, rather than silently allowing an invalid object to be created. See [#10384](https://github.com/Qiskit/qiskit-terra/issues/10384).
+
+*   Fixed a performance regression in the [`SabreLayout`](/api/qiskit/qiskit.transpiler.passes.SabreLayout "qiskit.transpiler.passes.SabreLayout") and [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler passes. Fixed [#10650](https://github.com/Qiskit/qiskit-terra/issues/10650)
+
+<span id="qiskit-0-44-0" />
+
 ## 0.44.0
 
 This release officially marks the end of support for the Qiskit IBMQ Provider package and the removal of Qiskit Aer from the Qiskit metapackage. After this release the metapackage only contains Qiskit Terra, so this is the final release we will refer to the Qiskit metapackage and Qiskit Terra as separate things. Starting in the next release Qiskit 0.45.0 the Qiskit package will just be what was previously Qiskit Terra and there will no longer be a separation between them.
@@ -832,69 +899,3 @@ Qiskit Terra 0.25 has dropped support for Python 3.7 following deprecation warni
 *   Fixed an issue with function `state_to_latex()`. Previously, it produced invalid LaTeX with unintended coefficient rounding, which resulted in errors when calling `state_drawer()`. Fixed [#9297](https://github.com/Qiskit/qiskit-terra/issues/9297).
 
 <span id="qiskit-0-43-3" />
-## 0.44.1
-
-<span id="terra-0-25-1" />
-
-<span id="release-notes-0-25-1" />
-
-### Terra 0.25.1
-
-<span id="release-notes-0-25-1-prelude" />
-
-#### Prelude
-
-Qiskit Terra 0.25.1 is a bugfix release, addressing some issues identified since the 0.25.1 release.
-
-<span id="release-notes-0-25-1-bug-fixes" />
-
-#### Bug Fixes
-
-*   Fixed a bug in QPY serialization ([`qiskit.qpy`](/api/qiskit/qpy#module-qiskit.qpy "qiskit.qpy")) where multiple controlled custom gates in a circuit could result in an invalid QPY file that could not be parsed. Fixed [#9746](https://github.com/Qiskit/qiskit-terra/issues/9746).
-
-*   Fixed [#9363](https://github.com/Qiskit/qiskit-terra/issues/9363). by labeling the non-registerless synthesis in the order that Tweedledum returns. For example, compare this example before and after the fix:
-
-    ```python
-    from qiskit.circuit import QuantumCircuit
-    from qiskit.circuit.classicalfunction import BooleanExpression
-
-    boolean_exp = BooleanExpression.from_dimacs_file("simple_v3_c2.cnf")
-    circuit = QuantumCircuit(boolean_exp.num_qubits)
-    circuit.append(boolean_exp, range(boolean_exp.num_qubits))
-    circuit.draw("text")
-
-    from qiskit.circuit.classicalfunction import classical_function
-    from qiskit.circuit.classicalfunction.types import Int1
-
-    @classical_function
-    def grover_oracle(a: Int1, b: Int1, c: Int1) -> Int1:
-        return (a and b and not c)
-
-    quantum_circuit = grover_oracle.synth(registerless=False)
-    print(quantum_circuit.draw())
-    ```
-
-    Which would print
-
-    ```python
-         Before             After
-
-         c: ──■──           a: ──■──
-              │                  │
-         b: ──■──           b: ──■──
-              │                  │
-         a: ──o──           c: ──o──
-            ┌─┴─┐              ┌─┴─┐
-    return: ┤ X ├      return: ┤ X ├
-            └───┘              └───┘
-    ```
-
-*   Fixed `plot_state_paulivec()`, which previously damped the state coefficients by a factor of $2^n$, where $n$ is the number of qubits. Now the bar graph correctly displays the coefficients as $\mathrm{Tr}(\sigma\rho)$, where $\rho$ is the state to be plotted and $\sigma$ iterates over all possible tensor products of single-qubit Paulis.
-
-*   Angles in the OpenQASM 2 exporter (`QuantumCircuit.qasm()`) will now always include a decimal point, for example in the case of `1.e-5`. This is required by a strict interpretation of the floating-point-literal specification in OpenQASM 2. Qiskit’s OpenQASM 2 parser ([`qasm2.load()`](/api/qiskit/qasm2#qiskit.qasm2.load "qiskit.qasm2.load") and [`loads()`](/api/qiskit/qasm2#qiskit.qasm2.loads "qiskit.qasm2.loads")) is more permissive by default, and will allow `1e-5` without the decimal point unless in `strict` mode.
-
-*   The setter for [`SparsePauliOp.paulis`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#paulis "qiskit.quantum_info.SparsePauliOp.paulis") will now correctly reject attempts to set the attribute with incorrectly shaped data, rather than silently allowing an invalid object to be created. See [#10384](https://github.com/Qiskit/qiskit-terra/issues/10384).
-
-*   Fixed a performance regression in the [`SabreLayout`](/api/qiskit/qiskit.transpiler.passes.SabreLayout "qiskit.transpiler.passes.SabreLayout") and [`SabreSwap`](/api/qiskit/qiskit.transpiler.passes.SabreSwap "qiskit.transpiler.passes.SabreSwap") transpiler passes. Fixed [#10650](https://github.com/Qiskit/qiskit-terra/issues/10650)
-
-<span id="qiskit-0-44-0" />


### PR DESCRIPTION
This PR changes the release notes to have a chronological descending order.

#### How to regenerate the release notes

To regenerate the release notes and fix the order of each version, I used the API generation script with some changes. We need to modify the writeSeparateReleaseNotes function from `releaseNotes.ts` and the `updateApiDocs.ts` script. 

The first step is to comment the `extractMarkdownReleaseNotesPatches` call in line 245, given that we don't want to write the latest release notes file. Also, we need to substitute the two arrays returned by that call for the release notes we want to regenerate and an empty dictionary. I did the regeneration in batches of 6 files:

```ts
//const [minorVersionsFound, markdownByPatchVersion] =
//  extractMarkdownReleaseNotesPatches(releaseNoteMarkdown);

const markdownByPatchVersion: {
  [id: string]: string;
} = {};

const minorVersionsFound = ['0.10', '0.15', '0.14', '0.13', '0.12', '0.11'];
```

The following step is to add some logic to read all the files and store each patch version we find in each file. With that information, we will re-write each release notes file at the end of the function with the correct order. That piece of code was extracted from the first version of the script which can be found in this commit https://github.com/Qiskit/documentation/pull/537/commits/7aa586f0540c74d5f092580313137ea91ddc4fe3. It was copied in the same place it appear in the commit.

```ts
const [_, markdownByPatchOldVersion] =
extractMarkdownReleaseNotesPatches(currentMarkdown);

for (let [versionPatch, markdownPatch] of Object.entries(
  markdownByPatchOldVersion,
)) {
  // We keep the release notes for a patch if it hasn't been modified for the current release notes.
  // Otherwise, we use the modified version.
  if (!markdownByPatchVersion.hasOwnProperty(versionPatch)) {
    markdownByPatchVersion[versionPatch] = markdownPatch;
  }
}
```

Finally, to speed up the process, I commented the files we regenerate in the `updateApiDocs.ts` script. This step is optional, and if used we have to make sure we restore all the docs before creating the PR.

```ts
async function convertHtmlToMarkdown(
  htmlPath: string,
  markdownPath: string,
  baseSourceUrl: string,
  pkg: Pkg,
) {
  const files = await globby(
    [
      //"apidocs/**.html",
      //"apidoc/**.html",
      //"stubs/**.html",
      "release_notes.html",
    ],
    {
      cwd: htmlPath,
    },
  );
```
Closes #538 