### PR TITLE
Run extended checks on API updates

### DIFF
--- a/.github/workflows/extended-checks.yml
+++ b/.github/workflows/extended-checks.yml
@@ -16,7 +16,7 @@
 name: Extended checks
 on:
   schedule:
-    - cron: "0 0 * * *"  # Every day at midnight UTC
+    - cron: "0 0 * * *" # Every day at midnight UTC
 
   # For translations, run checks during branch builds because CI will not be triggered
   # in the automated PR to download new translations. (That's a restriction by GitHub
@@ -26,13 +26,13 @@ on:
     branches:
       - main
     paths:
-      - 'translations/**/*'
+      - "translations/**/*"
 
   pull_request:
     paths:
-      - 'docs/api/qiskit/**/*'
-      - 'docs/api/qiskit-ibm-provider/**/*'
-      - 'docs/api/qiskit-ibm-runtime/**/*'
+      - "docs/api/qiskit/**/*"
+      - "docs/api/qiskit-ibm-provider/**/*"
+      - "docs/api/qiskit-ibm-runtime/**/*"
 
 jobs:
   extended-checks:

--- a/.github/workflows/extended-checks.yml
+++ b/.github/workflows/extended-checks.yml
@@ -10,16 +10,32 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# This Action runs every day at 00:00 UTC to check things that
-# we care about but would be too slow to check in every PR.
+# This Action runs checks things that we care about but would be
+# too slow to check in every PR.
 
-name: Nightly extended checks
+name: Extended checks
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *"  # Every day at midnight UTC
+
+  # For translations, run checks during branch builds because CI will not be triggered
+  # in the automated PR to download new translations. (That's a restriction by GitHub
+  # because we use the GitHub token to create the PR - a workflow can't
+  # call other workflows.)
+  push:
+    branches:
+      - main
+    paths:
+      - 'translations/**/*'
+
+  pull_request:
+    paths:
+      - 'docs/api/qiskit/**/*'
+      - 'docs/api/qiskit-ibm-provider/**/*'
+      - 'docs/api/qiskit-ibm-runtime/**/*'
 
 jobs:
-  nightly-extended-checks:
+  extended-checks:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'Qiskit'
     steps:


### PR DESCRIPTION
As of https://github.com/Qiskit/documentation/pull/569 and https://github.com/Qiskit/documentation/pull/572, our extended check PR now checks more than simply external links. It also checks:

* that all pages render for translations and API docs
* the internal links for API docs

So, we should run these extended checks when we make changes to the API and translations folders.