### PR TITLE
Collapse migration guides left sidebar

### DIFF
--- a/docs/api/migration-guides/_toc.json
+++ b/docs/api/migration-guides/_toc.json
@@ -1,5 +1,6 @@
 {
     "title": "Migration guides",
+    "collapsed": true,
     "children": [
       {
         "title": "Introduction",


### PR DESCRIPTION
This was an oversight. We want to always collapse the left sidebar.