### PR TITLE
Add source links when using `sphinx.ext.viewcode`

### DIFF
--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Estimator.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Estimator.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Estimator
 
 <span id="qiskit_ibm_runtime.Estimator" />
 
-`Estimator(backend=None, session=None, options=None)`
+`Estimator(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/estimator.py "view source code")
 
 Class for interacting with Qiskit Runtime Estimator primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.IBMBackend.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.IBMBackend
 
 <span id="qiskit_ibm_runtime.IBMBackend" />
 
-`IBMBackend(configuration, service, api_client, instance=None)`
+`IBMBackend(configuration, service, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/ibm_backend.py "view source code")
 
 Backend class interfacing with an IBM Quantum backend.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.ParameterNamespace.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.ParameterNamespace.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.ParameterNamespace
 
 <span id="qiskit_ibm_runtime.ParameterNamespace" />
 
-`ParameterNamespace(parameters)`
+`ParameterNamespace(parameters)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/runtime_program.py "view source code")
 
 A namespace for program parameters with validation.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.QiskitRuntimeService.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.QiskitRuntimeService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.QiskitRuntimeService
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService" />
 
-`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`
+`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/qiskit_runtime_service.py "view source code")
 
 Class for interacting with the Qiskit Runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeDecoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeDecoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeDecoder
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder" />
 
-`RuntimeDecoder(*args, **kwargs)`
+`RuntimeDecoder(*args, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Decoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeEncoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeEncoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeEncoder
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder" />
 
-`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`
+`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Encoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeJob.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeJob
 
 <span id="qiskit_ibm_runtime.RuntimeJob" />
 
-`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`
+`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/runtime_job.py "view source code")
 
 Representation of a runtime program execution.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeOptions
 
 <span id="qiskit_ibm_runtime.RuntimeOptions" />
 
-`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`
+`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/runtime_options.py "view source code")
 
 Class for representing generic runtime execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeProgram.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.RuntimeProgram.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeProgram
 
 <span id="qiskit_ibm_runtime.RuntimeProgram" />
 
-`RuntimeProgram(program_name, program_id, description, parameters=None, return_values=None, interim_results=None, max_execution_time=0, backend_requirements=None, creation_date='', update_date='', is_public=False, data='', api_client=None)`
+`RuntimeProgram(program_name, program_id, description, parameters=None, return_values=None, interim_results=None, max_execution_time=0, backend_requirements=None, creation_date='', update_date='', is_public=False, data='', api_client=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/runtime_program.py "view source code")
 
 Class representing program metadata.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Sampler.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Sampler.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Sampler
 
 <span id="qiskit_ibm_runtime.Sampler" />
 
-`Sampler(backend=None, session=None, options=None)`
+`Sampler(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/sampler.py "view source code")
 
 Class for interacting with Qiskit Runtime Sampler primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.Session.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Session
 
 <span id="qiskit_ibm_runtime.Session" />
 
-`Session(service=None, backend=None, max_time=None)`
+`Session(service=None, backend=None, max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/session.py "view source code")
 
 Class for creating a flexible Qiskit Runtime session.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.EnvironmentOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.EnvironmentOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.EnvironmentOptions
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions" />
 
-`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`
+`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/environment_options.py "view source code")
 
 Options related to the execution environment.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.ExecutionOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.ExecutionOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ExecutionOptions
 
 <span id="qiskit_ibm_runtime.options.ExecutionOptions" />
 
-`ExecutionOptions(shots=4000, init_qubits=True)`
+`ExecutionOptions(shots=4000, init_qubits=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/execution_options.py "view source code")
 
 Execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.Options.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.Options.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.Options
 
 <span id="qiskit_ibm_runtime.options.Options" />
 
-`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`
+`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/options.py "view source code")
 
 Options for the primitives.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.ResilienceOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.ResilienceOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ResilienceOptions
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions" />
 
-`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`
+`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/resilience_options.py "view source code")
 
 Resilience options.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.SimulatorOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.SimulatorOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.SimulatorOptions
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions" />
 
-`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`
+`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/simulator_options.py "view source code")
 
 Simulator options.
 

--- a/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.TranspilationOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.14/qiskit_ibm_runtime.options.TranspilationOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.TranspilationOptions
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions" />
 
-`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`
+`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.14/qiskit_ibm_runtime/options/transpilation_options.py "view source code")
 
 Transpilation options.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Estimator.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Estimator.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Estimator
 
 <span id="qiskit_ibm_runtime.Estimator" />
 
-`Estimator(backend=None, session=None, options=None)`
+`Estimator(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/estimator.py "view source code")
 
 Class for interacting with Qiskit Runtime Estimator primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.IBMBackend.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.IBMBackend
 
 <span id="qiskit_ibm_runtime.IBMBackend" />
 
-`IBMBackend(configuration, service, api_client, instance=None)`
+`IBMBackend(configuration, service, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/ibm_backend.py "view source code")
 
 Backend class interfacing with an IBM Quantum backend.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.ParameterNamespace.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.ParameterNamespace.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.ParameterNamespace
 
 <span id="qiskit_ibm_runtime.ParameterNamespace" />
 
-`ParameterNamespace(parameters)`
+`ParameterNamespace(parameters)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/runtime_program.py "view source code")
 
 A namespace for program parameters with validation.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.QiskitRuntimeService.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.QiskitRuntimeService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.QiskitRuntimeService
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService" />
 
-`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`
+`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/qiskit_runtime_service.py "view source code")
 
 Class for interacting with the Qiskit Runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeDecoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeDecoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeDecoder
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder" />
 
-`RuntimeDecoder(*args, **kwargs)`
+`RuntimeDecoder(*args, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Decoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeEncoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeEncoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeEncoder
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder" />
 
-`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`
+`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Encoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeJob.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeJob
 
 <span id="qiskit_ibm_runtime.RuntimeJob" />
 
-`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`
+`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/runtime_job.py "view source code")
 
 Representation of a runtime program execution.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeOptions
 
 <span id="qiskit_ibm_runtime.RuntimeOptions" />
 
-`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`
+`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/runtime_options.py "view source code")
 
 Class for representing generic runtime execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeProgram.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.RuntimeProgram.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeProgram
 
 <span id="qiskit_ibm_runtime.RuntimeProgram" />
 
-`RuntimeProgram(program_name, program_id, description, parameters=None, return_values=None, interim_results=None, max_execution_time=0, backend_requirements=None, creation_date='', update_date='', is_public=False, data='', api_client=None)`
+`RuntimeProgram(program_name, program_id, description, parameters=None, return_values=None, interim_results=None, max_execution_time=0, backend_requirements=None, creation_date='', update_date='', is_public=False, data='', api_client=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/runtime_program.py "view source code")
 
 Class representing program metadata.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Sampler.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Sampler.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Sampler
 
 <span id="qiskit_ibm_runtime.Sampler" />
 
-`Sampler(backend=None, session=None, options=None)`
+`Sampler(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/sampler.py "view source code")
 
 Class for interacting with Qiskit Runtime Sampler primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.Session.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Session
 
 <span id="qiskit_ibm_runtime.Session" />
 
-`Session(service=None, backend=None, max_time=None)`
+`Session(service=None, backend=None, max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/session.py "view source code")
 
 Class for creating a flexible Qiskit Runtime session.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.EnvironmentOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.EnvironmentOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.EnvironmentOptions
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions" />
 
-`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`
+`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/environment_options.py "view source code")
 
 Options related to the execution environment.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.ExecutionOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.ExecutionOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ExecutionOptions
 
 <span id="qiskit_ibm_runtime.options.ExecutionOptions" />
 
-`ExecutionOptions(shots=4000, init_qubits=True)`
+`ExecutionOptions(shots=4000, init_qubits=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/execution_options.py "view source code")
 
 Execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.Options.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.Options.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.Options
 
 <span id="qiskit_ibm_runtime.options.Options" />
 
-`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`
+`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/options.py "view source code")
 
 Options for the primitives.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.ResilienceOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.ResilienceOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ResilienceOptions
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions" />
 
-`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`
+`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/resilience_options.py "view source code")
 
 Resilience options.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.SimulatorOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.SimulatorOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.SimulatorOptions
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions" />
 
-`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`
+`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/simulator_options.py "view source code")
 
 Simulator options.
 

--- a/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.TranspilationOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.15/qiskit_ibm_runtime.options.TranspilationOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.TranspilationOptions
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions" />
 
-`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`
+`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.15/qiskit_ibm_runtime/options/transpilation_options.py "view source code")
 
 Transpilation options.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Estimator.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Estimator.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Estimator
 
 <span id="qiskit_ibm_runtime.Estimator" />
 
-`Estimator(backend=None, session=None, options=None)`
+`Estimator(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/estimator.py "view source code")
 
 Class for interacting with Qiskit Runtime Estimator primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.IBMBackend.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.IBMBackend
 
 <span id="qiskit_ibm_runtime.IBMBackend" />
 
-`IBMBackend(configuration, service, api_client, instance=None)`
+`IBMBackend(configuration, service, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/ibm_backend.py "view source code")
 
 Backend class interfacing with an IBM Quantum backend.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.QiskitRuntimeService.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.QiskitRuntimeService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.QiskitRuntimeService
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService" />
 
-`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`
+`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/qiskit_runtime_service.py "view source code")
 
 Class for interacting with the Qiskit Runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeDecoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeDecoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeDecoder
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder" />
 
-`RuntimeDecoder(*args, **kwargs)`
+`RuntimeDecoder(*args, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Decoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeEncoder.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeEncoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeEncoder
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder" />
 
-`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`
+`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Encoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeJob.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeJob
 
 <span id="qiskit_ibm_runtime.RuntimeJob" />
 
-`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`
+`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/runtime_job.py "view source code")
 
 Representation of a runtime program execution.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.RuntimeOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeOptions
 
 <span id="qiskit_ibm_runtime.RuntimeOptions" />
 
-`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`
+`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/runtime_options.py "view source code")
 
 Class for representing generic runtime execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Sampler.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Sampler.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Sampler
 
 <span id="qiskit_ibm_runtime.Sampler" />
 
-`Sampler(backend=None, session=None, options=None)`
+`Sampler(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/sampler.py "view source code")
 
 Class for interacting with Qiskit Runtime Sampler primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.Session.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Session
 
 <span id="qiskit_ibm_runtime.Session" />
 
-`Session(service=None, backend=None, max_time=None)`
+`Session(service=None, backend=None, max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/session.py "view source code")
 
 Class for creating a flexible Qiskit Runtime session.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.EnvironmentOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.EnvironmentOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.EnvironmentOptions
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions" />
 
-`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`
+`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/environment_options.py "view source code")
 
 Options related to the execution environment.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.ExecutionOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.ExecutionOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ExecutionOptions
 
 <span id="qiskit_ibm_runtime.options.ExecutionOptions" />
 
-`ExecutionOptions(shots=4000, init_qubits=True)`
+`ExecutionOptions(shots=4000, init_qubits=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/execution_options.py "view source code")
 
 Execution options.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.Options.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.Options.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.Options
 
 <span id="qiskit_ibm_runtime.options.Options" />
 
-`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`
+`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/options.py "view source code")
 
 Options for the primitives.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.ResilienceOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.ResilienceOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ResilienceOptions
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions" />
 
-`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`
+`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/resilience_options.py "view source code")
 
 Resilience options.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.SimulatorOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.SimulatorOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.SimulatorOptions
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions" />
 
-`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`
+`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/simulator_options.py "view source code")
 
 Simulator options.
 

--- a/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.TranspilationOptions.md
+++ b/docs/api/qiskit-ibm-runtime/0.16/qiskit_ibm_runtime.options.TranspilationOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.TranspilationOptions
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions" />
 
-`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`
+`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.16/qiskit_ibm_runtime/options/transpilation_options.py "view source code")
 
 Transpilation options.
 

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -169,7 +169,7 @@ zxMain(async () => {
     await downloadCIArtifact(pkg.name, artifactUrl, destination);
   }
 
-  const baseGitHubUrl = `https://github.com/${pkg.githubSlug}/tree/${pkg.versionWithoutPatch}/`;
+  const baseGitHubUrl = `https://github.com/${pkg.githubSlug}/tree/stable/${pkg.versionWithoutPatch}/`;
   const outputDir = pkg.historical
     ? `${getRoot()}/docs/api/${pkg.name}/${pkg.versionWithoutPatch}`
     : `${getRoot()}/docs/api/${pkg.name}`;

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -169,7 +169,7 @@ zxMain(async () => {
     await downloadCIArtifact(pkg.name, artifactUrl, destination);
   }
 
-  const baseSourceUrl = `https://github.com/${pkg.githubSlug}/tree/${pkg.versionWithoutPatch}/`;
+  const baseGitHubUrl = `https://github.com/${pkg.githubSlug}/tree/${pkg.versionWithoutPatch}/`;
   const outputDir = pkg.historical
     ? `${getRoot()}/docs/api/${pkg.name}/${pkg.versionWithoutPatch}`
     : `${getRoot()}/docs/api/${pkg.name}`;
@@ -188,7 +188,7 @@ zxMain(async () => {
   await convertHtmlToMarkdown(
     `${destination}/artifact`,
     outputDir,
-    baseSourceUrl,
+    baseGitHubUrl,
     pkg,
   );
 });
@@ -210,7 +210,7 @@ async function rmFilesInFolder(
 async function convertHtmlToMarkdown(
   htmlPath: string,
   markdownPath: string,
-  baseSourceUrl: string,
+  baseGitHubUrl: string,
   pkg: Pkg,
 ) {
   const files = await globby(
@@ -233,7 +233,7 @@ async function convertHtmlToMarkdown(
     const result = await sphinxHtmlToMarkdown({
       html,
       url: `${pkg.baseUrl}/${file}`,
-      baseSourceUrl,
+      baseGitHubUrl,
       imageDestination: pkg.historical
         ? `/images/api/${pkg.name}/${pkg.versionWithoutPatch}`
         : `/images/api/${pkg.name}`,

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -462,7 +462,7 @@ describe("sphinxHtmlToMarkdown", () => {
 
       <span id="qiskit_ibm_runtime.options.Options" />
 
-      \`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)\`
+      \`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/options/options.py "view source code")
       "
     `);
   });
@@ -589,7 +589,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 
       <span id="qiskit_ibm_runtime.Sampler" />
 
-      \`Sampler(circuits=None, parameters=None, service=None, session=None, options=None, skip_transpilation=False)\`
+      \`Sampler(circuits=None, parameters=None, service=None, session=None, options=None, skip_transpilation=False) \`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/sampler.py "view source code")
 
       Class for interacting with Qiskit Runtime Sampler primitive service.
       ",
@@ -670,7 +670,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 
       <span id="qiskit_ibm_runtime.Estimator.run" />
 
-      \`Estimator.run(circuits, observables, parameter_values=None, **kwargs)\`
+      \`Estimator.run(circuits, observables, parameter_values=None, **kwargs)\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/estimator.py "view source code")
 
       Submit a request to the estimator primitive program.
       ",
@@ -763,7 +763,7 @@ By default this is sys.stdout.</p></li>
 
       <span id="qiskit_ibm_provider.job.job_monitor" />
 
-      \`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)\`
+      \`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/job_monitor.py "view source code")
 
       Monitor the status of an \`IBMJob\` instance.
 
@@ -815,7 +815,7 @@ By default this is sys.stdout.</p></li>
 
       <span id="qiskit_ibm_provider.job.IBMJobError" />
 
-      \`IBMJobError(*message)\`
+      \`IBMJobError(*message)\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/exceptions.py "view source code")
 
       Base class for errors raised by the job modules.
 
@@ -886,7 +886,7 @@ By default this is sys.stdout.</p></li>
 
       <span id="qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state" />
 
-      \`IBMCircuitJob.wait_for_final_state(timeout=None)\`
+      \`IBMCircuitJob.wait_for_final_state(timeout=None) \`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
       ## Use the websocket server to wait for the final the state of a job. The server
 
@@ -956,7 +956,7 @@ bits.</p>
 
       <span id="qiskit.dagcircuit.DAGCircuit" />
 
-      \`qiskit.dagcircuit.DAGCircuit\`
+      \`qiskit.dagcircuit.DAGCircuit\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py "view source code")
 
       Bases: \`object\`
 
@@ -1439,7 +1439,7 @@ test("test dt tag without id", async () => {
   ).toMatchInlineSnapshot(`
   "In addition to the public abstract methods, subclasses should also implement the following private methods:
   
-  \`classmethod _default_options()\`
+  \`classmethod _default_options()\`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/providers/basicaer/qasm_simulator.py "view source code")
   
   Return the default options
   

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -16,7 +16,7 @@ import { sphinxHtmlToMarkdown } from "./htmlToMd";
 
 const DEFAULT_ARGS = {
   imageDestination: "/images/qiskit",
-  baseSourceUrl: "https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/",
+  baseGitHubUrl: "https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/",
   releaseNotesTitle: "My Quantum release notes",
 };
 

--- a/scripts/lib/api/htmlToMd.ts
+++ b/scripts/lib/api/htmlToMd.ts
@@ -34,9 +34,8 @@ export async function sphinxHtmlToMarkdown(options: {
   html: string;
   url: string;
   imageDestination: string;
-  // url links to a fixed version and ending in /
-  // https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/
-  baseSourceUrl: string;
+  // E.g. https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/
+  baseGitHubUrl: string;
   releaseNotesTitle: string;
 }): Promise<HtmlToMdResult> {
   const processedHtml = processHtml(options);

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -23,7 +23,7 @@ import {
   removeDownloadSourceCode,
   removePermalinks,
   removeColonSpans,
-  replaceSourceLinksWithGitHub,
+  replaceViewcodeLinksWithGitHub,
 } from "./processHtml";
 import { Metadata } from "./Metadata";
 
@@ -245,7 +245,7 @@ test("replaceSourceLinksWithGitHub()", () => {
   const doc = Doc.load(
     `<a class="reference internal" href="../_modules/qiskit_ibm_runtime/ibm_backend#IBMBackend"></a><a href="#qiskit_ibm_runtime.IBMBackend"></a>`,
   );
-  replaceSourceLinksWithGitHub(
+  replaceViewcodeLinksWithGitHub(
     doc.$,
     doc.$main,
     "https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/",

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -24,6 +24,7 @@ import {
   removePermalinks,
   removeColonSpans,
   replaceViewcodeLinksWithGitHub,
+  prepareGitHubLink,
 } from "./processHtml";
 import { Metadata } from "./Metadata";
 
@@ -295,6 +296,29 @@ describe("maybeSetModuleMetadata()", () => {
     checkModuleFound(
       `<section id="module-qiskit_ibm_provider.transpiler.passes.basis"><h1>Hello</h1></section>`,
       "qiskit_ibm_provider.transpiler.passes.basis",
+    );
+  });
+});
+
+describe("prepareGitHubLink()", () => {
+  test("no link", () => {
+    const html = `<span class="pre">None</span><span class="sig-paren">)</span><a class="headerlink" href="#qiskit_ibm_runtime.IBMBackend" title="Link to this definition">#</a>`;
+    const doc = Doc.load(html);
+    const result = prepareGitHubLink(doc.$, doc.$main);
+    expect(result).toEqual("");
+    doc.expectHtml(html);
+  });
+
+  test("link", () => {
+    const doc = Doc.load(
+      `<span class="pre">None</span><span class="sig-paren">)</span><a class="reference internal" href="https://ibm.com/my_link"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_runtime.IBMBackend" title="Link to this definition">#</a>`,
+    );
+    const result = prepareGitHubLink(doc.$, doc.$main);
+    expect(result).toEqual(
+      `<a href="https://ibm.com/my_link" title="view source code">GitHub</a>`,
+    );
+    doc.expectHtml(
+      `<span class="pre">None</span><span class="sig-paren">)</span><a class="headerlink" href="#qiskit_ibm_runtime.IBMBackend" title="Link to this definition">#</a>`,
     );
   });
 });

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -28,10 +28,10 @@ export function processHtml(options: {
   html: string;
   url: string;
   imageDestination: string;
-  baseSourceUrl: string;
+  baseGitHubUrl: string;
   releaseNotesTitle: string;
 }): ProcessedHtml {
-  const { html, url, imageDestination, baseSourceUrl, releaseNotesTitle } =
+  const { html, url, imageDestination, baseGitHubUrl, releaseNotesTitle } =
     options;
   const $ = load(html);
   const $main = $(`[role='main']`);
@@ -48,7 +48,7 @@ export function processHtml(options: {
   removeDownloadSourceCode($main);
   handleSphinxDesignCards($, $main);
   addLanguageClassToCodeBlocks($, $main);
-  replaceSourceLinksWithGitHub($, $main, baseSourceUrl);
+  replaceViewcodeLinksWithGitHub($, $main, baseGitHubUrl);
   convertRubricsToHeaders($, $main);
   processSimpleFieldLists($, $main);
   removeColonSpans($main);
@@ -159,11 +159,18 @@ export function addLanguageClassToCodeBlocks(
   });
 }
 
-// TODO(#519): figure out if this is working.
-export function replaceSourceLinksWithGitHub(
+/**
+ * Redirect URLS from sphinx.ext.viewcode to instead go to GitHub.
+ *
+ * These URLs will only go to the overall source code file, not the specific lines
+ * of code. This function only changes the URLs; the DOM still needs to be modified
+ * to remove the original `[source]` anchor element from Sphinx with our own `GitHub`
+ * anchor element in the correct location.
+ */
+export function replaceViewcodeLinksWithGitHub(
   $: CheerioAPI,
   $main: Cheerio<any>,
-  baseSourceUrl: string,
+  baseGitHubUrl: string,
 ): void {
   $main.find("a").each((_, a) => {
     const $a = $(a);
@@ -177,7 +184,7 @@ export function replaceSourceLinksWithGitHub(
     }
     //_modules/qiskit_ibm_runtime/ibm_backend
     const match = href.match(/_modules\/(.*?)(#|$)/)!;
-    const newHref = `${baseSourceUrl}${match[1]}.py`;
+    const newHref = `${baseGitHubUrl}${match[1]}.py`;
     $a.attr("href", newHref);
   });
 }

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -263,8 +263,8 @@ export function processMembersAndSetMeta(
       .toArray()
       .map((child) => {
         const $child = $(child);
-        $child.find(".viewcode-link").closest("a").remove();
         const id = $dl.find("dt").attr("id") || "";
+        const github = prepareGitHubLink($, $child);
 
         const apiType = getApiType($dl);
 
@@ -280,7 +280,7 @@ export function processMembersAndSetMeta(
 
         if (apiType == "class") {
           findByText($, $main, "em.property", "class").remove();
-          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code></p>`;
+          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
         }
 
         if (apiType == "property") {
@@ -291,7 +291,7 @@ export function processMembersAndSetMeta(
           findByText($, $main, "em.property", "property").remove();
           const signature = $child.find("em").text()?.replace(/^:\s+/, "");
           if (signature.trim().length === 0) return;
-          return `<span class="target" id='${id}'/><p><code>${signature}</code></p>`;
+          return `<span class="target" id='${id}'/><p><code>${signature}</code>${github}</p>`;
         }
 
         if (apiType == "method") {
@@ -307,7 +307,7 @@ export function processMembersAndSetMeta(
           }
 
           findByText($, $main, "em.property", "method").remove();
-          return `<span class="target" id='${id}'/><p><code>${$child.html()}</code></p>`;
+          return `<span class="target" id='${id}'/><p><code>${$child.html()}</code>${github}</p>`;
         }
 
         if (apiType == "attribute") {
@@ -319,7 +319,7 @@ export function processMembersAndSetMeta(
             findByText($, $main, "em.property", "attribute").remove();
             const signature = $child.find("em").text()?.replace(/^:\s+/, "");
             if (signature.trim().length === 0) return;
-            return `<span class="target" id='${id}'/><p><code>${signature}</code></p>`;
+            return `<span class="target" id='${id}'/><p><code>${signature}</code>${github}</p>`;
           }
 
           // Else, the attribute is embedded on the class
@@ -352,12 +352,12 @@ export function processMembersAndSetMeta(
 
         if (apiType === "function") {
           findByText($, $main, "em.property", "function").remove();
-          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code></p>`;
+          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
         }
 
         if (apiType === "exception") {
           findByText($, $main, "em.property", "exception").remove();
-          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code></p>`;
+          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
         }
 
         throw new Error(`Unhandled Python type: ${apiType}`);
@@ -366,6 +366,22 @@ export function processMembersAndSetMeta(
 
     $dl.replaceWith(`<div>${replacement}</div>`);
   }
+}
+
+/**
+ * Removes the original link from sphinx.ext.viewcode and returns the HTML string for our own link.
+ *
+ * This returns the HTML string, rather than directly inserting into the HTML, because the insertion
+ * logic is most easily handled by the calling code.
+ */
+export function prepareGitHubLink($: CheerioAPI, $child: Cheerio<any>): string {
+  const originalLink = $child.find(".viewcode-link").closest("a");
+  if (originalLink.length === 0) {
+    return "";
+  }
+  const href = originalLink.attr("href")!;
+  originalLink.remove();
+  return `<a href="${href}" title="view source code">GitHub</a>`;
 }
 
 export function maybeSetModuleMetadata(


### PR DESCRIPTION
Implements https://github.com/Qiskit/documentation/issues/454 for projects that are using `sphinx.ext.viewcode`. All 3 of our projects were historically using it until I turned it off after removing qiskit.org, so the historical API docs are good to go. I'll restore it for current versions of these projects and regenerate the docs. 

This implementation is not a perfect implementation:

1. The visual design is a little awkward, especially the lack of padding. This can be improved via https://github.com/Qiskit/documentation/issues/518

<img width="571" alt="Screenshot 2024-01-11 at 12 28 07 PM" src="https://github.com/Qiskit/documentation/assets/14852634/2d915b94-ec48-445a-a174-ace628655b4b">

2. The link only takes you to the overall code page, not the specific lines. This could be improved via https://github.com/Qiskit/documentation/issues/517.

But it's good enough to not block on these improvements.

This PR regenerates all Runtime historical versions, but not any current versions nor Qiskit historical versions.

## How source code URLs are determined

`sphinx.ext.viewcode` embeds a copy of every Python file used in API docs and uses internal relative links like `../modules/qiskit_ibm_runtime/ibm_backend.html`. They correspond to Python files we can be confident exist. We transform those relative links into GitHub links here:

https://github.com/Qiskit/documentation/blob/790e9372f64ab7d5f15eaccc229b4d0765781d44/scripts/lib/api/processHtml.ts#L94-L105

https://github.com/Qiskit/documentation/blob/790e9372f64ab7d5f15eaccc229b4d0765781d44/scripts/lib/api/processHtml.ts#L163-L183

Our links assume that there is a branch called `stable/<versionWithoutPatch` in GitHub, like `stable/0.8`.

## Replacing `[source]` with `GitHub ↗︎`

We remove the original link from Sphinx and replace it with our own. This is important so that the link is not included in the `<code>` HTML element incorrectly. It also allows us to set a custom link label and `title` (the text when highlighting).
