### PR TITLE
Add GitHub links for Provider API docs

### DIFF
--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackend.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackend
 
 <span id="qiskit_ibm_provider.IBMBackend" />
 
-`IBMBackend(configuration, provider, api_client, instance=None)`
+`IBMBackend(configuration, provider, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Backend class interfacing with an IBM Quantum device.
 
@@ -372,7 +372,7 @@ A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit 
 
 <span id="qiskit_ibm_provider.IBMBackend.acquire_channel" />
 
-`IBMBackend.acquire_channel(qubit)`
+`IBMBackend.acquire_channel(qubit)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the acquisition channel for the given qubit.
 
@@ -390,7 +390,7 @@ AcquireChannel
 
 <span id="qiskit_ibm_provider.IBMBackend.cancel_session" />
 
-`IBMBackend.cancel_session()`
+`IBMBackend.cancel_session()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Cancel session. All pending jobs will be cancelled.
 
@@ -404,7 +404,7 @@ Cancel session. All pending jobs will be cancelled.
 
 <span id="qiskit_ibm_provider.IBMBackend.close_session" />
 
-`IBMBackend.close_session()`
+`IBMBackend.close_session()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Close the session so new jobs will no longer be accepted, but existing queued or running jobs will run to completion. The session will be terminated once there are no more pending jobs.
 
@@ -418,7 +418,7 @@ Close the session so new jobs will no longer be accepted, but existing queued or
 
 <span id="qiskit_ibm_provider.IBMBackend.configuration" />
 
-`IBMBackend.configuration()`
+`IBMBackend.configuration()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the backend configuration.
 
@@ -440,7 +440,7 @@ The configuration for the backend.
 
 <span id="qiskit_ibm_provider.IBMBackend.control_channel" />
 
-`IBMBackend.control_channel(qubits)`
+`IBMBackend.control_channel(qubits)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the secondary drive channel for the given qubit.
 
@@ -464,7 +464,7 @@ List\[ControlChannel]
 
 <span id="qiskit_ibm_provider.IBMBackend.defaults" />
 
-`IBMBackend.defaults(refresh=False)`
+`IBMBackend.defaults(refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the pulse defaults for the backend.
 
@@ -488,7 +488,7 @@ The backend pulse defaults or `None` if the backend does not support pulse.
 
 <span id="qiskit_ibm_provider.IBMBackend.drive_channel" />
 
-`IBMBackend.drive_channel(qubit)`
+`IBMBackend.drive_channel(qubit)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the drive channel for the given qubit.
 
@@ -506,7 +506,7 @@ DriveChannel
 
 <span id="qiskit_ibm_provider.IBMBackend.get_translation_stage_plugin" />
 
-`classmethod IBMBackend.get_translation_stage_plugin()`
+`classmethod IBMBackend.get_translation_stage_plugin()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the default translation stage plugin name for IBM backends.
 
@@ -520,7 +520,7 @@ Return the default translation stage plugin name for IBM backends.
 
 <span id="qiskit_ibm_provider.IBMBackend.measure_channel" />
 
-`IBMBackend.measure_channel(qubit)`
+`IBMBackend.measure_channel(qubit)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the measure stimulus channel for the given qubit.
 
@@ -538,7 +538,7 @@ MeasureChannel
 
 <span id="qiskit_ibm_provider.IBMBackend.open_session" />
 
-`IBMBackend.open_session(max_time=None)`
+`IBMBackend.open_session(max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Open session
 
@@ -552,7 +552,7 @@ Open session
 
 <span id="qiskit_ibm_provider.IBMBackend.properties" />
 
-`IBMBackend.properties(refresh=False, datetime=None)`
+`IBMBackend.properties(refresh=False, datetime=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the backend properties, subject to optional filtering.
 
@@ -611,7 +611,7 @@ The `QubitProperties` object for the specified qubit. If a list of qubits is pro
 
 <span id="qiskit_ibm_provider.IBMBackend.run" />
 
-`IBMBackend.run(circuits, dynamic=None, job_tags=None, init_circuit=None, init_num_resets=None, header=None, shots=None, memory=None, meas_level=None, meas_return=None, rep_delay=None, init_qubits=None, use_measure_esp=None, noise_model=None, seed_simulator=None, **run_config)`
+`IBMBackend.run(circuits, dynamic=None, job_tags=None, init_circuit=None, init_num_resets=None, header=None, shots=None, memory=None, meas_level=None, meas_return=None, rep_delay=None, init_qubits=None, use_measure_esp=None, noise_model=None, seed_simulator=None, **run_config)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Run on the backend. If a keyword specified here is also present in the `options` attribute/object, the value specified here will be used for this run.
 
@@ -708,7 +708,7 @@ This method is used to update the options of a backend. If you need to change an
 
 <span id="qiskit_ibm_provider.IBMBackend.status" />
 
-`IBMBackend.status()`
+`IBMBackend.status()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 Return the backend status.
 
@@ -734,7 +734,7 @@ The status of the backend.
 
 <span id="qiskit_ibm_provider.IBMBackend.target_history" />
 
-`IBMBackend.target_history(datetime=None)`
+`IBMBackend.target_history(datetime=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend.py "view source code")
 
 A [`qiskit.transpiler.Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.45)") object for the backend. :rtype: [`Target`](/api/qiskit/qiskit.transpiler.Target "(in Qiskit v0.45)") :returns: Target with properties found on datetime
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendApiError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendApiError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackendApiError
 
 <span id="qiskit_ibm_provider.IBMBackendApiError" />
 
-`IBMBackendApiError(*message)`
+`IBMBackendApiError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Errors that occur unexpectedly when querying the server.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendApiProtocolError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendApiProtocolError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackendApiProtocolError
 
 <span id="qiskit_ibm_provider.IBMBackendApiProtocolError" />
 
-`IBMBackendApiProtocolError(*message)`
+`IBMBackendApiProtocolError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Errors raised when an unexpected value is received from the server.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackendError
 
 <span id="qiskit_ibm_provider.IBMBackendError" />
 
-`IBMBackendError(*message)`
+`IBMBackendError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Base class for errors raised by the backend modules.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendService.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackendService
 
 <span id="qiskit_ibm_provider.IBMBackendService" />
 
-`IBMBackendService(provider, hgp)`
+`IBMBackendService(provider, hgp)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend_service.py "view source code")
 
 Backend namespace for an IBM Quantum account.
 
@@ -48,7 +48,7 @@ IBMBackendService constructor.
 
 <span id="qiskit_ibm_provider.IBMBackendService.backends" />
 
-`IBMBackendService.backends(name=None, filters=None, min_num_qubits=None, instance=None, dynamic_circuits=None, **kwargs)`
+`IBMBackendService.backends(name=None, filters=None, min_num_qubits=None, instance=None, dynamic_circuits=None, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend_service.py "view source code")
 
 Return all backends accessible via this account, subject to optional filtering.
 
@@ -107,7 +107,7 @@ The list of available backends that match the filter.
 
 <span id="qiskit_ibm_provider.IBMBackendService.jobs" />
 
-`IBMBackendService.jobs(limit=10, skip=0, backend_name=None, status=None, start_datetime=None, end_datetime=None, job_tags=None, descending=True, instance=None, legacy=False)`
+`IBMBackendService.jobs(limit=10, skip=0, backend_name=None, status=None, start_datetime=None, end_datetime=None, job_tags=None, descending=True, instance=None, legacy=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend_service.py "view source code")
 
 Return a list of jobs, subject to optional filtering.
 
@@ -149,7 +149,7 @@ A list of `IBMJob` instances.
 
 <span id="qiskit_ibm_provider.IBMBackendService.retrieve_job" />
 
-`IBMBackendService.retrieve_job(job_id)`
+`IBMBackendService.retrieve_job(job_id)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_backend_service.py "view source code")
 
 Return a single job.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendValueError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMBackendValueError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMBackendValueError
 
 <span id="qiskit_ibm_provider.IBMBackendValueError" />
 
-`IBMBackendValueError(*message)`
+`IBMBackendValueError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Value errors raised by the backend modules.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMError
 
 <span id="qiskit_ibm_provider.IBMError" />
 
-`IBMError(*message)`
+`IBMError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Base class for errors raised by the provider modules.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProvider.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProvider.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMProvider
 
 <span id="qiskit_ibm_provider.IBMProvider" />
 
-`IBMProvider(token=None, url=None, name=None, instance=None, proxies=None, verify=None)`
+`IBMProvider(token=None, url=None, name=None, instance=None, proxies=None, verify=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Provides access to the IBM Quantum services available to an account.
 
@@ -145,7 +145,7 @@ The backend service instance.
 
 <span id="qiskit_ibm_provider.IBMProvider.active_account" />
 
-`IBMProvider.active_account()`
+`IBMProvider.active_account()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return the IBM Quantum account currently in use for the session.
 
@@ -163,7 +163,7 @@ A dictionary with information about the account currently in the session.
 
 <span id="qiskit_ibm_provider.IBMProvider.backends" />
 
-`IBMProvider.backends(name=None, filters=None, min_num_qubits=None, instance=None, **kwargs)`
+`IBMProvider.backends(name=None, filters=None, min_num_qubits=None, instance=None, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return all backends accessible via this account, subject to optional filtering.
 
@@ -213,7 +213,7 @@ The list of available backends that match the filter.
 
 <span id="qiskit_ibm_provider.IBMProvider.delete_account" />
 
-`static IBMProvider.delete_account(name=None)`
+`static IBMProvider.delete_account(name=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Delete a saved account from disk.
 
@@ -235,7 +235,7 @@ True if the account was deleted. False if no account was found.
 
 <span id="qiskit_ibm_provider.IBMProvider.get_backend" />
 
-`IBMProvider.get_backend(name=None, instance=None, **kwargs)`
+`IBMProvider.get_backend(name=None, instance=None, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return a single backend matching the specified filtering.
 
@@ -264,7 +264,7 @@ Backend
 
 <span id="qiskit_ibm_provider.IBMProvider.instances" />
 
-`IBMProvider.instances()`
+`IBMProvider.instances()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return the IBM Quantum instances list currently in use for the session.
 
@@ -282,7 +282,7 @@ A list with instances currently in the session.
 
 <span id="qiskit_ibm_provider.IBMProvider.jobs" />
 
-`IBMProvider.jobs(limit=10, skip=0, backend_name=None, status=None, start_datetime=None, end_datetime=None, job_tags=None, descending=True, instance=None, legacy=False)`
+`IBMProvider.jobs(limit=10, skip=0, backend_name=None, status=None, start_datetime=None, end_datetime=None, job_tags=None, descending=True, instance=None, legacy=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return a list of jobs, subject to optional filtering.
 
@@ -317,7 +317,7 @@ A list of `IBMJob` instances.
 
 <span id="qiskit_ibm_provider.IBMProvider.retrieve_job" />
 
-`IBMProvider.retrieve_job(job_id)`
+`IBMProvider.retrieve_job(job_id)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Return a single job.
 
@@ -339,7 +339,7 @@ The job with the given id.
 
 <span id="qiskit_ibm_provider.IBMProvider.save_account" />
 
-`static IBMProvider.save_account(token=None, url=None, instance=None, name=None, proxies=None, verify=None, overwrite=False)`
+`static IBMProvider.save_account(token=None, url=None, instance=None, name=None, proxies=None, verify=None, overwrite=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 Save the account to disk for future use.
 
@@ -363,7 +363,7 @@ Save the account to disk for future use.
 
 <span id="qiskit_ibm_provider.IBMProvider.saved_accounts" />
 
-`static IBMProvider.saved_accounts(default=None, name=None)`
+`static IBMProvider.saved_accounts(default=None, name=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/ibm_provider.py "view source code")
 
 List the accounts saved on disk.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProviderError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProviderError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMProviderError
 
 <span id="qiskit_ibm_provider.IBMProviderError" />
 
-`IBMProviderError(*message)`
+`IBMProviderError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Base class for errors raise by IBMProvider.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProviderValueError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.IBMProviderValueError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.IBMProviderValueError
 
 <span id="qiskit_ibm_provider.IBMProviderValueError" />
 
-`IBMProviderValueError(*message)`
+`IBMProviderValueError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/exceptions.py "view source code")
 
 Value errors raised by IBMProvider.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.Session.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.Session.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.Session
 
 <span id="qiskit_ibm_provider.Session" />
 
-`Session(max_time=None)`
+`Session(max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/session.py "view source code")
 
 Class for creating a flexible Qiskit Runtime session.
 
@@ -99,7 +99,7 @@ Session ID. None until a job runs in the session.
 
 <span id="qiskit_ibm_provider.Session.cancel" />
 
-`Session.cancel()`
+`Session.cancel()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/session.py "view source code")
 
 Set the session.\_active status to False
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCircuitJob.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCircuitJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMCircuitJob
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob" />
 
-`IBMCircuitJob(backend, api_client, job_id, creation_date=None, status=None, runtime_client=None, kind=None, name=None, time_per_step=None, result=None, error=None, session_id=None, tags=None, run_mode=None, client_info=None, **kwargs)`
+`IBMCircuitJob(backend, api_client, job_id, creation_date=None, status=None, runtime_client=None, kind=None, name=None, time_per_step=None, result=None, error=None, session_id=None, tags=None, run_mode=None, client_info=None, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Representation of a job that executes on an IBM Quantum backend.
 
@@ -139,7 +139,7 @@ Return the backend where this job was executed.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.backend_options" />
 
-`IBMCircuitJob.backend_options()`
+`IBMCircuitJob.backend_options()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the backend configuration options used for this job.
 
@@ -159,7 +159,7 @@ Backend options used for this job. An empty dictionary is returned if the option
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.cancel" />
 
-`IBMCircuitJob.cancel()`
+`IBMCircuitJob.cancel()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Attempt to cancel the job.
 
@@ -200,7 +200,7 @@ Return whether the job has been cancelled.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.circuits" />
 
-`IBMCircuitJob.circuits()`
+`IBMCircuitJob.circuits()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the circuits for this job.
 
@@ -218,7 +218,7 @@ The circuits or for this job. An empty list is returned if the circuits cannot b
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.creation_date" />
 
-`IBMCircuitJob.creation_date()`
+`IBMCircuitJob.creation_date()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return job creation date, in local time.
 
@@ -250,7 +250,7 @@ Return whether the job has successfully run.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.error_message" />
 
-`IBMCircuitJob.error_message()`
+`IBMCircuitJob.error_message()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Provide details about the reason of failure.
 
@@ -268,7 +268,7 @@ An error report if the job failed or `None` otherwise.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.header" />
 
-`IBMCircuitJob.header()`
+`IBMCircuitJob.header()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the user header specified for this job.
 
@@ -300,7 +300,7 @@ Return whether the job is in a final job state such as `DONE` or `ERROR`.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.job_id" />
 
-`IBMCircuitJob.job_id()`
+`IBMCircuitJob.job_id()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the job ID assigned by the server.
 
@@ -358,7 +358,7 @@ The backend properties used for this job, at the time the job was run, or `None`
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.queue_info" />
 
-`IBMCircuitJob.queue_info()`
+`IBMCircuitJob.queue_info()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return queue information for this job.
 
@@ -382,7 +382,7 @@ A [`QueueInfo`](qiskit_ibm_provider.job.QueueInfo "qiskit_ibm_provider.job.Queue
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.queue_position" />
 
-`IBMCircuitJob.queue_position(refresh=False)`
+`IBMCircuitJob.queue_position(refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the position of the job in the server queue.
 
@@ -408,7 +408,7 @@ Position in the queue or `None` if position is unknown or not applicable.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.refresh" />
 
-`IBMCircuitJob.refresh()`
+`IBMCircuitJob.refresh()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Obtain the latest job information from the server.
 
@@ -428,7 +428,7 @@ This method may add additional attributes to this job instance, if new informati
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.result" />
 
-`IBMCircuitJob.result(timeout=None, refresh=False)`
+`IBMCircuitJob.result(timeout=None, refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the result of the job.
 
@@ -510,7 +510,7 @@ The scheduling mode the job is in or `None` if the information is not available.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.status" />
 
-`IBMCircuitJob.status()`
+`IBMCircuitJob.status()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Query the server for the latest job status.
 
@@ -540,7 +540,7 @@ The status of the job.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.submit" />
 
-`IBMCircuitJob.submit()`
+`IBMCircuitJob.submit()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Unsupported method.
 
@@ -580,7 +580,7 @@ Tags assigned to this job.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.time_per_step" />
 
-`IBMCircuitJob.time_per_step()`
+`IBMCircuitJob.time_per_step()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Return the date and time information on each step of the job processing.
 
@@ -628,7 +628,7 @@ The new name associated with this job.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.update_tags" />
 
-`IBMCircuitJob.update_tags(new_tags)`
+`IBMCircuitJob.update_tags(new_tags)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 Update the tags associated with this job.
 
@@ -655,7 +655,7 @@ The new tags associated with this job.
 
 <span id="qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state" />
 
-`IBMCircuitJob.wait_for_final_state(timeout=None, wait=3)`
+`IBMCircuitJob.wait_for_final_state(timeout=None, wait=3)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_circuit_job.py "view source code")
 
 #### Use the websocket server to wait for the final the state of a job. The server
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCompositeJob.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMCompositeJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMCompositeJob
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob" />
 
-`IBMCompositeJob(backend, api_client, job_id=None, creation_date=None, jobs=None, circuits_list=None, run_config=None, name=None, tags=None, client_version=None)`
+`IBMCompositeJob(backend, api_client, job_id=None, creation_date=None, jobs=None, circuits_list=None, run_config=None, name=None, tags=None, client_version=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Representation of a set of jobs that execute on an IBM Quantum backend.
 
@@ -97,7 +97,7 @@ Return the backend where this job was executed.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.backend_options" />
 
-`IBMCompositeJob.backend_options()`
+`IBMCompositeJob.backend_options()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the backend configuration options used for this job.
 
@@ -117,7 +117,7 @@ Backend options used for this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.block_for_submit" />
 
-`IBMCompositeJob.block_for_submit()`
+`IBMCompositeJob.block_for_submit()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Block until all sub-jobs are submitted.
 
@@ -131,7 +131,7 @@ Block until all sub-jobs are submitted.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.cancel" />
 
-`IBMCompositeJob.cancel()`
+`IBMCompositeJob.cancel()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Attempt to cancel the job.
 
@@ -171,7 +171,7 @@ Return whether the job has been cancelled.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.circuits" />
 
-`IBMCompositeJob.circuits()`
+`IBMCompositeJob.circuits()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the circuits for this job.
 
@@ -189,7 +189,7 @@ The circuits for this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.creation_date" />
 
-`IBMCompositeJob.creation_date()`
+`IBMCompositeJob.creation_date()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return job creation date, in local time.
 
@@ -221,7 +221,7 @@ Return whether the job has successfully run.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.error_message" />
 
-`IBMCompositeJob.error_message()`
+`IBMCompositeJob.error_message()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Provide details about the reason of failure.
 
@@ -243,7 +243,7 @@ An error report if the job failed or `None` otherwise.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.from_jobs" />
 
-`classmethod IBMCompositeJob.from_jobs(job_id, jobs, api_client)`
+`classmethod IBMCompositeJob.from_jobs(job_id, jobs, api_client)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return an instance of this class.
 
@@ -269,7 +269,7 @@ An instance of this class.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.header" />
 
-`IBMCompositeJob.header()`
+`IBMCompositeJob.header()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the user header specified for this job.
 
@@ -333,7 +333,7 @@ Job name or `None` if no name was assigned to this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.properties" />
 
-`IBMCompositeJob.properties(refresh=False)`
+`IBMCompositeJob.properties(refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the backend properties for this job.
 
@@ -365,7 +365,7 @@ The backend properties used for this job, or `None` if properties are not availa
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.queue_info" />
 
-`IBMCompositeJob.queue_info()`
+`IBMCompositeJob.queue_info()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return queue information for this job.
 
@@ -391,7 +391,7 @@ A [`QueueInfo`](qiskit_ibm_provider.job.QueueInfo "qiskit_ibm_provider.job.Queue
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.queue_position" />
 
-`IBMCompositeJob.queue_position(refresh=False)`
+`IBMCompositeJob.queue_position(refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the position of the job in the server queue.
 
@@ -419,7 +419,7 @@ Position in the queue or `None` if position is unknown or not applicable.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.refresh" />
 
-`IBMCompositeJob.refresh()`
+`IBMCompositeJob.refresh()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Obtain the latest job information from the server.
 
@@ -439,7 +439,7 @@ This method may add additional attributes to this job instance, if new informati
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.report" />
 
-`IBMCompositeJob.report(detailed=True)`
+`IBMCompositeJob.report(detailed=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return a report on current sub-job statuses.
 
@@ -461,7 +461,7 @@ A report on sub-job statuses.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.rerun_failed" />
 
-`IBMCompositeJob.rerun_failed()`
+`IBMCompositeJob.rerun_failed()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Re-submit all failed sub-jobs.
 
@@ -479,7 +479,7 @@ Re-submit all failed sub-jobs.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.result" />
 
-`IBMCompositeJob.result(timeout=None, wait=5, partial=False, refresh=False)`
+`IBMCompositeJob.result(timeout=None, wait=5, partial=False, refresh=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the result of the job.
 
@@ -549,7 +549,7 @@ Return whether the job is actively running.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.scheduling_mode" />
 
-`IBMCompositeJob.scheduling_mode()`
+`IBMCompositeJob.scheduling_mode()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the scheduling mode the job is in.
 
@@ -573,7 +573,7 @@ The scheduling mode the job is in or `None` if the information is not available.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.status" />
 
-`IBMCompositeJob.status()`
+`IBMCompositeJob.status()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Query the server for the latest job status.
 
@@ -615,7 +615,7 @@ The status of the job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.sub_job" />
 
-`IBMCompositeJob.sub_job(circuit_index)`
+`IBMCompositeJob.sub_job(circuit_index)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Retrieve the job used to submit the specified circuit.
 
@@ -641,7 +641,7 @@ The Job submitted for the circuit, or `None` if the job has not been submitted o
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.sub_jobs" />
 
-`IBMCompositeJob.sub_jobs(block_for_submit=True)`
+`IBMCompositeJob.sub_jobs(block_for_submit=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return all submitted sub-jobs.
 
@@ -663,7 +663,7 @@ All submitted sub-jobs.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.submit" />
 
-`IBMCompositeJob.submit()`
+`IBMCompositeJob.submit()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Unsupported method.
 
@@ -703,7 +703,7 @@ Tags assigned to this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.time_per_step" />
 
-`IBMCompositeJob.time_per_step()`
+`IBMCompositeJob.time_per_step()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Return the date and time information on each step of the job processing.
 
@@ -729,7 +729,7 @@ Date and time information on job processing steps, in local time, or `None` if t
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.update_name" />
 
-`IBMCompositeJob.update_name(name)`
+`IBMCompositeJob.update_name(name)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Update the name associated with this job.
 
@@ -760,7 +760,7 @@ The new name associated with this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.update_tags" />
 
-`IBMCompositeJob.update_tags(new_tags)`
+`IBMCompositeJob.update_tags(new_tags)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Update the tags associated with this job.
 
@@ -791,7 +791,7 @@ The new tags associated with this job.
 
 <span id="qiskit_ibm_provider.job.IBMCompositeJob.wait_for_final_state" />
 
-`IBMCompositeJob.wait_for_final_state(timeout=None, wait=None, callback=None)`
+`IBMCompositeJob.wait_for_final_state(timeout=None, wait=None, callback=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/ibm_composite_job.py "view source code")
 
 Wait until the job progresses to a final state such as `DONE` or `ERROR`.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobApiError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobApiError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMJobApiError
 
 <span id="qiskit_ibm_provider.job.IBMJobApiError" />
 
-`IBMJobApiError(*message)`
+`IBMJobApiError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py "view source code")
 
 Errors that occur unexpectedly when querying the server.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMJobError
 
 <span id="qiskit_ibm_provider.job.IBMJobError" />
 
-`IBMJobError(*message)`
+`IBMJobError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py "view source code")
 
 Base class for errors raised by the job modules.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobFailureError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobFailureError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMJobFailureError
 
 <span id="qiskit_ibm_provider.job.IBMJobFailureError" />
 
-`IBMJobFailureError(*message)`
+`IBMJobFailureError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py "view source code")
 
 Errors raised when a job failed.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobInvalidStateError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobInvalidStateError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMJobInvalidStateError
 
 <span id="qiskit_ibm_provider.job.IBMJobInvalidStateError" />
 
-`IBMJobInvalidStateError(*message)`
+`IBMJobInvalidStateError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py "view source code")
 
 Errors raised when a job is not in a valid state for the operation.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobTimeoutError.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.IBMJobTimeoutError.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.IBMJobTimeoutError
 
 <span id="qiskit_ibm_provider.job.IBMJobTimeoutError" />
 
-`IBMJobTimeoutError(*message)`
+`IBMJobTimeoutError(*message)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py "view source code")
 
 Errors raised when a job operation times out.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.QueueInfo.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.QueueInfo.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.job.QueueInfo
 
 <span id="qiskit_ibm_provider.job.QueueInfo" />
 
-`QueueInfo(position_in_queue=None, status=None, estimated_start_time=None, estimated_completion_time=None, hub_priority=None, group_priority=None, project_priority=None, job_id=None, **kwargs)`
+`QueueInfo(position_in_queue=None, status=None, estimated_start_time=None, estimated_completion_time=None, hub_priority=None, group_priority=None, project_priority=None, job_id=None, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/queueinfo.py "view source code")
 
 Queue information for a job.
 
@@ -66,7 +66,7 @@ Return estimated start time in local time.
 
 <span id="qiskit_ibm_provider.job.QueueInfo.format" />
 
-`QueueInfo.format()`
+`QueueInfo.format()`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/queueinfo.py "view source code")
 
 Build a user-friendly report for the job queue information.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.job_monitor.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.job.job_monitor.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.job.job_monitor
 
 <span id="qiskit_ibm_provider.job.job_monitor" />
 
-`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)`
+`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/job_monitor.py "view source code")
 
 Monitor the status of an `IBMJob` instance.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.least_busy
 
 <span id="qiskit_ibm_provider.least_busy" />
 
-`least_busy(backends)`
+`least_busy(backends)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider.py "view source code")
 
 Return the least busy backend from a list.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.least_busy.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.least_busy
 
 <span id="qiskit_ibm_provider.least_busy" />
 
-`least_busy(backends)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider.py "view source code")
+`least_busy(backends)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/__init__.py "view source code")
 
 Return the least busy backend from a list.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAn
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis" />
 
-`ALAPScheduleAnalysis(durations)`
+`ALAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Dynamic circuits as-late-as-possible (ALAP) scheduling analysis pass.
 
@@ -121,7 +121,7 @@ Name of the pass.
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis.run" />
 
-`ALAPScheduleAnalysis.run(dag)`
+`ALAPScheduleAnalysis.run(dag)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Run the ASAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.45)") :param dag: DAG to schedule. :type dag: DAGCircuit
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAn
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis" />
 
-`ASAPScheduleAnalysis(durations)`
+`ASAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Dynamic circuits as-soon-as-possible (ASAP) scheduling analysis pass.
 
@@ -121,7 +121,7 @@ Name of the pass.
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis.run" />
 
-`ASAPScheduleAnalysis.run(dag)`
+`ASAPScheduleAnalysis.run(dag)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Run the ALAPSchedule pass on dag. :type dag: [`DAGCircuit`](/api/qiskit/qiskit.dagcircuit.DAGCircuit "(in Qiskit v0.45)") :param dag: DAG to schedule. :type dag: DAGCircuit
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadde
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder" />
 
-`BlockBasePadder(schedule_idle_qubits=False)`
+`BlockBasePadder(schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py "view source code")
 
 The base class of padding pass.
 
@@ -112,7 +112,7 @@ Name of the pass.
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder.run" />
 
-`BlockBasePadder.run(dag)`
+`BlockBasePadder.run(dag)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py "view source code")
 
 Run the padding pass on `dag`.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuit
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations" />
 
-`DynamicCircuitInstructionDurations(instruction_durations=None, dt=None, enable_patching=True)`
+`DynamicCircuitInstructionDurations(instruction_durations=None, dt=None, enable_patching=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/utils.py "view source code")
 
 For dynamic circuits the IBM Qiskit backend currently reports instruction durations that differ compared with those required for the legacy Qobj-based path. For now we use this class to report updated InstructionDurations. TODO: This would be mitigated by a specialized Backend/Target for dynamic circuit backends.
 
@@ -117,7 +117,7 @@ Set of units used in this instruction durations.
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.update" />
 
-`DynamicCircuitInstructionDurations.update(inst_durations, dt=None)`
+`DynamicCircuitInstructionDurations.update(inst_durations, dt=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/utils.py "view source code")
 
 Update self with inst\_durations (inst\_durations overwrite self). Overrides the default durations for certain hardcoded instructions.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay" />
 
-`PadDelay(fill_very_end=True, schedule_idle_qubits=False)`
+`PadDelay(fill_very_end=True, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/pad_delay.py "view source code")
 
 Padding idle time with Delay instructions.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDe
 
 <span id="qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling" />
 
-`PadDynamicalDecoupling(durations, dd_sequences, qubits=None, spacings=None, skip_reset_qubits=True, pulse_alignment=16, extra_slack_distribution='middle', sequence_min_length_ratios=None, insert_multiple_cycles=False, coupling_map=None, alt_spacings=None, schedule_idle_qubits=False)`
+`PadDynamicalDecoupling(durations, dd_sequences, qubits=None, spacings=None, skip_reset_qubits=True, pulse_alignment=16, extra_slack_distribution='middle', sequence_min_length_ratios=None, insert_multiple_cycles=False, coupling_map=None, alt_spacings=None, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py "view source code")
 
 Dynamical decoupling insertion pass for IBM dynamic circuit backends.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.seconds_to_duration.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.seconds_to_duration.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.utils.seconds_to_duration
 
 <span id="qiskit_ibm_provider.utils.seconds_to_duration" />
 
-`seconds_to_duration(seconds)`
+`seconds_to_duration(seconds)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/utils/converters.py "view source code")
 
 Converts seconds in a datetime delta to a duration.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.to_python_identifier.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.to_python_identifier.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.utils.to_python_identifier
 
 <span id="qiskit_ibm_provider.utils.to_python_identifier" />
 
-`to_python_identifier(name)`
+`to_python_identifier(name)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/utils/utils.py "view source code")
 
 Convert a name to a valid Python identifier.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.utc_to_local.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.utc_to_local.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.utils.utc_to_local
 
 <span id="qiskit_ibm_provider.utils.utc_to_local" />
 
-`utc_to_local(utc_dt)`
+`utc_to_local(utc_dt)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/utils/converters.py "view source code")
 
 Convert a UTC `datetime` object or string to a local timezone `datetime`.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.validate_job_tags.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.utils.validate_job_tags.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.utils.validate_job_tags
 
 <span id="qiskit_ibm_provider.utils.validate_job_tags" />
 
-`validate_job_tags(job_tags, exception)`
+`validate_job_tags(job_tags, exception)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/utils/utils.py "view source code")
 
 Validates input job tags.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.visualization.iplot_error_map.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.visualization.iplot_error_map.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.visualization.iplot_error_map
 
 <span id="qiskit_ibm_provider.visualization.iplot_error_map" />
 
-`iplot_error_map(backend, figsize=(800, 500), show_title=True, remove_badcal_edges=True, background_color='white', as_widget=False)`
+`iplot_error_map(backend, figsize=(800, 500), show_title=True, remove_badcal_edges=True, background_color='white', as_widget=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/visualization/interactive/error_map.py "view source code")
 
 Plot the error map of a device.
 

--- a/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.visualization.iplot_gate_map.md
+++ b/docs/api/qiskit-ibm-provider/qiskit_ibm_provider.visualization.iplot_gate_map.md
@@ -12,7 +12,7 @@ python_api_name: qiskit_ibm_provider.visualization.iplot_gate_map
 
 <span id="qiskit_ibm_provider.visualization.iplot_gate_map" />
 
-`iplot_gate_map(backend, figsize=(None, None), label_qubits=True, qubit_size=None, line_width=None, font_size=None, qubit_color='#2f4b7c', qubit_labels=None, line_color='#2f4b7c', font_color='white', background_color='white', as_widget=False)`
+`iplot_gate_map(backend, figsize=(None, None), label_qubits=True, qubit_size=None, line_width=None, font_size=None, qubit_color='#2f4b7c', qubit_labels=None, line_color='#2f4b7c', font_color='white', background_color='white', as_widget=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/visualization/interactive/gate_map.py "view source code")
 
 Plots an interactive gate map of a device.
 

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -244,15 +244,21 @@ test("addLanguageClassToCodeBlocks()", () => {
 test("replaceSourceLinksWithGitHub()", () => {
   // Assumes that removeHtmlExtensionsInRelativeLinks() has already removed .html from the URL.
   const doc = Doc.load(
-    `<a class="reference internal" href="../_modules/qiskit_ibm_runtime/ibm_backend#IBMBackend"></a><a href="#qiskit_ibm_runtime.IBMBackend"></a>`,
+    `<a href="../_modules/qiskit_ibm_runtime/ibm_backend#IBMBackend"></a>
+    <a href="../_modules/qiskit_ibm_provider/job/exceptions#IBMJobApiError"></a>
+    <a href="../_modules/qiskit_ibm_provider#least_busy"></a>
+    <a href="#qiskit_ibm_runtime.IBMBackend"></a>`,
   );
   replaceViewcodeLinksWithGitHub(
     doc.$,
     doc.$main,
-    "https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/",
+    "https://github.com/Qiskit/my-project/tree/stable/0.9/",
   );
   doc.expectHtml(
-    `<a class="reference internal" href="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py"></a><a href="#qiskit_ibm_runtime.IBMBackend"></a>`,
+    `<a href="https://github.com/Qiskit/my-project/tree/stable/0.9/qiskit_ibm_runtime/ibm_backend.py"></a>
+    <a href="https://github.com/Qiskit/my-project/tree/stable/0.9/qiskit_ibm_provider/job/exceptions.py"></a>
+    <a href="https://github.com/Qiskit/my-project/tree/stable/0.9/qiskit_ibm_provider/__init__.py"></a>
+    <a href="#qiskit_ibm_runtime.IBMBackend"></a>`,
   );
 });
 

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -187,12 +187,12 @@ export function replaceViewcodeLinksWithGitHub(
     ) {
       return;
     }
-    //_modules/qiskit_ibm_runtime/ibm_backend
-    let match = href.match(/_modules\/(.*?)(#|$)/)![1];
-    if (specialCases.has(match)) {
-      match = specialCases.get(match)!;
+    // E.g. `qiskit_ibm_runtime/ibm_backend`
+    let fullFileName = href.match(/_modules\/(.*?)(#|$)/)![1];
+    if (specialCases.has(fullFileName)) {
+      fullFileName = specialCases.get(fullFileName)!;
     }
-    const newHref = `${baseGitHubUrl}${match}.py`;
+    const newHref = `${baseGitHubUrl}${fullFileName}.py`;
     $a.attr("href", newHref);
   });
 }

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -172,6 +172,11 @@ export function replaceViewcodeLinksWithGitHub(
   $main: Cheerio<any>,
   baseGitHubUrl: string,
 ): void {
+  // Certain files do not map 1:1 between sphinx.ext.viewcode and GitHub.
+  // When adding new entries, add a dedicated test case!
+  const specialCases = new Map([
+    ["qiskit_ibm_provider", "qiskit_ibm_provider/__init__"],
+  ]);
   $main.find("a").each((_, a) => {
     const $a = $(a);
     const href = $a.attr("href");
@@ -183,8 +188,11 @@ export function replaceViewcodeLinksWithGitHub(
       return;
     }
     //_modules/qiskit_ibm_runtime/ibm_backend
-    const match = href.match(/_modules\/(.*?)(#|$)/)!;
-    const newHref = `${baseGitHubUrl}${match[1]}.py`;
+    let match = href.match(/_modules\/(.*?)(#|$)/)![1];
+    if (specialCases.has(match)) {
+      match = specialCases.get(match)!;
+    }
+    const newHref = `${baseGitHubUrl}${match}.py`;
     $a.attr("href", newHref);
   });
 }


### PR DESCRIPTION
I didn't realize that Provider already is using the `viewcode` Sphinx extension for current docs, so we didn't need to make any change to that repository to get GitHub source links working.

Note that this required adding a new mechanism to special-case certain files because they don't map 1:1 between GitHub and sphinx.ext.viewcode.

Other than that change, this PR was generated automatically by running `npm run gen-api -- -p qiskit-ibm-provider -v 0.7.3 -a https://github.com/Qiskit/qiskit-ibm-provider/actions/runs/7330787504/artifacts/1135354934`.