### PR TITLE
[Refactor] Move package path determination into own function

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -32,7 +32,7 @@ import { specialCaseResults } from "../lib/api/specialCaseResults";
 import addFrontMatter from "../lib/api/addFrontMatter";
 import { dedupeHtmlIdsFromResults } from "../lib/api/dedupeHtmlIds";
 import { removePrefix, removeSuffix } from "../lib/stringUtils";
-import { Pkg, PkgInfo, Link } from "../lib/sharedTypes";
+import { Pkg, PkgInfo, Link, getPkgRoot } from "../lib/sharedTypes";
 import { zxMain } from "../lib/zx";
 import { pathExists, getRoot } from "../lib/fs";
 import { downloadCIArtifact } from "../lib/api/downloadCIArtifacts";
@@ -170,9 +170,7 @@ zxMain(async () => {
   }
 
   const baseGitHubUrl = `https://github.com/${pkg.githubSlug}/tree/stable/${pkg.versionWithoutPatch}/`;
-  const outputDir = pkg.historical
-    ? `${getRoot()}/docs/api/${pkg.name}/${pkg.versionWithoutPatch}`
-    : `${getRoot()}/docs/api/${pkg.name}`;
+  const outputDir = getPkgRoot(pkg, `${getRoot()}/docs`);
 
   if (pkg.historical && !(await pathExists(outputDir))) {
     await mkdirp(outputDir);
@@ -234,9 +232,7 @@ async function convertHtmlToMarkdown(
       html,
       url: `${pkg.baseUrl}/${file}`,
       baseGitHubUrl,
-      imageDestination: pkg.historical
-        ? `/images/api/${pkg.name}/${pkg.versionWithoutPatch}`
-        : `/images/api/${pkg.name}`,
+      imageDestination: getPkgRoot(pkg, "/images"),
       releaseNotesTitle: `${pkg.title} ${pkg.versionWithoutPatch} release notes`,
     });
 

--- a/scripts/lib/api/saveImages.ts
+++ b/scripts/lib/api/saveImages.ts
@@ -14,7 +14,7 @@ import { mkdirp } from "mkdirp";
 import pMap from "p-map";
 import { copyFile } from "fs/promises";
 
-import { Pkg } from "../sharedTypes";
+import { Pkg, getPkgRoot } from "../sharedTypes";
 import { Image } from "./HtmlToMdResult";
 import { pathExists } from "../fs";
 
@@ -23,9 +23,7 @@ export async function saveImages(
   originalImagesFolderPath: string,
   pkg: Pkg,
 ) {
-  const imagesDestinationFolder = pkg.historical
-    ? `public/images/api/${pkg.name}/${pkg.versionWithoutPatch}`
-    : `public/images/api/${pkg.name}`;
+  const imagesDestinationFolder = getPkgRoot(pkg, "public/images");
   if (!(await pathExists(imagesDestinationFolder))) {
     await mkdirp(imagesDestinationFolder);
   }

--- a/scripts/lib/sharedTypes.ts
+++ b/scripts/lib/sharedTypes.ts
@@ -9,6 +9,7 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
+import { join } from "path";
 
 /**
  * Simple interface for scripts/command/updateApiDocs.ts
@@ -45,3 +46,11 @@ export type Pkg = PkgInfo & {
   releaseNoteEntries: { title: string; url: string }[];
   baseUrl: string;
 };
+
+export function getPkgRoot(pkg: Pkg, parentDir = "docs") {
+  let path = join(parentDir, "api", pkg.name);
+  if (pkg.historical) {
+    path = join(path, pkg.versionWithoutPatch);
+  }
+  return path;
+}


### PR DESCRIPTION
Very minor refactor to move duplicated logic into its own function.

I added this to `sharedTypes.ts` to keep it next to the type it acts on. I considered making `Pkg` a class and having this as a method but it seemed to convolute the code a bit. Open to suggestions of neater ways to do this.
