### PR TITLE
Simplify image extraction code

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -205,7 +205,7 @@ async function convertHtmlToMarkdown(
     const html = await readFile(join(htmlPath, file), "utf-8");
     const result = await sphinxHtmlToMarkdown({
       html,
-      url: `http://localhost:8000/${file}`,
+      file,
       baseGitHubUrl,
       imageDestination: getPkgRoot(pkg, "/images"),
       releaseNotesTitle: `${pkg.title} ${pkg.versionWithoutPatch} release notes`,
@@ -232,7 +232,7 @@ async function convertHtmlToMarkdown(
 
   const allImages = uniqBy(
     results.flatMap((result) => result.images),
-    (image) => image.src,
+    (image) => image.fileName,
   );
 
   const dirsNeeded = uniq(

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -205,7 +205,7 @@ async function convertHtmlToMarkdown(
     const html = await readFile(join(htmlPath, file), "utf-8");
     const result = await sphinxHtmlToMarkdown({
       html,
-      file,
+      fileName: file,
       baseGitHubUrl,
       imageDestination: getPkgRoot(pkg, "/images"),
       releaseNotesTitle: `${pkg.title} ${pkg.versionWithoutPatch} release notes`,

--- a/scripts/lib/api/HtmlToMdResult.ts
+++ b/scripts/lib/api/HtmlToMdResult.ts
@@ -13,7 +13,7 @@
 import { Metadata } from "./Metadata";
 
 export type Image = {
-  src: string;
+  fileName: string;
   dest: string;
 };
 

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -111,38 +111,6 @@ describe("sphinxHtmlToMarkdown", () => {
     ).toMatchInlineSnapshot(`""`);
   });
 
-  test("extract images", async () => {
-    expect(
-      await sphinxHtmlToMarkdown({
-        html: `
-           <div role='main'>
-            <img src="foo.png"/>
-            <img src="http://google.com/bar.png"/>
-           </div>
-          `,
-        url: "http://qiskit.org/docs/quantum-circuit.html",
-        ...DEFAULT_ARGS,
-      }),
-    ).toMatchInlineSnapshot(`
-        {
-          "images": [
-            {
-              "dest": "/images/qiskit/foo.png",
-              "src": "http://qiskit.org/docs/foo.png",
-            },
-            {
-              "dest": "/images/qiskit/bar.png",
-              "src": "http://google.com/bar.png",
-            },
-          ],
-          "isReleaseNotes": false,
-          "markdown": "![](/images/qiskit/foo.png) ![](/images/qiskit/bar.png)
-        ",
-          "meta": {},
-        }
-      `);
-  });
-
   test("handle tabs", async () => {
     expect(
       await toMd(`<div role='main'>
@@ -512,7 +480,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 <span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
 </div>
 `,
-          url: "https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.Sampler.html",
+          file: "stubs/qiskit_ibm_runtime.Sampler.html",
           ...DEFAULT_ARGS,
         })
       ).markdown,
@@ -1377,7 +1345,7 @@ test("identify release notes", async () => {
           to better support submitting multiple jobs at once.</p></li>
           </ul>
           `,
-      url: "http://qiskit.org/docs/release_notes.html",
+      file: "release_notes.html",
       ...DEFAULT_ARGS,
     }),
   ).toMatchInlineSnapshot(`
@@ -1461,7 +1429,7 @@ test("test dt tag without id", async () => {
 async function toMd(html: string) {
   return (
     await sphinxHtmlToMarkdown({
-      url: "https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.Sampler.html",
+      file: "stubs/qiskit_ibm_runtime.Sampler.html",
       html,
       ...DEFAULT_ARGS,
     })
@@ -1470,7 +1438,7 @@ async function toMd(html: string) {
 
 async function toMdWithMeta(html: string) {
   return await sphinxHtmlToMarkdown({
-    url: "https://qiskit.org/documentation/partners/qiskit_ibm_runtime/stubs/qiskit_ibm_runtime.Sampler.html",
+    file: "stubs/qiskit_ibm_runtime.Sampler.html",
     html,
     ...DEFAULT_ARGS,
   });

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -480,7 +480,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 <span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
 </div>
 `,
-          file: "stubs/qiskit_ibm_runtime.Sampler.html",
+          fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
           ...DEFAULT_ARGS,
         })
       ).markdown,
@@ -1345,7 +1345,7 @@ test("identify release notes", async () => {
           to better support submitting multiple jobs at once.</p></li>
           </ul>
           `,
-      file: "release_notes.html",
+      fileName: "release_notes.html",
       ...DEFAULT_ARGS,
     }),
   ).toMatchInlineSnapshot(`
@@ -1429,7 +1429,7 @@ test("test dt tag without id", async () => {
 async function toMd(html: string) {
   return (
     await sphinxHtmlToMarkdown({
-      file: "stubs/qiskit_ibm_runtime.Sampler.html",
+      fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
       html,
       ...DEFAULT_ARGS,
     })
@@ -1438,7 +1438,7 @@ async function toMd(html: string) {
 
 async function toMdWithMeta(html: string) {
   return await sphinxHtmlToMarkdown({
-    file: "stubs/qiskit_ibm_runtime.Sampler.html",
+    fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
     html,
     ...DEFAULT_ARGS,
   });

--- a/scripts/lib/api/htmlToMd.ts
+++ b/scripts/lib/api/htmlToMd.ts
@@ -32,7 +32,7 @@ import { remarkStringifyOptions } from "./commonParserConfig";
 
 export async function sphinxHtmlToMarkdown(options: {
   html: string;
-  url: string;
+  file: string;
   imageDestination: string;
   // E.g. https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/
   baseGitHubUrl: string;

--- a/scripts/lib/api/htmlToMd.ts
+++ b/scripts/lib/api/htmlToMd.ts
@@ -32,7 +32,7 @@ import { remarkStringifyOptions } from "./commonParserConfig";
 
 export async function sphinxHtmlToMarkdown(options: {
   html: string;
-  file: string;
+  fileName: string;
   imageDestination: string;
   // E.g. https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/
   baseGitHubUrl: string;

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -56,20 +56,14 @@ describe("loadImages()", () => {
     const doc = Doc.load(
       `<img src="../_static/logo.png" alt="Logo"><img src="../_static/images/view-page-source-icon.svg">`,
     );
-    const images = loadImages(
-      doc.$,
-      doc.$main,
-      "http://localhost:3000/api/my-file.html",
-      "/my-images",
-      false,
-    );
+    const images = loadImages(doc.$, doc.$main, "/my-images", false);
     expect(images).toEqual([
       {
-        src: "http://localhost:3000/_static/logo.png",
+        fileName: "logo.png",
         dest: "/my-images/logo.png",
       },
       {
-        src: "http://localhost:3000/_static/images/view-page-source-icon.svg",
+        fileName: "view-page-source-icon.svg",
         dest: "/my-images/view-page-source-icon.svg",
       },
     ]);
@@ -82,16 +76,10 @@ describe("loadImages()", () => {
     const doc = Doc.load(
       `<img src="../_static/images/view-page-source-icon.svg">`,
     );
-    const images = loadImages(
-      doc.$,
-      doc.$main,
-      "http://localhost:3000/api/release_notes.html",
-      "/my-images/0.45",
-      true,
-    );
+    const images = loadImages(doc.$, doc.$main, "/my-images/0.45", true);
     expect(images).toEqual([
       {
-        src: "http://localhost:3000/_static/images/view-page-source-icon.svg",
+        fileName: "view-page-source-icon.svg",
         dest: "/my-images/view-page-source-icon.svg",
       },
     ]);

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { last } from "lodash";
 import { CheerioAPI, Cheerio, load } from "cheerio";
 
 import { Image } from "./HtmlToMdResult";
@@ -26,17 +25,17 @@ export type ProcessedHtml = {
 
 export function processHtml(options: {
   html: string;
-  file: string;
+  fileName: string;
   imageDestination: string;
   baseGitHubUrl: string;
   releaseNotesTitle: string;
 }): ProcessedHtml {
-  const { html, file, imageDestination, baseGitHubUrl, releaseNotesTitle } =
+  const { html, fileName, imageDestination, baseGitHubUrl, releaseNotesTitle } =
     options;
   const $ = load(html);
   const $main = $(`[role='main']`);
 
-  const isReleaseNotes = file.endsWith("release_notes.html");
+  const isReleaseNotes = fileName.endsWith("release_notes.html");
   const images = loadImages($, $main, imageDestination, isReleaseNotes);
   if (isReleaseNotes) {
     renameAllH1s($, releaseNotesTitle);

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -75,8 +75,7 @@ export function loadImages(
     .map((img) => {
       const $img = $(img);
 
-      const imageUrl = new URL($img.attr("src")!, "https://doesnt-matter.com");
-      const fileName = last(imageUrl.toString().split("/"))!;
+      const fileName = $img.attr("src")!.split("/").pop()!;
 
       let dest = `${imageDestination}/${fileName}`;
       if (isReleaseNotes) {

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -26,19 +26,19 @@ export type ProcessedHtml = {
 
 export function processHtml(options: {
   html: string;
-  url: string;
+  file: string;
   imageDestination: string;
   baseGitHubUrl: string;
   releaseNotesTitle: string;
 }): ProcessedHtml {
-  const { html, url, imageDestination, baseGitHubUrl, releaseNotesTitle } =
+  const { html, file, imageDestination, baseGitHubUrl, releaseNotesTitle } =
     options;
   const $ = load(html);
   const $main = $(`[role='main']`);
 
-  const isReleaseNotes = url.endsWith("release_notes.html");
-  const images = loadImages($, $main, url, imageDestination, isReleaseNotes);
-  if (url.endsWith("release_notes.html")) {
+  const isReleaseNotes = file.endsWith("release_notes.html");
+  const images = loadImages($, $main, imageDestination, isReleaseNotes);
+  if (isReleaseNotes) {
     renameAllH1s($, releaseNotesTitle);
   }
 
@@ -66,7 +66,6 @@ export function processHtml(options: {
 export function loadImages(
   $: CheerioAPI,
   $main: Cheerio<any>,
-  url: string,
   imageDestination: string,
   isReleaseNotes: boolean,
 ): Image[] {
@@ -76,18 +75,17 @@ export function loadImages(
     .map((img) => {
       const $img = $(img);
 
-      const imageUrl = new URL($img.attr("src")!, url);
-      const src = imageUrl.toString();
+      const imageUrl = new URL($img.attr("src")!, "https://doesnt-matter.com");
+      const fileName = last(imageUrl.toString().split("/"))!;
 
-      const filename = last(src.split("/"));
-      let dest = `${imageDestination}/${filename}`;
+      let dest = `${imageDestination}/${fileName}`;
       if (isReleaseNotes) {
         // Release notes links should point to the current version
         dest = dest.replace(/[0-9].*\//, "");
       }
 
       $img.attr("src", dest);
-      return { src, dest: dest };
+      return { fileName, dest };
     });
 }
 

--- a/scripts/lib/api/saveImages.ts
+++ b/scripts/lib/api/saveImages.ts
@@ -23,22 +23,20 @@ export async function saveImages(
   originalImagesFolderPath: string,
   pkg: Pkg,
 ) {
-  const imagesDestinationFolder = getPkgRoot(pkg, "public/images");
-  if (!(await pathExists(imagesDestinationFolder))) {
-    await mkdirp(imagesDestinationFolder);
+  const destFolder = getPkgRoot(pkg, "public/images");
+  if (!(await pathExists(destFolder))) {
+    await mkdirp(destFolder);
   }
 
   await pMap(images, async (img) => {
-    const imgName = img.src.split("/").pop()!;
-
     // The release notes images are only saved in the current version to
     // avoid having duplicate files.
-    if (imgName.includes("release_notes") && pkg.historical) {
+    if (img.fileName.includes("release_notes") && pkg.historical) {
       return;
     }
 
     await copyFile(
-      `${originalImagesFolderPath}/${imgName}`,
+      `${originalImagesFolderPath}/${img.fileName}`,
       `public/${img.dest}`,
     );
   });


### PR DESCRIPTION
We can simplify our image extraction code now that we copy images from the downloaded CI artifact rather than downloading it from a URL. Before, we stored `src` as a URL; now we just need the `fileName`.