### PR TITLE
Refactor `Pkg` to be a class for API generation

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -31,7 +31,7 @@ import { updateLinks } from "../lib/api/updateLinks";
 import { specialCaseResults } from "../lib/api/specialCaseResults";
 import addFrontMatter from "../lib/api/addFrontMatter";
 import { dedupeHtmlIdsFromResults } from "../lib/api/dedupeHtmlIds";
-import { Pkg, VALID_PACKAGE_NAMES } from "../lib/api/Pkg";
+import { Pkg } from "../lib/api/Pkg";
 import { zxMain } from "../lib/zx";
 import { pathExists, getRoot, rmFilesInFolder } from "../lib/fs";
 import { downloadCIArtifact } from "../lib/api/downloadCIArtifacts";
@@ -56,7 +56,7 @@ const readArgs = (): Arguments => {
     .option("package", {
       alias: "p",
       type: "string",
-      choices: VALID_PACKAGE_NAMES,
+      choices: Pkg.VALID_NAMES,
       demandOption: true,
       description: "Which package to update",
     })

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -31,7 +31,7 @@ import { updateLinks } from "../lib/api/updateLinks";
 import { specialCaseResults } from "../lib/api/specialCaseResults";
 import addFrontMatter from "../lib/api/addFrontMatter";
 import { dedupeHtmlIdsFromResults } from "../lib/api/dedupeHtmlIds";
-import { Pkg, getPkgRoot, VALID_PACKAGE_NAMES } from "../lib/api/Pkg";
+import { Pkg, VALID_PACKAGE_NAMES } from "../lib/api/Pkg";
 import { zxMain } from "../lib/zx";
 import { pathExists, getRoot, rmFilesInFolder } from "../lib/fs";
 import { downloadCIArtifact } from "../lib/api/downloadCIArtifacts";
@@ -112,7 +112,7 @@ zxMain(async () => {
   }
 
   const baseGitHubUrl = `https://github.com/${pkg.githubSlug}/tree/stable/${pkg.versionWithoutPatch}/`;
-  const outputDir = getPkgRoot(pkg, `${getRoot()}/docs`);
+  const outputDir = pkg.outputDir(`${getRoot()}/docs`);
 
   if (pkg.historical && !(await pathExists(outputDir))) {
     await mkdirp(outputDir);
@@ -160,7 +160,7 @@ async function convertHtmlToMarkdown(
       html,
       fileName: file,
       baseGitHubUrl,
-      imageDestination: getPkgRoot(pkg, "/images"),
+      imageDestination: pkg.outputDir("/images"),
       releaseNotesTitle: `${pkg.title} ${pkg.versionWithoutPatch} release notes`,
     });
 
@@ -202,7 +202,7 @@ async function convertHtmlToMarkdown(
   await dedupeHtmlIdsFromResults(results);
   addFrontMatter(results, pkg);
 
-  await objectsInv.write(getPkgRoot(pkg, "public"));
+  await objectsInv.write(pkg.outputDir("public"));
   for (const result of results) {
     let path = urlToPath(result.url);
 

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -36,7 +36,6 @@ import { zxMain } from "../lib/zx";
 import { pathExists, getRoot, rmFilesInFolder } from "../lib/fs";
 import { downloadCIArtifact } from "../lib/api/downloadCIArtifacts";
 import {
-  findLegacyReleaseNotes,
   addNewReleaseNotes,
   generateReleaseNotesIndex,
   updateHistoricalTocFiles,
@@ -93,13 +92,12 @@ zxMain(async () => {
     );
   }
 
-  const pkg = Pkg.fromArgs(
+  const pkg = await Pkg.fromArgs(
     args.package,
     args.version,
     versionMatch[0],
     args.historical,
   );
-  pkg.releaseNoteEntries = await findLegacyReleaseNotes(pkg);
 
   const artifactFolder = pkg.ciArtifactFolder();
   if (await pathExists(artifactFolder)) {

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -12,6 +12,7 @@
 
 import { join } from "path/posix";
 
+import { findLegacyReleaseNotes } from "./releaseNotes";
 import { removePrefix, removeSuffix } from "../stringUtils";
 import { getRoot } from "../fs";
 
@@ -46,7 +47,7 @@ export class Pkg {
   readonly version: string;
   readonly versionWithoutPatch: string;
   readonly historical: boolean;
-  releaseNoteEntries: ReleaseNoteEntry[];
+  readonly releaseNoteEntries: ReleaseNoteEntry[];
 
   constructor(kwargs: {
     name: string;
@@ -70,27 +71,28 @@ export class Pkg {
     this.releaseNoteEntries = kwargs.releaseNoteEntries;
   }
 
-  static fromArgs(
+  static async fromArgs(
     name: string,
     version: string,
     versionWithoutPatch: string,
     historical: boolean,
-  ): Pkg {
+  ): Promise<Pkg> {
     const args = {
       name,
       version,
       versionWithoutPatch,
       historical,
-      releaseNoteEntries: [],
     };
 
     if (name === "qiskit") {
+      const releaseNoteEntries = await findLegacyReleaseNotes(name);
       return new Pkg({
         ...args,
         title: "Qiskit",
         name: "qiskit",
         githubSlug: "qiskit/qiskit",
         hasSeparateReleaseNotes: true,
+        releaseNoteEntries,
       });
     }
 
@@ -102,6 +104,7 @@ export class Pkg {
         githubSlug: "qiskit/qiskit-ibm-runtime",
         transformLink,
         hasSeparateReleaseNotes: false,
+        releaseNoteEntries: [],
       });
     }
 
@@ -113,6 +116,7 @@ export class Pkg {
         githubSlug: "qiskit/qiskit-ibm-provider",
         transformLink,
         hasSeparateReleaseNotes: false,
+        releaseNoteEntries: [],
       });
     }
 

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -16,12 +16,6 @@ import { findLegacyReleaseNotes } from "./releaseNotes";
 import { removePrefix, removeSuffix } from "../stringUtils";
 import { getRoot } from "../fs";
 
-export const VALID_PACKAGE_NAMES = [
-  "qiskit",
-  "qiskit-ibm-runtime",
-  "qiskit-ibm-provider",
-];
-
 /**
  * Simple interface for scripts/command/updateApiDocs.ts
  */
@@ -48,6 +42,8 @@ export class Pkg {
   readonly versionWithoutPatch: string;
   readonly historical: boolean;
   readonly releaseNoteEntries: ReleaseNoteEntry[];
+
+  static VALID_NAMES = ["qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider"];
 
   constructor(kwargs: {
     name: string;

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -105,14 +105,14 @@ export class Pkg {
     }
 
     if (name === "qiskit-ibm-provider") {
-      return {
+      return new Pkg({
         ...args,
         title: "Qiskit IBM Provider",
         name: "qiskit-ibm-provider",
         githubSlug: "qiskit/qiskit-ibm-provider",
         transformLink,
         hasSeparateReleaseNotes: false,
-      };
+      });
     }
 
     throw new Error(`Unrecognized package: ${name}`);
@@ -141,14 +141,14 @@ export class Pkg {
       releaseNoteEntries: kwargs.releaseNoteEntries ?? [],
     });
   }
-}
 
-export function getPkgRoot(pkg: Pkg, parentDir = "docs") {
-  let path = join(parentDir, "api", pkg.name);
-  if (pkg.historical) {
-    path = join(path, pkg.versionWithoutPatch);
+  outputDir(parentDir: string): string {
+    let path = join(parentDir, "api", this.name);
+    if (this.historical) {
+      path = join(path, this.versionWithoutPatch);
+    }
+    return path;
   }
-  return path;
 }
 
 function transformLink(link: Link): Link | undefined {

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -12,6 +12,14 @@
 
 import { join } from "path/posix";
 
+import { removePrefix, removeSuffix } from "../stringUtils";
+
+export const VALID_PACKAGE_NAMES = [
+  "qiskit",
+  "qiskit-ibm-runtime",
+  "qiskit-ibm-provider",
+];
+
 /**
  * Simple interface for scripts/command/updateApiDocs.ts
  */
@@ -20,30 +28,120 @@ export interface Link {
   text?: string; // What the user sees
 }
 
-/**
- * Python package (e.g. qiskit, qiskit-ibm-runtime).
- * This information does not depend on the generation script
- */
-export type PkgInfo = {
-  name: string;
-  githubSlug: string;
+export interface ReleaseNoteEntry {
   title: string;
-  hasSeparateReleaseNotes?: boolean;
-  transformLink?: (link: Link) => Link | undefined;
-};
+  url: string;
+}
 
 /**
- * Information about the specific package version we're dealing with.
- * This stuff _does_ depend on the parameters passed to the generation script,
- * and may be updated at the script runs.
+ * Information about the specific package and version we're dealing with, e.g. qiskit 0.45.
  */
-export type Pkg = PkgInfo & {
-  // Data related to the processing of a package
-  version: string;
-  versionWithoutPatch: string;
-  historical: boolean;
-  releaseNoteEntries: { title: string; url: string }[];
-};
+export class Pkg {
+  readonly name: string;
+  readonly title: string;
+  readonly githubSlug: string;
+  readonly hasSeparateReleaseNotes: boolean;
+  readonly transformLink?: (link: Link) => Link | undefined;
+  readonly version: string;
+  readonly versionWithoutPatch: string;
+  readonly historical: boolean;
+  releaseNoteEntries: ReleaseNoteEntry[];
+
+  constructor(kwargs: {
+    name: string;
+    title: string;
+    githubSlug: string;
+    hasSeparateReleaseNotes: boolean;
+    transformLink?: (link: Link) => Link | undefined;
+    version: string;
+    versionWithoutPatch: string;
+    historical: boolean;
+    releaseNoteEntries: ReleaseNoteEntry[];
+  }) {
+    this.name = kwargs.name;
+    this.title = kwargs.title;
+    this.githubSlug = kwargs.githubSlug;
+    this.hasSeparateReleaseNotes = kwargs.hasSeparateReleaseNotes;
+    this.transformLink = kwargs.transformLink;
+    this.version = kwargs.version;
+    this.versionWithoutPatch = kwargs.versionWithoutPatch;
+    this.historical = kwargs.historical;
+    this.releaseNoteEntries = kwargs.releaseNoteEntries;
+  }
+
+  static fromArgs(
+    name: string,
+    version: string,
+    versionWithoutPatch: string,
+    historical: boolean,
+  ): Pkg {
+    const args = {
+      name,
+      version,
+      versionWithoutPatch,
+      historical,
+      releaseNoteEntries: [],
+    };
+
+    if (name === "qiskit") {
+      return new Pkg({
+        ...args,
+        title: "Qiskit",
+        name: "qiskit",
+        githubSlug: "qiskit/qiskit",
+        hasSeparateReleaseNotes: true,
+      });
+    }
+
+    if (name === "qiskit-ibm-runtime") {
+      return new Pkg({
+        ...args,
+        title: "Qiskit Runtime IBM Client",
+        name: "qiskit-ibm-runtime",
+        githubSlug: "qiskit/qiskit-ibm-runtime",
+        transformLink,
+        hasSeparateReleaseNotes: false,
+      });
+    }
+
+    if (name === "qiskit-ibm-provider") {
+      return {
+        ...args,
+        title: "Qiskit IBM Provider",
+        name: "qiskit-ibm-provider",
+        githubSlug: "qiskit/qiskit-ibm-provider",
+        transformLink,
+        hasSeparateReleaseNotes: false,
+      };
+    }
+
+    throw new Error(`Unrecognized package: ${name}`);
+  }
+
+  static mock(kwargs: {
+    name?: string;
+    title?: string;
+    githubSlug?: string;
+    hasSeparateReleaseNotes?: boolean;
+    transformLink?: (link: Link) => Link | undefined;
+    version?: string;
+    versionWithoutPatch?: string;
+    historical?: boolean;
+    releaseNoteEntries?: ReleaseNoteEntry[];
+  }): Pkg {
+    return new Pkg({
+      name: kwargs.name ?? "my-quantum-project",
+      title: kwargs.title ?? "My Quantum Project",
+      githubSlug: kwargs.githubSlug ?? "qiskit/my-quantum-project",
+      hasSeparateReleaseNotes: kwargs.hasSeparateReleaseNotes ?? false,
+      transformLink: kwargs.transformLink,
+      version: kwargs.version ?? "0.1.0",
+      versionWithoutPatch: kwargs.versionWithoutPatch ?? "0.1",
+      historical: kwargs.historical ?? false,
+      releaseNoteEntries: kwargs.releaseNoteEntries ?? [],
+    });
+  }
+}
 
 export function getPkgRoot(pkg: Pkg, parentDir = "docs") {
   let path = join(parentDir, "api", pkg.name);
@@ -51,4 +149,24 @@ export function getPkgRoot(pkg: Pkg, parentDir = "docs") {
     path = join(path, pkg.versionWithoutPatch);
   }
   return path;
+}
+
+function transformLink(link: Link): Link | undefined {
+  const updateText = link.url === link.text;
+  const prefixes = [
+    "https://qiskit.org/documentation/apidoc/",
+    "https://qiskit.org/documentation/stubs/",
+  ];
+  const prefix = prefixes.find((prefix) => link.url.startsWith(prefix));
+  if (!prefix) {
+    return;
+  }
+  let [url, anchor] = link.url.split("#");
+  url = removePrefix(url, prefix);
+  url = removeSuffix(url, ".html");
+  if (anchor && anchor !== url) {
+    url = `${url}#${anchor}`;
+  }
+  const newText = updateText ? url : undefined;
+  return { url: `/api/qiskit/${url}`, text: newText };
 }

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -13,6 +13,7 @@
 import { join } from "path/posix";
 
 import { removePrefix, removeSuffix } from "../stringUtils";
+import { getRoot } from "../fs";
 
 export const VALID_PACKAGE_NAMES = [
   "qiskit",
@@ -148,6 +149,14 @@ export class Pkg {
       path = join(path, this.versionWithoutPatch);
     }
     return path;
+  }
+
+  ciArtifactFolder(): string {
+    return `${getRoot()}/.out/python/sources/${this.name}/${this.version}`;
+  }
+
+  baseGitHubUrl(): string {
+    return `https://github.com/${this.githubSlug}/tree/stable/${this.versionWithoutPatch}/`;
   }
 }
 

--- a/scripts/lib/api/addFrontMatter.test.ts
+++ b/scripts/lib/api/addFrontMatter.test.ts
@@ -53,11 +53,9 @@ test("addFrontMatter()", () => {
       isReleaseNotes: true,
     },
   ];
-  const pkg = {
-    versionWithoutPatch: "0.0",
+  const pkg = Pkg.mock({
     hasSeparateReleaseNotes: true,
-    title: "My Quantum Software Project",
-  } as Pkg;
+  });
 
   addFrontMatter(results, pkg);
   expect(results.map((result) => result.markdown)).toEqual([
@@ -86,8 +84,8 @@ python_api_name: quantum_software.MyClass
 # Python API
 `,
     `---
-title: My Quantum Software Project 0.0 release notes
-description: Changes made in My Quantum Software Project 0.0
+title: My Quantum Project 0.1 release notes
+description: Changes made in My Quantum Project 0.1
 in_page_toc_max_heading_level: 2
 ---
 

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -17,7 +17,7 @@ import { Pkg } from "./Pkg";
 
 describe("generateToc", () => {
   test("generate a toc", () => {
-    const toc = generateToc(pkg, [
+    const toc = generateToc(Pkg.mock({}), [
       {
         meta: {
           apiType: "module",
@@ -85,24 +85,23 @@ describe("generateToc", () => {
           },
           {
             "title": "Release notes",
-            "url": "/api/qiskit_ibm_runtime/release-notes",
+            "url": "/api/my-quantum-project/release-notes",
           },
         ],
         "collapsed": true,
-        "title": "Qiskit Runtime IBM Client",
+        "title": "My Quantum Project",
       }
     `);
   });
 
   test("TOC with distinct release note files", () => {
     const toc = generateToc(
-      {
-        ...pkg,
+      Pkg.mock({
         releaseNoteEntries: [
           { title: "0.39", url: "/docs/runtime/release-notes/0.39" },
           { title: "0.38", url: "/docs/runtime/release-notes/0.38" },
         ],
-      },
+      }),
       [
         {
           meta: {
@@ -136,17 +135,8 @@ describe("generateToc", () => {
           },
         ],
         "collapsed": true,
-        "title": "Qiskit Runtime IBM Client",
+        "title": "My Quantum Project",
       }
     `);
   });
 });
-
-const pkg = {
-  title: "Qiskit Runtime IBM Client",
-  name: "qiskit_ibm_runtime",
-  version: "1.0.0",
-  versionWithoutPatch: "1.0",
-  releaseNoteEntries: [],
-  historical: false,
-} as unknown as Pkg;

--- a/scripts/lib/api/releaseNotes.ts
+++ b/scripts/lib/api/releaseNotes.ts
@@ -10,29 +10,23 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { $ } from "zx";
-import { getRoot, pathExists } from "../fs";
 import { parse } from "path";
-import { Pkg } from "./Pkg";
 import { readFile, writeFile, readdir } from "fs/promises";
 
-interface releaseNoteEntry {
-  title: string;
-  url: string;
-}
+import { $ } from "zx";
+
+import { getRoot, pathExists } from "../fs";
+import type { Pkg, ReleaseNoteEntry } from "./Pkg";
 
 /**
  * Check for markdown files in `docs/api/package-name/release-notes/
  * then sort them and create entries for the TOC.
  */
 export const findLegacyReleaseNotes = async (
-  pkg: Pkg,
-): Promise<releaseNoteEntry[]> => {
-  if (!pkg.hasSeparateReleaseNotes) {
-    return [];
-  }
+  pkgName: string,
+): Promise<ReleaseNoteEntry[]> => {
   const legacyReleaseNoteVersions = (
-    await $`ls ${getRoot()}/docs/api/${pkg.name}/release-notes`.quiet()
+    await $`ls ${getRoot()}/docs/api/${pkgName}/release-notes`.quiet()
   ).stdout
     .trim()
     .split("\n")
@@ -57,7 +51,7 @@ export const findLegacyReleaseNotes = async (
   for (let version of legacyReleaseNoteVersions) {
     legacyReleaseNoteEntries.push({
       title: version,
-      url: `/api/${pkg.name}/release-notes/${version}`,
+      url: `/api/${pkgName}/release-notes/${version}`,
     });
   }
   return legacyReleaseNoteEntries;

--- a/scripts/lib/api/saveImages.ts
+++ b/scripts/lib/api/saveImages.ts
@@ -14,7 +14,7 @@ import { mkdirp } from "mkdirp";
 import pMap from "p-map";
 import { copyFile } from "fs/promises";
 
-import { Pkg, getPkgRoot } from "./Pkg";
+import { Pkg } from "./Pkg";
 import { Image } from "./HtmlToMdResult";
 import { pathExists } from "../fs";
 
@@ -23,7 +23,7 @@ export async function saveImages(
   originalImagesFolderPath: string,
   pkg: Pkg,
 ) {
-  const destFolder = getPkgRoot(pkg, "public/images");
+  const destFolder = pkg.outputDir("public/images");
   if (!(await pathExists(destFolder))) {
     await mkdirp(destFolder);
   }


### PR DESCRIPTION
To correctly generate source code links for Qiskit historical docs, we need complex logic to determine the `baseGithubUrl` because the versions between Qiskit and Qiskit Terra were different. Rather than putting that logic in `upsideApiDocs.ts`, it's cleaner to abstract it behind a method `Pkg.baseGithubUrl()`.

There are a few other methods that fit naturally on `Pkg`, rather than being free functions.

This also allows us to make the `Pkg` interface immutable. Before, we would build up the `Pkg` over time by modifying attributes. Now, every attribute is `readonly` and we set up everything in the constructor. That's useful because you no longer have to worry if you're dealing with a properly initialized `Pkg`; it will now always be properly initialized.