### PR TITLE
Handle historical Qiskit versions with GitHub source links

### DIFF
--- a/scripts/lib/api/Pkg.test.ts
+++ b/scripts/lib/api/Pkg.test.ts
@@ -31,6 +31,12 @@ test("Pkg.determineGithubUrlFn()", () => {
     versionWithoutPatch: "0.45",
   }).determineGithubUrlFn();
 
+  const historicalQiskit = Pkg.mock({
+    name: "qiskit",
+    githubSlug: "qiskit/qiskit",
+    versionWithoutPatch: "0.32",
+  }).determineGithubUrlFn();
+
   expect(provider("qiskit_ibm_provider/job/exceptions")).toEqual(
     "https://github.com/qiskit/qiskit-ibm-provider/tree/stable/0.7/qiskit_ibm_provider/job/exceptions.py",
   );
@@ -53,5 +59,33 @@ test("Pkg.determineGithubUrlFn()", () => {
   );
   expect(qiskit("qiskit/transpiler/preset_passmanagers")).toEqual(
     "https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/transpiler/preset_passmanagers/__init__.py",
+  );
+
+  expect(historicalQiskit("qiskit/exceptions")).toEqual(
+    "https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/exceptions.py",
+  );
+  expect(historicalQiskit("qiskit/qasm")).toEqual(
+    "https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/qasm/__init__.py",
+  );
+  expect(historicalQiskit("qiskit/aer/foo")).toEqual(
+    "https://github.com/qiskit/qiskit-aer/tree/stable/0.9/qiskit/aer/foo.py",
+  );
+  expect(historicalQiskit("qiskit/providers/aer/foo")).toEqual(
+    "https://github.com/qiskit/qiskit-aer/tree/stable/0.9/qiskit/providers/aer/foo.py",
+  );
+  expect(historicalQiskit("qiskit_aer/foo")).toEqual(
+    "https://github.com/qiskit/qiskit-aer/tree/stable/0.9/qiskit_aer/foo.py",
+  );
+  expect(historicalQiskit("qiskit/ignis/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/foo.py",
+  );
+  expect(historicalQiskit("qiskit/aqua/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/aqua/foo.py",
+  );
+  expect(historicalQiskit("qiskit/aer/foo")).toEqual(
+    "https://github.com/qiskit/qiskit-aer/tree/stable/0.9/qiskit/aer/foo.py",
+  );
+  expect(historicalQiskit("qiskit/providers/ibmq/foo")).toEqual(
+    "https://github.com/qiskit/qiskit-ibmq-provider/tree/stable/0.18/qiskit/providers/ibmq/foo.py",
   );
 });

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -167,18 +167,169 @@ export class Pkg {
     // file `my_module.py`. We need to add back the `/__init__.py` when linking to GitHub.
     const convertToInitPy = new Set([
       "qiskit_ibm_provider",
+      "qiskit/qasm",
       "qiskit/qasm2",
       "qiskit/qasm3",
       "qiskit/transpiler/preset_passmanagers",
     ]);
-    const baseUrl = `https://github.com/${this.githubSlug}/tree/stable/${this.versionWithoutPatch}/`;
-    return (fileName) => {
-      if (convertToInitPy.has(fileName)) {
-        fileName = `${fileName}/__init__`;
-      }
-      return `${baseUrl}${fileName}.py`;
-    };
+    const normalizeFile = (fp: string) =>
+      convertToInitPy.has(fp) ? `${fp}/__init__` : fp;
+
+    // Provider, Runtime, and Qiskit 0.45+ are simple: there is a branch called `stable/<version>`
+    // like `stable/0.45` in each GitHub project.
+    if (this.name !== "qiskit" || +this.versionWithoutPatch >= 0.45) {
+      const baseUrl = `https://github.com/${this.githubSlug}/tree/stable/${this.versionWithoutPatch}`;
+      return (fileName) => {
+        return `${baseUrl}/${normalizeFile(fileName)}.py`;
+      };
+    }
+
+    // Otherwise, we have to deal with Qiskit <0.45, when we had the qiskit-metapackage comprised of
+    // multiple packages. Refer to the version table in api/qiskit/release-notes/0.44.md.
+    return (fileName) =>
+      determineHistoricalQiskitGithubUrl(
+        this.versionWithoutPatch,
+        normalizeFile(fileName),
+      );
   }
+}
+
+const QISKIT_METAPACKAGE_TO_TERRA = new Map([
+  ["0.44", "0.25"],
+  ["0.43", "0.24"],
+  ["0.42", "0.23"],
+  ["0.41", "0.23"],
+  ["0.40", "0.23"],
+  ["0.39", "0.22"],
+  ["0.38", "0.21"],
+  ["0.37", "0.21"],
+  ["0.36", "0.20"],
+  ["0.35", "0.20"],
+  ["0.34", "0.19"],
+  ["0.33", "0.19"],
+  ["0.32", "0.18"],
+  ["0.31", "0.18"],
+  ["0.30", "0.18"],
+  ["0.29", "0.18"],
+  ["0.28", "0.18"],
+  ["0.27", "0.17"],
+  ["0.26", "0.17"],
+  ["0.25", "0.17"],
+  ["0.24", "0.16"],
+  ["0.19", "0.14"],
+]);
+const QISKIT_METAPACKAGE_TO_AER = new Map([
+  ["0.43", "0.12"],
+  ["0.42", "0.12"],
+  ["0.41", "0.11"],
+  ["0.40", "0.11"],
+  ["0.39", "0.11"],
+  ["0.38", "0.11"],
+  ["0.37", "0.10"],
+  ["0.36", "0.10"],
+  ["0.35", "0.10"],
+  ["0.34", "0.10"],
+  ["0.33", "0.9"],
+  ["0.32", "0.9"],
+  ["0.31", "0.9"],
+  ["0.30", "0.9"],
+  ["0.29", "0.8"],
+  ["0.28", "0.8"],
+  ["0.27", "0.8"],
+  ["0.26", "0.8"],
+  ["0.25", "0.8"],
+  ["0.24", "0.7"],
+  ["0.19", "0.5"],
+]);
+const QISKIT_METAPACKAGE_TO_IGNIS = new Map([
+  ["0.36", "0.7"],
+  ["0.35", "0.7"],
+  ["0.34", "0.7"],
+  ["0.33", "0.7"],
+  ["0.32", "0.6"],
+  ["0.31", "0.6"],
+  ["0.30", "0.6"],
+  ["0.29", "0.6"],
+  ["0.28", "0.6"],
+  ["0.27", "0.6"],
+  ["0.26", "0.6"],
+  ["0.25", "0.6"],
+  ["0.24", "0.5"],
+  ["0.19", "0.3"],
+]);
+const QISKIT_METAPACKAGE_TO_AQUA = new Map([
+  ["0.32", "0.9"],
+  ["0.31", "0.9"],
+  ["0.30", "0.9"],
+  ["0.29", "0.9"],
+  ["0.28", "0.9"],
+  ["0.27", "0.9"],
+  ["0.26", "0.9"],
+  ["0.25", "0.9"],
+  ["0.24", "0.8"],
+  ["0.19", "0.7"],
+]);
+const QISKIT_METAPACKAGE_TO_IBMQ_PROVIDER = new Map([
+  ["0.43", "0.20"],
+  ["0.42", "0.20"],
+  ["0.41", "0.20"],
+  ["0.40", "0.19"],
+  ["0.39", "0.19"],
+  ["0.38", "0.19"],
+  ["0.37", "0.19"],
+  ["0.36", "0.19"],
+  ["0.35", "0.18"],
+  ["0.34", "0.18"],
+  ["0.33", "0.18"],
+  ["0.32", "0.18"],
+  ["0.31", "0.17"],
+  ["0.30", "0.16"],
+  ["0.29", "0.16"],
+  ["0.28", "0.15"],
+  ["0.27", "0.14"],
+  ["0.26", "0.13"],
+  ["0.25", "0.12"],
+  ["0.24", "0.12"],
+  ["0.19", "0.7"],
+]);
+
+function determineHistoricalQiskitGithubUrl(
+  metapackageVersion: string,
+  fileName: string,
+): string {
+  const getOrThrow = (mapping: Map<string, string>): string => {
+    const result = mapping.get(metapackageVersion);
+    if (result === undefined) {
+      throw new Error(
+        `No compatible version found for the file ${fileName} with qiskit-metapackage ${metapackageVersion}}`,
+      );
+    }
+    return result;
+  };
+
+  let slug: string;
+  let version: string;
+  if (
+    fileName.includes("qiskit_aer") ||
+    fileName.includes("qiskit/aer") ||
+    fileName.includes("qiskit/providers/aer")
+  ) {
+    slug = "qiskit/qiskit-aer";
+    version = getOrThrow(QISKIT_METAPACKAGE_TO_AER);
+  } else if (fileName.includes("qiskit/ignis")) {
+    slug = "qiskit-community/qiskit-ignis";
+    version = getOrThrow(QISKIT_METAPACKAGE_TO_IGNIS);
+  } else if (fileName.includes("qiskit/aqua")) {
+    slug = "qiskit-community/qiskit-aqua";
+    version = getOrThrow(QISKIT_METAPACKAGE_TO_AQUA);
+  } else if (fileName.includes("qiskit/providers/ibmq")) {
+    slug = "qiskit/qiskit-ibmq-provider";
+    version = getOrThrow(QISKIT_METAPACKAGE_TO_IBMQ_PROVIDER);
+  } else {
+    slug = "qiskit/qiskit";
+    version = getOrThrow(QISKIT_METAPACKAGE_TO_TERRA);
+  }
+  return `https://github.com/${slug}/tree/stable/${version}/${fileName}.py`;
 }
 
 function transformLink(link: Link): Link | undefined {


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/454. Historical versions of Qiskit docs are tricky because of qiskit-metapackage referring to multiple distinct GitHub repositories.