### PR TITLE
Fix some broken learning links

### DIFF
--- a/docs/api/qiskit/release-notes/0.43.md
+++ b/docs/api/qiskit/release-notes/0.43.md
@@ -899,7 +899,7 @@ This release adds a new control flow operation, the switch statement. This is im
 
 ##### Algorithms Upgrade Notes
 
-*   The deprecated modules `factorizers` and `linear_solvers`, containing `HHL` and `Shor` have been removed from [`qiskit.algorithms`](/api/qiskit/algorithms#module-qiskit.algorithms "qiskit.algorithms"). These functionalities were originally deprecated as part of the 0.22.0 release (released on October 13, 2022). You can access the code through the Qiskit Textbook instead: [Linear Solvers (HHL)](https://learn.qiskit.org/course/ch-applications/solving-linear-systems-of-equations-using-hhl-and-its-qiskit-implementation) , [Factorizers (Shor)](https://learn.qiskit.org/course/ch-algorithms/shors-algorithm)
+*   The deprecated modules `factorizers` and `linear_solvers`, containing `HHL` and `Shor` have been removed from [`qiskit.algorithms`](/api/qiskit/algorithms#module-qiskit.algorithms "qiskit.algorithms"). These functionalities were originally deprecated as part of the 0.22.0 release (released on October 13, 2022). You can access the code through the Qiskit Textbook instead: [Linear Solvers (HHL)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-applications/hhl_tutorial.ipynb), [Factorizers (Shor)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-algorithms/shor.ipynb)
 
 <span id="release-notes-0-24-0-pulse-upgrade-notes" />
 

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -170,6 +170,7 @@ export class Pkg {
       "qiskit/qasm",
       "qiskit/qasm2",
       "qiskit/qasm3",
+      "qiskit/qobj",
       "qiskit/transpiler/preset_passmanagers",
     ]);
     const normalizeFile = (fp: string) =>

--- a/scripts/lib/links/ignores.ts
+++ b/scripts/lib/links/ignores.ts
@@ -50,6 +50,9 @@ const SHOULD_BE_FIXED: FilesToIgnores = {
   "docs/api/qiskit/qiskit.circuit.SwitchCaseOp.md": [
     "circuit#qiskit.circuit.CASE_DEFAULT",
   ],
+  "docs/api/qiskit/qiskit.circuit.library.PhaseEstimation.md": [
+    "https://learn.qiskit.org/course/ch-algorithms/quantum-phase-estimation",
+  ],
   "docs/api/qiskit/utils.md": [
     "https://github.com/python-constraint/python-constraint%3E__",
     "#qiskit.utils.optionals.HAS_TESTTOOLS",


### PR DESCRIPTION
learn.qiskit.org recently stopped working so the redirects are failing, breaking CI on main.