### PR TITLE
Fix broken GitHub source link

### DIFF
--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -171,6 +171,7 @@ export class Pkg {
       "qiskit/qasm2",
       "qiskit/qasm3",
       "qiskit/qobj",
+      "qiskit/providers/ibmq",
       "qiskit/transpiler/preset_passmanagers",
     ]);
     const normalizeFile = (fp: string) =>


### PR DESCRIPTION
This PR fixes the following link 'https://github.com/qiskit/qiskit-ibmq-provider/tree/stable/0.20/qiskit/providers/ibmq.py' found in the regeneration of Qiskit v0.42 at https://github.com/Qiskit/documentation/pull/658