### PR TITLE
API generation script - Fix loadImages function

### DIFF
--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -73,11 +73,16 @@ export function loadImages(
   imageDestination: string,
   isReleaseNotes: boolean,
 ): Image[] {
-  return $main
+  const images: Image[] = [];
+  $main
     .find("img")
     .toArray()
-    .map((img) => {
+    .forEach((img) => {
       const $img = $(img);
+
+      if (!$img.attr("src")) {
+        return;
+      }
 
       const fileName = $img.attr("src")!.split("/").pop()!;
 
@@ -88,8 +93,10 @@ export function loadImages(
       }
 
       $img.attr("src", dest);
-      return { fileName, dest };
+      images.push({ fileName, dest });
     });
+
+  return images;
 }
 
 export function removeHtmlExtensionsInRelativeLinks(

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -73,16 +73,12 @@ export function loadImages(
   imageDestination: string,
   isReleaseNotes: boolean,
 ): Image[] {
-  const images: Image[] = [];
-  $main
+  return $main
     .find("img")
     .toArray()
-    .forEach((img) => {
+    .filter((img) => $(img).attr("src"))
+    .map((img) => {
       const $img = $(img);
-
-      if (!$img.attr("src")) {
-        return;
-      }
 
       const fileName = $img.attr("src")!.split("/").pop()!;
 
@@ -93,10 +89,8 @@ export function loadImages(
       }
 
       $img.attr("src", dest);
-      images.push({ fileName, dest });
+      return { fileName, dest };
     });
-
-  return images;
 }
 
 export function removeHtmlExtensionsInRelativeLinks(


### PR DESCRIPTION
The `processHtml.ts` script assumes that we always have an `src` attribute in the `img` tags, and even though this is true for the latest API versions, for Qiskit historical versions, we can find cases like the following example:

**Qiskit v0.41 release_notes.html line 23360**
```html
<div class="animation">
  <img id="_anim_imga6548212aea7457ca5d2f940fabeaea3">
  <div class="anim-controls">
    <input id="_anim_slidera6548212aea7457ca5d2f940fabeaea3" type="range" class="anim-slider"
```

This PR adds an early return to the `loadImage` function to skip the images without a `src` attribute given that we can't find the image in the `_images` folder of the GitHub artifact.