### PR TITLE
Fix qiskit-aqua GitHub source links

### DIFF
--- a/scripts/lib/api/Pkg.test.ts
+++ b/scripts/lib/api/Pkg.test.ts
@@ -82,6 +82,18 @@ test("Pkg.determineGithubUrlFn()", () => {
   expect(historicalQiskit("qiskit/aqua/foo")).toEqual(
     "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/aqua/foo.py",
   );
+  expect(historicalQiskit("qiskit/chemistry/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/chemistry/foo.py",
+  );
+  expect(historicalQiskit("qiskit/finance/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/finance/foo.py",
+  );
+  expect(historicalQiskit("qiskit/ml/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/ml/foo.py",
+  );
+  expect(historicalQiskit("qiskit/optimization/foo")).toEqual(
+    "https://github.com/qiskit-community/qiskit-aqua/tree/stable/0.9/qiskit/optimization/foo.py",
+  );
   expect(historicalQiskit("qiskit/aer/foo")).toEqual(
     "https://github.com/qiskit/qiskit-aer/tree/stable/0.9/qiskit/aer/foo.py",
   );

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -333,7 +333,13 @@ function determineHistoricalQiskitGithubUrl(
   } else if (fileName.includes("qiskit/ignis")) {
     slug = "qiskit-community/qiskit-ignis";
     version = getOrThrow(QISKIT_METAPACKAGE_TO_IGNIS);
-  } else if (fileName.includes("qiskit/aqua")) {
+  } else if (
+    fileName.includes("qiskit/aqua") ||
+    fileName.includes("qiskit/chemistry") ||
+    fileName.includes("qiskit/finance") ||
+    fileName.includes("qiskit/ml") ||
+    fileName.includes("qiskit/optimization")
+  ) {
     slug = "qiskit-community/qiskit-aqua";
     version = getOrThrow(QISKIT_METAPACKAGE_TO_AQUA);
   } else if (fileName.includes("qiskit/providers/ibmq")) {


### PR DESCRIPTION
This PR extends the generation script to handle GitHub source links for the API docs starting with` qiskit/chemistry`, `qiskit/finance`, `qiskit/ml`, and `qiskit/optimization` as part of qiskit-aqua.

Regeneration tested at https://github.com/Qiskit/documentation/pull/684