### PR TITLE
[do not merge] Allow generating example API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ tsconfig.tsbuildinfo
 .out/
 poetry.lock
 pyproject.toml
+
+/docs/api/qiskit-sphinx-theme-example-docs
+/public/api/qiskit-sphinx-theme-example-docs

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -43,7 +43,8 @@ export class Pkg {
   readonly historical: boolean;
   readonly releaseNoteEntries: ReleaseNoteEntry[];
 
-  static VALID_NAMES = ["qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider"];
+  static VALID_NAMES = [
+    "qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider", "qiskit-sphinx-theme-example-docs"];
 
   constructor(kwargs: {
     name: string;
@@ -114,6 +115,17 @@ export class Pkg {
         hasSeparateReleaseNotes: false,
         releaseNoteEntries: [],
       });
+    }
+
+    if (name === "qiskit-sphinx-theme-example-docs") {
+      return new Pkg({
+        ...args,
+        title: "Example Docs",
+        name: "qiskit-sphinx-theme-example-docs",
+        githubSlug: "qiskit/qiskit-sphinx-theme",
+        hasSeparateReleaseNotes: false,
+        releaseNoteEntries: []
+      })
     }
 
     throw new Error(`Unrecognized package: ${name}`);


### PR DESCRIPTION
Grace wanted to see the styling of our APIs in our example docs from qiskit-sphinx-theme: https://github.com/Qiskit/qiskit_sphinx_theme/tree/main/tests/js/tests.js-snapshots

I used this code along with some manual steps. I'm putting up this PR in case we ever want to regenerate the example docs. We might want to make this PR more legit.

1. I manually downloaded the CI artifact from https://github.com/Qiskit/qiskit_sphinx_theme CI (from a PR) because the artifact extraction failed
2. I manually set up `.out/python/sources/qiskit-sphinx-theme-example-docs/0.1`. In the `artifact` folder, put all the Sphinx output. Also copy the top level `stubs` folder
3. Manually create `docs/api/qiskit-sphinx-theme-example-docs` folder
4. `npm run gen-api -- -p qiskit-sphinx-theme-example-docs -v 0.1.0 -a ''`