### PR TITLE
Add content label to bug and user-feedback templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: 🪲 Content bug or inaccuracy
 description: Report typos, bugs, out-of-date content, broken links, etc.
-labels: ["bug 🐛",  "content 📄"]
+labels: ["bug 🐛", "content 📄"]
 assignees:
   - abbycross
   - beckykd

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: 🪲 Content bug or inaccuracy
 description: Report typos, bugs, out-of-date content, broken links, etc.
-labels: ["bug 🐛"]
+labels: ["bug 🐛",  "content 📄"]
 assignees:
   - abbycross
   - beckykd

--- a/.github/ISSUE_TEMPLATE/user-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/user-feedback.yml
@@ -1,6 +1,6 @@
 name: Overall impressions and feedback
 description: Provide feedback that will be read by both the Docs team and the Design Research team.
-labels: ["user feedback 📥 "]
+labels: ["user feedback 📥 ", "content 📄"]
 assignees:
   - abbycross
   - beckykd


### PR DESCRIPTION
Adding the  "content 📄" label to the bug and user-feedback issue templates so that they will be included in a sort of all content-related issues. 