### PR TITLE
Add headers for exceptions

### DIFF
--- a/docs/api/qiskit/algorithms.md
+++ b/docs/api/qiskit/algorithms.md
@@ -193,6 +193,8 @@ Algorithms that compute the fidelity of pairs of quantum states.
 
 ### Exceptions
 
+### AlgorithmError
+
 <span id="qiskit.algorithms.AlgorithmError" />
 
 `qiskit.algorithms.AlgorithmError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/algorithms/exceptions.py "view source code")

--- a/docs/api/qiskit/circuit.md
+++ b/docs/api/qiskit/circuit.md
@@ -344,6 +344,8 @@ constructed circuit
 
 Almost all circuit functions and methods will raise a [`CircuitError`](#qiskit.circuit.CircuitError "qiskit.circuit.CircuitError") when encountering an error that is particular to usage of Qiskit (as opposed to regular typing or indexing problems, which will typically raise the corresponding standard Python error).
 
+### CircuitError
+
 <span id="qiskit.circuit.CircuitError" />
 
 `qiskit.circuit.CircuitError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/circuit/exceptions.py "view source code")

--- a/docs/api/qiskit/dagcircuit.md
+++ b/docs/api/qiskit/dagcircuit.md
@@ -32,6 +32,8 @@ python_api_name: qiskit.dagcircuit
 
 ## Exceptions
 
+### DAGCircuitError
+
 <span id="qiskit.dagcircuit.DAGCircuitError" />
 
 `qiskit.dagcircuit.DAGCircuitError(*msg)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/dagcircuit/exceptions.py "view source code")
@@ -39,6 +41,8 @@ python_api_name: qiskit.dagcircuit
 Base class for errors raised by the DAGCircuit object.
 
 Set the error message.
+
+### DAGDependencyError
 
 <span id="qiskit.dagcircuit.DAGDependencyError" />
 

--- a/docs/api/qiskit/exceptions.md
+++ b/docs/api/qiskit/exceptions.md
@@ -20,6 +20,8 @@ python_api_name: qiskit.exceptions
 
 All Qiskit-related errors raised by Qiskit are subclasses of the base:
 
+### QiskitError
+
 <span id="qiskit.exceptions.QiskitError" />
 
 `qiskit.exceptions.QiskitError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/exceptions.py "view source code")
@@ -36,6 +38,8 @@ Many of the Qiskit subpackages define their own more granular error, to help in 
 
 Qiskit has several optional features that depend on other packages that are not required for a minimal install. You can read more about those, and ways to check for their presence, in [`qiskit.utils.optionals`](utils#module-qiskit.utils.optionals "qiskit.utils.optionals"). Trying to use a feature that requires an optional extra will raise a particular error, which subclasses both [`QiskitError`](#qiskit.exceptions.QiskitError "qiskit.exceptions.QiskitError") and the Python built-in `ImportError`.
 
+### MissingOptionalLibraryError
+
 <span id="qiskit.exceptions.MissingOptionalLibraryError" />
 
 `qiskit.exceptions.MissingOptionalLibraryError(libname, name, pip_install=None, msg=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/exceptions.py "view source code")
@@ -46,6 +50,8 @@ Set the error message. :param libname: Name of missing library :param name: Name
 
 Two more uncommon errors relate to failures in reading user-configuration files, or specifying a filename that cannot be used:
 
+### QiskitUserConfigError
+
 <span id="qiskit.exceptions.QiskitUserConfigError" />
 
 `qiskit.exceptions.QiskitUserConfigError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/exceptions.py "view source code")
@@ -53,6 +59,8 @@ Two more uncommon errors relate to failures in reading user-configuration files,
 Raised when an error is encountered reading a user config file.
 
 Set the error message.
+
+### InvalidFileError
 
 <span id="qiskit.exceptions.InvalidFileError" />
 

--- a/docs/api/qiskit/extensions.md
+++ b/docs/api/qiskit/extensions.md
@@ -34,6 +34,8 @@ python_api_name: qiskit.extensions
 
 The additional gates in this module will tend to raise a custom exception when they encounter problems.
 
+### ExtensionError
+
 <span id="qiskit.extensions.ExtensionError" />
 
 `qiskit.extensions.ExtensionError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/extensions/exceptions.py "view source code")

--- a/docs/api/qiskit/opflow.md
+++ b/docs/api/qiskit/opflow.md
@@ -198,6 +198,8 @@ the double commutator
 
 ## Exceptions
 
+### OpflowError
+
 <span id="qiskit.opflow.OpflowError" />
 
 `qiskit.opflow.OpflowError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/opflow/exceptions.py "view source code")

--- a/docs/api/qiskit/passmanager.md
+++ b/docs/api/qiskit/passmanager.md
@@ -161,6 +161,8 @@ With the pass manager framework, a developer can flexibly customize the optimiza
 
 ### Exceptions
 
+### PassManagerError
+
 <span id="qiskit.passmanager.PassManagerError" />
 
 `qiskit.passmanager.PassManagerError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/passmanager/exceptions.py "view source code")

--- a/docs/api/qiskit/providers.md
+++ b/docs/api/qiskit/providers.md
@@ -75,6 +75,8 @@ It’s worth pointing out that Terra’s version support policy doesn’t mean p
 
 ### Exceptions
 
+### QiskitBackendNotFoundError
+
 <span id="qiskit.providers.QiskitBackendNotFoundError" />
 
 `qiskit.providers.QiskitBackendNotFoundError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/providers/exceptions.py "view source code")
@@ -82,6 +84,8 @@ It’s worth pointing out that Terra’s version support policy doesn’t mean p
 Base class for errors raised while looking for a backend.
 
 Set the error message.
+
+### BackendPropertyError
 
 <span id="qiskit.providers.BackendPropertyError" />
 
@@ -91,6 +95,8 @@ Base class for errors raised while looking for a backend property.
 
 Set the error message.
 
+### JobError
+
 <span id="qiskit.providers.JobError" />
 
 `qiskit.providers.JobError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/providers/exceptions.py "view source code")
@@ -99,6 +105,8 @@ Base class for errors raised by Jobs.
 
 Set the error message.
 
+### JobTimeoutError
+
 <span id="qiskit.providers.JobTimeoutError" />
 
 `qiskit.providers.JobTimeoutError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/providers/exceptions.py "view source code")
@@ -106,6 +114,8 @@ Set the error message.
 Base class for timeout errors raised by jobs.
 
 Set the error message.
+
+### BackendConfigurationError
 
 <span id="qiskit.providers.BackendConfigurationError" />
 

--- a/docs/api/qiskit/pulse.md
+++ b/docs/api/qiskit/pulse.md
@@ -2897,6 +2897,8 @@ The number of samples for the time to elapse
 
 ## Exceptions
 
+### PulseError
+
 <span id="qiskit.pulse.PulseError" />
 
 `qiskit.pulse.PulseError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/pulse/exceptions.py "view source code")
@@ -2904,6 +2906,8 @@ The number of samples for the time to elapse
 Errors raised by the pulse module.
 
 Set the error message.
+
+### BackendNotSet
 
 <span id="qiskit.pulse.BackendNotSet" />
 
@@ -2913,6 +2917,8 @@ Raised if the builder context does not have a backend.
 
 Set the error message.
 
+### NoActiveBuilder
+
 <span id="qiskit.pulse.NoActiveBuilder" />
 
 `qiskit.pulse.NoActiveBuilder(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/pulse/exceptions.py "view source code")
@@ -2921,6 +2927,8 @@ Raised if no builder context is active.
 
 Set the error message.
 
+### UnassignedDurationError
+
 <span id="qiskit.pulse.UnassignedDurationError" />
 
 `qiskit.pulse.UnassignedDurationError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/pulse/exceptions.py "view source code")
@@ -2928,6 +2936,8 @@ Set the error message.
 Raised if instruction duration is unassigned.
 
 Set the error message.
+
+### UnassignedReferenceError
 
 <span id="qiskit.pulse.UnassignedReferenceError" />
 

--- a/docs/api/qiskit/qasm2.md
+++ b/docs/api/qiskit/qasm2.md
@@ -170,6 +170,8 @@ An OpenQASM 2 string representing the circuit.
 
 This module defines a generic error type that derives from [`QiskitError`](exceptions#qiskit.exceptions.QiskitError "qiskit.exceptions.QiskitError") that can be used as a catch when you care about failures emitted by the interoperation layer specifically.
 
+### QASM2Error
+
 <span id="qiskit.qasm2.QASM2Error" />
 
 `qiskit.qasm2.QASM2Error(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/qasm2/exceptions.py "view source code")
@@ -180,6 +182,8 @@ Set the error message.
 
 In cases where the lexer or parser fails due to an invalid OpenQASM 2 file, the conversion functions will raise a more specific error with a message explaining what the failure is, and where in the file it occurred.
 
+### QASM2ParseError
+
 <span id="qiskit.qasm2.QASM2ParseError" />
 
 `qiskit.qasm2.QASM2ParseError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/qasm2/exceptions.py "view source code")
@@ -189,6 +193,8 @@ An error raised because of a failure to parse an OpenQASM 2 file.
 Set the error message.
 
 When the exporters fail to export a circuit, likely because it has structure that cannot be represented by OpenQASM 2.0, they will also emit a custom error.
+
+### QASM2ExportError
 
 <span id="qiskit.qasm2.QASM2ExportError" />
 

--- a/docs/api/qiskit/qasm3.md
+++ b/docs/api/qiskit/qasm3.md
@@ -113,6 +113,8 @@ Convert the circuit to OpenQASM 3, returning the result as a string.
 
 All of these interfaces will raise [`QASM3ExporterError`](#qiskit.qasm3.QASM3ExporterError "qiskit.qasm3.QASM3ExporterError") on failure.
 
+### QASM3ExporterError
+
 <span id="qiskit.qasm3.QASM3ExporterError" />
 
 `qiskit.qasm3.QASM3ExporterError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/qasm3/exceptions.py "view source code")
@@ -233,6 +235,8 @@ a circuit representation of the OpenQASM 3 program.
 [**QASM3ImporterError**](#qiskit.qasm3.QASM3ImporterError "qiskit.qasm3.QASM3ImporterError") – if the OpenQASM 3 file is invalid, or cannot be represented by a [`QuantumCircuit`](qiskit.circuit.QuantumCircuit "qiskit.circuit.QuantumCircuit").
 
 Both of these two functions raise [`QASM3ImporterError`](#qiskit.qasm3.QASM3ImporterError "qiskit.qasm3.QASM3ImporterError") on failure.
+
+### QASM3ImporterError
 
 <span id="qiskit.qasm3.QASM3ImporterError" />
 

--- a/docs/api/qiskit/qpy.md
+++ b/docs/api/qiskit/qpy.md
@@ -156,6 +156,8 @@ Which will save the qpy serialized circuit to the provided file.
 
 These functions will raise a custom subclass of [`QiskitError`](exceptions#qiskit.exceptions.QiskitError "qiskit.exceptions.QiskitError") if they encounter problems during serialization or deserialization.
 
+### QpyError
+
 <span id="qiskit.qpy.QpyError" />
 
 `qiskit.qpy.QpyError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/qpy/exceptions.py "view source code")

--- a/docs/api/qiskit/transpiler.md
+++ b/docs/api/qiskit/transpiler.md
@@ -938,6 +938,8 @@ See [https://arxiv.org/abs/2102.01682](https://arxiv.org/abs/2102.01682) for mor
 
 ### Exceptions
 
+### TranspilerError
+
 <span id="qiskit.transpiler.TranspilerError" />
 
 `qiskit.transpiler.TranspilerError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/transpiler/exceptions.py "view source code")
@@ -945,6 +947,8 @@ See [https://arxiv.org/abs/2102.01682](https://arxiv.org/abs/2102.01682) for mor
 Exceptions raised during transpilation.
 
 Set the error message.
+
+### TranspilerAccessError
 
 <span id="qiskit.transpiler.TranspilerAccessError" />
 
@@ -954,6 +958,8 @@ DEPRECATED: Exception of access error in the transpiler passes.
 
 Set the error message.
 
+### CouplingError
+
 <span id="qiskit.transpiler.CouplingError" />
 
 `qiskit.transpiler.CouplingError(*msg)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/transpiler/exceptions.py "view source code")
@@ -961,6 +967,8 @@ Set the error message.
 Base class for errors raised by the coupling graph object.
 
 Set the error message.
+
+### LayoutError
 
 <span id="qiskit.transpiler.LayoutError" />
 

--- a/docs/api/qiskit/visualization.md
+++ b/docs/api/qiskit/visualization.md
@@ -233,6 +233,8 @@ You can find code examples for each visualization functions on the individual fu
 
 ## Exceptions
 
+### VisualizationError
+
 <span id="qiskit.visualization.VisualizationError" />
 
 `qiskit.visualization.VisualizationError(*message)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/visualization/exceptions.py "view source code")

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -429,4 +429,65 @@ backends may not have this attribute.</p>
       apiName: "qiskit_ibm_provider.least_busy",
     });
   });
+
+  test("exception with added heading", () => {
+    const html = `<span class="target" id="module-qiskit.exceptions"><span id="qiskit-exceptions"></span></span><section id="top-level-exceptions-qiskit-exceptions">
+<h1>Top-level exceptions (<a class="reference internal" href="#module-qiskit.exceptions" title="qiskit.exceptions"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.exceptions</span></code></a>)<a class="headerlink" href="#top-level-exceptions-qiskit-exceptions" title="Permalink to this heading">¶</a></h1>
+<p>All Qiskit-related errors raised by Qiskit are subclasses of the base:</p>
+<dl class="py exception">
+<dt class="sig sig-object py" id="qiskit.exceptions.QiskitError">
+<em class="property"><span class="pre">exception</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">qiskit.exceptions.</span></span><span class="sig-name descname"><span class="pre">QiskitError</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">*</span></span><span class="n"><span class="pre">message</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit/exceptions.html#QiskitError"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit.exceptions.QiskitError" title="Permalink to this definition">¶</a></dt>
+<dd><p>Base class for errors raised by Qiskit.</p>
+<p>Set the error message.</p>
+</dd></dl>
+
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Errors that are just general programming errors, such as incorrect typing, may still raise
+standard Python errors such as <code class="docutils literal notranslate"><span class="pre">TypeError</span></code>.  <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a> is generally for errors raised
+in usage that is particular to Qiskit.</p>
+</div>
+<p>Many of the Qiskit subpackages define their own more granular error, to help in catching only the
+subset of errors you care about.  For example, <a class="reference internal" href="circuit.html#module-qiskit.circuit" title="qiskit.circuit"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.circuit</span></code></a> almost exclusively uses
+<a class="reference internal" href="circuit.html#qiskit.circuit.CircuitError" title="qiskit.circuit.CircuitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">CircuitError</span></code></a>, while both <a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2ExportError" title="qiskit.qasm2.QASM2ExportError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2ExportError</span></code></a> and <a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2ParseError" title="qiskit.qasm2.QASM2ParseError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2ParseError</span></code></a> derive from
+<a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2Error" title="qiskit.qasm2.QASM2Error"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2Error</span></code></a> in <a class="reference internal" href="qasm2.html#module-qiskit.qasm2" title="qiskit.qasm2"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.qasm2</span></code></a>, which is in turn a type of <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a>.</p>
+<p>Qiskit has several optional features that depend on other packages that are not required for a
+minimal install.  You can read more about those, and ways to check for their presence, in
+<a class="reference internal" href="utils.html#module-qiskit.utils.optionals" title="qiskit.utils.optionals"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.utils.optionals</span></code></a>.  Trying to use a feature that requires an optional extra will raise a
+particular error, which subclasses both <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a> and the Python built-in <code class="docutils literal notranslate"><span class="pre">ImportError</span></code>.</p>
+</section>
+`;
+    const doc = Doc.load(html);
+    const meta: Metadata = {};
+    processMembersAndSetMeta(doc.$, doc.$main, meta);
+    doc.expectHtml(`<span class="target" id="module-qiskit.exceptions"><span id="qiskit-exceptions"></span></span><section id="top-level-exceptions-qiskit-exceptions">
+<h1>Top-level exceptions (<a class="reference internal" href="#module-qiskit.exceptions" title="qiskit.exceptions"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.exceptions</span></code></a>)<a class="headerlink" href="#top-level-exceptions-qiskit-exceptions" title="Permalink to this heading">¶</a></h1>
+<p>All Qiskit-related errors raised by Qiskit are subclasses of the base:</p>
+<div><h3>QiskitError</h3><span class="target" id="qiskit.exceptions.QiskitError"><p><code>
+<span class="sig-prename descclassname"><span class="pre">qiskit.exceptions.</span></span><span class="sig-name descname"><span class="pre">QiskitError</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">*</span></span><span class="n"><span class="pre">message</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#qiskit.exceptions.QiskitError" title="Permalink to this definition">¶</a></code><a href="../_modules/qiskit/exceptions.html#QiskitError" title="view source code">GitHub</a></p>
+<div><p>Base class for errors raised by Qiskit.</p>
+<p>Set the error message.</p>
+</div></span></div>
+
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Errors that are just general programming errors, such as incorrect typing, may still raise
+standard Python errors such as <code class="docutils literal notranslate"><span class="pre">TypeError</span></code>.  <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a> is generally for errors raised
+in usage that is particular to Qiskit.</p>
+</div>
+<p>Many of the Qiskit subpackages define their own more granular error, to help in catching only the
+subset of errors you care about.  For example, <a class="reference internal" href="circuit.html#module-qiskit.circuit" title="qiskit.circuit"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.circuit</span></code></a> almost exclusively uses
+<a class="reference internal" href="circuit.html#qiskit.circuit.CircuitError" title="qiskit.circuit.CircuitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">CircuitError</span></code></a>, while both <a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2ExportError" title="qiskit.qasm2.QASM2ExportError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2ExportError</span></code></a> and <a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2ParseError" title="qiskit.qasm2.QASM2ParseError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2ParseError</span></code></a> derive from
+<a class="reference internal" href="qasm2.html#qiskit.qasm2.QASM2Error" title="qiskit.qasm2.QASM2Error"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QASM2Error</span></code></a> in <a class="reference internal" href="qasm2.html#module-qiskit.qasm2" title="qiskit.qasm2"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.qasm2</span></code></a>, which is in turn a type of <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a>.</p>
+<p>Qiskit has several optional features that depend on other packages that are not required for a
+minimal install.  You can read more about those, and ways to check for their presence, in
+<a class="reference internal" href="utils.html#module-qiskit.utils.optionals" title="qiskit.utils.optionals"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit.utils.optionals</span></code></a>.  Trying to use a feature that requires an optional extra will raise a
+particular error, which subclasses both <a class="reference internal" href="#qiskit.exceptions.QiskitError" title="qiskit.exceptions.QiskitError"><code class="xref py py-exc docutils literal notranslate"><span class="pre">QiskitError</span></code></a> and the Python built-in <code class="docutils literal notranslate"><span class="pre">ImportError</span></code>.</p>
+</section>
+`);
+    expect(meta).toEqual({
+      apiName: "qiskit.exceptions.QiskitError",
+      apiType: "exception",
+    });
+  });
 });

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -357,23 +357,18 @@ export function processMembersAndSetMeta(
           return output.join("\n");
         }
 
-        if (apiType === "function") {
-          findByText($, $main, "em.property", "function").remove();
-          const funcDescription = `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
+        if (apiType === "function" || apiType === "exception") {
+          findByText($, $main, "em.property", apiType).remove();
+          const descriptionHtml = `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
 
           const pageHeading = $dl.siblings("h1").text();
           if (id.endsWith(pageHeading) && pageHeading != "") {
-            // Page is already dedicated to function; no heading needed
-            return funcDescription;
+            // Page is already dedicated to apiType; no heading needed
+            return descriptionHtml;
           }
 
-          const funcName = id.split(".").slice(-1)[0];
-          return `<h3>${funcName}</h3>${funcDescription}`;
-        }
-
-        if (apiType === "exception") {
-          findByText($, $main, "em.property", "exception").remove();
-          return `<span class="target" id="${id}"/><p><code>${$child.html()}</code>${github}</p>`;
+          const apiName = id.split(".").slice(-1)[0];
+          return `<h3>${apiName}</h3>${descriptionHtml}`;
         }
 
         throw new Error(`Unhandled Python type: ${apiType}`);


### PR DESCRIPTION
Quick fix to use the same logic for functions and exceptions. Closes #712.

A known problem with this implementation is that some headings should not be `h3`, but it depends on the page. See https://github.com/Qiskit/documentation/issues/714.