### PR TITLE
[WIP] Use Git LFS for zip files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.zip filter=lfs diff=lfs merge=lfs -text
+scripts/api-artifacts/**/*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Part of #719

The CI artifacts used for our API generation script will be stored in a directory called `/scripts/api-artifacts/<pkg-name>/<versions-without-patch>/`. We need to use Git LFS to avoid storing big zip files and slowing down the performance of the repo. Different compressing methods were tested and we decided to keep using zip files given the little improvement in space and to simplify our script due to the fact that the artifacts are downloaded as a zip file from GitHub.

This decision can be revisited! We thought it was the most sensible for now, but it might make sense to change it later.

This PR is a precursor for another PR that will store all API versions' artifacts.