### PR TITLE
Update details on finding the supported Python versions

### DIFF
--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -11,7 +11,7 @@ Whether you will work locally or in a cloud environment, the first step for all 
 <span id="local"></span>
 ## Install and set up Qiskit with the Qiskit Runtime client
 
-1. Install Python. Check the requirements in the [setup.py](https://github.com/Qiskit/qiskit/blob/main/setup.py) file to determine which Python versions are supported.  For download instructions, see the [Python Beginners Guide.](https://wiki.python.org/moin/BeginnersGuide/Download)
+1. Install Python. Check the "Programming Language" section on the [Qiskit PyPI project page](https://pypi.org/project/qiskit/) to determine which Python versions are supported by the most recent release. For download instructions, see the [Python Beginners Guide.](https://wiki.python.org/moin/BeginnersGuide/Download)
 
     We recommend that you use [Python virtual environments](https://docs.python.org/3.10/tutorial/venv.html) to separate Qiskit from other applications.  We also recommend that you use the [Jupyter](https://jupyter.org/install) development environment to interact with Qiskit.
 


### PR DESCRIPTION
This commit updates the isntall guide to point to a more permenant location on where to find the supported python versions for a release. Previously the guide pointed people to setup.py on github. This was problematic for two reasons, first the supported version information isn't present there anymore as we moved to using the pyproject.toml file to contain all the static metadata about the project, second the data on main refers to the next release not the current one. Instead this commit points people to project page on PyPI which is where the metadata from the previous location gets hosted for each release. This is the cannonical source for which python versions are supported of any given Qiskit release (or the corresponding metadata in the package file itself).