### PR TITLE
Fix bug in notebook tester

### DIFF
--- a/scripts/nb-tester/test-notebook.py
+++ b/scripts/nb-tester/test-notebook.py
@@ -94,7 +94,7 @@ def print_yellow(s: str, **kwargs):
     """
     Use ANSI escape codes to print yellow text
     """
-    print(f"\033[0;33m{str}\033[0m", **kwargs)
+    print(f"\033[0;33m{s}\033[0m", **kwargs)
 
 
 def extract_warnings(notebook: nbformat.NotebookNode) -> list[NotebookWarning]:


### PR DESCRIPTION
Was reporting warnings as `<class 'str'>`, which wasn't very helpful.

See https://github.com/Qiskit/documentation/actions/runs/7745198894/job/21120640259 for an example.
