### PR TITLE
API generating script: historical images

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -245,7 +245,7 @@ async function convertHtmlToMarkdown(
     JSON.stringify(pkg_json, null, 2) + "\n",
   );
 
-  if (await pathExists(`${htmlPath}/_images`)){
+  if (!pkg.historical || await pathExists(`${htmlPath}/_images`)){
     // Some historical versions don't have the `_images` folder in the artifact store in Box (https://ibm.ent.box.com/folder/246867452622)
     console.log("Saving images");
     await saveImages(allImages, `${htmlPath}/_images`, pkg);

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -245,7 +245,7 @@ async function convertHtmlToMarkdown(
     JSON.stringify(pkg_json, null, 2) + "\n",
   );
 
-  if (!pkg.historical || await pathExists(`${htmlPath}/_images`)){
+  if (!pkg.historical || (await pathExists(`${htmlPath}/_images`))) {
     // Some historical versions don't have the `_images` folder in the artifact store in Box (https://ibm.ent.box.com/folder/246867452622)
     console.log("Saving images");
     await saveImages(allImages, `${htmlPath}/_images`, pkg);

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -245,8 +245,11 @@ async function convertHtmlToMarkdown(
     JSON.stringify(pkg_json, null, 2) + "\n",
   );
 
-  console.log("Saving images");
-  await saveImages(allImages, `${htmlPath}/_images`, pkg);
+  if (await pathExists(`${htmlPath}/_images`)){
+    // Some historical versions don't have the `_images` folder in the artifact store in Box (https://ibm.ent.box.com/folder/246867452622)
+    console.log("Saving images");
+    await saveImages(allImages, `${htmlPath}/_images`, pkg);
+  }
 }
 
 function urlToPath(url: string) {


### PR DESCRIPTION
Some historical versions don't have the `_images` folder in the artifact store in Box (https://ibm.ent.box.com/folder/246867452622), and we don't want the script to fail when trying to save them, especially in the automatic regeneration.