### PR TITLE
Fix inlining methods for qiskit historical versions

### DIFF
--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -199,7 +199,11 @@ export function convertRubricsToHeaders(
   // <strong>
   function appropriateHtmlTag(html: string | null) {
     html = String(html);
-    return html == "Methods" || html == "Attributes" ? "h2" : "strong";
+    return html == "Methods" ||
+      html == "Methods Defined Here" ||
+      html == "Attributes"
+      ? "h2"
+      : "strong";
   }
 
   $main.find(".rubric").each((_, el) => {


### PR DESCRIPTION
Old releases of Qiskit used "Methods Defined Here" instead of "Methods" as a title for the methods section. We need to check for the former in order to inline correctly the methods when generating the API docs.