### PR TITLE
Fix bad Latex for all Qiskit API docs versions

### DIFF
--- a/docs/api/qiskit/0.24/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.24/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -12,37 +12,37 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-F\vert x\rangle\vert 0\rangle = \sqrt{1 - \hat{f}(x)} \vert x\rangle\vert 0\rangle + \sqrt{\hat{f}(x)}
-    \vert x\rangle\vert 1\rangle.
+                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+                      |x\rangle|1\rangle.\]
 $$
 
-for a function $\hat{f}: \{0, ..., 2^n - 1} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
+for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
 
 This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this case, the mapping $F$ can be approximately implemented using a Taylor expansion and linearly controlled Pauli-Y rotations, see \[1, 2] for more detail. This approximation uses a `rescaling_factor` to determine the accuracy of the Taylor expansion.
 
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Usng an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
+                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
 $$
 
 with
 
 $$
-\phi(x) = a + \frac{b - a}{2^n - 1} x.
+                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
+                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.24/qiskit.quantum_info.concurrence.md
+++ b/docs/api/qiskit/0.24/qiskit.quantum_info.concurrence.md
@@ -12,14 +12,14 @@ python_api_name: qiskit.quantum_info.concurrence
 
 <span id="qiskit.quantum_info.concurrence" />
 
-`concurrence(state)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/quantum_info/states/measures.py "view source code")
+`concurrence(state) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/quantum_info/states/measures.py "view source code")
 
 Calculate the concurrence of a quantum state.
 
 The concurrence of a bipartite [`Statevector`](qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") $\vert \psi\rangle$ is given by
 
 $$
-C(\vert \psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}
+                      \[C(|\psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}\]
 $$
 
 where $\rho_0 = Tr_1[\vert \psi\rangle\!\langle\psi\vert ]$ is the reduced state from by taking the $~qiskit.quantum_info.partial_trace$ of the input state.
@@ -27,7 +27,7 @@ where $\rho_0 = Tr_1[\vert \psi\rangle\!\langle\psi\vert ]$ is the reduced state
 For density matrices the concurrence is only defined for 2-qubit states, it is given by:
 
 $$
-C(\rho) = \max(0, \lambda_1 - \lambda_2 - \lamda_3 - \lambda_4)
+                      \[C(\rho) = \max(0, \lambda_1 - \lambda_2 - \lambda_3 - \lambda_4)\]
 $$
 
 where $\lambda _1 \ge \lambda _2 \ge \lambda _3 \ge \lambda _4$ are the ordered eigenvalues of the matrix $R=\sqrt{\sqrt{\rho }(Y\otimes Y)\overline{\rho}(Y\otimes Y)\sqrt{\rho}}$.

--- a/docs/api/qiskit/0.25/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.25/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,37 +10,37 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-F\vert x\rangle\vert 0\rangle = \sqrt{1 - \hat{f}(x)} \vert x\rangle\vert 0\rangle + \sqrt{\hat{f}(x)}
-    \vert x\rangle\vert 1\rangle.
+                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+                      |x\rangle|1\rangle.\]
 $$
 
-for a function $\hat{f}: \{0, ..., 2^n - 1} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
+for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
 
 This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this case, the mapping $F$ can be approximately implemented using a Taylor expansion and linearly controlled Pauli-Y rotations, see \[1, 2] for more detail. This approximation uses a `rescaling_factor` to determine the accuracy of the Taylor expansion.
 
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
+                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
 $$
 
 with
 
 $$
-\phi(x) = a + \frac{b - a}{2^n - 1} x.
+                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
+                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.25/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.25/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.25/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.25/qiskit.quantum_info.process_fidelity.md
@@ -10,19 +10,19 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
-The process fidelity $F_{\text{pro}}(\mathcal{E}, \methcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
+The process fidelity $F_{\text{pro}}(\mathcal{E}, \mathcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
 
 where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit.quantum_info.state_fidelity"), $\rho_{\mathcal{E}} = \Lambda_{\mathcal{E}} / d$ is the normalized [`Choi`](qiskit.quantum_info.Choi "qiskit.quantum_info.Choi") matrix for the channel $\mathcal{E}$, and $d$ is the input dimension of $\mathcal{E}$.
 
 When the target channel is unitary this is equivalent to
 
 $$
-F_{\text{pro}}(\mathcal{E}, U)
-    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
+                      \[F_{\text{pro}}(\mathcal{E}, U)
+                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.26/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.26/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,37 +10,37 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-F\vert x\rangle\vert 0\rangle = \sqrt{1 - \hat{f}(x)} \vert x\rangle\vert 0\rangle + \sqrt{\hat{f}(x)}
-    \vert x\rangle\vert 1\rangle.
+                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+                      |x\rangle|1\rangle.\]
 $$
 
-for a function $\hat{f}: \{0, ..., 2^n - 1} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
+for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
 
 This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this case, the mapping $F$ can be approximately implemented using a Taylor expansion and linearly controlled Pauli-Y rotations, see \[1, 2] for more detail. This approximation uses a `rescaling_factor` to determine the accuracy of the Taylor expansion.
 
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
+                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
 $$
 
 with
 
 $$
-\phi(x) = a + \frac{b - a}{2^n - 1} x.
+                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
+                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.26/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.26/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.26/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.26/qiskit.quantum_info.process_fidelity.md
@@ -10,19 +10,19 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
-The process fidelity $F_{\text{pro}}(\mathcal{E}, \methcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
+The process fidelity $F_{\text{pro}}(\mathcal{E}, \mathcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
 
 where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit.quantum_info.state_fidelity"), $\rho_{\mathcal{E}} = \Lambda_{\mathcal{E}} / d$ is the normalized [`Choi`](qiskit.quantum_info.Choi "qiskit.quantum_info.Choi") matrix for the channel $\mathcal{E}$, and $d$ is the input dimension of $\mathcal{E}$.
 
 When the target channel is unitary this is equivalent to
 
 $$
-F_{\text{pro}}(\mathcal{E}, U)
-    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
+                      \[F_{\text{pro}}(\mathcal{E}, U)
+                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.27/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.27/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,37 +10,37 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-F\vert x\rangle\vert 0\rangle = \sqrt{1 - \hat{f}(x)} \vert x\rangle\vert 0\rangle + \sqrt{\hat{f}(x)}
-    \vert x\rangle\vert 1\rangle.
+                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+                      |x\rangle|1\rangle.\]
 $$
 
-for a function $\hat{f}: \{0, ..., 2^n - 1} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
+for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $\vert x\rangle$ is a $n$ qubit state.
 
 This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this case, the mapping $F$ can be approximately implemented using a Taylor expansion and linearly controlled Pauli-Y rotations, see \[1, 2] for more detail. This approximation uses a `rescaling_factor` to determine the accuracy of the Taylor expansion.
 
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
+                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
 $$
 
 with
 
 $$
-\phi(x) = a + \frac{b - a}{2^n - 1} x.
+                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
+                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.27/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.27/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.27/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.27/qiskit.quantum_info.process_fidelity.md
@@ -10,19 +10,19 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
-The process fidelity $F_{\text{pro}}(\mathcal{E}, \methcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
+The process fidelity $F_{\text{pro}}(\mathcal{E}, \mathcal{F})$ between two quantum channels $\mathcal{E}, \mathcal{F}$ is given by
 
 where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit.quantum_info.state_fidelity"), $\rho_{\mathcal{E}} = \Lambda_{\mathcal{E}} / d$ is the normalized [`Choi`](qiskit.quantum_info.Choi "qiskit.quantum_info.Choi") matrix for the channel $\mathcal{E}$, and $d$ is the input dimension of $\mathcal{E}$.
 
 When the target channel is unitary this is equivalent to
 
 $$
-F_{\text{pro}}(\mathcal{E}, U)
-    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
+                      \[F_{\text{pro}}(\mathcal{E}, U)
+                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.28/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.28/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.29/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.29/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.30/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.30/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.31/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.31/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.32/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.32/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.33/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.33/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.35/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
+++ b/docs/api/qiskit/0.35/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
@@ -10,13 +10,13 @@ python_api_name: qiskit.algorithms.linear_solvers.AbsoluteAverage
 
 <span id="qiskit.algorithms.linear_solvers.AbsoluteAverage" />
 
-`AbsoluteAverage`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
+`AbsoluteAverage `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
 
 Bases: `qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable`
 
 An observable for the absolute average of a linear system of equations solution.
 
-For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\abs{\frac{1}{N}\sum_{i=1}^{N}x_i}$.
+For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\left\vert \frac{1}{N}\sum_{i=1}^{N}x_i\right\vert $.
 
 **Examples**
 

--- a/docs/api/qiskit/0.35/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.35/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
+                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
-X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
-Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
-Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
+                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
+                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
+                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
 $$
 
 The $k$ and $x$ arrays
 
 $$
-\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
+                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.36/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
+++ b/docs/api/qiskit/0.36/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
@@ -10,13 +10,13 @@ python_api_name: qiskit.algorithms.linear_solvers.AbsoluteAverage
 
 <span id="qiskit.algorithms.linear_solvers.AbsoluteAverage" />
 
-`AbsoluteAverage`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
+`AbsoluteAverage `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
 
 Bases: `qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable`
 
 An observable for the absolute average of a linear system of equations solution.
 
-For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\abs{\frac{1}{N}\sum_{i=1}^{N}x_i}$.
+For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\left\vert \frac{1}{N}\sum_{i=1}^{N}x_i\right\vert $.
 
 **Examples**
 

--- a/docs/api/qiskit/0.36/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.36/qiskit.quantum_info.Pauli.md
@@ -64,7 +64,7 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays

--- a/docs/api/qiskit/0.37/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
+++ b/docs/api/qiskit/0.37/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
@@ -10,13 +10,13 @@ python_api_name: qiskit.algorithms.linear_solvers.AbsoluteAverage
 
 <span id="qiskit.algorithms.linear_solvers.AbsoluteAverage" />
 
-`AbsoluteAverage`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
+`AbsoluteAverage `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
 
 Bases: [`qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable`](qiskit.algorithms.linear_solvers.LinearSystemObservable "qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable")
 
 An observable for the absolute average of a linear system of equations solution.
 
-For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\abs{\frac{1}{N}\sum_{i=1}^{N}x_i}$.
+For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\left\vert \frac{1}{N}\sum_{i=1}^{N}x_i\right\vert $.
 
 **Examples**
 

--- a/docs/api/qiskit/0.38/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
+++ b/docs/api/qiskit/0.38/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
@@ -10,13 +10,13 @@ python_api_name: qiskit.algorithms.linear_solvers.AbsoluteAverage
 
 <span id="qiskit.algorithms.linear_solvers.AbsoluteAverage" />
 
-`AbsoluteAverage`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
+`AbsoluteAverage `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
 
 Bases: [`qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable`](qiskit.algorithms.linear_solvers.LinearSystemObservable "qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable")
 
 An observable for the absolute average of a linear system of equations solution.
 
-For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\abs{\frac{1}{N}\sum_{i=1}^{N}x_i}$.
+For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\left\vert \frac{1}{N}\sum_{i=1}^{N}x_i\right\vert $.
 
 **Examples**
 

--- a/docs/api/qiskit/0.39/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
+++ b/docs/api/qiskit/0.39/qiskit.algorithms.linear_solvers.AbsoluteAverage.md
@@ -10,13 +10,13 @@ python_api_name: qiskit.algorithms.linear_solvers.AbsoluteAverage
 
 <span id="qiskit.algorithms.linear_solvers.AbsoluteAverage" />
 
-`AbsoluteAverage`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.22/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
+`AbsoluteAverage `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.22/qiskit/algorithms/linear_solvers/observables/absolute_average.py "view source code")
 
 Bases: [`qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable`](qiskit.algorithms.linear_solvers.LinearSystemObservable "qiskit.algorithms.linear_solvers.observables.linear_system_observable.LinearSystemObservable")
 
 The deprecated observable for the absolute average of a linear system of equations solution.
 
-For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\abs{\frac{1}{N}\sum_{i=1}^{N}x_i}$.
+For a vector $x=(x_1,...,x_N)$, the absolute average is defined as $\left\vert \frac{1}{N}\sum_{i=1}^{N}x_i\right\vert $.
 
 **Examples**
 

--- a/docs/api/qiskit/release-notes/0.45.md
+++ b/docs/api/qiskit/release-notes/0.45.md
@@ -945,7 +945,7 @@ Some feature highlights of Qiskit 0.45.0 are:
 
 *   Added support to allow `SparsePauliOp` default initialization passing an empty iterable to the static methods [`from_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_list "qiskit.quantum_info.SparsePauliOp.from_list") and [`from_sparse_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_sparse_list "qiskit.quantum_info.SparsePauliOp.from_sparse_list"). Fixed [#10159](https://github.com/Qiskit/qiskit-terra/issues/10159).
 
-*   The use of the (deprecated) `Optimizer` class on [`AQC`](/api/qiskit/0.45/qiskit.transpiler.synthesis.aqc.AQC "qiskit.transpiler.synthesis.aqc.AQC") did not have a non-deprecated alternative path, which should have been introduced in Qiskit 0.44. It now accepts a callable that implements the [`Minimizer`](/api/qiskit/qiskit.algorithms.optimizers.Minimizer "qiskit.algorithms.optimizers.Minimizer") protocol, as explicitly stated in the deprecation warning. The callable can look like the following example:
+*   The use of the (deprecated) `Optimizer` class on [`AQC`](/api/qiskit/qiskit.transpiler.synthesis.aqc.AQC "qiskit.transpiler.synthesis.aqc.AQC") did not have a non-deprecated alternative path, which should have been introduced in Qiskit 0.44. It now accepts a callable that implements the [`Minimizer`](/api/qiskit/qiskit.algorithms.optimizers.Minimizer "qiskit.algorithms.optimizers.Minimizer") protocol, as explicitly stated in the deprecation warning. The callable can look like the following example:
 
     > ```python
     > from scipy.optimize import minimize

--- a/docs/api/qiskit/release-notes/0.45.md
+++ b/docs/api/qiskit/release-notes/0.45.md
@@ -945,7 +945,7 @@ Some feature highlights of Qiskit 0.45.0 are:
 
 *   Added support to allow `SparsePauliOp` default initialization passing an empty iterable to the static methods [`from_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_list "qiskit.quantum_info.SparsePauliOp.from_list") and [`from_sparse_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_sparse_list "qiskit.quantum_info.SparsePauliOp.from_sparse_list"). Fixed [#10159](https://github.com/Qiskit/qiskit-terra/issues/10159).
 
-*   The use of the (deprecated) `Optimizer` class on [`AQC`](/api/qiskit/qiskit.transpiler.synthesis.aqc.AQC "qiskit.transpiler.synthesis.aqc.AQC") did not have a non-deprecated alternative path, which should have been introduced in Qiskit 0.44. It now accepts a callable that implements the [`Minimizer`](/api/qiskit/qiskit.algorithms.optimizers.Minimizer "qiskit.algorithms.optimizers.Minimizer") protocol, as explicitly stated in the deprecation warning. The callable can look like the following example:
+*   The use of the (deprecated) `Optimizer` class on [`AQC`](/api/qiskit/0.45/qiskit.transpiler.synthesis.aqc.AQC "qiskit.transpiler.synthesis.aqc.AQC") did not have a non-deprecated alternative path, which should have been introduced in Qiskit 0.44. It now accepts a callable that implements the [`Minimizer`](/api/qiskit/qiskit.algorithms.optimizers.Minimizer "qiskit.algorithms.optimizers.Minimizer") protocol, as explicitly stated in the deprecation warning. The callable can look like the following example:
 
     > ```python
     > from scipy.optimize import minimize


### PR DESCRIPTION
This PR fixes bad latex expressions for all Qiskit API docs versions thanks to @kevinsung's fix

Part of https://github.com/Qiskit/documentation/issues/673.
