### PR TITLE
Make output more useful for pages failing to render

### DIFF
--- a/scripts/commands/checkPagesRender.ts
+++ b/scripts/commands/checkPagesRender.ts
@@ -59,13 +59,13 @@ zxMain(async () => {
   await validateDockerRunning();
   const files = await determineFilePaths(args);
 
-  let allGood = true;
+  let failures: string[] = [];
   let numFilesChecked = 1;
   for (const fp of files) {
     const rendered = await canRender(fp);
     if (!rendered) {
       console.error(`❌ Failed to render: ${fp}`);
-      allGood = false;
+      failures.push(fp);
     }
 
     // This script can be slow, so log progress every 10 files.
@@ -75,13 +75,14 @@ zxMain(async () => {
     numFilesChecked++;
   }
 
-  if (allGood) {
+  if (failures.length === 0) {
     console.info("✅ All pages render without crashing");
   } else {
     console.error(
       "💔 Some pages crash when rendering. This is usually due to invalid syntax, such as forgetting " +
         "the closing component tag, like `</Admonition>`. You can sometimes get a helpful error message " +
-        "by previewing the docs locally or in CI. See the README for instructions.",
+        "by previewing the docs locally or in CI. See the README for instructions.\n\n" +
+        failures.join("\n"),
     );
     process.exit(1);
   }


### PR DESCRIPTION
It's nice that we eagerly load failures while the script is still running because it can be really slow to run so that gets you feedback sooner. But right now it's too hard to get the final list of failures at the end.