### PR TITLE
Regenerate Qiskit 0.19 QuantumInstance

### DIFF
--- a/docs/api/qiskit/0.19/qiskit.aqua.QuantumInstance.md
+++ b/docs/api/qiskit/0.19/qiskit.aqua.QuantumInstance.md
@@ -46,47 +46,11 @@ Quantum Instance holds a Qiskit Terra backend as well as configuration for circu
 
 ## Attributes
 
-### BACKEND\_CONFIG
-
-<span id="qiskit.aqua.QuantumInstance.BACKEND_CONFIG" />
-
-`= ['basis_gates', 'coupling_map']`
-
-### BACKEND\_OPTIONS
-
-<span id="qiskit.aqua.QuantumInstance.BACKEND_OPTIONS" />
-
-`= ['initial_statevector', 'chop_threshold', 'max_parallel_threads', 'max_parallel_experiments', 'statevector_parallel_threshold', 'statevector_hpc_gate_opt', 'statevector_sample_measure_opt', 'max_parallel_shots']`
-
 ### BACKEND\_OPTIONS\_QASM\_ONLY
 
 <span id="qiskit.aqua.QuantumInstance.BACKEND_OPTIONS_QASM_ONLY" />
 
 `= ['statevector_sample_measure_opt', 'max_parallel_shots']`
-
-### COMPILE\_CONFIG
-
-<span id="qiskit.aqua.QuantumInstance.COMPILE_CONFIG" />
-
-`= ['pass_manager', 'initial_layout', 'seed_transpiler', 'optimization_level']`
-
-### NOISE\_CONFIG
-
-<span id="qiskit.aqua.QuantumInstance.NOISE_CONFIG" />
-
-`= ['noise_model']`
-
-### QJOB\_CONFIG
-
-<span id="qiskit.aqua.QuantumInstance.QJOB_CONFIG" />
-
-`= ['timeout', 'wait']`
-
-### RUN\_CONFIG
-
-<span id="qiskit.aqua.QuantumInstance.RUN_CONFIG" />
-
-`= ['shots', 'max_credits', 'memory', 'seed_simulator']`
 
 ### backend
 


### PR DESCRIPTION
This PR regenerates the qiskit 0.19 API docs.

QuantumInstance had two HTML for some properties where a file in ALL_CAPS defined the property itself and another file in lowercase was the getter. Our script, when run on case-insensitive operating systems like macOS, wasn't able to download both files, and we ended up losing the getters.

The artifact stored on Box (https://ibm.ent.box.com/folder/246867920686) was modified to preserve all the getters and remove the properties.

Closes #769 