### PR TITLE
Add `type` attribute to `_package.json`

### DIFF
--- a/docs/api/qiskit-ibm-provider/_package.json
+++ b/docs/api/qiskit-ibm-provider/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-provider",
-  "version": "0.7.3"
+  "version": "0.7.3",
+  "type": "latest"
 }

--- a/docs/api/qiskit-ibm-runtime/0.14/_package.json
+++ b/docs/api/qiskit-ibm-runtime/0.14/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.14.0"
+  "version": "0.14.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit-ibm-runtime/0.15/_package.json
+++ b/docs/api/qiskit-ibm-runtime/0.15/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.15.0"
+  "version": "0.15.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit-ibm-runtime/0.16/_package.json
+++ b/docs/api/qiskit-ibm-runtime/0.16/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.16.1"
+  "version": "0.16.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit-ibm-runtime/0.17/_package.json
+++ b/docs/api/qiskit-ibm-runtime/0.17/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.17.0"
+  "version": "0.17.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.18.0"
+  "version": "0.18.0",
+  "type": "latest"
 }

--- a/docs/api/qiskit/0.19/_package.json
+++ b/docs/api/qiskit/0.19/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.19.6"
+  "version": "0.19.6",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.24/_package.json
+++ b/docs/api/qiskit/0.24/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.24.1"
+  "version": "0.24.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.25/_package.json
+++ b/docs/api/qiskit/0.25/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.25.4"
+  "version": "0.25.4",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.26/_package.json
+++ b/docs/api/qiskit/0.26/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.26.2"
+  "version": "0.26.2",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.27/_package.json
+++ b/docs/api/qiskit/0.27/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.27.0"
+  "version": "0.27.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.28/_package.json
+++ b/docs/api/qiskit/0.28/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.28.0"
+  "version": "0.28.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.29/_package.json
+++ b/docs/api/qiskit/0.29/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.29.1"
+  "version": "0.29.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.30/_package.json
+++ b/docs/api/qiskit/0.30/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.30.1"
+  "version": "0.30.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.31/_package.json
+++ b/docs/api/qiskit/0.31/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.31.0"
+  "version": "0.31.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.32/_package.json
+++ b/docs/api/qiskit/0.32/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.32.1"
+  "version": "0.32.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.33/_package.json
+++ b/docs/api/qiskit/0.33/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.33.1"
+  "version": "0.33.1",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.35/_package.json
+++ b/docs/api/qiskit/0.35/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.35.0"
+  "version": "0.35.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.36/_package.json
+++ b/docs/api/qiskit/0.36/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.36.0"
+  "version": "0.36.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.37/_package.json
+++ b/docs/api/qiskit/0.37/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.37.2"
+  "version": "0.37.2",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.38/_package.json
+++ b/docs/api/qiskit/0.38/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.38.0"
+  "version": "0.38.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.39/_package.json
+++ b/docs/api/qiskit/0.39/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.39.5"
+  "version": "0.39.5",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.40/_package.json
+++ b/docs/api/qiskit/0.40/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.40.0"
+  "version": "0.40.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.41/_package.json
+++ b/docs/api/qiskit/0.41/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.41.0"
+  "version": "0.41.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.42/_package.json
+++ b/docs/api/qiskit/0.42/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.42.0"
+  "version": "0.42.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.43/_package.json
+++ b/docs/api/qiskit/0.43/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.43.0"
+  "version": "0.43.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.44/_package.json
+++ b/docs/api/qiskit/0.44/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.44.0"
+  "version": "0.44.0",
+  "type": "historical"
 }

--- a/docs/api/qiskit/0.45/_package.json
+++ b/docs/api/qiskit/0.45/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.45.3"
+  "version": "0.45.2",
+  "type": "historical"
 }

--- a/docs/api/qiskit/_package.json
+++ b/docs/api/qiskit/_package.json
@@ -1,4 +1,5 @@
 {
   "name": "qiskit",
-  "version": "0.46.0"
+  "version": "0.46.0",
+  "type": "latest"
 }

--- a/scripts/commands/convertApiDocsToHistorical.ts
+++ b/scripts/commands/convertApiDocsToHistorical.ts
@@ -110,7 +110,7 @@ async function generateJsonFiles(
   projectNewHistoricalFolder: string,
 ) {
   console.log("Generating version file");
-  const pkgName_json = { name: pkgName, version: version };
+  const pkgName_json = { name: pkgName, version: version, type: "historical" };
   await writeFile(
     `${projectNewHistoricalFolder}/_package.json`,
     JSON.stringify(pkgName_json, null, 2) + "\n",

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -240,7 +240,7 @@ async function convertHtmlToMarkdown(
 
   console.log("Generating version file");
   const type = pkg.historical ? "historical" : "latest";
-  const pkg_json = { name: pkg.name, version: pkg.version, type: type };
+  const pkg_json = { name: pkg.name, version: pkg.version, type };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -239,7 +239,8 @@ async function convertHtmlToMarkdown(
   }
 
   console.log("Generating version file");
-  const pkg_json = { name: pkg.name, version: pkg.version };
+  const type = pkg.historical ? "historical" : "latest";
+  const pkg_json = { name: pkg.name, version: pkg.version, type: type };
   await writeFile(
     `${markdownPath}/_package.json`,
     JSON.stringify(pkg_json, null, 2) + "\n",


### PR DESCRIPTION
Part of #316

This PR adds the attribute `type` in the `_package.json` files to be able to differentiate between the latest, historical, and the dev version once is implemented.

This new attribute will be used to determine when to add a label in the version selector of the API docs