### PR TITLE
Always check if pages render in extended CI check

### DIFF
--- a/.github/workflows/extended-checks.yml
+++ b/.github/workflows/extended-checks.yml
@@ -51,8 +51,10 @@ jobs:
         run: |
           ./start &
           sleep 20
+        if: always()
       - name: Check current API pages render
         run: >
           npm run check-pages-render --
           --qiskit-release-notes
           --current-apis
+        if: always()

--- a/.github/workflows/extended-checks.yml
+++ b/.github/workflows/extended-checks.yml
@@ -51,10 +51,10 @@ jobs:
         run: |
           ./start &
           sleep 20
-        if: always()
+        if: !cancelled()
       - name: Check current API pages render
         run: >
           npm run check-pages-render --
           --qiskit-release-notes
           --current-apis
-        if: always()
+        if: !cancelled()


### PR DESCRIPTION
Sometimes the link checker fails due to flakes. It's annoying that that means the page render check won't run.