### PR TITLE
Extend the API generation script to generate dev versions

### DIFF
--- a/.github/workflows/extended-checks.yml
+++ b/.github/workflows/extended-checks.yml
@@ -43,6 +43,7 @@ jobs:
           npm run check:links --
           --qiskit-release-notes
           --current-apis
+          --dev-apis
           --historical-apis
           --skip-broken-historical
           --external
@@ -57,4 +58,5 @@ jobs:
           npm run check-pages-render --
           --qiskit-release-notes
           --current-apis
+          --dev-apis
         if: ${{ !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ npm run check:links -- --external
 
 # By default, only the non-API docs are checked. You can add any of the
 # below arguments to also check API docs and/or Qiskit release notes.
-npm run check:links -- --current-apis --historical-apis --qiskit-release-notes
+npm run check:links -- --current-apis --dev-apis --historical-apis --qiskit-release-notes
 
 # However, `--historical-apis` currently has failing versions, so you may
 # want to add `--skip-broken-historical`.
@@ -227,7 +227,7 @@ To check that all the non-API docs render:
 1. Start up the local preview with `./start` by following the instructions at [Preview the docs locally](#preview-the-docs-locally)
 2. In a new tab, `npm run check-pages-render`
 
-You can also check that API docs and translations render by using any of these arguments: `npm run check-pages-render -- --qiskit-release-notes --current-apis --historical-apis --translations`. Warning that this is exponentially slower.
+You can also check that API docs and translations render by using any of these arguments: `npm run check-pages-render -- --qiskit-release-notes --current-apis --dev-apis --historical-apis --translations`. Warning that this is exponentially slower.
 
 CI will check on every PR that non-API docs correctly render. We also run a nightly cron job to check the API docs and
 translations.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Alternatively, you can also regenerate one specific version:
 2. Run `npm run gen-api -- -p <pkg-name> -v <version>`,
    e.g. `npm run gen-api -- -p qiskit -v 0.45.0`
 
-If the version is not for the latest stable minor release series, then add `--historical` to the arguments. For example, use `--historical` if the latest stable release is 0.45.\* but you're generating docs for the patch release 0.44.3.
+If the version is not for the latest stable minor release series, then add `--historical` to the arguments. For example, use `--historical` if the latest stable release is 0.45.\* but you're generating docs for the patch release 0.44.3. Additionally, If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`.
 
 In this case, no commit will be automatically created.
 
@@ -286,6 +286,8 @@ This is useful when new docs content is published, usually corresponding to new 
 10. Modify the `scripts/api-html-artifacts.json` file adding the new versions with the direct link from step 9.
 11. Run `npm run gen-api -- -p <pkg-name> -v <version>`,
     e.g. `npm run gen-api -- -p qiskit -v 0.45.0`
+
+If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`.
 
 In case you want to save the current version and convert it into a historical one, you can run `npm run make-historical -- -p <pkg-name>` beforehand.
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ Alternatively, you can also regenerate one specific version:
 2. Run `npm run gen-api -- -p <pkg-name> -v <version>`,
    e.g. `npm run gen-api -- -p qiskit -v 0.45.0`
 
-If the version is not for the latest stable minor release series, then add `--historical` to the arguments. For example, use `--historical` if the latest stable release is 0.45.\* but you're generating docs for the patch release 0.44.3. Additionally, If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`.
+If the version is not for the latest stable minor release series, then add `--historical` to the arguments. For example, use `--historical` if the latest stable release is 0.45.\* but you're generating docs for the patch release 0.44.3.
+
+Additionally, If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`. For dev versions, end the `--version` in `-dev`, e.g. `-v 1.0.0-dev`. If a release candidate has already been released, use `-v 1.0.0rc1`, for example.
 
 In this case, no commit will be automatically created.
 
@@ -287,7 +289,7 @@ This is useful when new docs content is published, usually corresponding to new 
 11. Run `npm run gen-api -- -p <pkg-name> -v <version>`,
     e.g. `npm run gen-api -- -p qiskit -v 0.45.0`
 
-If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`.
+If you are regenerating a dev version, then you can add `--dev` as an argument and the documentation will be built at `/docs/api/<pkg-name>/dev`. For dev versions, end the `--version` in `-dev`, e.g. `-v 1.0.0-dev`. If a release candidate has already been released, use `-v 1.0.0rc1`, for example.
 
 In case you want to save the current version and convert it into a historical one, you can run `npm run make-historical -- -p <pkg-name>` beforehand.
 

--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -16,6 +16,7 @@ import { globby } from "globby";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
+import { pathExists } from "../lib/fs";
 import { File } from "../lib/links/LinkChecker";
 import { FileBatch } from "../lib/links/FileBatch";
 
@@ -30,6 +31,7 @@ interface Arguments {
   [x: string]: unknown;
   external: boolean;
   currentApis: boolean;
+  devApis: boolean;
   historicalApis: boolean;
   qiskitReleaseNotes: boolean;
   skipBrokenHistorical: boolean;
@@ -48,6 +50,11 @@ const readArgs = (): Arguments => {
       type: "boolean",
       default: false,
       description: "Check the links in the current API docs.",
+    })
+    .option("dev-apis", {
+      type: "boolean",
+      default: false,
+      description: "Check the links in the /dev API docs.",
     })
     .option("historical-apis", {
       type: "boolean",
@@ -97,19 +104,28 @@ async function main() {
 
 async function determineFileBatches(args: Arguments): Promise<FileBatch[]> {
   const currentBatch = await determineCurrentDocsFileBatch(args);
-  if (!args.historicalApis) {
-    return [currentBatch];
+  const result = [currentBatch];
+
+  if (args.devApis) {
+    const devBatches = await determineDevFileBatches();
+    result.push(...devBatches);
   }
 
-  const provider = await determineHistoricalFileBatches("qiskit-ibm-provider");
-  const runtime = await determineHistoricalFileBatches("qiskit-ibm-runtime", [
-    "docs/api/qiskit/providers_models.md",
-  ]);
-  let qiskit: FileBatch[] = [];
-  if (!args.skipBrokenHistorical) {
-    qiskit = await determineHistoricalFileBatches("qiskit");
+  if (args.historicalApis) {
+    const provider = await determineHistoricalFileBatches(
+      "qiskit-ibm-provider",
+    );
+    const runtime = await determineHistoricalFileBatches("qiskit-ibm-runtime", [
+      "docs/api/qiskit/providers_models.md",
+    ]);
+    let qiskit: FileBatch[] = [];
+    if (!args.skipBrokenHistorical) {
+      qiskit = await determineHistoricalFileBatches("qiskit");
+    }
+    result.push(...provider, ...runtime, ...qiskit);
   }
-  return [currentBatch, ...provider, ...runtime, ...qiskit];
+
+  return result;
 }
 
 async function determineCurrentDocsFileBatch(
@@ -121,6 +137,9 @@ async function determineCurrentDocsFileBatch(
     // Ignore historical versions
     "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*",
     "!public/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*",
+    // Ignore dev version
+    "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*",
+    "!public/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*",
   ];
   const toLoad = [
     "docs/api/qiskit/0.44/{algorithms,opflow}.md",
@@ -155,6 +174,30 @@ async function determineCurrentDocsFileBatch(
   }
 
   return FileBatch.fromGlobs(toCheck, toLoad, description);
+}
+
+async function determineDevFileBatches(): Promise<FileBatch[]> {
+  const devProjects = [];
+  for (const project of [
+    "qiskit",
+    "qiskit-ibm-provider",
+    "qiskit-ibm-runtime",
+  ]) {
+    if (await pathExists(`docs/api/${project}/dev`)) {
+      devProjects.push(project);
+    }
+  }
+
+  const result = [];
+  for (const project of devProjects) {
+    const fileBatch = await FileBatch.fromGlobs(
+      [`docs/api/${project}/dev/*`, `public/api/${project}/dev/objects.inv`],
+      [],
+      `${project} dev docs`,
+    );
+    result.push(fileBatch);
+  }
+  return result;
 }
 
 async function determineHistoricalFileBatches(

--- a/scripts/commands/checkPagesRender.ts
+++ b/scripts/commands/checkPagesRender.ts
@@ -21,6 +21,7 @@ const PORT = 3000;
 interface Arguments {
   [x: string]: unknown;
   currentApis: boolean;
+  devApis: boolean;
   historicalApis: boolean;
   qiskitReleaseNotes: boolean;
   translations: boolean;
@@ -33,6 +34,11 @@ const readArgs = (): Arguments => {
       type: "boolean",
       default: false,
       description: "Check the pages in the current API docs.",
+    })
+    .option("dev-apis", {
+      type: "boolean",
+      default: false,
+      description: "Check the /dev API docs.",
     })
     .option("historical-apis", {
       type: "boolean",
@@ -138,6 +144,11 @@ async function determineFilePaths(args: Arguments): Promise<string[]> {
   if (!args.historicalApis) {
     globs.push(
       "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*",
+    );
+  }
+  if (!args.devApis) {
+    globs.push(
+      "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*",
     );
   }
   if (!args.qiskitReleaseNotes) {

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -104,11 +104,11 @@ zxMain(async () => {
   }
 
   const devRegex = /[0-9](-rc|-dev)/;
-  if (args.dev && !args.version.match(devRegex)) {
-    throw new Error(
-      `${args.package} ${args.version} is not a correct dev version. Please make sure the version has one of the following suffixes with a hyphen immediately following the patch version: -rc, -dev. e.g. 1.0.0-rc1 or 1.0.0-dev`,
-    );
-  }
+  //if (args.dev && !args.version.match(devRegex)) {
+  //  throw new Error(
+  //    `${args.package} ${args.version} is not a correct dev version. Please make sure the version has one of the following suffixes with a hyphen immediately following the patch version: -rc, -dev. e.g. 1.0.0-rc1 or 1.0.0-dev`,
+  //  );
+  //}
 
   const type = args.historical ? "historical" : args.dev ? "dev" : "latest";
 
@@ -227,7 +227,7 @@ async function convertHtmlToMarkdown(
 
     // Dev versions haven't been released yet and we don't want to modify the release notes
     // of prior versions
-    if (pkg.isDev()) {
+    if (pkg.isDev() && path.endsWith("release-notes.md")) {
       continue;
     }
 

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -218,6 +218,12 @@ async function convertHtmlToMarkdown(
       continue;
     }
 
+    // Dev versions haven't been released yet and we don't want to modify the release notes
+    // of prior versions
+    if (pkg.isDev()) {
+      continue;
+    }
+
     if (pkg.hasSeparateReleaseNotes && path.endsWith("release-notes.md")) {
       // Convert the relative links to absolute links
       result.markdown = transformLinks(result.markdown, (link, _) =>

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -103,6 +103,13 @@ zxMain(async () => {
     );
   }
 
+  const devRegex = /[0-9](-rc|-dev)/;
+  if (args.dev && !args.version.match(devRegex)) {
+    throw new Error(
+      `${args.package} ${args.version} is not a correct dev version. Please make sure the version has one of the following suffixes with a hyphen immediately following the patch version: -rc, -dev. e.g. 1.0.0-rc1 or 1.0.0-dev`,
+    );
+  }
+
   const type = args.historical ? "historical" : args.dev ? "dev" : "latest";
 
   const pkg = await Pkg.fromArgs(

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -103,12 +103,12 @@ zxMain(async () => {
     );
   }
 
-  const devRegex = /[0-9](-rc|-dev)/;
-  //if (args.dev && !args.version.match(devRegex)) {
-  //  throw new Error(
-  //    `${args.package} ${args.version} is not a correct dev version. Please make sure the version has one of the following suffixes with a hyphen immediately following the patch version: -rc, -dev. e.g. 1.0.0-rc1 or 1.0.0-dev`,
-  //  );
-  //}
+  const devRegex = /[0-9](rc|-dev)/;
+  if (args.dev && !args.version.match(devRegex)) {
+    throw new Error(
+      `${args.package} ${args.version} is not a correct dev version. Please make sure the version has one of the following suffixes immediately following the patch version: rc, -dev. e.g. 1.0.0rc1 or 1.0.0-dev`,
+    );
+  }
 
   const type = args.historical ? "historical" : args.dev ? "dev" : "latest";
 

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -99,7 +99,7 @@ zxMain(async () => {
 
   if (args.historical && args.dev) {
     throw new Error(
-      `${args.package} ${args.version} cannot be historical and dev at the same time`,
+      `${args.package} ${args.version} cannot be historical and dev at the same time. Please remove at least only one of these two arguments: --historical, --dev.`,
     );
   }
 

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -29,7 +29,7 @@ export interface ReleaseNoteEntry {
   url: string;
 }
 
-type PackageType = "latest" | "historical";
+type PackageType = "latest" | "historical" | "dev";
 
 /**
  * Information about the specific package and version we're dealing with, e.g. qiskit 0.45.
@@ -149,6 +149,8 @@ export class Pkg {
     let path = join(parentDir, "api", this.name);
     if (this.isHistorical()) {
       path = join(path, this.versionWithoutPatch);
+    } else if (this.isDev()) {
+      path = join(path, "dev");
     }
     return path;
   }
@@ -159,6 +161,14 @@ export class Pkg {
 
   isHistorical(): boolean {
     return this.type == "historical";
+  }
+
+  isDev(): boolean {
+    return this.type == "dev";
+  }
+
+  isLatest(): boolean {
+    return this.type == "latest";
   }
 
   hasObjectsInv(): boolean {

--- a/scripts/lib/api/saveImages.ts
+++ b/scripts/lib/api/saveImages.ts
@@ -16,7 +16,7 @@ import { copyFile } from "fs/promises";
 
 import { Pkg } from "./Pkg";
 import { Image } from "./HtmlToMdResult";
-import { pathExists } from "../fs";
+import { pathExists, rmFilesInFolder } from "../fs";
 
 export async function saveImages(
   images: Image[],
@@ -26,6 +26,8 @@ export async function saveImages(
   const destFolder = pkg.outputDir("public/images");
   if (!(await pathExists(destFolder))) {
     await mkdirp(destFolder);
+  } else {
+    await rmFilesInFolder(destFolder);
   }
 
   await pMap(images, async (img) => {

--- a/scripts/lib/api/saveImages.ts
+++ b/scripts/lib/api/saveImages.ts
@@ -26,7 +26,9 @@ export async function saveImages(
   const destFolder = pkg.outputDir("public/images");
   if (!(await pathExists(destFolder))) {
     await mkdirp(destFolder);
-  } else {
+  } else if (pkg.isDev()) {
+    // We don't want to store images from other versions when we generate a
+    // different dev version
     await rmFilesInFolder(destFolder);
   }
 


### PR DESCRIPTION
This PR adds support to generate dev versions for the API generation script.

For the moment, the automatic regeneration will not take into account dev versions to keep this PR easy to review. I'll add support for that in a follow-up, together with the documentation of the dev versions.

Part of #316 