### PR TITLE
Fix Latex errors from bad HTML formatting

### DIFF
--- a/docs/api/qiskit/0.19/qiskit.circuit.library.PauliFeatureMap.md
+++ b/docs/api/qiskit/0.19/qiskit.circuit.library.PauliFeatureMap.md
@@ -26,7 +26,8 @@ The circuit contains `reps` repetitions of this transformation. The variable $P_
 $$
 \begin{split}\phi_S(\vec{x}) = \begin{cases}
     x_0 \text{ if } k = 1 \\
-    \prod_{j \in S} (\pi - x_j)\end{split}
+    \prod_{j \in S} (\pi - x_j) \text{ otherwise }
+    \end{cases}\end{split}
 $$
 
 For example, if the Pauli strings are chosen to be $P_0 = Z$ and $P_{0,1} = YY$ on 2 qubits and with 1 repetition using the default data-mapping, the Pauli evolution feature map is represented by:

--- a/docs/api/qiskit/0.19/qiskit.quantum_info.OneQubitEulerDecomposer.md
+++ b/docs/api/qiskit/0.19/qiskit.quantum_info.OneQubitEulerDecomposer.md
@@ -21,7 +21,7 @@ The resulting decomposition is parameterized by 3 Euler rotation angle parameter
 | ‘ZYZ’ | $Z(\phi) Y(\theta) Z(\lambda)$ | $e^{i\gamma} R_Z(\phi).R_Y(\theta).R_Z(\lambda)$                                                                         |
 | ‘ZXZ’ | $Z(\phi) X(\theta) Z(\lambda)$ | $e^{i\gamma} R_Z(\phi).R_X(\theta).R_Z(\lambda)$                                                                         |
 | ‘XYX’ | $X(\phi) Y(\theta) X(\lambda)$ | $e^{i\gamma} R_X(\phi).R_Y(\theta).R_X(\lambda)$                                                                         |
-| ‘U3’  | $Z(\phi) Y(\theta) Z(\lambda)$ | $e^{i\gamma}{2}\right)\right)} U_3(\theta,\phi,\lambda)$                                                                 |
+| ‘U3’  | $Z(\phi) Y(\theta) Z(\lambda)$ | $e^{i\gamma} U_3(\theta,\phi,\lambda)$                                                                                   |
 | ‘U1X’ | $Z(\phi) Y(\theta) Z(\lambda)$ | $e^{i \gamma} U_1(\phi+\pi).R_X\left(\frac{\pi}{2}\right).$ $U_1(\theta+\pi).R_X\left(\frac{\pi}{2}\right).U_1(\lambda)$ |
 | ‘RR’  | $Z(\phi) Y(\theta) Z(\lambda)$ | $e^{i\gamma} R\left(-\pi,\frac{\phi-\lambda+\pi}{2}\right).$ $R\left(\theta+\pi,\frac{\pi}{2}-\lambda\right)$            |
 

--- a/docs/api/qiskit/0.19/qiskit.quantum_info.concurrence.md
+++ b/docs/api/qiskit/0.19/qiskit.quantum_info.concurrence.md
@@ -20,7 +20,7 @@ where $\rho_0 = Tr_1[|\psi\rangle\!\langle\psi|]$ is the reduced state from by t
 
 For density matrices the concurrence is only defined for 2-qubit states, it is given by:
 
-where $\lambda _1 \ge \lambda _2 \ge \lambda _3 \ge \lambda _4$ are the ordered eigenvalues of the matrix $R=\sqrt{\sqrt{\rho }(Y\otimes Y)\overline{\rho}(Y\otimes Y)\sqrt{\rho}}}$.
+where $\lambda _1 \ge \lambda _2 \ge \lambda _3 \ge \lambda _4$ are the ordered eigenvalues of the matrix $R=\sqrt{\sqrt{\rho }(Y\otimes Y)\overline{\rho}(Y\otimes Y)\sqrt{\rho}}$.
 
 **Parameters**
 

--- a/docs/api/qiskit/0.19/qiskit.quantum_info.purity.md
+++ b/docs/api/qiskit/0.19/qiskit.quantum_info.purity.md
@@ -27,7 +27,7 @@ The purity of a density matrix $\rho$ is
 
 **Returns**
 
-the purity $\Tr[\rho^2]$.
+the purity $Tr[\rho^2]$.
 
 **Return type**
 

--- a/docs/api/qiskit/0.24/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.24/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -12,15 +12,15 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
-                      |x\rangle|1\rangle.\]
+F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+    |x\rangle|1\rangle.
 $$
 
 for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $|x\rangle$ is a $n$ qubit state.
@@ -30,19 +30,19 @@ This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this ca
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Usng an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
+\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
 $$
 
 with
 
 $$
-                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
+\phi(x) = a + \frac{b - a}{2^n - 1} x.
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
+f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.24/qiskit.quantum_info.concurrence.md
+++ b/docs/api/qiskit/0.24/qiskit.quantum_info.concurrence.md
@@ -12,14 +12,14 @@ python_api_name: qiskit.quantum_info.concurrence
 
 <span id="qiskit.quantum_info.concurrence" />
 
-`concurrence(state) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/quantum_info/states/measures.py "view source code")
+`concurrence(state)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.16/qiskit/quantum_info/states/measures.py "view source code")
 
 Calculate the concurrence of a quantum state.
 
 The concurrence of a bipartite [`Statevector`](qiskit.quantum_info.Statevector "qiskit.quantum_info.Statevector") $|\psi\rangle$ is given by
 
 $$
-                      \[C(|\psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}\]
+C(|\psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}
 $$
 
 where $\rho_0 = Tr_1[|\psi\rangle\!\langle\psi|]$ is the reduced state from by taking the $~qiskit.quantum_info.partial_trace$ of the input state.
@@ -27,7 +27,7 @@ where $\rho_0 = Tr_1[|\psi\rangle\!\langle\psi|]$ is the reduced state from by t
 For density matrices the concurrence is only defined for 2-qubit states, it is given by:
 
 $$
-                      \[C(\rho) = \max(0, \lambda_1 - \lambda_2 - \lambda_3 - \lambda_4)\]
+C(\rho) = \max(0, \lambda_1 - \lambda_2 - \lambda_3 - \lambda_4)
 $$
 
 where $\lambda _1 \ge \lambda _2 \ge \lambda _3 \ge \lambda _4$ are the ordered eigenvalues of the matrix $R=\sqrt{\sqrt{\rho }(Y\otimes Y)\overline{\rho}(Y\otimes Y)\sqrt{\rho}}$.

--- a/docs/api/qiskit/0.25/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.25/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,15 +10,15 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
-                      |x\rangle|1\rangle.\]
+F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+    |x\rangle|1\rangle.
 $$
 
 for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $|x\rangle$ is a $n$ qubit state.
@@ -28,19 +28,19 @@ This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this ca
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
+\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
 $$
 
 with
 
 $$
-                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
+\phi(x) = a + \frac{b - a}{2^n - 1} x.
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
+f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.25/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.25/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.25/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.25/qiskit.quantum_info.process_fidelity.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
@@ -21,8 +21,8 @@ where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit
 When the target channel is unitary this is equivalent to
 
 $$
-                      \[F_{\text{pro}}(\mathcal{E}, U)
-                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
+F_{\text{pro}}(\mathcal{E}, U)
+    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.26/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.26/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,15 +10,15 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
-                      |x\rangle|1\rangle.\]
+F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+    |x\rangle|1\rangle.
 $$
 
 for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $|x\rangle$ is a $n$ qubit state.
@@ -28,19 +28,19 @@ This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this ca
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
+\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
 $$
 
 with
 
 $$
-                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
+\phi(x) = a + \frac{b - a}{2^n - 1} x.
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
+f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.26/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.26/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.26/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.26/qiskit.quantum_info.process_fidelity.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
@@ -21,8 +21,8 @@ where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit
 When the target channel is unitary this is equivalent to
 
 $$
-                      \[F_{\text{pro}}(\mathcal{E}, U)
-                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
+F_{\text{pro}}(\mathcal{E}, U)
+    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.27/qiskit.circuit.library.LinearAmplitudeFunction.md
+++ b/docs/api/qiskit/0.27/qiskit.circuit.library.LinearAmplitudeFunction.md
@@ -10,15 +10,15 @@ python_api_name: qiskit.circuit.library.LinearAmplitudeFunction
 
 <span id="qiskit.circuit.library.LinearAmplitudeFunction" />
 
-`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F') `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
+`LinearAmplitudeFunction(num_state_qubits, slope, offset, domain, image, rescaling_factor=1, breakpoints=None, name='F')`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/circuit/library/arithmetic/linear_amplitude_function.py "view source code")
 
 A circuit implementing a (piecewise) linear function on qubit amplitudes.
 
 An amplitude function $F$ of a function $f$ is a mapping
 
 $$
-                      \[F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
-                      |x\rangle|1\rangle.\]
+F|x\rangle|0\rangle = \sqrt{1 - \hat{f}(x)} |x\rangle|0\rangle + \sqrt{\hat{f}(x)}
+    |x\rangle|1\rangle.
 $$
 
 for a function $\hat{f}: \{0, ..., 2^n - 1\} \rightarrow [0, 1]$, where $|x\rangle$ is a $n$ qubit state.
@@ -28,19 +28,19 @@ This circuit implements $F$ for piecewise linear functions $\hat{f}$. In this ca
 In general, the function of interest $f$ is defined from some interval $[a,b]$, the `domain` to $[c,d]$, the `image`, instead of :math\`\{1, …, N}\` to $[0, 1]$. Using an affine transformation we can rescale $f$ to $\hat{f}$:
 
 $$
-                      \[\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}\]
+\hat{f(x)} = \frac{f(\phi(x)) - c}{d - c}
 $$
 
 with
 
 $$
-                      \[\phi(x) = a + \frac{b - a}{2^n - 1} x.\]
+\phi(x) = a + \frac{b - a}{2^n - 1} x.
 $$
 
 If $f$ is a piecewise linear function on $m$ intervals $[p_{i-1}, p_i], i \in \{1, ..., m\}$ with slopes $\alpha_i$ and offsets beta\_i it can be written as
 
 $$
-                      \[f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)\]
+f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i}(x) (\alpha_i x + \beta_i)
 $$
 
 where $1_[a, b]$ is an indication function that is 1 if the argument is in the interval $[a, b]$ and otherwise 0. The breakpoints $p_i$ can be specified by the `breakpoints` argument.

--- a/docs/api/qiskit/0.27/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.27/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.27/qiskit.quantum_info.process_fidelity.md
+++ b/docs/api/qiskit/0.27/qiskit.quantum_info.process_fidelity.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.process_fidelity
 
 <span id="qiskit.quantum_info.process_fidelity" />
 
-`process_fidelity(channel, target=None, require_cp=True, require_tp=True) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
+`process_fidelity(channel, target=None, require_cp=True, require_tp=True)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.17/qiskit/quantum_info/operators/measures.py "view source code")
 
 Return the process fidelity of a noisy quantum channel.
 
@@ -21,8 +21,8 @@ where $F$ is the [`state_fidelity()`](qiskit.quantum_info.state_fidelity "qiskit
 When the target channel is unitary this is equivalent to
 
 $$
-                      \[F_{\text{pro}}(\mathcal{E}, U)
-                      = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}\]
+F_{\text{pro}}(\mathcal{E}, U)
+    = \frac{Tr[S_U^\dagger S_{\mathcal{E}}]}{d^2}
 $$
 
 where $S_{\mathcal{E}}, S_{U}$ are the [`SuperOp`](qiskit.quantum_info.SuperOp "qiskit.quantum_info.SuperOp") matrices for the *input* quantum channel $\mathcal{E}$ and *target* unitary $U$ respectively, and $d$ is the input dimension of the channel.

--- a/docs/api/qiskit/0.28/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.28/qiskit.quantum_info.Pauli.md
@@ -10,23 +10,23 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 N-qubit Pauli operator.
 
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -62,14 +62,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.29/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.29/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.30/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.30/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.31/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.31/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.32/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.32/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.18/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.33/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.33/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.

--- a/docs/api/qiskit/0.35/qiskit.quantum_info.Pauli.md
+++ b/docs/api/qiskit/0.35/qiskit.quantum_info.Pauli.md
@@ -10,7 +10,7 @@ python_api_name: qiskit.quantum_info.Pauli
 
 <span id="qiskit.quantum_info.Pauli" />
 
-`Pauli(data=None, x=None, *, z=None, label=None) `[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
+`Pauli(data=None, x=None, *, z=None, label=None)`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/quantum_info/operators/symplectic/pauli.py "view source code")
 
 Bases: `qiskit.quantum_info.operators.symplectic.base_pauli.BasePauli`
 
@@ -19,16 +19,16 @@ N-qubit Pauli operator.
 This class represents an operator $P$ from the full $n$-qubit *Pauli* group
 
 $$
-                      \[P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}\]
+P = (-i)^{q} P_{n-1} \otimes ... \otimes P_{0}
 $$
 
 where $q\in \mathbb{Z}_4$ and $P_i \in \{I, X, Y, Z\}$ are single-qubit Pauli matrices:
 
 $$
-                      \[\begin{split}I = \begin{pmatrix} 1 & 0 \\ 0 & 1 \end{pmatrix},
-                      X = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
-                      Y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix},
-                      Z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}.\end{split}\]
+\begin{split}I = \begin{pmatrix} 1 & 0  \\ 0 & 1  \end{pmatrix},
+X = \begin{pmatrix} 0 & 1  \\ 1 & 0  \end{pmatrix},
+Y = \begin{pmatrix} 0 & -i \\ i & 0  \end{pmatrix},
+Z = \begin{pmatrix} 1 & 0  \\ 0 & -1 \end{pmatrix}.\end{split}
 $$
 
 **Initialization**
@@ -64,14 +64,14 @@ The string representation can be converted to a `Pauli` using the class initiali
 The internal data structure of an $n$-qubit Pauli is two length-$n$ boolean vectors $z \in \mathbb{Z}_2^N$, $x \in \mathbb{Z}_2^N$, and an integer $q \in \mathbb{Z}_4$ defining the Pauli operator
 
 $$
-                      \[P = (-i)^{q + z\cdot x} Z^z \cdot X^x.\]
+P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 $$
 
 The $k$ and $x$ arrays
 
 $$
-                      \[\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
-                      P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}\]
+\begin{split}P &= P_{n-1} \otimes ... \otimes P_{0} \\
+P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}\end{split}
 $$
 
 where `z[k] = P.z[k]`, `x[k] = P.x[k]` respectively.


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/673.

This follows up on https://github.com/Qiskit/documentation/pull/763. While it fixed legit Latex issues, it introduced new problems because the HTML was autoformatted, which broke other math snippets.

This change was implemented entirely by changing the folder in Box as follows:

1. Used the latest folders as the base
2. Downloaded our original copies of the folders and replaced the failing files with these original copies
3. Manually fixed the bad HTML that was fixed in #763 
4. Uploaded the zip files and re-generated the docs

This also fixes 0.19 issues, which were never fixed in #763.