### PR TITLE
API generation script uses correct artifact names

### DIFF
--- a/scripts/api-html-artifacts.json
+++ b/scripts/api-html-artifacts.json
@@ -1,6 +1,6 @@
 {
   "qiskit": {
-    "1.0-dev": "https://ibm.box.com/shared/static/eh9tzx3senx5xkq1vvtsr5h697r6j7gk.zip",
+    "dev": "https://ibm.box.com/shared/static/eh9tzx3senx5xkq1vvtsr5h697r6j7gk.zip",
     "0.46": "https://ibm.box.com/shared/static/74ppfh7b3rx73fntmk9p8pw4asf6pp4a.zip",
     "0.45": "https://ibm.box.com/shared/static/e2rwbrztml4dg6lkk1w3e0kmevkw9w7s.zip",
     "0.44": "https://ibm.box.com/shared/static/myfk3g20xsp5xj8f3f1fd81p7ywgl7an.zip",
@@ -31,7 +31,7 @@
     "0.9": "https://ibm.box.com/shared/static/wkvhm1z5d61y64hvjxzio7t6974fpwem.zip"
   },
   "qiskit-ibm-runtime": {
-    "0.19-dev": "https://ibm.box.com/shared/static/wlwpn8n6i6g1er0n6cebejb07hrealb7.zip",
+    "dev": "https://ibm.box.com/shared/static/wlwpn8n6i6g1er0n6cebejb07hrealb7.zip",
     "0.19": "https://ibm.box.com/shared/static/ojpnzc71aex4d8itnktwbp9m7l15nazs.zip",
     "0.18": "https://ibm.box.com/shared/static/rbjdfogq8t1a4tquw1bh6gy4qdcv521v.zip",
     "0.17": "https://ibm.box.com/shared/static/dnjto1rpvk0qknqb9ir8nr3yv6n0yzhk.zip",

--- a/scripts/api-html-artifacts.json
+++ b/scripts/api-html-artifacts.json
@@ -1,5 +1,6 @@
 {
   "qiskit": {
+    "1.0-dev": "https://ibm.box.com/shared/static/eh9tzx3senx5xkq1vvtsr5h697r6j7gk.zip",
     "0.46": "https://ibm.box.com/shared/static/74ppfh7b3rx73fntmk9p8pw4asf6pp4a.zip",
     "0.45": "https://ibm.box.com/shared/static/e2rwbrztml4dg6lkk1w3e0kmevkw9w7s.zip",
     "0.44": "https://ibm.box.com/shared/static/myfk3g20xsp5xj8f3f1fd81p7ywgl7an.zip",
@@ -30,6 +31,7 @@
     "0.9": "https://ibm.box.com/shared/static/wkvhm1z5d61y64hvjxzio7t6974fpwem.zip"
   },
   "qiskit-ibm-runtime": {
+    "0.19-dev": "https://ibm.box.com/shared/static/wlwpn8n6i6g1er0n6cebejb07hrealb7.zip",
     "0.19": "https://ibm.box.com/shared/static/ojpnzc71aex4d8itnktwbp9m7l15nazs.zip",
     "0.18": "https://ibm.box.com/shared/static/rbjdfogq8t1a4tquw1bh6gy4qdcv521v.zip",
     "0.17": "https://ibm.box.com/shared/static/dnjto1rpvk0qknqb9ir8nr3yv6n0yzhk.zip",

--- a/scripts/lib/api/apiArtifacts.ts
+++ b/scripts/lib/api/apiArtifacts.ts
@@ -45,7 +45,8 @@ export async function downloadCIArtifact(pkg: Pkg, artifactFolder: string) {
     fs.readFileSync(`${getRoot()}/scripts/api-html-artifacts.json`, "utf-8"),
   );
 
-  if (!(`${pkg.versionWithoutPatch}` in artifactJson[`${pkg.name}`])) {
+  const artifactName = `${pkg.versionWithoutPatch}${pkg.isDev() ? "-dev" : ""}`;
+  if (!(`${artifactName}` in artifactJson[`${pkg.name}`])) {
     throw new Error(
       `Package ${pkg.name} version ${pkg.versionWithoutPatch} doesn't have an artifact stored. You can add one to https://ibm.ent.box.com/folder/246867452622
       following the steps detailed in the \`Generate the API docs\` section on the repo's README. If you are not an IBMer with access to the Box folder,
@@ -53,7 +54,7 @@ export async function downloadCIArtifact(pkg: Pkg, artifactFolder: string) {
       even localhost for a server you start up; the URL needs to result in downloading the zip file.`,
     );
   }
-  const artifactUrl = artifactJson[`${pkg.name}`][`${pkg.versionWithoutPatch}`];
+  const artifactUrl = artifactJson[`${pkg.name}`][`${artifactName}`];
 
   await downloadFromBox(
     pkg.name,

--- a/scripts/lib/api/apiArtifacts.ts
+++ b/scripts/lib/api/apiArtifacts.ts
@@ -45,7 +45,7 @@ export async function downloadCIArtifact(pkg: Pkg, artifactFolder: string) {
     fs.readFileSync(`${getRoot()}/scripts/api-html-artifacts.json`, "utf-8"),
   );
 
-  const artifactName = `${pkg.versionWithoutPatch}${pkg.isDev() ? "-dev" : ""}`;
+  const artifactName = pkg.isDev() ? "dev" : `${pkg.versionWithoutPatch}`;
   if (!(`${artifactName}` in artifactJson[`${pkg.name}`])) {
     throw new Error(
       `Package ${pkg.name} version ${pkg.versionWithoutPatch} doesn't have an artifact stored. You can add one to https://ibm.ent.box.com/folder/246867452622


### PR DESCRIPTION
Part of #316 

This PR adds the artifacts for the dev versions of qiskit and qiskit-ibm-runtime and fixes how we read the JSON file to take into account the new names of the artifacts.