### PR TITLE
Deduplicate link checker error messages

### DIFF
--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -116,12 +116,12 @@ export class FileBatch {
     }
 
     let allGood = true;
-    results.forEach((linkErrors) => {
-      linkErrors.forEach((errorMessage) => {
-        console.error(errorMessage);
+    results
+      .filter((res) => res !== undefined)
+      .forEach((linkError) => {
+        console.error(linkError);
         allGood = false;
       });
-    });
     return allGood;
   }
 }

--- a/scripts/lib/links/LinkChecker.test.ts
+++ b/scripts/lib/links/LinkChecker.test.ts
@@ -71,32 +71,32 @@ describe("Validate links", () => {
     let testLink = new Link("/testpath", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate non-existing internal links with absolute path", async () => {
     let testLink = new Link("/test-alternative-path", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([
-      "❌ /testorigin.mdx: Could not find link '/test-alternative-path'",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '/test-alternative-path'\n    /testorigin.mdx",
+    );
   });
 
   test("Validate existing internal links with relative path", async () => {
     let testLink = new Link("../testpath", ["docs/test/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate non-existing internal links with relative path", async () => {
     let testLink = new Link("../testpath", ["docs/test1/test2/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([
-      "❌ docs/test1/test2/testorigin.mdx: Could not find link '../testpath'",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '../testpath'\n    docs/test1/test2/testorigin.mdx",
+    );
   });
 
   test("Validate existing internal links with absolute path and multiple origin files", async () => {
@@ -109,7 +109,7 @@ describe("Validate links", () => {
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate non-existing internal links with absolute path and multiple origin files", async () => {
@@ -122,12 +122,13 @@ describe("Validate links", () => {
     let testFile1 = new File("docs/test/testpath.mdx", []);
     let testFile2 = new File("docs/test2/test3/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
-    expect(results).toEqual([
-      "❌ docs/test/testorigin.mdx: Could not find link '/testpath' ❓ Did you mean '/test/testpath'?",
-      "❌ docs/test/test2/testorigin.mdx: Could not find link '/testpath' ❓ Did you mean '/test/testpath'?",
-      "❌ docs/test/test3/testorigin.mdx: Could not find link '/testpath' ❓ Did you mean '/test/testpath'?",
-      "❌ docs/test/test2/test4/testorigin.mdx: Could not find link '/testpath' ❓ Did you mean '/test/testpath'?",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '/testpath'\n" +
+        "    docs/test/test2/test4/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
+        "    docs/test/test2/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
+        "    docs/test/test3/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
+        "    docs/test/testorigin.mdx    ❓ Did you mean '/test/testpath'?",
+    );
   });
 
   test("Validate internal links with relative path and multiple origin files", async () => {
@@ -142,26 +143,25 @@ describe("Validate links", () => {
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
-    expect(results).toEqual([
-      "❌ docs/test/test2/testorigin.mdx: Could not find link '../testpath'",
-      "❌ docs/test/test3/testorigin.mdx: Could not find link '../testpath'",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '../testpath'\n    docs/test/test2/testorigin.mdx\n    docs/test/test3/testorigin.mdx",
+    );
   });
 
   test("Validate anchor of existing internal links with absolute path", async () => {
     let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate anchor of non-existing internal links with absolute path", async () => {
     let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([
-      "❌ /testorigin.mdx: Could not find link '/testpath#test_anchor' ❓ Did you mean '/testpath#test_diff_anchor'?",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '/testpath#test_anchor'\n    /testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
+    );
   });
 
   test("Validate anchor of existing internal links with relative path", async () => {
@@ -170,7 +170,7 @@ describe("Validate links", () => {
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate anchor of non-existing internal links with relative path", async () => {
@@ -179,15 +179,15 @@ describe("Validate links", () => {
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
-    expect(results).toEqual([
-      "❌ docs/test/testorigin.mdx: Could not find link '../testpath#test-anchor' ❓ Did you mean '/testpath#test_diff_anchor'?",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link '../testpath#test-anchor'\n    docs/test/testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
+    );
   });
 
   test("Validate existing external links", async () => {
     let testLink = new Link("https://github.com/Qiskit", ["/testorigin.mdx"]);
     const results = await testLink.checkLink([]);
-    expect(results).toEqual([]);
+    expect(results).toBeUndefined();
   });
 
   test("Validate existing external links", async () => {
@@ -195,9 +195,9 @@ describe("Validate links", () => {
       "/testorigin.mdx",
     ]);
     const results = await testLink.checkLink([]);
-    expect(results).toEqual([
-      "❌ /testorigin.mdx: Could not find link 'https://github.com/QiskitNotExistingRepo'",
-    ]);
+    expect(results).toEqual(
+      "❌ Could not find link 'https://github.com/QiskitNotExistingRepo'\n    /testorigin.mdx",
+    );
   });
 });
 

--- a/scripts/lib/links/LinkChecker.test.ts
+++ b/scripts/lib/links/LinkChecker.test.ts
@@ -79,7 +79,7 @@ describe("Validate links", () => {
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual(
-      "❌ Could not find link '/test-alternative-path'\n    /testorigin.mdx",
+      "❌ Could not find link '/test-alternative-path'. Appears in:\n    /testorigin.mdx",
     );
   });
 
@@ -95,7 +95,7 @@ describe("Validate links", () => {
     let testFile = new File("docs/testpath.mdx", []);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual(
-      "❌ Could not find link '../testpath'\n    docs/test1/test2/testorigin.mdx",
+      "❌ Could not find link '../testpath'. Appears in:\n    docs/test1/test2/testorigin.mdx",
     );
   });
 
@@ -123,7 +123,7 @@ describe("Validate links", () => {
     let testFile2 = new File("docs/test2/test3/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
     expect(results).toEqual(
-      "❌ Could not find link '/testpath'\n" +
+      "❌ Could not find link '/testpath'. Appears in:\n" +
         "    docs/test/test2/test4/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
         "    docs/test/test2/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
         "    docs/test/test3/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
@@ -144,7 +144,7 @@ describe("Validate links", () => {
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
     const results = await testLink.checkLink([testFile1, testFile2]);
     expect(results).toEqual(
-      "❌ Could not find link '../testpath'\n    docs/test/test2/testorigin.mdx\n    docs/test/test3/testorigin.mdx",
+      "❌ Could not find link '../testpath'. Appears in:\n    docs/test/test2/testorigin.mdx\n    docs/test/test3/testorigin.mdx",
     );
   });
 
@@ -160,7 +160,7 @@ describe("Validate links", () => {
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual(
-      "❌ Could not find link '/testpath#test_anchor'\n    /testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
+      "❌ Could not find link '/testpath#test_anchor'. Appears in:\n    /testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
     );
   });
 
@@ -180,7 +180,7 @@ describe("Validate links", () => {
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
     const results = await testLink.checkLink([testFile]);
     expect(results).toEqual(
-      "❌ Could not find link '../testpath#test-anchor'\n    docs/test/testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
+      "❌ Could not find link '../testpath#test-anchor'. Appears in:\n    docs/test/testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
     );
   });
 
@@ -196,7 +196,7 @@ describe("Validate links", () => {
     ]);
     const results = await testLink.checkLink([]);
     expect(results).toEqual(
-      "❌ Could not find link 'https://github.com/QiskitNotExistingRepo'\n    /testorigin.mdx",
+      "❌ Could not find link 'https://github.com/QiskitNotExistingRepo'. Appears in:\n    /testorigin.mdx",
     );
   });
 });

--- a/scripts/lib/links/LinkChecker.ts
+++ b/scripts/lib/links/LinkChecker.ts
@@ -187,35 +187,34 @@ export class Link {
   }
 
   /**
-   * Returns an error message for each origin of
-   * the link, true if the link is in `existingFiles`
-   * or is a valid external link, otherwise false
+   * Returns an error message if link failed.
    */
-  async checkLink(existingFiles: File[]): Promise<string[]> {
-    const errorMessages: string[] = [];
-
+  async checkLink(existingFiles: File[]): Promise<string | undefined> {
     if (!this.isExternal) {
-      // Internal link
+      const failingFiles: string[] = [];
       this.originFiles.forEach((originFile) => {
-        if (!this.checkInternalLink(existingFiles, originFile)) {
-          const resultSuggestion = this.didYouMean(existingFiles, originFile);
-          const suggestedPath = resultSuggestion ? ` ${resultSuggestion}` : "";
-          errorMessages.push(
-            `❌ ${originFile}: Could not find link '${this.value}${this.anchor}'${suggestedPath}`,
-          );
+        if (this.checkInternalLink(existingFiles, originFile)) {
+          return;
         }
+        const resultSuggestion = this.didYouMean(existingFiles, originFile);
+        const suggestedPath = resultSuggestion ? `    ${resultSuggestion}` : "";
+        failingFiles.push(`    ${originFile}${suggestedPath}`);
       });
 
-      return errorMessages;
+      return failingFiles.length === 0
+        ? undefined
+        : `❌ Could not find link '${this.value}${this.anchor}'\n${failingFiles
+            .sort()
+            .join("\n")}`;
     }
 
-    // External link
-    const errorMessage = await this.checkExternalLink();
-    if (errorMessage) {
-      this.originFiles.forEach((originFile: string) => {
-        errorMessages.push(`❌ ${originFile}: ${errorMessage}`);
-      });
+    const externalError = await this.checkExternalLink();
+    if (!externalError) {
+      return;
     }
-    return errorMessages;
+    const fileList = Array.from(this.originFiles)
+      .sort()
+      .map((originFile) => `    ${originFile}`);
+    return `❌ ${externalError}\n${fileList.join("\n")}`;
   }
 }

--- a/scripts/lib/links/LinkChecker.ts
+++ b/scripts/lib/links/LinkChecker.ts
@@ -203,9 +203,9 @@ export class Link {
 
       return failingFiles.length === 0
         ? undefined
-        : `❌ Could not find link '${this.value}${this.anchor}'\n${failingFiles
-            .sort()
-            .join("\n")}`;
+        : `❌ Could not find link '${this.value}${
+            this.anchor
+          }'. Appears in:\n${failingFiles.sort().join("\n")}`;
     }
 
     const externalError = await this.checkExternalLink();
@@ -215,6 +215,6 @@ export class Link {
     const fileList = Array.from(this.originFiles)
       .sort()
       .map((originFile) => `    ${originFile}`);
-    return `❌ ${externalError}\n${fileList.join("\n")}`;
+    return `❌ ${externalError}. Appears in:\n${fileList.join("\n")}`;
   }
 }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/749. Now we focus the message around the broken link.

Before:

```
❌ docs/api/qiskit/release-notes/0.15.md: Could not find link '/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer' ❓ Did you mean '/api/qiskit/qiskit.synthesis.OneQubitEulerDecomposer'?
❌ docs/api/qiskit/release-notes/0.18.md: Could not find link '/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer' ❓ Did you mean '/api/qiskit/qiskit.synthesis.OneQubitEulerDecomposer'?
```

After:

```
❌ Could not find link '/api/qiskit/qiskit.quantum_info.OneQubitEulerDecomposer'
    docs/api/qiskit/release-notes/0.15.md    ❓ Did you mean '/api/qiskit/qiskit.synthesis.OneQubitEulerDecomposer'?
    docs/api/qiskit/release-notes/0.18.md    ❓ Did you mean '/api/qiskit/qiskit.synthesis.OneQubitEulerDecomposer'?
```