### PR TITLE
Fix GitHub source code link for dev doc versions

### DIFF
--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Estimator.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Estimator.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Estimator
 
 <span id="qiskit_ibm_runtime.Estimator" />
 
-`Estimator(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/estimator.py "view source code")
+`Estimator(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/estimator.py "view source code")
 
 Class for interacting with Qiskit Runtime Estimator primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.IBMBackend.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.IBMBackend.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.IBMBackend
 
 <span id="qiskit_ibm_runtime.IBMBackend" />
 
-`IBMBackend(configuration, service, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/ibm_backend.py "view source code")
+`IBMBackend(configuration, service, api_client, instance=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/ibm_backend.py "view source code")
 
 Backend class interfacing with an IBM Quantum backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.QiskitRuntimeService.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.QiskitRuntimeService.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.QiskitRuntimeService
 
 <span id="qiskit_ibm_runtime.QiskitRuntimeService" />
 
-`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/qiskit_runtime_service.py "view source code")
+`QiskitRuntimeService(channel=None, token=None, url=None, filename=None, name=None, instance=None, proxies=None, verify=None, channel_strategy=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/qiskit_runtime_service.py "view source code")
 
 Class for interacting with the Qiskit Runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeDecoder.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeDecoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeDecoder
 
 <span id="qiskit_ibm_runtime.RuntimeDecoder" />
 
-`RuntimeDecoder(*args, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/utils/json.py "view source code")
+`RuntimeDecoder(*args, **kwargs)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Decoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeEncoder.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeEncoder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeEncoder
 
 <span id="qiskit_ibm_runtime.RuntimeEncoder" />
 
-`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/utils/json.py "view source code")
+`RuntimeEncoder(*, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, sort_keys=False, indent=None, separators=None, default=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/utils/json.py "view source code")
 
 JSON Encoder used by runtime service.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeJob.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeJob.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeJob
 
 <span id="qiskit_ibm_runtime.RuntimeJob" />
 
-`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/runtime_job.py "view source code")
+`RuntimeJob(backend, api_client, client_params, job_id, program_id, service, params=None, creation_date=None, user_callback=None, result_decoder=None, image='', session_id=None, tags=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/runtime_job.py "view source code")
 
 Representation of a runtime program execution.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.RuntimeOptions
 
 <span id="qiskit_ibm_runtime.RuntimeOptions" />
 
-`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/runtime_options.py "view source code")
+`RuntimeOptions(backend=None, image=None, log_level=None, instance=None, job_tags=None, max_execution_time=None, session_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/runtime_options.py "view source code")
 
 Class for representing generic runtime execution options.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Sampler.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Sampler.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Sampler
 
 <span id="qiskit_ibm_runtime.Sampler" />
 
-`Sampler(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/sampler.py "view source code")
+`Sampler(backend=None, session=None, options=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/sampler.py "view source code")
 
 Class for interacting with Qiskit Runtime Sampler primitive service.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Session.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.Session.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.Session
 
 <span id="qiskit_ibm_runtime.Session" />
 
-`Session(service=None, backend=None, max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/session.py "view source code")
+`Session(service=None, backend=None, max_time=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/session.py "view source code")
 
 Class for creating a flexible Qiskit Runtime session.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAlmaden.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAlmaden.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeAlmaden
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeAlmaden" />
 
-`FakeAlmaden`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py "view source code")
+`FakeAlmaden`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py "view source code")
 
 A fake Almaden backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAlmadenV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAlmadenV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeAlmadenV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeAlmadenV2" />
 
-`FakeAlmadenV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py "view source code")
+`FakeAlmadenV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/almaden/fake_almaden.py "view source code")
 
 A fake Almaden V2 backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeArmonk.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeArmonk.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeArmonk
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeArmonk" />
 
-`FakeArmonk`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py "view source code")
+`FakeArmonk`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py "view source code")
 
 A fake 1 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeArmonkV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeArmonkV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeArmonkV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeArmonkV2" />
 
-`FakeArmonkV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py "view source code")
+`FakeArmonkV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/armonk/fake_armonk.py "view source code")
 
 A fake 1 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAthens.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAthens.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeAthens
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeAthens" />
 
-`FakeAthens`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py "view source code")
+`FakeAthens`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAthensV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAthensV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeAthensV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeAthensV2" />
 
-`FakeAthensV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py "view source code")
+`FakeAthensV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/athens/fake_athens.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAuckland.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeAuckland.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeAuckland
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeAuckland" />
 
-`FakeAuckland`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py "view source code")
+`FakeAuckland`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/auckland/fake_auckland.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBelem.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBelem.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBelem
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBelem" />
 
-`FakeBelem`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py "view source code")
+`FakeBelem`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBelemV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBelemV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBelemV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBelemV2" />
 
-`FakeBelemV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py "view source code")
+`FakeBelemV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/belem/fake_belem.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBoeblingen.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBoeblingen.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBoeblingen
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBoeblingen" />
 
-`FakeBoeblingen`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py "view source code")
+`FakeBoeblingen`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py "view source code")
 
 A fake Boeblingen backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2" />
 
-`FakeBoeblingenV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py "view source code")
+`FakeBoeblingenV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/boeblingen/fake_boeblingen.py "view source code")
 
 A fake Boeblingen V2 backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBogota.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBogota.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBogota
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBogota" />
 
-`FakeBogota`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py "view source code")
+`FakeBogota`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBogotaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBogotaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBogotaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBogotaV2" />
 
-`FakeBogotaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py "view source code")
+`FakeBogotaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/bogota/fake_bogota.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBrooklyn.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBrooklyn.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBrooklyn
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBrooklyn" />
 
-`FakeBrooklyn`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py "view source code")
+`FakeBrooklyn`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py "view source code")
 
 A fake Brooklyn backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBrooklynV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBrooklynV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBrooklynV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBrooklynV2" />
 
-`FakeBrooklynV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py "view source code")
+`FakeBrooklynV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/brooklyn/fake_brooklyn.py "view source code")
 
 A fake Brooklyn V2 backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBurlington.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBurlington.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBurlington
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBurlington" />
 
-`FakeBurlington`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py "view source code")
+`FakeBurlington`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2" />
 
-`FakeBurlingtonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py "view source code")
+`FakeBurlingtonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/burlington/fake_burlington.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCairo.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCairo.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCairo
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCairo" />
 
-`FakeCairo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py "view source code")
+`FakeCairo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCairoV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCairoV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCairoV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCairoV2" />
 
-`FakeCairoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py "view source code")
+`FakeCairoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/cairo/fake_cairo.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCambridge.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCambridge.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCambridge
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCambridge" />
 
-`FakeCambridge`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py "view source code")
+`FakeCambridge`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py "view source code")
 
 A fake Cambridge backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCambridgeV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCambridgeV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCambridgeV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCambridgeV2" />
 
-`FakeCambridgeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py "view source code")
+`FakeCambridgeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/cambridge/fake_cambridge.py "view source code")
 
 A fake Cambridge backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCasablanca.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCasablanca.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCasablanca
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCasablanca" />
 
-`FakeCasablanca`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py "view source code")
+`FakeCasablanca`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCasablancaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeCasablancaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeCasablancaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeCasablancaV2" />
 
-`FakeCasablancaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py "view source code")
+`FakeCasablancaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/casablanca/fake_casablanca.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeEssex.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeEssex.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeEssex
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeEssex" />
 
-`FakeEssex`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py "view source code")
+`FakeEssex`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeEssexV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeEssexV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeEssexV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeEssexV2" />
 
-`FakeEssexV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py "view source code")
+`FakeEssexV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/essex/fake_essex.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGeneva.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGeneva.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeGeneva
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeGeneva" />
 
-`FakeGeneva`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py "view source code")
+`FakeGeneva`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/geneva/fake_geneva.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGuadalupe.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGuadalupe.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeGuadalupe
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeGuadalupe" />
 
-`FakeGuadalupe`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py "view source code")
+`FakeGuadalupe`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py "view source code")
 
 A fake 16 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2" />
 
-`FakeGuadalupeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py "view source code")
+`FakeGuadalupeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/guadalupe/fake_guadalupe.py "view source code")
 
 A fake 16 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeHanoi.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeHanoi.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeHanoi
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeHanoi" />
 
-`FakeHanoi`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py "view source code")
+`FakeHanoi`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeHanoiV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeHanoiV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeHanoiV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeHanoiV2" />
 
-`FakeHanoiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py "view source code")
+`FakeHanoiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/hanoi/fake_hanoi.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJakarta.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJakarta.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeJakarta
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeJakarta" />
 
-`FakeJakarta`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py "view source code")
+`FakeJakarta`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJakartaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJakartaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeJakartaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeJakartaV2" />
 
-`FakeJakartaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py "view source code")
+`FakeJakartaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/jakarta/fake_jakarta.py "view source code")
 
 A fake 7 qubit V2 backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJohannesburg.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJohannesburg.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeJohannesburg
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeJohannesburg" />
 
-`FakeJohannesburg`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py "view source code")
+`FakeJohannesburg`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py "view source code")
 
 A fake Johannesburg backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2" />
 
-`FakeJohannesburgV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py "view source code")
+`FakeJohannesburgV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/johannesburg/fake_johannesburg.py "view source code")
 
 A fake Johannesburg V2 backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeKolkata.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeKolkata.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeKolkata
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeKolkata" />
 
-`FakeKolkata`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py "view source code")
+`FakeKolkata`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeKolkataV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeKolkataV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeKolkataV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeKolkataV2" />
 
-`FakeKolkataV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py "view source code")
+`FakeKolkataV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/kolkata/fake_kolkata.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLagos.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLagos.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLagos
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLagos" />
 
-`FakeLagos`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py "view source code")
+`FakeLagos`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLagosV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLagosV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLagosV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLagosV2" />
 
-`FakeLagosV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py "view source code")
+`FakeLagosV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/lagos/fake_lagos.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLima.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLima.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLima
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLima" />
 
-`FakeLima`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py "view source code")
+`FakeLima`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLimaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLimaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLimaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLimaV2" />
 
-`FakeLimaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py "view source code")
+`FakeLimaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/lima/fake_lima.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLondon.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLondon.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLondon
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLondon" />
 
-`FakeLondon`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py "view source code")
+`FakeLondon`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLondonV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeLondonV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeLondonV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeLondonV2" />
 
-`FakeLondonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py "view source code")
+`FakeLondonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/london/fake_london.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManhattan.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManhattan.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeManhattan
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeManhattan" />
 
-`FakeManhattan`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py "view source code")
+`FakeManhattan`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py "view source code")
 
 A fake Manhattan backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManhattanV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManhattanV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeManhattanV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeManhattanV2" />
 
-`FakeManhattanV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py "view source code")
+`FakeManhattanV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/manhattan/fake_manhattan.py "view source code")
 
 A fake Manhattan backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManila.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManila.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeManila
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeManila" />
 
-`FakeManila`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py "view source code")
+`FakeManila`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManilaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeManilaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeManilaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeManilaV2" />
 
-`FakeManilaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py "view source code")
+`FakeManilaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/manila/fake_manila.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMelbourne.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMelbourne.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMelbourne
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMelbourne" />
 
-`FakeMelbourne`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py "view source code")
+`FakeMelbourne`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py "view source code")
 
 A fake 14 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMelbourneV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMelbourneV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMelbourneV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMelbourneV2" />
 
-`FakeMelbourneV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py "view source code")
+`FakeMelbourneV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/melbourne/fake_melbourne.py "view source code")
 
 A fake 14 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMontreal.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMontreal.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMontreal
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMontreal" />
 
-`FakeMontreal`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py "view source code")
+`FakeMontreal`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMontrealV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMontrealV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMontrealV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMontrealV2" />
 
-`FakeMontrealV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py "view source code")
+`FakeMontrealV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/montreal/fake_montreal.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMumbai.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMumbai.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMumbai
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMumbai" />
 
-`FakeMumbai`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py "view source code")
+`FakeMumbai`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMumbaiV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeMumbaiV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeMumbaiV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeMumbaiV2" />
 
-`FakeMumbaiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py "view source code")
+`FakeMumbaiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/mumbai/fake_mumbai.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeNairobi.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeNairobi.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeNairobi
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeNairobi" />
 
-`FakeNairobi`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py "view source code")
+`FakeNairobi`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeNairobiV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeNairobiV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeNairobiV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeNairobiV2" />
 
-`FakeNairobiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py "view source code")
+`FakeNairobiV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/nairobi/fake_nairobi.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOslo.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOslo.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeOslo
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeOslo" />
 
-`FakeOslo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py "view source code")
+`FakeOslo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/oslo/fake_oslo.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOurense.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOurense.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeOurense
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeOurense" />
 
-`FakeOurense`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py "view source code")
+`FakeOurense`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOurenseV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeOurenseV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeOurenseV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeOurenseV2" />
 
-`FakeOurenseV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py "view source code")
+`FakeOurenseV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/ourense/fake_ourense.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeParis.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeParis.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeParis
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeParis" />
 
-`FakeParis`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py "view source code")
+`FakeParis`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py "view source code")
 
 A fake Paris backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeParisV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeParisV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeParisV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeParisV2" />
 
-`FakeParisV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py "view source code")
+`FakeParisV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/paris/fake_paris.py "view source code")
 
 A fake Paris backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePerth.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePerth.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakePerth
 
 <span id="qiskit_ibm_runtime.fake_provider.FakePerth" />
 
-`FakePerth`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py "view source code")
+`FakePerth`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/perth/fake_perth.py "view source code")
 
 A fake 7 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePoughkeepsie.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePoughkeepsie.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakePoughkeepsie
 
 <span id="qiskit_ibm_runtime.fake_provider.FakePoughkeepsie" />
 
-`FakePoughkeepsie`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py "view source code")
+`FakePoughkeepsie`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py "view source code")
 
 A fake Poughkeepsie backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2" />
 
-`FakePoughkeepsieV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py "view source code")
+`FakePoughkeepsieV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/poughkeepsie/fake_poughkeepsie.py "view source code")
 
 A fake Poughkeepsie backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePrague.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakePrague.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakePrague
 
 <span id="qiskit_ibm_runtime.fake_provider.FakePrague" />
 
-`FakePrague`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py "view source code")
+`FakePrague`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/prague/fake_prague.py "view source code")
 
 A fake 33 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeProvider.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeProvider.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeProvider
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeProvider" />
 
-`FakeProvider`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/fake_provider.py "view source code")
+`FakeProvider`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/fake_provider.py "view source code")
 
 Fake provider containing fake V1 backends.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2" />
 
-`FakeProviderForBackendV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/fake_provider.py "view source code")
+`FakeProviderForBackendV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/fake_provider.py "view source code")
 
 Fake provider containing fake V2 backends.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeQuito.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeQuito.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeQuito
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeQuito" />
 
-`FakeQuito`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py "view source code")
+`FakeQuito`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeQuitoV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeQuitoV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeQuitoV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeQuitoV2" />
 
-`FakeQuitoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py "view source code")
+`FakeQuitoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/quito/fake_quito.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRochester.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRochester.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeRochester
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeRochester" />
 
-`FakeRochester`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py "view source code")
+`FakeRochester`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py "view source code")
 
 A fake Rochester backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRochesterV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRochesterV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeRochesterV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeRochesterV2" />
 
-`FakeRochesterV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py "view source code")
+`FakeRochesterV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/rochester/fake_rochester.py "view source code")
 
 A fake Rochester backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRome.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRome.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeRome
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeRome" />
 
-`FakeRome`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py "view source code")
+`FakeRome`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRomeV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRomeV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeRomeV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeRomeV2" />
 
-`FakeRomeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py "view source code")
+`FakeRomeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/rome/fake_rome.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRueschlikon.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeRueschlikon.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeRueschlikon
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeRueschlikon" />
 
-`FakeRueschlikon`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/rueschlikon/fake_rueschlikon.py "view source code")
+`FakeRueschlikon`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/rueschlikon/fake_rueschlikon.py "view source code")
 
 A fake 16 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSantiago.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSantiago.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSantiago
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSantiago" />
 
-`FakeSantiago`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py "view source code")
+`FakeSantiago`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py "view source code")
 
 A fake Santiago backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSantiagoV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSantiagoV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSantiagoV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSantiagoV2" />
 
-`FakeSantiagoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py "view source code")
+`FakeSantiagoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/santiago/fake_santiago.py "view source code")
 
 A fake Santiago backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSherbrooke.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSherbrooke.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSherbrooke
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSherbrooke" />
 
-`FakeSherbrooke`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py "view source code")
+`FakeSherbrooke`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/sherbrooke/fake_sherbrooke.py "view source code")
 
 A fake 127 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSingapore.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSingapore.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSingapore
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSingapore" />
 
-`FakeSingapore`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py "view source code")
+`FakeSingapore`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py "view source code")
 
 A fake Singapore backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSingaporeV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSingaporeV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSingaporeV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSingaporeV2" />
 
-`FakeSingaporeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py "view source code")
+`FakeSingaporeV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/singapore/fake_singapore.py "view source code")
 
 A fake Singapore backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSydney.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSydney.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSydney
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSydney" />
 
-`FakeSydney`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py "view source code")
+`FakeSydney`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSydneyV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeSydneyV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeSydneyV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeSydneyV2" />
 
-`FakeSydneyV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py "view source code")
+`FakeSydneyV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/sydney/fake_sydney.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTenerife.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTenerife.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeTenerife
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeTenerife" />
 
-`FakeTenerife`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/tenerife/fake_tenerife.py "view source code")
+`FakeTenerife`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/tenerife/fake_tenerife.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTokyo.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTokyo.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeTokyo
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeTokyo" />
 
-`FakeTokyo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/tokyo/fake_tokyo.py "view source code")
+`FakeTokyo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/tokyo/fake_tokyo.py "view source code")
 
 A fake 20 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeToronto.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeToronto.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeToronto
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeToronto" />
 
-`FakeToronto`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py "view source code")
+`FakeToronto`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTorontoV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeTorontoV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeTorontoV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeTorontoV2" />
 
-`FakeTorontoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py "view source code")
+`FakeTorontoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/toronto/fake_toronto.py "view source code")
 
 A fake 27 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeValencia.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeValencia.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeValencia
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeValencia" />
 
-`FakeValencia`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py "view source code")
+`FakeValencia`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeValenciaV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeValenciaV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeValenciaV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeValenciaV2" />
 
-`FakeValenciaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py "view source code")
+`FakeValenciaV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/valencia/fake_valencia.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeVigo.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeVigo.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeVigo
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeVigo" />
 
-`FakeVigo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py "view source code")
+`FakeVigo`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeVigoV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeVigoV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeVigoV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeVigoV2" />
 
-`FakeVigoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py "view source code")
+`FakeVigoV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/vigo/fake_vigo.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeWashington.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeWashington.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeWashington
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeWashington" />
 
-`FakeWashington`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py "view source code")
+`FakeWashington`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py "view source code")
 
 A fake 127 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeWashingtonV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeWashingtonV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeWashingtonV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeWashingtonV2" />
 
-`FakeWashingtonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py "view source code")
+`FakeWashingtonV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/washington/fake_washington.py "view source code")
 
 A fake 127 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeYorktown.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeYorktown.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeYorktown
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeYorktown" />
 
-`FakeYorktown`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py "view source code")
+`FakeYorktown`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeYorktownV2.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.fake_provider.FakeYorktownV2.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.fake_provider.FakeYorktownV2
 
 <span id="qiskit_ibm_runtime.fake_provider.FakeYorktownV2" />
 
-`FakeYorktownV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py "view source code")
+`FakeYorktownV2`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/fake_provider/backends/yorktown/fake_yorktown.py "view source code")
 
 A fake 5 qubit backend.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.EnvironmentOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.EnvironmentOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.EnvironmentOptions
 
 <span id="qiskit_ibm_runtime.options.EnvironmentOptions" />
 
-`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/environment_options.py "view source code")
+`EnvironmentOptions(log_level='WARNING', callback=None, job_tags=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/environment_options.py "view source code")
 
 Options related to the execution environment.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.ExecutionOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.ExecutionOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ExecutionOptions
 
 <span id="qiskit_ibm_runtime.options.ExecutionOptions" />
 
-`ExecutionOptions(shots=4000, init_qubits=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/execution_options.py "view source code")
+`ExecutionOptions(shots=4000, init_qubits=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/execution_options.py "view source code")
 
 Execution options.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.Options.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.Options.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.Options
 
 <span id="qiskit_ibm_runtime.options.Options" />
 
-`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/options.py "view source code")
+`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/options.py "view source code")
 
 Options for the primitives.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.ResilienceOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.ResilienceOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.ResilienceOptions
 
 <span id="qiskit_ibm_runtime.options.ResilienceOptions" />
 
-`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/resilience_options.py "view source code")
+`ResilienceOptions(noise_amplifier=None, noise_factors=None, extrapolator=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/resilience_options.py "view source code")
 
 Resilience options.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.SimulatorOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.SimulatorOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.SimulatorOptions
 
 <span id="qiskit_ibm_runtime.options.SimulatorOptions" />
 
-`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/simulator_options.py "view source code")
+`SimulatorOptions(noise_model=None, seed_simulator=None, coupling_map=None, basis_gates=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/simulator_options.py "view source code")
 
 Simulator options.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.TranspilationOptions.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.options.TranspilationOptions.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.options.TranspilationOptions
 
 <span id="qiskit_ibm_runtime.options.TranspilationOptions" />
 
-`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/options/transpilation_options.py "view source code")
+`TranspilationOptions(skip_transpilation=False, initial_layout=None, layout_method=None, routing_method=None, approximation_degree=None)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/options/transpilation_options.py "view source code")
 
 Transpilation options.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAna
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis" />
 
-`ALAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py "view source code")
+`ALAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Dynamic circuits as-late-as-possible (ALAP) scheduling analysis pass.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAna
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis" />
 
-`ASAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py "view source code")
+`ASAPScheduleAnalysis(durations)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/scheduler.py "view source code")
 
 Dynamic circuits as-soon-as-possible (ASAP) scheduling analysis pass.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder" />
 
-`BlockBasePadder(schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py "view source code")
+`BlockBasePadder(schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/block_base_padder.py "view source code")
 
 The base class of padding pass.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitI
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations" />
 
-`DynamicCircuitInstructionDurations(instruction_durations=None, dt=None, enable_patching=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py "view source code")
+`DynamicCircuitInstructionDurations(instruction_durations=None, dt=None, enable_patching=True)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/utils.py "view source code")
 
 For dynamic circuits the IBM Qiskit backend currently reports instruction durations that differ compared with those required for the legacy Qobj-based path. For now we use this class to report updated InstructionDurations. TODO: This would be mitigated by a specialized Backend/Target for dynamic circuit backends.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay" />
 
-`PadDelay(fill_very_end=True, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py "view source code")
+`PadDelay(fill_very_end=True, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/pad_delay.py "view source code")
 
 Padding idle time with Delay instructions.
 

--- a/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling.md
+++ b/docs/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling.md
@@ -10,7 +10,7 @@ python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDec
 
 <span id="qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling" />
 
-`PadDynamicalDecoupling(durations, dd_sequences, qubits=None, spacings=None, skip_reset_qubits=True, pulse_alignment=16, extra_slack_distribution='middle', sequence_min_length_ratios=None, insert_multiple_cycles=False, coupling_map=None, alt_spacings=None, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/stable/0.19/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py "view source code")
+`PadDynamicalDecoupling(durations, dd_sequences, qubits=None, spacings=None, skip_reset_qubits=True, pulse_alignment=16, extra_slack_distribution='middle', sequence_min_length_ratios=None, insert_multiple_cycles=False, coupling_map=None, alt_spacings=None, schedule_idle_qubits=False)`[GitHub](https://github.com/qiskit/qiskit-ibm-runtime/tree/main/qiskit_ibm_runtime/transpiler/passes/scheduling/dynamical_decoupling.py "view source code")
 
 Dynamical decoupling insertion pass for IBM dynamic circuit backends.
 

--- a/scripts/lib/api/Pkg.test.ts
+++ b/scripts/lib/api/Pkg.test.ts
@@ -18,23 +18,41 @@ test("Pkg.determineGithubUrlFn()", () => {
   const provider = Pkg.mock({
     name: "qiskit-ibm-provider",
     githubSlug: "qiskit/qiskit-ibm-provider",
+    type: "latest",
     versionWithoutPatch: "0.7",
   }).determineGithubUrlFn();
   const runtime = Pkg.mock({
     name: "qiskit-ibm-runtime",
     githubSlug: "qiskit/qiskit-ibm-runtime",
+    type: "latest",
     versionWithoutPatch: "0.15",
   }).determineGithubUrlFn();
   const qiskit = Pkg.mock({
     name: "qiskit",
     githubSlug: "qiskit/qiskit",
+    type: "latest",
     versionWithoutPatch: "0.45",
   }).determineGithubUrlFn();
 
   const historicalQiskit = Pkg.mock({
     name: "qiskit",
     githubSlug: "qiskit/qiskit",
+    type: "historical",
     versionWithoutPatch: "0.32",
+  }).determineGithubUrlFn();
+
+  const dev = Pkg.mock({
+    name: "qiskit",
+    githubSlug: "qiskit/qiskit",
+    type: "dev",
+    version: "1.0.0-dev",
+  }).determineGithubUrlFn();
+  const rc = Pkg.mock({
+    name: "qiskit",
+    githubSlug: "qiskit/qiskit",
+    type: "dev",
+    version: "1.0.0rc1",
+    versionWithoutPatch: "1.0",
   }).determineGithubUrlFn();
 
   expect(provider("qiskit_ibm_provider/job/exceptions")).toEqual(
@@ -59,6 +77,13 @@ test("Pkg.determineGithubUrlFn()", () => {
   );
   expect(qiskit("qiskit/transpiler/preset_passmanagers")).toEqual(
     "https://github.com/qiskit/qiskit/tree/stable/0.45/qiskit/transpiler/preset_passmanagers/__init__.py",
+  );
+
+  expect(dev("qiskit/exceptions")).toEqual(
+    "https://github.com/qiskit/qiskit/tree/main/qiskit/exceptions.py",
+  );
+  expect(rc("qiskit/exceptions")).toEqual(
+    "https://github.com/qiskit/qiskit/tree/stable/1.0/qiskit/exceptions.py",
   );
 
   expect(historicalQiskit("qiskit/exceptions")).toEqual(

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -207,8 +207,16 @@ export class Pkg {
 
     // Provider, Runtime, and Qiskit 0.45+ are simple: there is a branch called `stable/<version>`
     // like `stable/0.45` in each GitHub project.
-    if (this.name !== "qiskit" || +this.versionWithoutPatch >= 0.45) {
-      const baseUrl = `https://github.com/${this.githubSlug}/tree/stable/${this.versionWithoutPatch}`;
+    if (
+      this.name !== "qiskit" ||
+      this.type === "dev" ||
+      +this.versionWithoutPatch >= 0.45
+    ) {
+      const branchName =
+        this.type === "dev" && this.version.endsWith("-dev")
+          ? "main"
+          : `stable/${this.versionWithoutPatch}`;
+      const baseUrl = `https://github.com/${this.githubSlug}/tree/${branchName}`;
       return (fileName) => {
         return `${baseUrl}/${normalizeFile(fileName)}.py`;
       };


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/806.

Regenerates Runtime with `npm run gen-api -- -p qiskit-ibm-runtime -v 0.19.2-dev --dev`.