### PR TITLE
Update platform support description

### DIFF
--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -153,9 +153,9 @@ If you are planning to work locally and use simulators built into Qiskit, then y
 <span id="os-support"></span>
 ## Operating system support
 
-Qiskit strives to support as many operating systems as possible, but due to limitations in available testing resources and operating system availability, not all operating systems can be supported. Operating system support for Qiskit is broken into three tiers with different levels of support for each tier. For operating systems outside these, Qiskit is probably still installable, but it is not tested and you will have to build Qiskit (and likely Qiskit’s dependencies) from source.
+Qiskit strives to support as many operating systems as possible, but due to limitations in available testing resources and operating system availability, not all operating systems can be supported. Operating system support for Qiskit is broken into three tiers with different levels of support for each tier. For platforms outside these such as FreeBSD or WebAssembly (WASI), Qiskit may still be installable, but it is not tested and you will have to build Qiskit (and likely Qiskit’s dependencies) from source.
 
-Additionally, Qiskit only supports CPython. Running with other Python interpreters is not supported.
+Additionally, Qiskit only supports the CPython implementation of the Python language. Running with other Python interpreters such as PyPy is not supported.
 
 <details>
   <summary>

--- a/docs/start/install.mdx
+++ b/docs/start/install.mdx
@@ -153,7 +153,7 @@ If you are planning to work locally and use simulators built into Qiskit, then y
 <span id="os-support"></span>
 ## Operating system support
 
-Qiskit strives to support as many operating systems as possible, but due to limitations in available testing resources and operating system availability, not all operating systems can be supported. Operating system support for Qiskit is broken into three tiers with different levels of support for each tier. For platforms outside these such as FreeBSD or WebAssembly (WASI), Qiskit may still be installable, but it is not tested and you will have to build Qiskit (and likely Qiskit’s dependencies) from source.
+Qiskit strives to support as many operating systems as possible, but due to limitations in available testing resources and operating system availability, not all operating systems can be supported. Operating system support for Qiskit is broken into three tiers with different levels of support for each tier. For platforms outside these, such as FreeBSD or WebAssembly (WASI), Qiskit may still be installable, but it is not tested and you will have to build Qiskit (and likely Qiskit’s dependencies) from source.
 
 Additionally, Qiskit only supports the CPython implementation of the Python language. Running with other Python interpreters such as PyPy is not supported.
 


### PR DESCRIPTION
* Mention a few non-supported modes (FreeBSD, WebAssembly, PyPy) by name so they come up more easily for someone searching for them.
* Fix typo (missing "be").
* Downgrade confidence that Qiskit will work on other platforms
* Expand reference to CPython