### PR TITLE
Qiskit-bot local configuration

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -1,0 +1,15 @@
+---
+# We use quotes around users who don`t want a GitHub notification,
+# but whom we still want their name in the Qiskit Bot message so
+# people know they are relevant.
+notifications:
+    "docs/start/index.mdx":
+        - "@javabster"
+        - "`@abbycross`"
+always_notify: true
+notification_prelude: |
+    Thanks for contributing to Qiskit documentation!
+
+    Before your PR can be merged, it will first need to pass continuous
+    integration tests and be reviewed. Sometimes the review process can be slow,
+    so please be patient.


### PR DESCRIPTION
Part of #50 

This PR creates the `qiskit_bot.yaml` file to set a local configuration for the qiskit-bot. The file only contains one rule of notifications. The rest will be added in a follow-up.