### PR TITLE
Fix link checker for historical objects.inv files

### DIFF
--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -21,6 +21,7 @@ on:
       - "docs/api/qiskit/**/*"
       - "docs/api/qiskit-ibm-provider/**/*"
       - "docs/api/qiskit-ibm-runtime/**/*"
+      - "public/api/**/*"
       - "scripts/checkLinks.ts"
       - "scripts/lib/links/ignores.ts"
 

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -13,7 +13,11 @@
 import { globby } from "globby";
 
 import { Link, File } from "./LinkChecker";
-import { FILES_TO_IGNORES, ALWAYS_IGNORED_URLS } from "./ignores";
+import {
+  ALWAYS_IGNORED_URLS,
+  FILES_TO_IGNORES,
+  IGNORED_FILES,
+} from "./ignores";
 import { parseFile } from "./extractLinks";
 
 export class FileBatch {
@@ -72,7 +76,9 @@ export class FileBatch {
     for (const filePath of this.toCheck) {
       const parsed = await parseFile(filePath);
       files.push(new File(filePath, parsed.anchors));
-      addLinksToMap(filePath, parsed.links, linksToOriginFiles);
+      if (!IGNORED_FILES.has(filePath)) {
+        addLinksToMap(filePath, parsed.links, linksToOriginFiles);
+      }
     }
 
     const internalLinks: Link[] = [];

--- a/scripts/lib/links/ignores.ts
+++ b/scripts/lib/links/ignores.ts
@@ -59,21 +59,6 @@ export const ALWAYS_IGNORED_URLS = new Set([
 // A mapping of files to lists of links that will not be searched.
 type FilesToIgnores = { [id: string]: string[] };
 
-const _FAKE_PROVIDER_IGNORES = [
-  "#id1",
-  "#id2",
-  "#id3",
-  "_downloads/a640acbc08577560dc62a3c02c6ca2ac/fake_provider-1_00.png",
-  "_downloads/98e08086a49350bea51e64248343d7ac/fake_provider-1_00.hires.png",
-  "_downloads/684bf35d507376624fcead10d9aedaed/fake_provider-1_00.pdf",
-  "_downloads/0844f2fac7677af0994f8d82d680b6b4/fake_provider-1_01.png",
-  "_downloads/68a68ba43192e04547a9e6d7e6d53481/fake_provider-1_01.hires.png",
-  "_downloads/afd203635ac2d35ca0d4a52a3380788d/fake_provider-1_01.pdf",
-  "_downloads/14c310b17e4b148108e1e5e2c63c7030/fake_provider-1_02.png",
-  "_downloads/20b45a9c9dd80c4687a3546bdcb4db06/fake_provider-1_02.hires.png",
-  "_downloads/fe03f365d979eee2c9543dbb39696011/fake_provider-1_02.pdf",
-];
-
 const _QPY_IGNORES = ["#f1", "#f2", "#f3", "#id2", "#id4", "#id6", "#id8"];
 
 const _RUNTIME_OBJECT_INV = Object.fromEntries(
@@ -90,10 +75,6 @@ const _RUNTIME_OBJECT_INV = Object.fromEntries(
 const FILES_TO_IGNORES__EXPECTED: FilesToIgnores = {};
 
 const FILES_TO_IGNORES__SHOULD_FIX: FilesToIgnores = {
-  // Runtime
-  "docs/api/qiskit-ibm-runtime/fake_provider.md": _FAKE_PROVIDER_IGNORES,
-  "docs/api/qiskit-ibm-runtime/0.18/fake_provider.md": _FAKE_PROVIDER_IGNORES,
-  "docs/api/qiskit-ibm-runtime/dev/fake_provider.md": _FAKE_PROVIDER_IGNORES,
   // Provider
   "docs/api/qiskit-ibm-provider/release-notes.md": [
     "https://github.com/Qiskit/qiskit-ibm-provider/blob/main/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb",

--- a/scripts/lib/links/ignores.ts
+++ b/scripts/lib/links/ignores.ts
@@ -11,6 +11,16 @@
 // that they have been altered from the originals.
 
 // -----------------------------------------------------------------------------------
+// Ignored files
+// -----------------------------------------------------------------------------------
+
+export const IGNORED_FILES = new Set([
+  "public/api/qiskit-ibm-runtime/0.14/objects.inv",
+  "public/api/qiskit-ibm-runtime/0.15/objects.inv",
+  "public/api/qiskit-ibm-runtime/0.16/objects.inv",
+]);
+
+// -----------------------------------------------------------------------------------
 // Always ignored URLs
 // -----------------------------------------------------------------------------------
 
@@ -66,6 +76,17 @@ const _FAKE_PROVIDER_IGNORES = [
 
 const _QPY_IGNORES = ["#f1", "#f2", "#f3", "#id2", "#id4", "#id6", "#id8"];
 
+const _RUNTIME_OBJECT_INV = Object.fromEntries(
+  ["", "dev/", "0.16/", "0.17/", "0.18/"].map((vers) => [
+    `public/api/qiskit-ibm-runtime/${vers}objects.inv`,
+    [
+      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.RuntimeEncoder#key_separator`,
+      `/api/qiskit-ibm-runtime/${vers}index#next-steps`,
+      `/api/qiskit-ibm-runtime/${vers}index#qiskit-runtime-version-api-docs-preview`,
+    ],
+  ]),
+);
+
 const FILES_TO_IGNORES__EXPECTED: FilesToIgnores = {};
 
 const FILES_TO_IGNORES__SHOULD_FIX: FilesToIgnores = {
@@ -84,16 +105,7 @@ const FILES_TO_IGNORES__SHOULD_FIX: FilesToIgnores = {
   "docs/api/qiskit/qpy.md": _QPY_IGNORES,
   "docs/api/qiskit/dev/qpy.md": _QPY_IGNORES,
   // objects.inv
-  "public/api/qiskit-ibm-runtime/objects.inv": [
-    "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.RuntimeEncoder#key_separator",
-    "/api/qiskit-ibm-runtime/index#next-steps",
-    "/api/qiskit-ibm-runtime/index#qiskit-runtime-version-api-docs-preview",
-  ],
-  "public/api/qiskit-ibm-runtime/dev/objects.inv": [
-    "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.RuntimeEncoder#key_separator",
-    "/api/qiskit-ibm-runtime/dev/index#next-steps",
-    "/api/qiskit-ibm-runtime/dev/index#qiskit-runtime-version-api-docs-preview",
-  ],
+  ..._RUNTIME_OBJECT_INV,
   "public/api/qiskit/objects.inv": [
     "/api/qiskit/circuit#qiskit.circuit.CASE_DEFAULT",
     "/api/qiskit/qiskit.pulse.instructions.Reference#scope_delimiter",


### PR DESCRIPTION
The API checks didn't run in https://github.com/Qiskit/documentation/pull/850 because our GitHub Action didn't include `public/api` in its globs. So, we accidentally broke the link checker.

This PR adds the new mechanism of `IGNORED_FILES`. The `objects.inv` has way too many errors in 0.14 - 0.16 to be worth trying to fix or blocklist specific failures.

Finally, it removes ignores that are now stale thanks to https://github.com/Qiskit/documentation/pull/848.