### PR TITLE
Remove old style of Matplotlib figures

### DIFF
--- a/docs/api/qiskit/0.41/providers_fake_provider.md
+++ b/docs/api/qiskit/0.41/providers_fake_provider.md
@@ -54,15 +54,9 @@ plot_histogram(counts)
 
 ![../\_images/providers\_fake\_provider-1\_00.png](/images/api/qiskit/0.41/providers_fake_provider-1_00.png)
 
-Fig. 18 ([`png`](_downloads/5828673743dbf0e9b00a26ba9ff29862/providers_fake_provider-1_00.png), [`hires.png`](_downloads/b01f53e25e80fefe83dbe23605de3444/providers_fake_provider-1_00.hires.png), [`pdf`](_downloads/60ce946926738a7dbf56b1528c0ffa57/providers_fake_provider-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/providers\_fake\_provider-1\_01.png](/images/api/qiskit/0.41/providers_fake_provider-1_01.png)
 
-Fig. 19 ([`png`](_downloads/ec61c4ad44da25f371f7ee7c3353b477/providers_fake_provider-1_01.png), [`hires.png`](_downloads/9c627f615e6df0d9741c9e90d440bfc0/providers_fake_provider-1_01.hires.png), [`pdf`](_downloads/9262dcc7cff2be4e2f3f8e6c26ba71a0/providers_fake_provider-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/providers\_fake\_provider-1\_02.png](/images/api/qiskit/0.41/providers_fake_provider-1_02.png)
-
-Fig. 20 ([`png`](_downloads/1f733fb2488ea6ca71c8e11c0445c973/providers_fake_provider-1_02.png), [`hires.png`](_downloads/b962b924b487aac96d4dcc21ff19f41a/providers_fake_provider-1_02.hires.png), [`pdf`](_downloads/230e3abfd7fc8c2b543c02d2f102fdc0/providers_fake_provider-1_02.pdf))[¶](#id3 "Permalink to this image")
 
 <Admonition title="Important" type="danger">
   Please note that the simulation is done using a noise model generated from system snapshots obtained in the past (sometimes a few years ago) and the results are not representative of the latest behaviours of the real quantum system which the fake backend is mimicking. If you want to run noisy simulations to compare with the real quantum system, please follow steps below to generate a simulator mimics a real quantum system with the latest calibration results.

--- a/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.LinearSystemMatrix.md
+++ b/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.LinearSystemMatrix.md
@@ -152,11 +152,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-1\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.png)
 
-Fig. 25 ([`png`](_downloads/cd550726533aad6278ef4e40ce940e1c/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.png), [`hires.png`](_downloads/39b69d087a394429049b9a9d69990951/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.hires.png), [`pdf`](_downloads/258369a9f161fbcfa34e6213fdfdd896/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-1\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.png)
-
-Fig. 26 ([`png`](_downloads/4a30002841eb93a693be5938bfb0b0e5/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.png), [`hires.png`](_downloads/f923a52dee57aba3d011bdc5c2f3c9e7/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.hires.png), [`pdf`](_downloads/5167b8d610c71df8ab38092760ef7967/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -176,11 +172,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-2\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.png)
 
-Fig. 27 ([`png`](_downloads/d82ebfbd464692524a3cec301e3448a0/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.png), [`hires.png`](_downloads/84426e962194124c31fad6d986767537/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.hires.png), [`pdf`](_downloads/d63d9bf3a1ada6cdd5606b3263cb0c70/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-2\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.png)
-
-Fig. 28 ([`png`](_downloads/1ab0454b7612a39b23db77ed3f413aba/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.png), [`hires.png`](_downloads/535f1b74876e49d677d52429ea77cdd5/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.hires.png), [`pdf`](_downloads/dcf041f48c758b3f5cad8855392316ef/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.NumPyMatrix.md
+++ b/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.NumPyMatrix.md
@@ -174,11 +174,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-1\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.png)
 
-Fig. 29 ([`png`](_downloads/0ee03cd86e2a382fa5fb1900d937ee2f/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.png), [`hires.png`](_downloads/238c146f0154e894f6aef45211c9c748/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.hires.png), [`pdf`](_downloads/ed52dbeb6ca69ec4fea1e3b0abce8861/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-1\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.png)
-
-Fig. 30 ([`png`](_downloads/b21b94e2a58a0e5b7f8e5a4b6ae9c99e/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.png), [`hires.png`](_downloads/03b9e379c9047651591e64e53761637b/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.hires.png), [`pdf`](_downloads/cba8e47be3f1af5b5648a4df1dc3f665/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -198,11 +194,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-2\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.png)
 
-Fig. 31 ([`png`](_downloads/671a2ffb644686ba0cbe58973601fd83/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.png), [`hires.png`](_downloads/63a6b5d75d9b2238feb4d9531c35f742/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.hires.png), [`pdf`](_downloads/4c16358d7b26b6c07e1f30e0cf36a9c1/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-2\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.png)
-
-Fig. 32 ([`png`](_downloads/e49c821a5e323757198aae20c11e5d00/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.png), [`hires.png`](_downloads/0c5636304ba11d9a701c823032805b02/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.hires.png), [`pdf`](_downloads/036a3d2c96ecd0e9dac675b80c016e20/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.TridiagonalToeplitz.md
+++ b/docs/api/qiskit/0.41/qiskit.algorithms.linear_solvers.TridiagonalToeplitz.md
@@ -187,11 +187,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-1\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.png)
 
-Fig. 33 ([`png`](_downloads/ff37c226764247e560e3a85343b86685/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.png), [`hires.png`](_downloads/b6aef7c23aef550fd1398a759defe7d8/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.hires.png), [`pdf`](_downloads/6119677b2f68f968c433135996279a71/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-1\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.png)
-
-Fig. 34 ([`png`](_downloads/9922ce15188659badfba018fb101d895/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.png), [`hires.png`](_downloads/0f2f9b13f42a057a7a16bf92c86d3b4f/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.hires.png), [`pdf`](_downloads/1a04f6dc7569c4788e0e451044beba59/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -211,11 +207,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-2\_00.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.png)
 
-Fig. 35 ([`png`](_downloads/4e122536e8fdb50b6f3293dd127d5a1c/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.png), [`hires.png`](_downloads/1cd69e6b3fcfc6c39ed237fb902b9f31/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.hires.png), [`pdf`](_downloads/e84c98f08b17e05affe6ce6b0ad0f9be/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-2\_01.png](/images/api/qiskit/0.41/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.png)
-
-Fig. 36 ([`png`](_downloads/c491eec85d0433dc7b13e3649ddae562/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.png), [`hires.png`](_downloads/dec07cdb65038f6ea9504bfee738004a/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.hires.png), [`pdf`](_downloads/c310b95de6f2569250d21a31bdd26d30/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.41/qiskit.circuit.Parameter.md
+++ b/docs/api/qiskit/0.41/qiskit.circuit.Parameter.md
@@ -41,11 +41,7 @@ bc.draw('mpl')
 
 ![../\_images/qiskit-circuit-Parameter-1\_00.png](/images/api/qiskit/0.41/qiskit-circuit-Parameter-1_00.png)
 
-Fig. 10 ([`png`](_downloads/ab99ec3b79e96f461e690ca262f73570/qiskit-circuit-Parameter-1_00.png), [`hires.png`](_downloads/8f162098942691a551ddc54febd00942/qiskit-circuit-Parameter-1_00.hires.png), [`pdf`](_downloads/4ffb4a85e35d9e6dc73418baf585eca1/qiskit-circuit-Parameter-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-Parameter-1\_01.png](/images/api/qiskit/0.41/qiskit-circuit-Parameter-1_01.png)
-
-Fig. 11 ([`png`](_downloads/1c26b648060e2d78752c9beb0472d916/qiskit-circuit-Parameter-1_01.png), [`hires.png`](_downloads/c8063434b010c2d84a30da468d91c5f8/qiskit-circuit-Parameter-1_01.hires.png), [`pdf`](_downloads/28d6024cb9854bb4f04f88a6c6777726/qiskit-circuit-Parameter-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Create a new named [`Parameter`](#qiskit.circuit.Parameter "qiskit.circuit.Parameter").
 

--- a/docs/api/qiskit/0.41/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.41/qiskit.circuit.QuantumCircuit.md
@@ -230,11 +230,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-1\_00.png](/images/api/qiskit/0.41/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.png)
 
-Fig. 6 ([`png`](_downloads/d2421053d5eeaf8afb1b546673dadbf5/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.png), [`hires.png`](_downloads/786e7abef7c00faa686fe238db265a63/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.hires.png), [`pdf`](_downloads/09c257670eece307b2190a862c4a3437/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-1\_01.png](/images/api/qiskit/0.41/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.png)
-
-Fig. 7 ([`png`](_downloads/33b341747f4f2726fe59c77dd387e711/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.png), [`hires.png`](_downloads/9541dc384fb2520544ec6aeb1d0f3275/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.hires.png), [`pdf`](_downloads/32cc634a4061b139f5a7335af6ba953c/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -254,11 +250,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-2\_00.png](/images/api/qiskit/0.41/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.png)
 
-Fig. 8 ([`png`](_downloads/4a65fc397ae868b65761780aa0013433/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.png), [`hires.png`](_downloads/f936574ca467dbf470bb3e62996b8aa4/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.hires.png), [`pdf`](_downloads/f6506b3b78cbacabed43c69d96b568dc/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-2\_01.png](/images/api/qiskit/0.41/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.png)
-
-Fig. 9 ([`png`](_downloads/e15ada4dc0293578ac577fd7c1da7d3f/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.png), [`hires.png`](_downloads/9d8ffd778f6ca66fbbc3b196880f9a38/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.hires.png), [`pdf`](_downloads/8e2e301d98ba6b3d97d4ae9de1ee0e55/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.41/qiskit.transpiler.passes.DynamicalDecoupling.md
+++ b/docs/api/qiskit/0.41/qiskit.transpiler.passes.DynamicalDecoupling.md
@@ -68,11 +68,7 @@ timeline_drawer(circ_dd)
 
 ![../\_images/qiskit-transpiler-passes-DynamicalDecoupling-1\_00.png](/images/api/qiskit/0.41/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png)
 
-Fig. 23 ([`png`](_downloads/dc45751fb822be8815f217a267bae356/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png), [`hires.png`](_downloads/16422e7545ee14003706693459de64e2/qiskit-transpiler-passes-DynamicalDecoupling-1_00.hires.png), [`pdf`](_downloads/e872644fa4d73ec0d7933d354c8b5059/qiskit-transpiler-passes-DynamicalDecoupling-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-transpiler-passes-DynamicalDecoupling-1\_01.png](/images/api/qiskit/0.41/qiskit-transpiler-passes-DynamicalDecoupling-1_01.png)
-
-Fig. 24 ([`png`](_downloads/53fd5fc6bb784c9ab811978842d9b3d1/qiskit-transpiler-passes-DynamicalDecoupling-1_01.png), [`hires.png`](_downloads/26516316e2c0c58fddd6ab262df0a289/qiskit-transpiler-passes-DynamicalDecoupling-1_01.hires.png), [`pdf`](_downloads/de66a83309cd3c854ee1dc534a5d465d/qiskit-transpiler-passes-DynamicalDecoupling-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Dynamical decoupling initializer.
 

--- a/docs/api/qiskit/0.41/qiskit.transpiler.passes.PadDynamicalDecoupling.md
+++ b/docs/api/qiskit/0.41/qiskit.transpiler.passes.PadDynamicalDecoupling.md
@@ -69,11 +69,7 @@ timeline_drawer(circ_dd)
 
 ![../\_images/qiskit-transpiler-passes-PadDynamicalDecoupling-1\_00.png](/images/api/qiskit/0.41/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.png)
 
-Fig. 21 ([`png`](_downloads/77c296cb945ba0294e4f741643f74b03/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.png), [`hires.png`](_downloads/d85fd432b248c4a18b945a3085ec0153/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.hires.png), [`pdf`](_downloads/5721283413f40c9d4fbd65d76d494e58/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-transpiler-passes-PadDynamicalDecoupling-1\_01.png](/images/api/qiskit/0.41/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.png)
-
-Fig. 22 ([`png`](_downloads/221e8a90d9816980f043bd325afd7fdf/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.png), [`hires.png`](_downloads/8e49f5936a9645949b3592df2065fb9d/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.hires.png), [`pdf`](_downloads/47aa302b7c447fe9745c5ca7d8c7a7c8/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 <Admonition title="Note" type="note">
   You may need to call alignment pass before running dynamical decoupling to guarantee your circuit satisfies acquisition alignment constraints.

--- a/docs/api/qiskit/0.41/qiskit.visualization.plot_distribution.md
+++ b/docs/api/qiskit/0.41/qiskit.visualization.plot_distribution.md
@@ -71,13 +71,7 @@ dist2 = plot_distribution(counts, sort='hamming', target_string='001')
 
 ![../\_images/qiskit-visualization-plot\_distribution-1\_00.png](/images/api/qiskit/0.41/qiskit-visualization-plot_distribution-1_00.png)
 
-Fig. 15 ([`png`](_downloads/38ff20d45b828b37a4e861e3bf0fbd49/qiskit-visualization-plot_distribution-1_00.png), [`hires.png`](_downloads/a3cfc72d23050f16a9f8eb9454613f2a/qiskit-visualization-plot_distribution-1_00.hires.png), [`pdf`](_downloads/429b65cdd15b0187b45b8b82a0a16b59/qiskit-visualization-plot_distribution-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_distribution-1\_01.png](/images/api/qiskit/0.41/qiskit-visualization-plot_distribution-1_01.png)
 
-Fig. 16 ([`png`](_downloads/3e5d1f9b298f3aa556e2afb1361d94de/qiskit-visualization-plot_distribution-1_01.png), [`hires.png`](_downloads/f4797be397c5517caa9cba2d3210e0d4/qiskit-visualization-plot_distribution-1_01.hires.png), [`pdf`](_downloads/31077ff3f04c3d05a394b198dece5249/qiskit-visualization-plot_distribution-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_distribution-1\_02.png](/images/api/qiskit/0.41/qiskit-visualization-plot_distribution-1_02.png)
-
-Fig. 17 ([`png`](_downloads/ab09ba350ca0888f337336372ebf62f6/qiskit-visualization-plot_distribution-1_02.png), [`hires.png`](_downloads/009236530201ab51a592725e37f75bdf/qiskit-visualization-plot_distribution-1_02.hires.png), [`pdf`](_downloads/74684a8061bef7b40153e044fbf37b3b/qiskit-visualization-plot_distribution-1_02.pdf))[¶](#id3 "Permalink to this image")
 

--- a/docs/api/qiskit/0.41/qiskit.visualization.plot_histogram.md
+++ b/docs/api/qiskit/0.41/qiskit.visualization.plot_histogram.md
@@ -72,13 +72,7 @@ hist2 = plot_histogram(counts, sort='hamming', target_string='001')
 
 ![../\_images/qiskit-visualization-plot\_histogram-1\_00.png](/images/api/qiskit/0.41/qiskit-visualization-plot_histogram-1_00.png)
 
-Fig. 12 ([`png`](_downloads/26deaece4ea494ab9758079b25d5c5dd/qiskit-visualization-plot_histogram-1_00.png), [`hires.png`](_downloads/425c8d385f776bb4c88146d3d019248d/qiskit-visualization-plot_histogram-1_00.hires.png), [`pdf`](_downloads/542540a5fb79520758b101ba87d28589/qiskit-visualization-plot_histogram-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_histogram-1\_01.png](/images/api/qiskit/0.41/qiskit-visualization-plot_histogram-1_01.png)
 
-Fig. 13 ([`png`](_downloads/55a3594a89845bca666aee0efef509f8/qiskit-visualization-plot_histogram-1_01.png), [`hires.png`](_downloads/cd3f838a3db20f6b8e2cc0cb6eaefd41/qiskit-visualization-plot_histogram-1_01.hires.png), [`pdf`](_downloads/da4018c246a66cbb9a548ad0b9a7235d/qiskit-visualization-plot_histogram-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_histogram-1\_02.png](/images/api/qiskit/0.41/qiskit-visualization-plot_histogram-1_02.png)
-
-Fig. 14 ([`png`](_downloads/efd7c19999031113bdd0e123c41f8323/qiskit-visualization-plot_histogram-1_02.png), [`hires.png`](_downloads/6132c650b158b81004d174a8ab695230/qiskit-visualization-plot_histogram-1_02.hires.png), [`pdf`](_downloads/c7a1bf4fc99ee7b4a413eccb0421d3cf/qiskit-visualization-plot_histogram-1_02.pdf))[¶](#id3 "Permalink to this image")
 

--- a/docs/api/qiskit/0.42/providers_fake_provider.md
+++ b/docs/api/qiskit/0.42/providers_fake_provider.md
@@ -54,15 +54,9 @@ plot_histogram(counts)
 
 ![../\_images/providers\_fake\_provider-1\_00.png](/images/api/qiskit/0.42/providers_fake_provider-1_00.png)
 
-Fig. 18 ([`png`](_downloads/5828673743dbf0e9b00a26ba9ff29862/providers_fake_provider-1_00.png), [`hires.png`](_downloads/b01f53e25e80fefe83dbe23605de3444/providers_fake_provider-1_00.hires.png), [`pdf`](_downloads/60ce946926738a7dbf56b1528c0ffa57/providers_fake_provider-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/providers\_fake\_provider-1\_01.png](/images/api/qiskit/0.42/providers_fake_provider-1_01.png)
 
-Fig. 19 ([`png`](_downloads/ec61c4ad44da25f371f7ee7c3353b477/providers_fake_provider-1_01.png), [`hires.png`](_downloads/9c627f615e6df0d9741c9e90d440bfc0/providers_fake_provider-1_01.hires.png), [`pdf`](_downloads/9262dcc7cff2be4e2f3f8e6c26ba71a0/providers_fake_provider-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/providers\_fake\_provider-1\_02.png](/images/api/qiskit/0.42/providers_fake_provider-1_02.png)
-
-Fig. 20 ([`png`](_downloads/1f733fb2488ea6ca71c8e11c0445c973/providers_fake_provider-1_02.png), [`hires.png`](_downloads/b962b924b487aac96d4dcc21ff19f41a/providers_fake_provider-1_02.hires.png), [`pdf`](_downloads/230e3abfd7fc8c2b543c02d2f102fdc0/providers_fake_provider-1_02.pdf))[¶](#id3 "Permalink to this image")
 
 <Admonition title="Important" type="danger">
   Please note that the simulation is done using a noise model generated from system snapshots obtained in the past (sometimes a few years ago) and the results are not representative of the latest behaviours of the real quantum system which the fake backend is mimicking. If you want to run noisy simulations to compare with the real quantum system, please follow steps below to generate a simulator mimics a real quantum system with the latest calibration results.

--- a/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.LinearSystemMatrix.md
+++ b/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.LinearSystemMatrix.md
@@ -152,11 +152,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-1\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.png)
 
-Fig. 25 ([`png`](_downloads/cd550726533aad6278ef4e40ce940e1c/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.png), [`hires.png`](_downloads/39b69d087a394429049b9a9d69990951/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.hires.png), [`pdf`](_downloads/258369a9f161fbcfa34e6213fdfdd896/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-1\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.png)
-
-Fig. 26 ([`png`](_downloads/4a30002841eb93a693be5938bfb0b0e5/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.png), [`hires.png`](_downloads/f923a52dee57aba3d011bdc5c2f3c9e7/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.hires.png), [`pdf`](_downloads/5167b8d610c71df8ab38092760ef7967/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -176,11 +172,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-2\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.png)
 
-Fig. 27 ([`png`](_downloads/d82ebfbd464692524a3cec301e3448a0/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.png), [`hires.png`](_downloads/84426e962194124c31fad6d986767537/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.hires.png), [`pdf`](_downloads/d63d9bf3a1ada6cdd5606b3263cb0c70/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-LinearSystemMatrix-assign\_parameters-2\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.png)
-
-Fig. 28 ([`png`](_downloads/1ab0454b7612a39b23db77ed3f413aba/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.png), [`hires.png`](_downloads/535f1b74876e49d677d52429ea77cdd5/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.hires.png), [`pdf`](_downloads/dcf041f48c758b3f5cad8855392316ef/qiskit-algorithms-linear_solvers-LinearSystemMatrix-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.NumPyMatrix.md
+++ b/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.NumPyMatrix.md
@@ -174,11 +174,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-1\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.png)
 
-Fig. 29 ([`png`](_downloads/0ee03cd86e2a382fa5fb1900d937ee2f/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.png), [`hires.png`](_downloads/238c146f0154e894f6aef45211c9c748/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.hires.png), [`pdf`](_downloads/ed52dbeb6ca69ec4fea1e3b0abce8861/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-1\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.png)
-
-Fig. 30 ([`png`](_downloads/b21b94e2a58a0e5b7f8e5a4b6ae9c99e/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.png), [`hires.png`](_downloads/03b9e379c9047651591e64e53761637b/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.hires.png), [`pdf`](_downloads/cba8e47be3f1af5b5648a4df1dc3f665/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -198,11 +194,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-2\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.png)
 
-Fig. 31 ([`png`](_downloads/671a2ffb644686ba0cbe58973601fd83/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.png), [`hires.png`](_downloads/63a6b5d75d9b2238feb4d9531c35f742/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.hires.png), [`pdf`](_downloads/4c16358d7b26b6c07e1f30e0cf36a9c1/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-NumPyMatrix-assign\_parameters-2\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.png)
-
-Fig. 32 ([`png`](_downloads/e49c821a5e323757198aae20c11e5d00/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.png), [`hires.png`](_downloads/0c5636304ba11d9a701c823032805b02/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.hires.png), [`pdf`](_downloads/036a3d2c96ecd0e9dac675b80c016e20/qiskit-algorithms-linear_solvers-NumPyMatrix-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.TridiagonalToeplitz.md
+++ b/docs/api/qiskit/0.42/qiskit.algorithms.linear_solvers.TridiagonalToeplitz.md
@@ -187,11 +187,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-1\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.png)
 
-Fig. 33 ([`png`](_downloads/ff37c226764247e560e3a85343b86685/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.png), [`hires.png`](_downloads/b6aef7c23aef550fd1398a759defe7d8/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.hires.png), [`pdf`](_downloads/6119677b2f68f968c433135996279a71/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-1\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.png)
-
-Fig. 34 ([`png`](_downloads/9922ce15188659badfba018fb101d895/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.png), [`hires.png`](_downloads/0f2f9b13f42a057a7a16bf92c86d3b4f/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.hires.png), [`pdf`](_downloads/1a04f6dc7569c4788e0e451044beba59/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -211,11 +207,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-2\_00.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.png)
 
-Fig. 35 ([`png`](_downloads/4e122536e8fdb50b6f3293dd127d5a1c/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.png), [`hires.png`](_downloads/1cd69e6b3fcfc6c39ed237fb902b9f31/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.hires.png), [`pdf`](_downloads/e84c98f08b17e05affe6ce6b0ad0f9be/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-algorithms-linear\_solvers-TridiagonalToeplitz-assign\_parameters-2\_01.png](/images/api/qiskit/0.42/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.png)
-
-Fig. 36 ([`png`](_downloads/c491eec85d0433dc7b13e3649ddae562/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.png), [`hires.png`](_downloads/dec07cdb65038f6ea9504bfee738004a/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.hires.png), [`pdf`](_downloads/c310b95de6f2569250d21a31bdd26d30/qiskit-algorithms-linear_solvers-TridiagonalToeplitz-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.42/qiskit.circuit.Parameter.md
+++ b/docs/api/qiskit/0.42/qiskit.circuit.Parameter.md
@@ -41,11 +41,7 @@ bc.draw('mpl')
 
 ![../\_images/qiskit-circuit-Parameter-1\_00.png](/images/api/qiskit/0.42/qiskit-circuit-Parameter-1_00.png)
 
-Fig. 10 ([`png`](_downloads/ab99ec3b79e96f461e690ca262f73570/qiskit-circuit-Parameter-1_00.png), [`hires.png`](_downloads/8f162098942691a551ddc54febd00942/qiskit-circuit-Parameter-1_00.hires.png), [`pdf`](_downloads/4ffb4a85e35d9e6dc73418baf585eca1/qiskit-circuit-Parameter-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-Parameter-1\_01.png](/images/api/qiskit/0.42/qiskit-circuit-Parameter-1_01.png)
-
-Fig. 11 ([`png`](_downloads/1c26b648060e2d78752c9beb0472d916/qiskit-circuit-Parameter-1_01.png), [`hires.png`](_downloads/c8063434b010c2d84a30da468d91c5f8/qiskit-circuit-Parameter-1_01.hires.png), [`pdf`](_downloads/28d6024cb9854bb4f04f88a6c6777726/qiskit-circuit-Parameter-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Create a new named [`Parameter`](#qiskit.circuit.Parameter "qiskit.circuit.Parameter").
 

--- a/docs/api/qiskit/0.42/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.42/qiskit.circuit.QuantumCircuit.md
@@ -230,11 +230,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-1\_00.png](/images/api/qiskit/0.42/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.png)
 
-Fig. 6 ([`png`](_downloads/d2421053d5eeaf8afb1b546673dadbf5/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.png), [`hires.png`](_downloads/786e7abef7c00faa686fe238db265a63/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.hires.png), [`pdf`](_downloads/09c257670eece307b2190a862c4a3437/qiskit-circuit-QuantumCircuit-assign_parameters-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-1\_01.png](/images/api/qiskit/0.42/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.png)
-
-Fig. 7 ([`png`](_downloads/33b341747f4f2726fe59c77dd387e711/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.png), [`hires.png`](_downloads/9541dc384fb2520544ec6aeb1d0f3275/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.hires.png), [`pdf`](_downloads/32cc634a4061b139f5a7335af6ba953c/qiskit-circuit-QuantumCircuit-assign_parameters-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Bind the values out-of-place by list and get a copy of the original circuit.
 
@@ -254,11 +250,7 @@ circuit.draw('mpl')
 
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-2\_00.png](/images/api/qiskit/0.42/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.png)
 
-Fig. 8 ([`png`](_downloads/4a65fc397ae868b65761780aa0013433/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.png), [`hires.png`](_downloads/f936574ca467dbf470bb3e62996b8aa4/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.hires.png), [`pdf`](_downloads/f6506b3b78cbacabed43c69d96b568dc/qiskit-circuit-QuantumCircuit-assign_parameters-2_00.pdf))[¶](#id3 "Permalink to this image")
-
 ![../\_images/qiskit-circuit-QuantumCircuit-assign\_parameters-2\_01.png](/images/api/qiskit/0.42/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.png)
-
-Fig. 9 ([`png`](_downloads/e15ada4dc0293578ac577fd7c1da7d3f/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.png), [`hires.png`](_downloads/9d8ffd778f6ca66fbbc3b196880f9a38/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.hires.png), [`pdf`](_downloads/8e2e301d98ba6b3d97d4ae9de1ee0e55/qiskit-circuit-QuantumCircuit-assign_parameters-2_01.pdf))[¶](#id4 "Permalink to this image")
 
 ### barrier
 

--- a/docs/api/qiskit/0.42/qiskit.transpiler.passes.DynamicalDecoupling.md
+++ b/docs/api/qiskit/0.42/qiskit.transpiler.passes.DynamicalDecoupling.md
@@ -68,11 +68,7 @@ timeline_drawer(circ_dd)
 
 ![../\_images/qiskit-transpiler-passes-DynamicalDecoupling-1\_00.png](/images/api/qiskit/0.42/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png)
 
-Fig. 23 ([`png`](_downloads/dc45751fb822be8815f217a267bae356/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png), [`hires.png`](_downloads/16422e7545ee14003706693459de64e2/qiskit-transpiler-passes-DynamicalDecoupling-1_00.hires.png), [`pdf`](_downloads/e872644fa4d73ec0d7933d354c8b5059/qiskit-transpiler-passes-DynamicalDecoupling-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-transpiler-passes-DynamicalDecoupling-1\_01.png](/images/api/qiskit/0.42/qiskit-transpiler-passes-DynamicalDecoupling-1_01.png)
-
-Fig. 24 ([`png`](_downloads/53fd5fc6bb784c9ab811978842d9b3d1/qiskit-transpiler-passes-DynamicalDecoupling-1_01.png), [`hires.png`](_downloads/26516316e2c0c58fddd6ab262df0a289/qiskit-transpiler-passes-DynamicalDecoupling-1_01.hires.png), [`pdf`](_downloads/de66a83309cd3c854ee1dc534a5d465d/qiskit-transpiler-passes-DynamicalDecoupling-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 Dynamical decoupling initializer.
 

--- a/docs/api/qiskit/0.42/qiskit.transpiler.passes.PadDynamicalDecoupling.md
+++ b/docs/api/qiskit/0.42/qiskit.transpiler.passes.PadDynamicalDecoupling.md
@@ -69,11 +69,7 @@ timeline_drawer(circ_dd)
 
 ![../\_images/qiskit-transpiler-passes-PadDynamicalDecoupling-1\_00.png](/images/api/qiskit/0.42/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.png)
 
-Fig. 21 ([`png`](_downloads/77c296cb945ba0294e4f741643f74b03/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.png), [`hires.png`](_downloads/d85fd432b248c4a18b945a3085ec0153/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.hires.png), [`pdf`](_downloads/5721283413f40c9d4fbd65d76d494e58/qiskit-transpiler-passes-PadDynamicalDecoupling-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-transpiler-passes-PadDynamicalDecoupling-1\_01.png](/images/api/qiskit/0.42/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.png)
-
-Fig. 22 ([`png`](_downloads/221e8a90d9816980f043bd325afd7fdf/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.png), [`hires.png`](_downloads/8e49f5936a9645949b3592df2065fb9d/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.hires.png), [`pdf`](_downloads/47aa302b7c447fe9745c5ca7d8c7a7c8/qiskit-transpiler-passes-PadDynamicalDecoupling-1_01.pdf))[¶](#id2 "Permalink to this image")
 
 <Admonition title="Note" type="note">
   You may need to call alignment pass before running dynamical decoupling to guarantee your circuit satisfies acquisition alignment constraints.

--- a/docs/api/qiskit/0.42/qiskit.visualization.plot_distribution.md
+++ b/docs/api/qiskit/0.42/qiskit.visualization.plot_distribution.md
@@ -71,13 +71,7 @@ dist2 = plot_distribution(counts, sort='hamming', target_string='001')
 
 ![../\_images/qiskit-visualization-plot\_distribution-1\_00.png](/images/api/qiskit/0.42/qiskit-visualization-plot_distribution-1_00.png)
 
-Fig. 15 ([`png`](_downloads/38ff20d45b828b37a4e861e3bf0fbd49/qiskit-visualization-plot_distribution-1_00.png), [`hires.png`](_downloads/a3cfc72d23050f16a9f8eb9454613f2a/qiskit-visualization-plot_distribution-1_00.hires.png), [`pdf`](_downloads/429b65cdd15b0187b45b8b82a0a16b59/qiskit-visualization-plot_distribution-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_distribution-1\_01.png](/images/api/qiskit/0.42/qiskit-visualization-plot_distribution-1_01.png)
 
-Fig. 16 ([`png`](_downloads/3e5d1f9b298f3aa556e2afb1361d94de/qiskit-visualization-plot_distribution-1_01.png), [`hires.png`](_downloads/f4797be397c5517caa9cba2d3210e0d4/qiskit-visualization-plot_distribution-1_01.hires.png), [`pdf`](_downloads/31077ff3f04c3d05a394b198dece5249/qiskit-visualization-plot_distribution-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_distribution-1\_02.png](/images/api/qiskit/0.42/qiskit-visualization-plot_distribution-1_02.png)
-
-Fig. 17 ([`png`](_downloads/ab09ba350ca0888f337336372ebf62f6/qiskit-visualization-plot_distribution-1_02.png), [`hires.png`](_downloads/009236530201ab51a592725e37f75bdf/qiskit-visualization-plot_distribution-1_02.hires.png), [`pdf`](_downloads/74684a8061bef7b40153e044fbf37b3b/qiskit-visualization-plot_distribution-1_02.pdf))[¶](#id3 "Permalink to this image")
 

--- a/docs/api/qiskit/0.42/qiskit.visualization.plot_histogram.md
+++ b/docs/api/qiskit/0.42/qiskit.visualization.plot_histogram.md
@@ -72,13 +72,7 @@ hist2 = plot_histogram(counts, sort='hamming', target_string='001')
 
 ![../\_images/qiskit-visualization-plot\_histogram-1\_00.png](/images/api/qiskit/0.42/qiskit-visualization-plot_histogram-1_00.png)
 
-Fig. 12 ([`png`](_downloads/26deaece4ea494ab9758079b25d5c5dd/qiskit-visualization-plot_histogram-1_00.png), [`hires.png`](_downloads/425c8d385f776bb4c88146d3d019248d/qiskit-visualization-plot_histogram-1_00.hires.png), [`pdf`](_downloads/542540a5fb79520758b101ba87d28589/qiskit-visualization-plot_histogram-1_00.pdf))[¶](#id1 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_histogram-1\_01.png](/images/api/qiskit/0.42/qiskit-visualization-plot_histogram-1_01.png)
 
-Fig. 13 ([`png`](_downloads/55a3594a89845bca666aee0efef509f8/qiskit-visualization-plot_histogram-1_01.png), [`hires.png`](_downloads/cd3f838a3db20f6b8e2cc0cb6eaefd41/qiskit-visualization-plot_histogram-1_01.hires.png), [`pdf`](_downloads/da4018c246a66cbb9a548ad0b9a7235d/qiskit-visualization-plot_histogram-1_01.pdf))[¶](#id2 "Permalink to this image")
-
 ![../\_images/qiskit-visualization-plot\_histogram-1\_02.png](/images/api/qiskit/0.42/qiskit-visualization-plot_histogram-1_02.png)
-
-Fig. 14 ([`png`](_downloads/efd7c19999031113bdd0e123c41f8323/qiskit-visualization-plot_histogram-1_02.png), [`hires.png`](_downloads/6132c650b158b81004d174a8ab695230/qiskit-visualization-plot_histogram-1_02.hires.png), [`pdf`](_downloads/c7a1bf4fc99ee7b4a413eccb0421d3cf/qiskit-visualization-plot_histogram-1_02.pdf))[¶](#id3 "Permalink to this image")
 

--- a/scripts/lib/api/processHtml.test.ts
+++ b/scripts/lib/api/processHtml.test.ts
@@ -193,7 +193,7 @@ test("removeColonSpans()", () => {
 });
 
 describe("removeMatplotlibFigCaptions()", () => {
-  test("removes captions in matches", () => {
+  test("removes <figcaption>", () => {
     const doc = Doc.load(`
     <figure class="align-default" id="id1">
       <img alt="../_images/fake_provider-1_00.png" class="plot-directive" src="../_images/fake_provider-1_00.png" />
@@ -229,60 +229,56 @@ describe("removeMatplotlibFigCaptions()", () => {
   `);
   });
 
-  test("leaves captions alone in non-matches", () => {
+  test("removes <div>", () => {
     const doc = Doc.load(`
-    <figure class="align-default" id="id1">
-      <img alt="../_images/fake_provider-1_00.png" class="plot-directive" src="../_images/fake_provider-1_00.png" />
-      <figcaption>
-        <p>
-          <span class="caption-number">Fig. 1 </span>
-          <span class="caption-text">
-              (
-              <a class="reference download" download="" href="../_downloads/a640acbc08577560dc62a3c02c6ca2ac/fake_provider-1_00.png">
-                  <code class="xref download docutils literal notranslate"><span class="pre">png</span></code>
-              </a>
-              ,
-              <a class="reference download" download="" href="../_downloads/98e08086a49350bea51e64248343d7ac/fake_provider-1_00.hires.png">
-                  <code class="xref download docutils literal notranslate"><span class="pre">hires.png</span></code>
-              </a>
-              ,
-              <a class="reference download" download="" href="../_downloads/684bf35d507376624fcead10d9aedaed/fake_provider-1_00.pdf">
-                  <code class="xref download docutils literal notranslate"><span class="pre">pdf</span></code>
-              </a>
-              )
-          </span>
-          <a class="headerlink" href="#id1" title="Link to this image">¶</a>
-        </p>
-      </figcaption>
-    </figure>
-  `);
+    <div class="figure align-default" id="id1">
+      <img alt="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png" class="plot-directive" src="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png" />
+      <p class="caption">
+        <span class="caption-number">Fig. 23 </span>
+        <span class="caption-text">
+            (
+            <a class="reference download internal" download="" href="../_downloads/dc45751fb822be8815f217a267bae356/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png">
+                <code class="xref download docutils literal notranslate"><span class="pre">png</span></code>
+            </a>
+            ,
+            <a class="reference download internal" download="" href="../_downloads/16422e7545ee14003706693459de64e2/qiskit-transpiler-passes-DynamicalDecoupling-1_00.hires.png">
+                <code class="xref download docutils literal notranslate"><span class="pre">hires.png</span></code>
+            </a>
+            ,
+            <a class="reference download internal" download="" href="../_downloads/e872644fa4d73ec0d7933d354c8b5059/qiskit-transpiler-passes-DynamicalDecoupling-1_00.pdf">
+                <code class="xref download docutils literal notranslate"><span class="pre">pdf</span></code>
+            </a>
+            )
+        </span>
+        <a class="headerlink" href="#id1" title="Permalink to this image">¶</a>
+      </p>
+    </div>
+   `);
     removeMatplotlibFigCaptions(doc.$main);
     doc.expectHtml(`
+     <div class="figure align-default" id="id1">
+      <img alt="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png" class="plot-directive" src="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png">
+      
+    </div>
+  `);
+  });
+
+  test("ignores non-matches", () => {
+    const html = `
     <figure class="align-default" id="id1">
       <img alt="../_images/fake_provider-1_00.png" class="plot-directive" src="../_images/fake_provider-1_00.png">
-      <figcaption>
-        <p>
-          <span class="caption-number">Fig. 1 </span>
-          <span class="caption-text">
-              (
-              <a class="reference download" download="" href="../_downloads/a640acbc08577560dc62a3c02c6ca2ac/fake_provider-1_00.png">
-                  <code class="xref download docutils literal notranslate"><span class="pre">png</span></code>
-              </a>
-              ,
-              <a class="reference download" download="" href="../_downloads/98e08086a49350bea51e64248343d7ac/fake_provider-1_00.hires.png">
-                  <code class="xref download docutils literal notranslate"><span class="pre">hires.png</span></code>
-              </a>
-              ,
-              <a class="reference download" download="" href="../_downloads/684bf35d507376624fcead10d9aedaed/fake_provider-1_00.pdf">
-                  <code class="xref download docutils literal notranslate"><span class="pre">pdf</span></code>
-              </a>
-              )
-          </span>
-          <a class="headerlink" href="#id1" title="Link to this image">¶</a>
-        </p>
+      <figcaption><p>My caption</p>
       </figcaption>
     </figure>
-  `);
+
+    <div class="figure align-default" id="id1">
+      <img alt="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png" class="plot-directive" src="../_images/qiskit-transpiler-passes-DynamicalDecoupling-1_00.png">
+      <p>My caption</p>
+    </div>
+  `;
+    const doc = Doc.load(html);
+    removeMatplotlibFigCaptions(doc.$main);
+    doc.expectHtml(html);
   });
 });
 

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -129,7 +129,7 @@ export function removeDownloadSourceCode($main: Cheerio<any>): void {
 
 export function removeMatplotlibFigCaptions($main: Cheerio<any>): void {
   $main
-    .find("figcaption")
+    .find("figcaption, div.figure p.caption")
     .has("span.caption-text a.download.internal.reference")
     .remove();
 }


### PR DESCRIPTION
Follow up to https://github.com/Qiskit/documentation/pull/848. Sphinx used to use a different HTML structure we weren't accounting for.

After this PR, there are no more bad URLs:

```
❯ rg '_downloads' -l
scripts/lib/api/htmlToMd.test.ts
scripts/lib/links/ignores.ts
scripts/lib/api/processHtml.test.ts
```