### PR TITLE
Refactor how we relativize links to qiskit.org

### DIFF
--- a/docs/api/qiskit/0.38/aer_primitives.md
+++ b/docs/api/qiskit/0.38/aer_primitives.md
@@ -16,7 +16,7 @@ python_api_name: qiskit_aer.primitives
 
 `qiskit_aer.primitives`
 
-This module is Aer implementation of primitives. See the docs [https://qiskit.org/documentation/apidoc/primitives.html](https://qiskit.org/documentation/apidoc/primitives.html) for general descriptions.
+This module is Aer implementation of primitives. See the docs [primitives](/api/qiskit/primitives) for general descriptions.
 
 ## Classes
 

--- a/docs/api/qiskit/0.39/aer_primitives.md
+++ b/docs/api/qiskit/0.39/aer_primitives.md
@@ -16,7 +16,7 @@ python_api_name: qiskit_aer.primitives
 
 `qiskit_aer.primitives`
 
-This module is Aer implementation of primitives. See the docs [https://qiskit.org/documentation/apidoc/primitives.html](https://qiskit.org/documentation/apidoc/primitives.html) for general descriptions.
+This module is Aer implementation of primitives. See the docs [primitives](/api/qiskit/primitives) for general descriptions.
 
 ## Classes
 

--- a/docs/api/qiskit/0.40/aer_primitives.md
+++ b/docs/api/qiskit/0.40/aer_primitives.md
@@ -16,7 +16,7 @@ python_api_name: qiskit_aer.primitives
 
 `qiskit_aer.primitives`
 
-This module is Aer implementation of primitives. See the docs [https://qiskit.org/documentation/apidoc/primitives.html](https://qiskit.org/documentation/apidoc/primitives.html) for general descriptions.
+This module is Aer implementation of primitives. See the docs [primitives](/api/qiskit/primitives) for general descriptions.
 
 ## Classes
 

--- a/docs/api/qiskit/0.41/aer_primitives.md
+++ b/docs/api/qiskit/0.41/aer_primitives.md
@@ -16,7 +16,7 @@ python_api_name: qiskit_aer.primitives
 
 `qiskit_aer.primitives`
 
-This module is Aer implementation of primitives. See the docs [https://qiskit.org/documentation/apidoc/primitives.html](https://qiskit.org/documentation/apidoc/primitives.html) for general descriptions.
+This module is Aer implementation of primitives. See the docs [primitives](/api/qiskit/primitives) for general descriptions.
 
 ## Classes
 

--- a/docs/api/qiskit/0.42/aer_primitives.md
+++ b/docs/api/qiskit/0.42/aer_primitives.md
@@ -16,7 +16,7 @@ python_api_name: qiskit_aer.primitives
 
 `qiskit_aer.primitives`
 
-This module is Aer implementation of primitives. See the docs [https://qiskit.org/documentation/apidoc/primitives.html](https://qiskit.org/documentation/apidoc/primitives.html) for general descriptions.
+This module is Aer implementation of primitives. See the docs [primitives](/api/qiskit/primitives) for general descriptions.
 
 ## Classes
 

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -207,7 +207,7 @@ async function convertHtmlToMarkdown(
   results = await mergeClassMembers(results);
   flattenFolders(results);
   specialCaseResults(results);
-  await updateLinks(results, maybeObjectsInv, pkg.transformLink);
+  await updateLinks(results, maybeObjectsInv);
   await dedupeHtmlIdsFromResults(results);
   addFrontMatter(results, pkg);
 

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -13,16 +13,7 @@
 import { join } from "path/posix";
 
 import { findLegacyReleaseNotes } from "./releaseNotes";
-import { removePrefix, removeSuffix } from "../stringUtils";
 import { getRoot } from "../fs";
-
-/**
- * Simple interface for scripts/command/updateApiDocs.ts
- */
-export interface Link {
-  url: string; // Where the link goes
-  text?: string; // What the user sees
-}
 
 export interface ReleaseNoteEntry {
   title: string;
@@ -39,7 +30,6 @@ export class Pkg {
   readonly title: string;
   readonly githubSlug: string;
   readonly hasSeparateReleaseNotes: boolean;
-  readonly transformLink?: (link: Link) => Link | undefined;
   readonly version: string;
   readonly versionWithoutPatch: string;
   readonly type: PackageType;
@@ -52,7 +42,6 @@ export class Pkg {
     title: string;
     githubSlug: string;
     hasSeparateReleaseNotes: boolean;
-    transformLink?: (link: Link) => Link | undefined;
     version: string;
     versionWithoutPatch: string;
     type: PackageType;
@@ -62,7 +51,6 @@ export class Pkg {
     this.title = kwargs.title;
     this.githubSlug = kwargs.githubSlug;
     this.hasSeparateReleaseNotes = kwargs.hasSeparateReleaseNotes;
-    this.transformLink = kwargs.transformLink;
     this.version = kwargs.version;
     this.versionWithoutPatch = kwargs.versionWithoutPatch;
     this.type = kwargs.type;
@@ -100,7 +88,6 @@ export class Pkg {
         title: "Qiskit Runtime IBM Client",
         name: "qiskit-ibm-runtime",
         githubSlug: "qiskit/qiskit-ibm-runtime",
-        transformLink,
         hasSeparateReleaseNotes: false,
         releaseNoteEntries: [],
       });
@@ -112,7 +99,6 @@ export class Pkg {
         title: "Qiskit IBM Provider",
         name: "qiskit-ibm-provider",
         githubSlug: "qiskit/qiskit-ibm-provider",
-        transformLink,
         hasSeparateReleaseNotes: false,
         releaseNoteEntries: [],
       });
@@ -126,7 +112,6 @@ export class Pkg {
     title?: string;
     githubSlug?: string;
     hasSeparateReleaseNotes?: boolean;
-    transformLink?: (link: Link) => Link | undefined;
     version?: string;
     versionWithoutPatch?: string;
     type?: PackageType;
@@ -137,7 +122,6 @@ export class Pkg {
       title: kwargs.title ?? "My Quantum Project",
       githubSlug: kwargs.githubSlug ?? "qiskit/my-quantum-project",
       hasSeparateReleaseNotes: kwargs.hasSeparateReleaseNotes ?? false,
-      transformLink: kwargs.transformLink,
       version: kwargs.version ?? "0.1.0",
       versionWithoutPatch: kwargs.versionWithoutPatch ?? "0.1",
       type: kwargs.type ?? "latest",
@@ -381,24 +365,4 @@ function determineHistoricalQiskitGithubUrl(
   }
 
   return `https://github.com/${slug}/tree/stable/${version}/${fileName}.py`;
-}
-
-function transformLink(link: Link): Link | undefined {
-  const updateText = link.url === link.text;
-  const prefixes = [
-    "https://qiskit.org/documentation/apidoc/",
-    "https://qiskit.org/documentation/stubs/",
-  ];
-  const prefix = prefixes.find((prefix) => link.url.startsWith(prefix));
-  if (!prefix) {
-    return;
-  }
-  let [url, anchor] = link.url.split("#");
-  url = removePrefix(url, prefix);
-  url = removeSuffix(url, ".html");
-  if (anchor && anchor !== url) {
-    url = `${url}#${anchor}`;
-  }
-  const newText = updateText ? url : undefined;
-  return { url: `/api/qiskit/${url}`, text: newText };
 }

--- a/scripts/lib/api/objectsInv.ts
+++ b/scripts/lib/api/objectsInv.ts
@@ -129,7 +129,7 @@ export class ObjectsInv {
     return uri;
   }
 
-  updateUris(transformLink: Function): void {
+  updateUris(transformLink: (uri: string) => string): void {
     for (const entry of this.entries) {
       entry.uri = entry.uri.replace(/\.html/, "");
       entry.uri = transformLink(entry.uri);

--- a/scripts/lib/api/updateLinks.test.ts
+++ b/scripts/lib/api/updateLinks.test.ts
@@ -12,9 +12,8 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { ObjectsInv } from "./objectsInv";
-import { last } from "lodash";
 
-import { updateLinks, updateUrl } from "./updateLinks";
+import { updateLinks, normalizeUrl, relativizeLink } from "./updateLinks";
 import { HtmlToMdResultWithUrl } from "./HtmlToMdResult";
 
 describe("updateLinks", () => {
@@ -29,6 +28,8 @@ describe("updateLinks", () => {
 [link5](../apidocs/qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob)
 [link6](qiskit_ibm_runtime.RuntimeJob)
 [link7](#qiskit_ibm_runtime.RuntimeJob.job)
+[link8](https://qiskit.org/documentation/apidoc/algorithms.html)
+[link9](https://qiskit.org/documentation/stubs/qiskit.circuit.BreakLoopOp.html#assemble)
           `,
         meta: {
           apiType: "class",
@@ -91,6 +92,8 @@ describe("updateLinks", () => {
       [link5](qiskit_ibm_runtime.RuntimeJob)
       [link6](qiskit_ibm_runtime.RuntimeJob)
       [link7](#qiskit_ibm_runtime.RuntimeJob.job)
+      [link8](/api/qiskit/algorithms)
+      [link9](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)
       ",
           "meta": {
             "apiName": "qiskit_ibm_runtime.RuntimeJob",
@@ -127,136 +130,48 @@ describe("updateLinks", () => {
       ]
     `);
   });
-
-  test("update links using a transform function", async () => {
-    const data: HtmlToMdResultWithUrl[] = [
-      {
-        markdown: `
-[link1](algorithms)
-[link2](../apidocs/algorithms)
-[link3](qiskit.algorithms.minimum_eigensolvers.VQE#qiskit.algorithms.minimum_eigensolvers.VQE)
-[link3](../stubs/qiskit.algorithms.minimum_eigensolvers.VQE#qiskit.algorithms.minimum_eigensolvers.VQE)
-[link7](#qiskit_ibm_runtime.RuntimeJob.job)
-          `,
-        meta: {
-          apiType: "class",
-          apiName: "qiskit_ibm_runtime.RuntimeJob",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
-        images: [],
-        isReleaseNotes: false,
-      },
-    ];
-
-    const objectsInvEntries = [
-      "stubs/qiskit.algorithms.Eigensolver.html#$",
-      "stubs/qiskit.algorithms.Eigensolver.html#$",
-      "stubs/qiskit.algorithms.EigensolverResult.html#$",
-      "stubs/qiskit.algorithms.EstimationProblem.html#$",
-      "stubs/qiskit.algorithms.EvolutionProblem.html#$",
-      "stubs/qiskit.algorithms.EvolutionProblem.html#$",
-      "stubs/qiskit.algorithms.FasterAmplitudeEstimationResult.html#$",
-      "stubs/qiskit.algorithms.FasterAmplitudeEstimationResult.html#$",
-    ].map((uri) => {
-      return {
-        name: "-",
-        domainAndRole: "-",
-        priority: "-",
-        uri,
-        dispname: "-",
-      };
-    });
-    const objectsInv = new ObjectsInv(
-      "# Here's a simple preamble",
-      objectsInvEntries,
-    );
-
-    await updateLinks(data, objectsInv, (link) => {
-      let path = last(link.url.split("/"))!;
-      if (path.includes("#")) {
-        path = path.split("#").join(".html#");
-      } else {
-        path += ".html";
-      }
-
-      if (path?.startsWith("algorithms"))
-        return { url: `http://qiskit.org/documentation/apidoc/${path}` };
-      if (path?.startsWith("qiskit.algorithms."))
-        return { url: `http://qiskit.org/documentation/stubs/${path}` };
-    });
-    expect(data).toMatchInlineSnapshot(`
-      [
-        {
-          "images": [],
-          "isReleaseNotes": false,
-          "markdown": "[link1](http://qiskit.org/documentation/apidoc/algorithms.html)
-      [link2](http://qiskit.org/documentation/apidoc/algorithms.html)
-      [link3](http://qiskit.org/documentation/stubs/qiskit.algorithms.minimum_eigensolvers.VQE.html#qiskit.algorithms.minimum_eigensolvers.VQE)
-      [link3](http://qiskit.org/documentation/stubs/qiskit.algorithms.minimum_eigensolvers.VQE.html#qiskit.algorithms.minimum_eigensolvers.VQE)
-      [link7](#qiskit_ibm_runtime.RuntimeJob.job)
-      ",
-          "meta": {
-            "apiName": "qiskit_ibm_runtime.RuntimeJob",
-            "apiType": "class",
-          },
-          "url": "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
-        },
-      ]
-    `);
-    expect(objectsInv.entries.map((e) => e.uri)).toMatchInlineSnapshot(`
-      [
-        "qiskit.algorithms.Eigensolver#$",
-        "qiskit.algorithms.Eigensolver#$",
-        "qiskit.algorithms.EigensolverResult#$",
-        "qiskit.algorithms.EstimationProblem#$",
-        "qiskit.algorithms.EvolutionProblem#$",
-        "qiskit.algorithms.EvolutionProblem#$",
-        "qiskit.algorithms.FasterAmplitudeEstimationResult#$",
-        "qiskit.algorithms.FasterAmplitudeEstimationResult#$",
-      ]
-   `);
-  });
 });
 
-describe("updateUrl", () => {
-  test("update url", async () => {
-    const urls = [
-      `qiskit_ibm_runtime.RuntimeJob`,
-      `qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob`,
-      `qiskit_ibm_runtime.RuntimeJob.job#wut`,
-      `../stubs/qiskit_ibm_runtime.RuntimeJob`,
-      `../apidocs/qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob`,
-      `qiskit_ibm_runtime.RuntimeJob`,
-      `#qiskit_ibm_runtime.RuntimeJob.job`,
-      `qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob.run`,
-      `stubs/qiskit_ibm_runtime.RuntimeJob`,
-    ];
-    const resultsByName: { [key: string]: HtmlToMdResultWithUrl } = {
-      "qiskit_ibm_runtime.RuntimeJob": {
-        markdown: "",
-        meta: {
-          apiType: "class",
-          apiName: "qiskit_ibm_runtime.RuntimeJob",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
-        images: [],
-        isReleaseNotes: false,
+test("normalizeUrl()", () => {
+  const urls = [
+    `qiskit_ibm_runtime.RuntimeJob`,
+    `qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob`,
+    `qiskit_ibm_runtime.RuntimeJob.job#wut`,
+    `../stubs/qiskit_ibm_runtime.RuntimeJob`,
+    `../apidocs/qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob`,
+    `qiskit_ibm_runtime.RuntimeJob`,
+    `#qiskit_ibm_runtime.RuntimeJob.job`,
+    `qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob.run`,
+    `stubs/qiskit_ibm_runtime.RuntimeJob`,
+  ];
+  const resultsByName: { [key: string]: HtmlToMdResultWithUrl } = {
+    "qiskit_ibm_runtime.RuntimeJob": {
+      markdown: "",
+      meta: {
+        apiType: "class",
+        apiName: "qiskit_ibm_runtime.RuntimeJob",
       },
-      "qiskit_ibm_runtime.Sampler": {
-        markdown: "",
-        meta: {
-          apiType: "class",
-          apiName: "qiskit_ibm_runtime.Sampler",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
-        images: [],
-        isReleaseNotes: false,
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+      images: [],
+      isReleaseNotes: false,
+    },
+    "qiskit_ibm_runtime.Sampler": {
+      markdown: "",
+      meta: {
+        apiType: "class",
+        apiName: "qiskit_ibm_runtime.Sampler",
       },
-    };
-    const itemNames = new Set(["qiskit_ibm_runtime.RuntimeJob"]);
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+      images: [],
+      isReleaseNotes: false,
+    },
+  };
+  const itemNames = new Set(["qiskit_ibm_runtime.RuntimeJob"]);
 
-    const newUrls = urls.map((url) => updateUrl(url, resultsByName, itemNames));
-    expect(newUrls).toMatchInlineSnapshot(`
+  const newUrls = urls.map((url) =>
+    normalizeUrl(url, resultsByName, itemNames),
+  );
+  expect(newUrls).toMatchInlineSnapshot(`
       [
         "qiskit_ibm_runtime.RuntimeJob",
         "qiskit_ibm_runtime.RuntimeJob",
@@ -269,5 +184,41 @@ describe("updateUrl", () => {
         "qiskit_ibm_runtime.RuntimeJob",
       ]
     `);
+});
+
+describe("relativizeLink()", () => {
+  test.each([
+    "https://ibm.com",
+    "https://qiskit.org/ecosystem/nature",
+    "https://qiskit.org/documentation/index.html",
+  ])("ignore irrelevant links", (input) => {
+    expect(relativizeLink({ url: input })).toBeUndefined();
+  });
+
+  test.each([
+    [
+      "https://qiskit.org/documentation/apidoc/algorithms.html",
+      "/api/qiskit/algorithms",
+    ],
+    [
+      "https://qiskit.org/documentation/stubs/qiskit.circuit.BreakLoopOp.html",
+      "/api/qiskit/qiskit.circuit.BreakLoopOp",
+    ],
+    [
+      "https://qiskit.org/documentation/apidoc/qiskit.circuit.BreakLoopOp.html#method",
+      "/api/qiskit/qiskit.circuit.BreakLoopOp#method",
+    ],
+    [
+      "https://qiskit.org/documentation/apidoc/qiskit.circuit.BreakLoopOp.html#qiskit.circuit.BreakLoopOp",
+      "/api/qiskit/qiskit.circuit.BreakLoopOp",
+    ],
+  ])("transform qiskit.org Qiskit API links", (input, expected) => {
+    expect(relativizeLink({ url: input })).toEqual({ url: expected });
+  });
+
+  test("update link text when the same as the URL", () => {
+    const url = "https://qiskit.org/documentation/apidoc/algorithms.html";
+    expect(relativizeLink({ url, text: url })?.text).toEqual("algorithms");
+    expect(relativizeLink({ url, text: "my text" })?.text).toBeUndefined();
   });
 });

--- a/scripts/lib/api/updateLinks.ts
+++ b/scripts/lib/api/updateLinks.ts
@@ -21,12 +21,16 @@ import remarkGfm from "remark-gfm";
 import remarkMdx from "remark-mdx";
 import remarkStringify from "remark-stringify";
 
-import { removePart, removePrefix } from "../stringUtils";
+import { removePart, removePrefix, removeSuffix } from "../stringUtils";
 import { HtmlToMdResultWithUrl } from "./HtmlToMdResult";
 import { remarkStringifyOptions } from "./commonParserConfig";
-import { Link } from "./Pkg";
 import { ObjectsInv } from "./objectsInv";
 import { transformSpecialCaseUrl } from "./specialCaseResults";
+
+export interface Link {
+  url: string; // Where the link goes
+  text?: string; // What the user sees
+}
 
 /**
  * Anchors generated from markdown headings are always lower case but, if these
@@ -50,7 +54,7 @@ function lowerCaseIfMarkdownAnchor(url: string): string {
   return `${base}#${newAnchor}`;
 }
 
-export function updateUrl(
+export function normalizeUrl(
   url: string,
   resultsByName: { [key: string]: HtmlToMdResultWithUrl },
   itemNames: Set<string>,
@@ -95,10 +99,29 @@ export function updateUrl(
   return url;
 }
 
+export function relativizeLink(link: Link): Link | undefined {
+  const prefixes = [
+    "https://qiskit.org/documentation/apidoc/",
+    "https://qiskit.org/documentation/stubs/",
+  ];
+  const prefix = prefixes.find((prefix) => link.url.startsWith(prefix));
+  if (!prefix) {
+    return;
+  }
+  let [url, anchor] = link.url.split("#");
+  url = removePrefix(url, prefix);
+  url = removeSuffix(url, ".html");
+  if (anchor && anchor !== url) {
+    url = `${url}#${anchor}`;
+  }
+
+  const newText = link.url === link.text ? url : undefined;
+  return { url: `/api/qiskit/${url}`, text: newText };
+}
+
 export async function updateLinks(
   results: HtmlToMdResultWithUrl[],
   maybeObjectsInv?: ObjectsInv,
-  transformLink?: (link: Link) => Link | undefined,
 ): Promise<void> {
   const resultsByName = keyBy(results, (result) => result.meta.apiName!);
   const itemNames = new Set(keys(resultsByName));
@@ -109,29 +132,24 @@ export async function updateLinks(
       .use(remarkMath)
       .use(remarkGfm)
       .use(remarkMdx)
-      .use(() => {
-        return async (tree: Root) => {
-          visit(tree, "link", (node) => {
-            if (transformLink) {
-              const textNode =
-                node.children?.[0]?.type === "text"
-                  ? node.children?.[0]
-                  : undefined;
-              const transformedLink = transformLink({
-                url: node.url,
-                text: textNode?.value,
-              });
-              if (transformedLink) {
-                node.url = transformedLink.url;
-                if (textNode && transformedLink.text) {
-                  textNode.value = transformedLink.text;
-                }
-                return;
-              }
-            }
-            node.url = updateUrl(node.url, resultsByName, itemNames);
+      .use(() => async (tree: Root) => {
+        visit(tree, "link", (node) => {
+          const textNode =
+            node.children?.[0]?.type === "text"
+              ? node.children?.[0]
+              : undefined;
+          const relativizedLink = relativizeLink({
+            url: node.url,
+            text: textNode?.value,
           });
-        };
+          if (relativizedLink) {
+            node.url = relativizedLink.url;
+            if (textNode && relativizedLink.text) {
+              textNode.value = relativizedLink.text;
+            }
+          }
+          node.url = normalizeUrl(node.url, resultsByName, itemNames);
+        });
       })
       .use(remarkStringify, remarkStringifyOptions)
       .process(result.markdown);
@@ -140,6 +158,6 @@ export async function updateLinks(
   }
 
   maybeObjectsInv?.updateUris((uri: string) =>
-    updateUrl(uri, resultsByName, itemNames),
+    normalizeUrl(uri, resultsByName, itemNames),
   );
 }


### PR DESCRIPTION
This is prework for https://github.com/Qiskit/documentation/issues/493 to relativize links to docs.quantum.ibm.com. 

This refactors the code that we'll be modifying:

* Always applies the link transformation, whereas before it wasn't used on Qiskit.
* renames `updateUrl` to `normalizeUrl`
* renames `transformLink` to `relativizeLink`
* adds tests for `relativizeLink`