### PR TITLE
Store Sphinx artifacts in a less verbose location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 node_modules
 tsconfig.tsbuildinfo
 
-.out/
+/.out/
+/.sphinx-artifacts/
 poetry.lock
 pyproject.toml

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -34,7 +34,7 @@ import { dedupeHtmlIdsFromResults } from "../lib/api/dedupeHtmlIds";
 import { Pkg } from "../lib/api/Pkg";
 import { zxMain } from "../lib/zx";
 import { pathExists, getRoot, rmFilesInFolder } from "../lib/fs";
-import { downloadCIArtifact } from "../lib/api/apiArtifacts";
+import { downloadSphinxArtifact } from "../lib/api/sphinxArtifacts";
 import {
   addNewReleaseNotes,
   generateReleaseNotesIndex,
@@ -119,11 +119,16 @@ zxMain(async () => {
     type,
   );
 
-  const artifactFolder = pkg.ciArtifactFolder();
-  if (args.skipDownload && (await pathExists(`${artifactFolder}/artifact`))) {
-    console.log(`Skip downloading sources for ${pkg.name}:${pkg.version}`);
+  const sphinxArtifactFolder = pkg.sphinxArtifactFolder();
+  if (
+    args.skipDownload &&
+    (await pathExists(`${sphinxArtifactFolder}/artifact`))
+  ) {
+    console.log(
+      `Skip downloading sources for ${pkg.name}:${pkg.versionWithoutPatch}`,
+    );
   } else {
-    await downloadCIArtifact(pkg, artifactFolder);
+    await downloadSphinxArtifact(pkg, sphinxArtifactFolder);
   }
 
   const outputDir = pkg.outputDir(`${getRoot()}/docs`);
@@ -139,7 +144,11 @@ zxMain(async () => {
   console.log(
     `Convert sphinx html to markdown for ${pkg.name}:${pkg.versionWithoutPatch}`,
   );
-  await convertHtmlToMarkdown(`${artifactFolder}/artifact`, outputDir, pkg);
+  await convertHtmlToMarkdown(
+    `${sphinxArtifactFolder}/artifact`,
+    outputDir,
+    pkg,
+  );
 });
 
 async function convertHtmlToMarkdown(

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -140,8 +140,10 @@ export class Pkg {
     return path;
   }
 
-  ciArtifactFolder(): string {
-    return `${getRoot()}/.out/python/sources/${this.name}/${this.version}`;
+  sphinxArtifactFolder(): string {
+    return `${getRoot()}/.sphinx-artifacts/${this.name}/${
+      this.versionWithoutPatch
+    }`;
   }
 
   isHistorical(): boolean {

--- a/scripts/lib/api/sphinxArtifacts.ts
+++ b/scripts/lib/api/sphinxArtifacts.ts
@@ -34,7 +34,7 @@ async function downloadFromBox(
   }
 }
 
-export async function downloadCIArtifact(pkg: Pkg, artifactFolder: string) {
+export async function downloadSphinxArtifact(pkg: Pkg, artifactFolder: string) {
   if (await pathExists(artifactFolder)) {
     await $`rm -rf ${artifactFolder}/*`;
   } else {


### PR DESCRIPTION
Before: `.out/python/sources/qiskit/0.40.0`
After: `.sphinx-artifacts/qiskit/0.40`

We weren't storing anything else in `.out`, so there was no need to have those subfolders.

It also isn't necessary to put the patch version in the folder name since we only ever have one patch per minor release.