### PR TITLE
Link checker: Qiskit legacy release notes in a single FileBatch

### DIFF
--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -318,7 +318,7 @@ async function determineQiskitLegacyReleaseNotes(): Promise<FileBatch> {
 
   return await FileBatch.fromGlobs(
     toCheck,
-    [`docs/api/qiskit/0.44/*`],
+    [`docs/api/qiskit/0.45/*`],
     `qiskit legacy release notes`,
   );
 }

--- a/scripts/lib/api/releaseNotes.ts
+++ b/scripts/lib/api/releaseNotes.ts
@@ -97,6 +97,37 @@ export function currentReleaseNotesPath(pkg: Pkg): string {
 }
 
 /**
+ * Compares two release note versions. Returns `1` if version1
+ * is newer than version2, and `-1` otherwise. In case of being
+ * the same version, the function returns `0`
+ */
+export function compareReleaseNotes(version1: string, version2: string) {
+  const major1 = version1.split(".")[0];
+  const major2 = version2.split(".")[0];
+
+  const compareMajorVersion = major1.localeCompare(major2, "en", {
+    numeric: true,
+    sensitivity: "base",
+  });
+  if (compareMajorVersion != 0) {
+    return compareMajorVersion;
+  }
+
+  const minor1 = version1.split(".")[1];
+  const minor2 = version2.split(".")[1];
+
+  const compareMinorVersion = minor1.localeCompare(minor2, "en", {
+    numeric: true,
+    sensitivity: "base",
+  });
+  if (compareMinorVersion != 0) {
+    return compareMinorVersion;
+  }
+
+  return 0;
+}
+
+/**
  * Adds a new entry for the release notes of the current API version to the _toc.json
  * of all historical API versions.
  */


### PR DESCRIPTION
The legacy release notes of qiskit were generated from qiskit 0.45 and we need to check them loading those docs. This PR groups together all the legacy release notes in a FileBatch to avoid loading the same docs multiple times.

We define a legacy version to be prior to qiskit 0.45. In order to compare which version is newer or older than 0.45, this PR introduces a new function named `compareReleaseNotes`. We can't use simple comparisons like +version < 0.45 as we do in the other scripts because the comparison between version 0.5 and 0.45 will be incorrect.