### PR TITLE
Split out `InternalLink` and `ExternalLink` classes

### DIFF
--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -17,7 +17,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
 import { pathExists } from "../lib/fs";
-import { File } from "../lib/links/LinkChecker";
+import { File } from "../lib/links/InternalLink";
 import { FileBatch } from "../lib/links/FileBatch";
 import { QISKIT_MISSING_VERSION_MAPPING } from "../lib/qiskitMetapackage";
 

--- a/scripts/lib/links/ExternalLink.test.ts
+++ b/scripts/lib/links/ExternalLink.test.ts
@@ -1,0 +1,39 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2024.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { describe, expect, test } from "@jest/globals";
+import { ExternalLink } from "./ExternalLink";
+
+test("ExternalLink constructor ignores anchors", () => {
+  const link = new ExternalLink("https://ibm.com#my-anchor", []);
+  expect(link.value).toEqual("https://ibm.com");
+});
+
+describe("ExternalLink.check()", () => {
+  test("valid link", async () => {
+    let link = new ExternalLink("https://github.com/Qiskit", [
+      "/testorigin.mdx",
+    ]);
+    const result = await link.check();
+    expect(result).toBeUndefined();
+  });
+
+  test("Validate existing external links", async () => {
+    let link = new ExternalLink("https://github.com/QiskitNotExistingRepo", [
+      "/testorigin.mdx",
+    ]);
+    const result = await link.check();
+    expect(result).toEqual(
+      "❌ Could not find link 'https://github.com/QiskitNotExistingRepo'. Appears in:\n    /testorigin.mdx",
+    );
+  });
+});

--- a/scripts/lib/links/ExternalLink.ts
+++ b/scripts/lib/links/ExternalLink.ts
@@ -1,0 +1,58 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2024.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+export class ExternalLink {
+  readonly value: string;
+  readonly originFiles: Set<string>;
+
+  /**
+   * linkString: Link as it appears in source file
+   * originFiles: Paths to source file containing link
+   */
+  constructor(linkString: string, originFiles: string[]) {
+    if (!linkString.startsWith("http")) {
+      throw new Error(
+        `Invalid ExternalLink, should start with 'http': ${linkString}`,
+      );
+    }
+
+    // We strip anchors.
+    this.value = linkString.split("#", 2)[0];
+    this.originFiles = new Set(originFiles);
+  }
+
+  /**
+   * Returns an error message if link failed.
+   */
+  async check(): Promise<string | undefined> {
+    let error: string = "";
+    try {
+      const response = await fetch(this.value, {
+        headers: { "User-Agent": "qiskit-documentation-broken-links-finder" },
+      });
+      if (response.status >= 300) {
+        error = `Could not find link '${this.value}'`;
+      }
+    } catch (error) {
+      error = `Failed to fetch '${this.value}': ${(error as Error).message}`;
+    }
+
+    if (!error) {
+      return;
+    }
+
+    const fileList = Array.from(this.originFiles)
+      .sort()
+      .map((originFile) => `    ${originFile}`);
+    return `❌ ${error}. Appears in:\n${fileList.join("\n")}`;
+  }
+}

--- a/scripts/lib/links/FileBatch.ts
+++ b/scripts/lib/links/FileBatch.ts
@@ -117,9 +117,7 @@ export class FileBatch {
     const [docsFiles, internalLinkList, externalLinkList] = await this.load();
     const existingFiles = docsFiles.concat(otherFiles);
 
-    const results = await Promise.all(
-      internalLinkList.map((link) => link.check(existingFiles)),
-    );
+    const results = internalLinkList.map((link) => link.check(existingFiles));
 
     if (externalLinks) {
       // For loop reduces the risk of rate-limiting.

--- a/scripts/lib/links/InternalLink.test.ts
+++ b/scripts/lib/links/InternalLink.test.ts
@@ -11,96 +11,71 @@
 // that they have been altered from the originals.
 
 import { describe, expect, test } from "@jest/globals";
-import { File, Link } from "./LinkChecker";
+import { File, InternalLink } from "./InternalLink";
 
-describe("Test the constructor of Link", () => {
-  test("Initialize internal link without anchors", () => {
-    let testLink = new Link("/testpath", ["/testorigin.mdx"]);
-    const attributes = [
-      testLink.value,
-      testLink.anchor,
-      testLink.originFiles,
-      testLink.isExternal,
-    ];
-    const correct_values = [
-      "/testpath",
-      "",
-      new Set(["/testorigin.mdx"]),
-      false,
-    ];
+describe("Test the constructor of InternalLink", () => {
+  test("without anchors", () => {
+    let testLink = new InternalLink("/testpath", ["/testorigin.mdx"]);
+    const attributes = [testLink.value, testLink.anchor, testLink.originFiles];
+    const correct_values = ["/testpath", "", new Set(["/testorigin.mdx"])];
     expect(attributes).toEqual(correct_values);
   });
 
-  test("Initialize internal link with anchors", () => {
-    let testLink = new Link("/testpath#testanchor", ["/testorigin.mdx"]);
-    const attributes = [
-      testLink.value,
-      testLink.anchor,
-      testLink.originFiles,
-      testLink.isExternal,
-    ];
+  test("with anchors", () => {
+    let testLink = new InternalLink("/testpath#testanchor", [
+      "/testorigin.mdx",
+    ]);
+    const attributes = [testLink.value, testLink.anchor, testLink.originFiles];
     const correct_values = [
       "/testpath",
       "#testanchor",
       new Set(["/testorigin.mdx"]),
-      false,
-    ];
-    expect(attributes).toEqual(correct_values);
-  });
-
-  test("Initialize external link", () => {
-    let testLink = new Link("https://test.link.com", ["/testorigin.mdx"]);
-    const attributes = [
-      testLink.value,
-      testLink.anchor,
-      testLink.originFiles,
-      testLink.isExternal,
-    ];
-    const correct_values = [
-      "https://test.link.com",
-      "",
-      new Set(["/testorigin.mdx"]),
-      true,
     ];
     expect(attributes).toEqual(correct_values);
   });
 });
 
 describe("Validate links", () => {
-  test("Validate existing internal links with absolute path", async () => {
-    let testLink = new Link("/testpath", ["/testorigin.mdx"]);
+  test("existing with absolute path", async () => {
+    let testLink = new InternalLink("/testpath", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("Validate non-existing internal links with absolute path", async () => {
-    let testLink = new Link("/test-alternative-path", ["/testorigin.mdx"]);
+  test("non-existing with absolute path", async () => {
+    let testLink = new InternalLink("/test-alternative-path", [
+      "/testorigin.mdx",
+    ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '/test-alternative-path'. Appears in:\n    /testorigin.mdx",
     );
   });
 
-  test("Validate existing internal links with relative path", async () => {
-    let testLink = new Link("../testpath", ["docs/test/testorigin.mdx"]);
+  test("existing with relative path", async () => {
+    let testLink = new InternalLink("../testpath", [
+      "docs/test/testorigin.mdx",
+    ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("Validate non-existing internal links with relative path", async () => {
-    let testLink = new Link("../testpath", ["docs/test1/test2/testorigin.mdx"]);
+  test("non-existing with relative path", async () => {
+    let testLink = new InternalLink("../testpath", [
+      "docs/test1/test2/testorigin.mdx",
+    ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath'. Appears in:\n    docs/test1/test2/testorigin.mdx",
     );
   });
 
-  test("Validate existing internal links with absolute path and multiple origin files", async () => {
-    let testLink = new Link("/testpath", [
+  test("existing absolute path and multiple origin files", async () => {
+    let testLink = new InternalLink("/testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
       "docs/test/test3/testorigin.mdx",
@@ -108,12 +83,12 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile1, testFile2]);
+    const results = await testLink.check([testFile1, testFile2]);
     expect(results).toBeUndefined();
   });
 
-  test("Validate non-existing internal links with absolute path and multiple origin files", async () => {
-    let testLink = new Link("/testpath", [
+  test("non-existing with absolute path and multiple origin files", async () => {
+    let testLink = new InternalLink("/testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
       "docs/test/test3/testorigin.mdx",
@@ -121,7 +96,7 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/test/testpath.mdx", []);
     let testFile2 = new File("docs/test2/test3/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile1, testFile2]);
+    const results = await testLink.check([testFile1, testFile2]);
     expect(results).toEqual(
       "❌ Could not find link '/testpath'. Appears in:\n" +
         "    docs/test/test2/test4/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
@@ -131,8 +106,8 @@ describe("Validate links", () => {
     );
   });
 
-  test("Validate internal links with relative path and multiple origin files", async () => {
-    let testLink = new Link("../testpath", [
+  test("relative path and multiple origin files", async () => {
+    let testLink = new InternalLink("../testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
       // Duplicate of the above value to confirm we de-duplicate originFiles.
@@ -142,68 +117,58 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
-    const results = await testLink.checkLink([testFile1, testFile2]);
+    const results = await testLink.check([testFile1, testFile2]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath'. Appears in:\n    docs/test/test2/testorigin.mdx\n    docs/test/test3/testorigin.mdx",
     );
   });
 
-  test("Validate anchor of existing internal links with absolute path", async () => {
-    let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
+  test("anchor with absolute path", async () => {
+    let testLink = new InternalLink("/testpath#test_anchor", [
+      "/testorigin.mdx",
+    ]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("Validate anchor of non-existing internal links with absolute path", async () => {
-    let testLink = new Link("/testpath#test_anchor", ["/testorigin.mdx"]);
+  test("non-existing anchor with absolute path", async () => {
+    let testLink = new InternalLink("/testpath#test_anchor", [
+      "/testorigin.mdx",
+    ]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '/testpath#test_anchor'. Appears in:\n    /testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
     );
   });
 
-  test("Validate anchor of existing internal links with relative path", async () => {
-    let testLink = new Link("../testpath#test_anchor", [
+  test("anchor with relative path", async () => {
+    let testLink = new InternalLink("../testpath#test_anchor", [
       "docs/test/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("Validate anchor of non-existing internal links with relative path", async () => {
-    let testLink = new Link("../testpath#test-anchor", [
+  test("non-existing anchor with relative path", async () => {
+    let testLink = new InternalLink("../testpath#test-anchor", [
       "docs/test/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
-    const results = await testLink.checkLink([testFile]);
+    const results = await testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath#test-anchor'. Appears in:\n    docs/test/testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
-    );
-  });
-
-  test("Validate existing external links", async () => {
-    let testLink = new Link("https://github.com/Qiskit", ["/testorigin.mdx"]);
-    const results = await testLink.checkLink([]);
-    expect(results).toBeUndefined();
-  });
-
-  test("Validate existing external links", async () => {
-    let testLink = new Link("https://github.com/QiskitNotExistingRepo", [
-      "/testorigin.mdx",
-    ]);
-    const results = await testLink.checkLink([]);
-    expect(results).toEqual(
-      "❌ Could not find link 'https://github.com/QiskitNotExistingRepo'. Appears in:\n    /testorigin.mdx",
     );
   });
 });
 
 describe("Generate the possible paths of a given link", () => {
-  test("Possible links for an internal link with a relative path", () => {
-    let testLink = new Link("../testFile", ["docs/test/test2/testorigin.mdx"]);
+  test("Possible links with a relative path", () => {
+    let testLink = new InternalLink("../testFile", [
+      "docs/test/test2/testorigin.mdx",
+    ]);
     let possiblePaths = testLink.possibleFilePaths(
       "docs/test/test2/testorigin.mdx",
     );
@@ -218,8 +183,10 @@ describe("Generate the possible paths of a given link", () => {
     expect(possiblePaths).toEqual(expectedPaths);
   });
 
-  test("Possible links for an internal link with an absolute path", () => {
-    let testLink = new Link("/testFile", ["docs/test/test2/testorigin.mdx"]);
+  test("Possible links with an absolute path", () => {
+    let testLink = new InternalLink("/testFile", [
+      "docs/test/test2/testorigin.mdx",
+    ]);
     let possiblePaths = testLink.possibleFilePaths(
       "docs/test/test2/testorigin.mdx",
     );

--- a/scripts/lib/links/InternalLink.test.ts
+++ b/scripts/lib/links/InternalLink.test.ts
@@ -36,45 +36,45 @@ describe("Test the constructor of InternalLink", () => {
 });
 
 describe("Validate links", () => {
-  test("existing with absolute path", async () => {
+  test("existing with absolute path", () => {
     let testLink = new InternalLink("/testpath", ["/testorigin.mdx"]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("non-existing with absolute path", async () => {
+  test("non-existing with absolute path", () => {
     let testLink = new InternalLink("/test-alternative-path", [
       "/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '/test-alternative-path'. Appears in:\n    /testorigin.mdx",
     );
   });
 
-  test("existing with relative path", async () => {
+  test("existing with relative path", () => {
     let testLink = new InternalLink("../testpath", [
       "docs/test/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("non-existing with relative path", async () => {
+  test("non-existing with relative path", () => {
     let testLink = new InternalLink("../testpath", [
       "docs/test1/test2/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", []);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath'. Appears in:\n    docs/test1/test2/testorigin.mdx",
     );
   });
 
-  test("existing absolute path and multiple origin files", async () => {
+  test("existing absolute path and multiple origin files", () => {
     let testLink = new InternalLink("/testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
@@ -83,11 +83,11 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
-    const results = await testLink.check([testFile1, testFile2]);
+    const results = testLink.check([testFile1, testFile2]);
     expect(results).toBeUndefined();
   });
 
-  test("non-existing with absolute path and multiple origin files", async () => {
+  test("non-existing with absolute path and multiple origin files", () => {
     let testLink = new InternalLink("/testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
@@ -96,7 +96,7 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/test/testpath.mdx", []);
     let testFile2 = new File("docs/test2/test3/testpath.mdx", []);
-    const results = await testLink.check([testFile1, testFile2]);
+    const results = testLink.check([testFile1, testFile2]);
     expect(results).toEqual(
       "❌ Could not find link '/testpath'. Appears in:\n" +
         "    docs/test/test2/test4/testorigin.mdx    ❓ Did you mean '/test/testpath'?\n" +
@@ -106,7 +106,7 @@ describe("Validate links", () => {
     );
   });
 
-  test("relative path and multiple origin files", async () => {
+  test("relative path and multiple origin files", () => {
     let testLink = new InternalLink("../testpath", [
       "docs/test/testorigin.mdx",
       "docs/test/test2/testorigin.mdx",
@@ -117,47 +117,47 @@ describe("Validate links", () => {
     ]);
     let testFile1 = new File("docs/testpath.mdx", []);
     let testFile2 = new File("docs/test/test2/testpath.mdx", []);
-    const results = await testLink.check([testFile1, testFile2]);
+    const results = testLink.check([testFile1, testFile2]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath'. Appears in:\n    docs/test/test2/testorigin.mdx\n    docs/test/test3/testorigin.mdx",
     );
   });
 
-  test("anchor with absolute path", async () => {
+  test("anchor with absolute path", () => {
     let testLink = new InternalLink("/testpath#test_anchor", [
       "/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("non-existing anchor with absolute path", async () => {
+  test("non-existing anchor with absolute path", () => {
     let testLink = new InternalLink("/testpath#test_anchor", [
       "/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '/testpath#test_anchor'. Appears in:\n    /testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
     );
   });
 
-  test("anchor with relative path", async () => {
+  test("anchor with relative path", () => {
     let testLink = new InternalLink("../testpath#test_anchor", [
       "docs/test/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_anchor"]);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toBeUndefined();
   });
 
-  test("non-existing anchor with relative path", async () => {
+  test("non-existing anchor with relative path", () => {
     let testLink = new InternalLink("../testpath#test-anchor", [
       "docs/test/testorigin.mdx",
     ]);
     let testFile = new File("docs/testpath.mdx", ["#test_diff_anchor"]);
-    const results = await testLink.check([testFile]);
+    const results = testLink.check([testFile]);
     expect(results).toEqual(
       "❌ Could not find link '../testpath#test-anchor'. Appears in:\n    docs/test/testorigin.mdx    ❓ Did you mean '/testpath#test_diff_anchor'?",
     );

--- a/scripts/lib/links/InternalLink.ts
+++ b/scripts/lib/links/InternalLink.ts
@@ -172,7 +172,7 @@ export class InternalLink {
   /**
    * Returns an error message if link failed.
    */
-  async check(existingFiles: File[]): Promise<string | undefined> {
+  check(existingFiles: File[]): string | undefined {
     const failingFiles: string[] = [];
     this.originFiles.forEach((originFile) => {
       if (this.isValid(existingFiles, originFile)) {

--- a/scripts/lib/links/InternalLink.ts
+++ b/scripts/lib/links/InternalLink.ts
@@ -22,7 +22,7 @@ export class File {
   readonly synthetic: boolean;
 
   /**
-   *    path: Path to the file
+   * path: Path to the file
    * anchors: Anchors available in the file
    */
   constructor(path: string, anchors: string[], synthetic: boolean = false) {
@@ -32,22 +32,25 @@ export class File {
   }
 }
 
-export class Link {
+export class InternalLink {
   readonly value: string;
   readonly anchor: string;
   readonly originFiles: Set<string>;
-  readonly isExternal: boolean;
 
   /**
    *  linkString: Link as it appears in source file
    * originFiles: Paths to source file containing link
    */
   constructor(linkString: string, originFiles: string[]) {
+    if (linkString.startsWith("http")) {
+      throw new Error(
+        `Invalid InternalLink, cannot start with 'http': ${linkString}`,
+      );
+    }
     const splitLink = linkString.split("#", 2);
     this.value = splitLink[0];
     this.anchor = splitLink.length > 1 ? `#${splitLink[1]}` : "";
     this.originFiles = new Set(originFiles);
-    this.isExternal = linkString.startsWith("http");
   }
 
   /*
@@ -83,29 +86,9 @@ export class Link {
   }
 
   /**
-   * Returns a string with the error found, or null
-   * if there are no errors.
+   * Returns true if link is in `existingFiles`, otherwise false.
    */
-  async checkExternalLink(): Promise<string | null> {
-    try {
-      const response = await fetch(this.value, {
-        headers: { "User-Agent": "qiskit-documentation-broken-links-finder" },
-      });
-
-      if (response.status >= 300) {
-        return `Could not find link '${this.value}'`;
-      }
-    } catch (error) {
-      return `Failed to fetch '${this.value}': ${(error as Error).message}`;
-    }
-
-    return null;
-  }
-
-  /**
-   * True if link is in `existingFiles`, otherwise false
-   */
-  checkInternalLink(existingFiles: File[], originFile: string): boolean {
+  isValid(existingFiles: File[], originFile: string): boolean {
     const possiblePaths = this.possibleFilePaths(originFile);
     return possiblePaths.some((filePath) =>
       existingFiles.some(
@@ -189,32 +172,21 @@ export class Link {
   /**
    * Returns an error message if link failed.
    */
-  async checkLink(existingFiles: File[]): Promise<string | undefined> {
-    if (!this.isExternal) {
-      const failingFiles: string[] = [];
-      this.originFiles.forEach((originFile) => {
-        if (this.checkInternalLink(existingFiles, originFile)) {
-          return;
-        }
-        const resultSuggestion = this.didYouMean(existingFiles, originFile);
-        const suggestedPath = resultSuggestion ? `    ${resultSuggestion}` : "";
-        failingFiles.push(`    ${originFile}${suggestedPath}`);
-      });
+  async check(existingFiles: File[]): Promise<string | undefined> {
+    const failingFiles: string[] = [];
+    this.originFiles.forEach((originFile) => {
+      if (this.isValid(existingFiles, originFile)) {
+        return;
+      }
+      const resultSuggestion = this.didYouMean(existingFiles, originFile);
+      const suggestedPath = resultSuggestion ? `    ${resultSuggestion}` : "";
+      failingFiles.push(`    ${originFile}${suggestedPath}`);
+    });
 
-      return failingFiles.length === 0
-        ? undefined
-        : `❌ Could not find link '${this.value}${
-            this.anchor
-          }'. Appears in:\n${failingFiles.sort().join("\n")}`;
-    }
-
-    const externalError = await this.checkExternalLink();
-    if (!externalError) {
-      return;
-    }
-    const fileList = Array.from(this.originFiles)
-      .sort()
-      .map((originFile) => `    ${originFile}`);
-    return `❌ ${externalError}. Appears in:\n${fileList.join("\n")}`;
+    return failingFiles.length === 0
+      ? undefined
+      : `❌ Could not find link '${this.value}${
+          this.anchor
+        }'. Appears in:\n${failingFiles.sort().join("\n")}`;
   }
 }

--- a/scripts/lib/links/extractLinks.ts
+++ b/scripts/lib/links/extractLinks.ts
@@ -29,7 +29,7 @@ export type ParsedFile = {
   /** Anchors that the file defines. These can be linked to from other files. */
   anchors: string[];
   /** Links that this file has to other places. These need to be validated. */
-  links: string[];
+  rawLinks: string[];
 };
 
 interface JupyterCell {
@@ -83,7 +83,7 @@ async function parseObjectsInv(filePath: string): Promise<ParsedFile> {
   // All URIs are relative to the objects.inv file
   const dirname = removePrefix(path.dirname(filePath), "public");
   const links = objinv.entries.map((entry) => path.join(dirname, entry.uri));
-  return { links, anchors: [] };
+  return { rawLinks: links, anchors: [] };
 }
 
 export async function parseFile(filePath: string): Promise<ParsedFile> {
@@ -94,5 +94,5 @@ export async function parseFile(filePath: string): Promise<ParsedFile> {
   const markdown =
     path.extname(filePath) === ".ipynb" ? markdownFromNotebook(source) : source;
   const links = await parseLinks(markdown);
-  return { anchors: parseAnchors(markdown), links };
+  return { anchors: parseAnchors(markdown), rawLinks: links };
 }


### PR DESCRIPTION
We decided as part of https://github.com/Qiskit/documentation/issues/876 that we should have distinct programs for checking internal vs external links, since they are such distinct workflows.

This PR is a refactor to prepare for that change. The link checker program still behaves the same as before; this is only a refactor.