### PR TITLE
Fix logic for checking historical Qiskit docs

### DIFF
--- a/scripts/commands/checkLinks.ts
+++ b/scripts/commands/checkLinks.ts
@@ -172,8 +172,11 @@ async function determineCurrentDocsFileBatch(
     "!docs/api/qiskit/release-notes/*",
   ];
   const toLoad = [
-    // The 0.46 docs are used by migration guides.
-    "docs/api/qiskit/0.46/*.md",
+    // These docs are used by the migration guides.
+    "docs/api/qiskit/0.46/{algorithms,opflow,execute}.md",
+    "docs/api/qiskit/0.46/qiskit.{algorithms,extensions,opflow}.*",
+    "docs/api/qiskit/0.46/qiskit.utils.QuantumInstance.md",
+    "docs/api/qiskit/0.46/qiskit.primitives.Base{Estimator,Sampler}.md",
     "docs/api/qiskit/0.44/qiskit.extensions.{Hamiltonian,Unitary}Gate.md",
     "docs/api/qiskit/release-notes/index.md",
   ];
@@ -200,11 +203,12 @@ async function determineCurrentDocsFileBatch(
 
   let description: string;
   if (args.currentApis && args.qiskitReleaseNotes) {
-    description = "non-API docs, current API docs, and Qiskit release notes";
+    description =
+      "non-API docs, current API docs, and latest Qiskit release note";
   } else if (args.currentApis) {
     description = "non-API docs and current API docs";
   } else if (args.qiskitReleaseNotes) {
-    description = "non-API docs and Qiskit release notes";
+    description = "non-API docs and latest Qiskit release note";
   } else {
     description = "non-API docs";
   }
@@ -254,23 +258,25 @@ async function determineHistoricalFileBatches(
     const toCheck: string[] = [];
     const toLoad = [...extraGlobsToLoad];
 
+    // Qiskit legacy release notes (< 0.45) have their own FileBatch, and we don't
+    // need to check them here.
+    const isBeforeQiskit0_45 = projectName === "qiskit" && +folder.name < 0.45;
+    if (!checkHistoricalApiDocs && isBeforeQiskit0_45) {
+      continue;
+    }
+
     if (checkHistoricalApiDocs) {
       toCheck.push(
         `docs/api/${projectName}/${folder.name}/*`,
         `public/api/${projectName}/${folder.name}/objects.inv`,
       );
-    } else {
-      toLoad.push(`docs/api/${projectName}/${folder.name}/*`);
     }
 
-    if (checkSeparateReleaseNotes) {
-      // Qiskit legacy release notes (< 0.45) have their own FileBatch, and we don't
-      // need to check them here
-      if (projectName == "qiskit" && +folder.name < 0.45) {
-        continue;
-      }
-
+    if (checkSeparateReleaseNotes && !isBeforeQiskit0_45) {
       toCheck.push(`docs/api/${projectName}/release-notes/${folder.name}.md`);
+      if (!checkHistoricalApiDocs) {
+        toLoad.push(`docs/api/${projectName}/${folder.name}/*`);
+      }
     }
 
     const fileBatch = await FileBatch.fromGlobs(


### PR DESCRIPTION
Fixes a bug in https://github.com/Qiskit/documentation/pull/881. It handled `--qiskit-release-notes` correctly, but it incorrectly would skip `--historical-apis` for Qiskit versions before 0.45.

This also loads fewer files for the migration guides.