### PR TITLE
Deduplicate headers for overloaded methods

### DIFF
--- a/docs/api/qiskit/0.33/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.33/qiskit.circuit.QuantumCircuit.md
@@ -1259,13 +1259,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1550,13 +1546,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4050,13 +4042,9 @@ Apply unitary gate to q.
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.19/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.35/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.35/qiskit.circuit.QuantumCircuit.md
@@ -1259,13 +1259,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1550,13 +1546,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4166,13 +4158,9 @@ Apply unitary gate to q.
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.35/utils.md
+++ b/docs/api/qiskit/0.35/utils.md
@@ -168,13 +168,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -194,13 +190,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.36/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.36/qiskit.circuit.QuantumCircuit.md
@@ -1259,13 +1259,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1550,13 +1546,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4166,13 +4158,9 @@ Apply unitary gate to q.
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.20/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.36/utils.md
+++ b/docs/api/qiskit/0.36/utils.md
@@ -168,13 +168,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -194,13 +190,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.37/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.37/qiskit.circuit.QuantumCircuit.md
@@ -1310,13 +1310,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1609,13 +1605,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4259,13 +4251,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.37/utils.md
+++ b/docs/api/qiskit/0.37/utils.md
@@ -170,13 +170,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -196,13 +192,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.38/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.38/qiskit.circuit.QuantumCircuit.md
@@ -1310,13 +1310,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1609,13 +1605,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4113,13 +4105,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.21/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.38/utils.md
+++ b/docs/api/qiskit/0.38/utils.md
@@ -170,13 +170,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -196,13 +192,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.39/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.39/qiskit.circuit.QuantumCircuit.md
@@ -1392,13 +1392,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.22/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1691,13 +1687,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.22/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -4197,13 +4189,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.22/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.39/utils.md
+++ b/docs/api/qiskit/0.39/utils.md
@@ -171,13 +171,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -197,13 +193,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.40/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.40/qiskit.circuit.QuantumCircuit.md
@@ -1247,13 +1247,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1567,13 +1563,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -3935,13 +3927,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.40/utils.md
+++ b/docs/api/qiskit/0.40/utils.md
@@ -172,13 +172,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -198,13 +194,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.41/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.41/qiskit.circuit.QuantumCircuit.md
@@ -1229,13 +1229,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1549,13 +1545,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -3915,13 +3907,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.41/utils.md
+++ b/docs/api/qiskit/0.41/utils.md
@@ -172,13 +172,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -198,13 +194,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.42/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.42/qiskit.circuit.QuantumCircuit.md
@@ -1229,13 +1229,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Optional[qiskit.circuit.parameter.Parameter], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 
@@ -1549,13 +1545,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], true_body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str] = 'None') → qiskit.circuit.instructionset.InstructionSet`
 
@@ -3915,13 +3907,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: None, qubits: None, clbits: None, *, label: Optional[str]) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.23/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: Tuple[Union[qiskit.circuit.classicalregister.ClassicalRegister, qiskit.circuit.classicalregister.Clbit], int], body: QuantumCircuit, qubits: Sequence[Union[qiskit.circuit.quantumregister.Qubit, qiskit.circuit.quantumregister.QuantumRegister, int, slice, Sequence[Union[qiskit.circuit.quantumregister.Qubit, int]]]], clbits: Sequence[Union[qiskit.circuit.classicalregister.Clbit, qiskit.circuit.classicalregister.ClassicalRegister, int, slice, Sequence[Union[qiskit.circuit.classicalregister.Clbit, int]]]], *, label: Optional[str]) → qiskit.circuit.instructionset.InstructionSet`
 

--- a/docs/api/qiskit/0.42/utils.md
+++ b/docs/api/qiskit/0.42/utils.md
@@ -172,13 +172,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -198,13 +194,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.43/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.43/qiskit.circuit.QuantumCircuit.md
@@ -180,13 +180,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-##### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `QuantumCircuit.assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False) → QuantumCircuit`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.24/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `QuantumCircuit.assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False) → None`
 
@@ -1307,13 +1303,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-##### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.for_loop.ForLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.24/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `QuantumCircuit.for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1678,13 +1670,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-##### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.if_else.IfContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.24/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `QuantumCircuit.if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3300,13 +3288,9 @@ A handle to the instructions created.
 
 ### switch
 
-##### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `QuantumCircuit.switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.switch_case.SwitchContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.24/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `QuantumCircuit.switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3770,13 +3754,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-##### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: tuple[ClassicalRegister | Clbit, int], body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`[GitHub](https://github.com/qiskit/qiskit/tree/stable/0.24/qiskit/circuit/quantumcircuit.py "view source code")
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `QuantumCircuit.while_loop(condition: tuple[ClassicalRegister | Clbit, int], body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/0.43/utils.md
+++ b/docs/api/qiskit/0.43/utils.md
@@ -179,13 +179,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -205,13 +201,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.44/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.44/qiskit.circuit.QuantumCircuit.md
@@ -361,13 +361,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False, *, flat_input: bool = False, strict: bool = True) → QuantumCircuit`
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False, *, flat_input: bool = False, strict: bool = True) → None`
 
@@ -1416,13 +1412,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.for_loop.ForLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1769,13 +1761,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.if_else.IfContext`
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3294,13 +3282,9 @@ A handle to the instructions created.
 
 ### switch
 
-### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.switch_case.SwitchContext`
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3734,13 +3718,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/0.44/utils.md
+++ b/docs/api/qiskit/0.44/utils.md
@@ -543,13 +543,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -569,13 +565,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.45/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.45/qiskit.circuit.QuantumCircuit.md
@@ -361,13 +361,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False, *, flat_input: bool = False, strict: bool = True) → QuantumCircuit`
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False, *, flat_input: bool = False, strict: bool = True) → None`
 
@@ -1429,13 +1425,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.for_loop.ForLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1786,13 +1778,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.if_else.IfContext`
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3330,13 +3318,9 @@ A handle to the instructions created.
 
 ### switch
 
-### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.switch_case.SwitchContext`
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3786,13 +3770,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/0.45/utils.md
+++ b/docs/api/qiskit/0.45/utils.md
@@ -543,13 +543,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -569,13 +565,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/0.46/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/0.46/qiskit.circuit.QuantumCircuit.md
@@ -361,13 +361,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False, *, flat_input: bool = False, strict: bool = True) → QuantumCircuit`
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False, *, flat_input: bool = False, strict: bool = True) → None`
 
@@ -1429,13 +1425,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.for_loop.ForLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1786,13 +1778,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.if_else.IfContext`
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3334,13 +3322,9 @@ A handle to the instructions created.
 
 ### switch
 
-### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.switch_case.SwitchContext`
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3790,13 +3774,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: None, qubits: None, clbits: None, *, label: str | None) → qiskit.circuit.controlflow.while_loop.WhileLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/0.46/utils.md
+++ b/docs/api/qiskit/0.46/utils.md
@@ -616,13 +616,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -642,13 +638,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/dev/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/dev/qiskit.circuit.QuantumCircuit.md
@@ -346,13 +346,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False, *, flat_input: bool = False, strict: bool = True) → QuantumCircuit`
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False, *, flat_input: bool = False, strict: bool = True) → None`
 
@@ -1345,13 +1341,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → ForLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1497,13 +1489,9 @@ list of (instruction, qargs, cargs).
 
 ### get\_parameter
 
-### get\_parameter
-
 <span id="qiskit.circuit.QuantumCircuit.get_parameter" />
 
 `get_parameter(name: str, default: T) → Parameter | T`
-
-<span id="qiskit.circuit.QuantumCircuit.get_parameter" />
 
 `get_parameter(name: str, default: ellipsis = Ellipsis) → Parameter`
 
@@ -1695,13 +1683,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → IfContext`
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3028,13 +3012,9 @@ A handle to the instructions created.
 
 ### switch
 
-### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → SwitchContext`
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3323,13 +3303,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: None, qubits: None, clbits: None, *, label: str | None) → WhileLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/dev/utils.md
+++ b/docs/api/qiskit/dev/utils.md
@@ -444,13 +444,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -470,13 +466,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/docs/api/qiskit/qiskit.circuit.QuantumCircuit.md
+++ b/docs/api/qiskit/qiskit.circuit.QuantumCircuit.md
@@ -346,13 +346,9 @@ a handle to the [`CircuitInstruction`](qiskit.circuit.CircuitInstruction "qiskit
 
 ### assign\_parameters
 
-### assign\_parameters
-
 <span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[False] = False, *, flat_input: bool = False, strict: bool = True) → QuantumCircuit`
-
-<span id="qiskit.circuit.QuantumCircuit.assign_parameters" />
 
 `assign_parameters(parameters: Mapping[Parameter, ParameterExpression | float] | Sequence[ParameterExpression | float], inplace: Literal[True] = False, *, flat_input: bool = False, strict: bool = True) → None`
 
@@ -1345,13 +1341,9 @@ The circuit index of an [`AncillaQubit`](qiskit.circuit.AncillaQubit "qiskit.cir
 
 ### for\_loop
 
-### for\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: None, qubits: None, clbits: None, *, label: str | None) → ForLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.for_loop" />
 
 `for_loop(indexset: Iterable[int], loop_parameter: Parameter | None, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -1497,13 +1489,9 @@ list of (instruction, qargs, cargs).
 
 ### get\_parameter
 
-### get\_parameter
-
 <span id="qiskit.circuit.QuantumCircuit.get_parameter" />
 
 `get_parameter(name: str, default: T) → Parameter | T`
-
-<span id="qiskit.circuit.QuantumCircuit.get_parameter" />
 
 `get_parameter(name: str, default: ellipsis = Ellipsis) → Parameter`
 
@@ -1695,13 +1683,9 @@ A handle to the instruction created.
 
 ### if\_test
 
-### if\_test
-
 <span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: None, qubits: None, clbits: None, *, label: str | None) → IfContext`
-
-<span id="qiskit.circuit.QuantumCircuit.if_test" />
 
 `if_test(condition: tuple[ClassicalRegister | Clbit, int], true_body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None = None) → InstructionSet`
 
@@ -3028,13 +3012,9 @@ A handle to the instructions created.
 
 ### switch
 
-### switch
-
 <span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: None, qubits: None, clbits: None, *, label: str | None) → SwitchContext`
-
-<span id="qiskit.circuit.QuantumCircuit.switch" />
 
 `switch(target: Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int], cases: Iterable[Tuple[Any, QuantumCircuit]], qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 
@@ -3323,13 +3303,9 @@ circuit.unitary(matrix, [0, 1])
 
 ### while\_loop
 
-### while\_loop
-
 <span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: None, qubits: None, clbits: None, *, label: str | None) → WhileLoopContext`
-
-<span id="qiskit.circuit.QuantumCircuit.while_loop" />
 
 `while_loop(condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr, body: QuantumCircuit, qubits: Sequence[Qubit | QuantumRegister | int | slice | Sequence[Qubit | int]], clbits: Sequence[Clbit | ClassicalRegister | int | slice | Sequence[Clbit | int]], *, label: str | None) → InstructionSet`
 

--- a/docs/api/qiskit/utils.md
+++ b/docs/api/qiskit/utils.md
@@ -444,13 +444,9 @@ Create a context, during which the value of the dependency manager will be `Fals
 
 ### require\_in\_call
 
-### require\_in\_call
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: Callable) → Callable`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_call" />
 
 `require_in_call(feature_or_callable: str) → Callable[[Callable], Callable]`
 
@@ -470,13 +466,9 @@ Callable
 
 ### require\_in\_instance
 
-### require\_in\_instance
-
 <span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: Type) → Type`
-
-<span id="qiskit.utils.LazyDependencyManager.require_in_instance" />
 
 `require_in_instance(feature_or_class: str) → Callable[[Type], Type]`
 

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -319,6 +319,10 @@ export function processMembersAndSetMeta(
           if (id) {
             if (!priorApiType) {
               $dl.siblings("h1").text(getLastPartFromFullIdentifier(id));
+            } else if (!$child.attr("id")) {
+              // Overload methods have more than one <dt> tag, but only the first one
+              // contains an id.
+              return `<p><code>${$child.html()}</code>${github}</p>`;
             } else {
               // Inline methods
               $(`<h3>${getLastPartFromFullIdentifier(id)}</h3>`).insertBefore(


### PR DESCRIPTION
Closes #167

The script was creating a title for every `<dt>` tag inside a `<dl>` tag. This is almost always correct given that we only have a `<dt>` tag for each method. The problem with overload methods is that we have a `<dt>` for each `@typing.overload` definition.

For example, the `quantumcircuit.py` file overloads the definition of for_loop:

https://github.com/Qiskit/qiskit/blob/244940a10c17f1dc3d74e2665a3ae869dc3d7291/qiskit/circuit/quantumcircuit.py#L4862-L4884

This is an example of the HTML generated

```html
<dl class="py method">
    <dt class="sig sig-object py" id="qiskit.circuit.QuantumCircuit.for_loop">
    <span class="sig-name descname"><span class="pre">for_loop</span>

    <dt class="sig sig-object py">
    <span class="sig-name descname"><span class="pre">for_loop</span>
    
    <dd><p>Create a <code class="docutils literal notranslate"><span class="pre">for</span></code> loop on this circuit.</p>
```
To solve the problem this PR adds an extra condition to check whether the `<dt>` tag has an id or not. Only the first `<dt>` tag will have an id, so we can use this fact to create only one `<h3>` for each method.