### PR TITLE
Replace Squeaky CI advice with custom advice

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -90,6 +90,7 @@ jobs:
             sys.exit(1)
 
       - name: Execute notebooks
+        if: "!cancelled()"
         shell: python
         run: |
           import subprocess
@@ -98,6 +99,7 @@ jobs:
           subprocess.run(args, check=True)
 
       - name: Upload executed notebooks
+        if: "!cancelled()"
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -77,10 +77,18 @@ jobs:
       - name: Check lint
         shell: python
         run: |
-          import subprocess
+          import subprocess, sys
           files = """${{ steps.all-changed-files.outputs.all_changed_files }}"""
           args = ["tox", "-e", "lint", "--"] + files.split("\n")
-          subprocess.run(args, check=True)
+          try:
+            subprocess.run(args, check=True)
+          except:
+            print(
+              "To fix, install `tox` and run `tox -e fix`\n"
+              "For more information, see https://github.com/Qiskit/documentation?tab=readme-ov-file#lint-notebooks"
+            )
+            sys.exit(1)
+
 
       - name: Execute notebooks
         shell: python

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -89,7 +89,6 @@ jobs:
             )
             sys.exit(1)
 
-
       - name: Execute notebooks
         shell: python
         run: |

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -84,7 +84,10 @@ jobs:
             subprocess.run(args, check=True)
           except:
             print(
-              "To fix, install `tox` and run `tox -e fix`\n"
+              "To fix, install `tox` and run `tox -e fix` or download the fixed "
+              "notebook from this run by clicking \"Summary\" on the upper-left "
+              "of this page, and downloading the \"Executed notebooks\" artifact."
+              "\n\n"
               "For more information, see https://github.com/Qiskit/documentation/blob/main/README.md#lint-notebooks"
             )
             sys.exit(1)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,13 @@ page, click "Summary", then download "Executed notebooks".
 ## Lint notebooks
 
 We use [`squeaky`](https://github.com/frankharkins/squeaky) to lint our
-notebooks. To check if a notebook needs linting:
+notebooks. First install `tox` using [pipx](https://pipx.pypa.io/stable/).
+
+```sh
+pipx install tox
+```
+
+To check if a notebook needs linting:
 
 ```sh
 # Check all notebooks in ./docs

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -6,4 +6,4 @@ ipykernel~=6.29.2
 qiskit[all]~=1.0
 qiskit-aer~=0.13.1
 qiskit-ibm-runtime~=0.19.1
-squeaky==0.5.0
+squeaky==0.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
 commands = python scripts/nb-tester/test-notebook.py {posargs}
 
 [testenv:lint]
-commands = squeaky --check {posargs}
+commands = squeaky --check --no-advice {posargs}
 
 [testenv:fix]
 commands = squeaky {posargs}


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/838.

Replaces the message in CI with correct instructions for our repository. I've added a switch to remove the advice from the printed message, I think this is the neatest net logic change: https://github.com/frankharkins/squeaky/commit/33e24f8eb633d25758c787c4efd5d645458c352f.


<img width="600" alt="Screenshot 2024-02-27 at 17 20 42" src="https://github.com/Qiskit/documentation/assets/36071638/dff70ada-2eca-4041-83fd-e0177bc52bca">

See https://github.com/frankharkins/documentation/pull/2 for the test PR.

This doesn't display the message when running `tox -e lint`, but I think it's unlikely a contributor would run that command locally without first encountering it in CI.