### PR TITLE
[wip] Pages render check only runs on changed files

### DIFF
--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: 18
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Check links
+      - name: Check internal links
         run: >
           npm run check:links --
           --qiskit-release-notes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run check:metadata
       - name: Spellcheck
         run: npm run check:spelling
-      - name: Link checker
+      - name: Internal link checker
         run: npm run check:links
       - name: Formatting
         run: npm run check:fmt
@@ -39,9 +39,19 @@ jobs:
       - name: Infrastructure tests
         run: npm test
 
+      - name: Get all changed docs files
+        id: changed-docs-files
+        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
+        with:
+          files: docs/**/*.{md,mdx,ipynb}
+          separator: "\n"
       - name: Start local Docker preview
+        if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |
           ./start &
           sleep 20
       - name: Check that pages render
-        run: npm run check-pages-render
+        if: steps.changed-docs-files.outputs.any_changed == 'true'
+        run: |
+          echo "${{ steps.all-changed-files.outputs.all_changed_files }}" > changed.txt
+          npm run check-pages-render -- --from-file changed.txt

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Check all pages render
         run: >
           npm run check-pages-render --
+          --non-api
           --qiskit-release-notes
           --current-apis
           --dev-apis

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -10,20 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-name: API checks
+name: Weekly checks
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "docs/api/qiskit/**/*"
-      - "docs/api/qiskit-ibm-provider/**/*"
-      - "docs/api/qiskit-ibm-runtime/**/*"
-      - "public/api/**/*"
-      - "scripts/checkLinks.ts"
-      - "scripts/lib/links/ignores.ts"
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
 
 jobs:
-  api-checks:
+  pages-render:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'Qiskit'
     steps:
@@ -34,7 +28,30 @@ jobs:
           node-version: 18
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Check links
+      - name: Start local Docker preview
+        run: |
+          ./start &
+          sleep 20
+      - name: Check all pages render
+        run: >
+          npm run check-pages-render --
+          --qiskit-release-notes
+          --current-apis
+          --dev-apis
+          --historical-apis
+
+  external-link-checker:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Qiskit'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install Node.js dependencies
+        run: npm ci
+      - name: Check external links
         run: >
           npm run check:links --
           --qiskit-release-notes
@@ -42,3 +59,4 @@ jobs:
           --dev-apis
           --historical-apis
           --skip-broken-historical
+          --external

--- a/README.md
+++ b/README.md
@@ -260,12 +260,11 @@ It's possible to write broken pages that crash when loaded. This is usually due 
 To check that all the non-API docs render:
 
 1. Start up the local preview with `./start` by following the instructions at [Preview the docs locally](#preview-the-docs-locally)
-2. In a new tab, `npm run check-pages-render`
+2. In a new tab, `npm run check-pages-render -- --non-apis`
 
-You can also check that API docs and translations render by using any of these arguments: `npm run check-pages-render -- --qiskit-release-notes --current-apis --dev-apis --historical-apis --translations`. Warning that this is exponentially slower.
+You can also check that API docs and translations render by using any of these arguments: `npm run check-pages-render -- --non-apis --qiskit-release-notes --current-apis --dev-apis --historical-apis --translations`. Warning that this is exponentially slower.
 
-CI will check on every PR that non-API docs correctly render. We also run a nightly cron job to check the API docs and
-translations.
+CI will check on every PR that any changed files render correctly. We also run a weekly cron job to check that every page renders correctly.
 
 ## Format TypeScript files
 

--- a/docs/build/bit-ordering.mdx
+++ b/docs/build/bit-ordering.mdx
@@ -3,6 +3,7 @@ title: Bit-ordering in Qiskit
 description: Learn about Qiskit's ordering conventions and why we chose them
 ---
 
+
 # Bit-ordering in Qiskit
 
 If you have a set of $n$ bits (or qubits), you'll usually label each bit $0

--- a/docs/build/index.mdx
+++ b/docs/build/index.mdx
@@ -12,6 +12,7 @@ All tasks require building one or more [quantum circuits](circuit-construction).
 
 Qiskit&reg; enables working with circuits (and, to some extent, operators) at various abstraction levels: abstract, virtual, physical, scheduled, and pulse programs. At the most abstract level is a task-oriented lens in the [circuit library](circuit-library). You can also express operations in abstract mathematical terms using operators, isometries, and classical/Boolean functions. For virtual circuits, mathematical abstractions take on a concrete representation in terms of a concrete gate set. At the physical level, those instructions are mapped to specific physical qubits, and instructions are re-written to reflect the connectivity and native gate set of a target hardware platform. Scheduled circuits introduce timing information, and [pulse programs](pulse) represent signals on channels.
 
+
 Qiskit and [OpenQASM](introduction-to-qasm) further support the notion of extended circuits, which expand the set of allowed operations to include real-time computations on classical values. Qiskit's tooling for working with this richer family of circuits is found in the section on [Classical feedforward and control flow](classical-feedforward-and-control-flow).
 
 ## Next steps


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/886. As explained there, it's safe to only run this check on changed files because whether a page renders is independent from all the other pages. 

We use a weekly cron job, though, to check all pages. That reduces our risk from things like the docs preview Docker image changing on us and resulting in some pages now failing to render.

--

This PR also stops checking external links in API docs builds and instead moves the check to the new weekly cron job. Relates to https://github.com/Qiskit/documentation/issues/876.

Per https://github.com/Qiskit/documentation/pull/372, it's annoying to check external links in CI because it can be flaky (https://github.com/Qiskit/documentation/issues/823).