### PR TITLE
Fix learning uploader to handle tutorials

### DIFF
--- a/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
+++ b/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
@@ -11,7 +11,7 @@ from yaspin.spinners import Spinners
 
 
 class Lesson:
-    def __init__(self, lesson_path, lesson_url):
+    def __init__(self, lesson_path: str, lesson_url: str):
         self.path = Path(lesson_path)
         self.name = self.path.parts[-1]
         self.url = lesson_url
@@ -172,10 +172,15 @@ class API:
         lesson_slug = response.json()["data"]["slug"]
 
         log("Getting URLs...")
-        response = requests.get(
-            f"{self.url}/items/courses/{response.json()['data']['course']}",
-            headers=self.auth_header,
-        )
-        response.raise_for_status()
-        course_slug = response.json()["data"]["slug"]
-        return f"{self.website_url}/course/{course_slug}/{lesson_slug}"
+
+        if lesson.url.startswith("tutorial"):
+            parent_path = "tutorial"
+        else:
+            # Need to find the course it belongs to
+            response = requests.get(
+                f"{self.url}/items/courses/{response.json()['data']['course']}",
+                headers=self.auth_header,
+            )
+            response.raise_for_status()
+            parent_path = "course/" + response.json()["data"]["slug"]
+        return f"{self.website_url}/{parent_path}/{lesson_slug}"

--- a/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
+++ b/scripts/ibm-quantum-learning-uploader/src/learning_uploader/upload.py
@@ -165,18 +165,22 @@ class API:
 
         # 6. Return URLs
         log("Getting URLs...")
+
         response = requests.get(
             f"{self.url}/items/{lesson.url}", headers=self.auth_header
         )
         response.raise_for_status()
         lesson_slug = response.json()["data"]["slug"]
 
-        log("Getting URLs...")
-
         if lesson.url.startswith("tutorial"):
+            # Tutorials don't belong to a course so are under
+            # `tutorial/<lesson-name>`
             parent_path = "tutorial"
         else:
-            # Need to find the course it belongs to
+            # Other pages do belong to a course and have URL
+            # `course/<course-name>/<lesson-name>`.
+            # Do a request to get the course name.
+            log("Getting parent course...")
             response = requests.get(
                 f"{self.url}/items/courses/{response.json()['data']['course']}",
                 headers=self.auth_header,

--- a/scripts/ibm-quantum-learning-uploader/test/assert-string-on-page.py
+++ b/scripts/ibm-quantum-learning-uploader/test/assert-string-on-page.py
@@ -1,11 +1,18 @@
 import sys
+import time
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
+
+PAGES_TO_CHECK = [
+    "https://learning.www-dev.quantum.ibm.com/course/upload-tool-tester/test-lesson",
+    "https://learning.www-dev.quantum.ibm.com/tutorial/e2-e-uploader-test-tutorial"
+]
+
 options = Options()
 options.add_argument("--headless")
 driver = webdriver.Firefox(options)
-driver.get('https://learning.www-dev.quantum.ibm.com/course/upload-tool-tester/test-lesson')
-import time
-time.sleep(2)
-assert sys.argv[1] in driver.page_source
+for page in PAGES_TO_CHECK:
+    driver.get(page)
+    time.sleep(2)
+    assert sys.argv[1] in driver.page_source
 driver.quit()

--- a/scripts/ibm-quantum-learning-uploader/test/e2e-test.sh
+++ b/scripts/ibm-quantum-learning-uploader/test/e2e-test.sh
@@ -18,13 +18,14 @@ pip install ../
 
 UUID=$(python -c "import uuid; print(uuid.uuid4())")
 echo "Attempting to upload to staging with UUID: $UUID"
-mkdir -p test-lesson
+mkdir -p test-lesson test-tutorial
 sed "s/_REPLACE_WITH_UUID_/$UUID/" template.ipynb > test-lesson/upload-me.ipynb
+cp test-lesson/upload-me.ipynb test-tutorial/upload-me.ipynb
 sync-lessons
-rm test-lesson/upload-me.ipynb
+rm test-lesson/upload-me.ipynb test-tutorial/upload-me.ipynb
 
 echo "Sleeping 2s to let changes reflect on-site"
 sleep 2
 
-echo "Checking for UUID in web page"
+echo "Checking for UUID in web pages"
 python assert-string-on-page.py $UUID

--- a/scripts/ibm-quantum-learning-uploader/test/learning-api.conf.yaml
+++ b/scripts/ibm-quantum-learning-uploader/test/learning-api.conf.yaml
@@ -1,3 +1,5 @@
 lessons:
   - path: test-lesson
     urlStaging: lessons/37bce289-fe09-4018-8a39-67749bcd5385
+  - path: test-tutorial
+    urlStaging: tutorials/69f9e8d4-0680-4233-af83-c21398e098eb


### PR DESCRIPTION
The logic that calculates the URL to display to the user expects the page to belong to a course. This crashes when uploading a tutorial as tutorials don't belong to a course.

This PR fixes that and updates the e2e test to include a tutorial page.

***

Resolves #799