### PR TITLE
Refactor `htmlToMd.ts`: Split `prepareHandlers` function

### DIFF
--- a/scripts/lib/api/htmlToMd.ts
+++ b/scripts/lib/api/htmlToMd.ts
@@ -247,9 +247,10 @@ function buildDeprecatedAdmonition(
     "versionmodified",
   );
   const title = toText(titleNode).trim().replace(/:$/, "");
-  const otherChildren: Array<any> = without(node.children[0].children, titleNode).map(
-    (node: any) => toMdast(node, { handlers }),
-  );
+  const otherChildren: Array<any> = without(
+    node.children[0].children,
+    titleNode,
+  ).map((node: any) => toMdast(node, { handlers }));
 
   return {
     type: "mdxJsxFlowElement",


### PR DESCRIPTION
Part of #845

This PR refactors the `htmlToMd.ts` script. It splits the `prepareHandlers` function into some helper functions to simplify the logic and improve the readability.