### PR TITLE
Document how to pull in new versions of preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ API name.
 
 For translations, put the language code in front of the URL, like http://localhost:3000/es/start or http://localhost:3000/fr/start. You can find the language codes by looking in the `translations/` folder.
 
+Warning: `./start` does not check if there is a new version of the docs application available. Run `docker pull qiskit/documentation` to update to the latest version of the app.
+
 ## Preview the docs in PRs
 
 Contributors with write access to this repository can use live previews of the docs: GitHub will deploy a website using your changes.

--- a/start
+++ b/start
@@ -12,6 +12,7 @@
 # that they have been altered from the originals.
 
 import subprocess
+import sys
 from pathlib import Path
 from typing import Iterator
 
@@ -30,6 +31,11 @@ def translation_volume_mounts() -> Iterator[str]:
 
 
 def main() -> None:
+    print(
+        "Warning: this may be using an outdated version of the app. Run "
+        + "`docker pull qiskit/documentation` to check for updates.",
+        file=sys.stderr,
+    )
     subprocess.run(
         # Keep this aligned with the Dockerfile at the root of the repository.
         [


### PR DESCRIPTION
It's confusing when `./start` diverges from `docs.quantum.ibm.com`.

We now warn every time when running `./start`:

```
❯ ./start 
Warning: this may be using an outdated version of the app. Run `docker pull qiskit/documentation` to check for updates.
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
   ▲ Next.js 14.0.1
   - Local:        http://f9e8103d2cee:3000
   - Network:      http://172.17.0.2:3000

 ✓ Ready in 1377ms
[remoteRefresh] server is listening at port 5001
```

I debated always running `docker pull qiskit/documentation` automatically, but I think it's too slow and annoying.