### PR TITLE
Improve Qiskit release notes ToC settings

### DIFF
--- a/docs/api/qiskit/release-notes/0.10.md
+++ b/docs/api/qiskit/release-notes/0.10.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.10 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.10
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.10 release notes

--- a/docs/api/qiskit/release-notes/0.11.md
+++ b/docs/api/qiskit/release-notes/0.11.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.11 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.11
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.11 release notes

--- a/docs/api/qiskit/release-notes/0.12.md
+++ b/docs/api/qiskit/release-notes/0.12.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.12 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.12
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.12 release notes

--- a/docs/api/qiskit/release-notes/0.13.md
+++ b/docs/api/qiskit/release-notes/0.13.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.13 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.13
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.13 release notes

--- a/docs/api/qiskit/release-notes/0.14.md
+++ b/docs/api/qiskit/release-notes/0.14.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.14 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.14
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.14 release notes

--- a/docs/api/qiskit/release-notes/0.15.md
+++ b/docs/api/qiskit/release-notes/0.15.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.15 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.15
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.15 release notes

--- a/docs/api/qiskit/release-notes/0.16.md
+++ b/docs/api/qiskit/release-notes/0.16.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.16 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.16
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.16 release notes

--- a/docs/api/qiskit/release-notes/0.17.md
+++ b/docs/api/qiskit/release-notes/0.17.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.17 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.17
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.17 release notes

--- a/docs/api/qiskit/release-notes/0.18.md
+++ b/docs/api/qiskit/release-notes/0.18.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.18 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.18
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.18 release notes

--- a/docs/api/qiskit/release-notes/0.19.md
+++ b/docs/api/qiskit/release-notes/0.19.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.19 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.19
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.19 release notes

--- a/docs/api/qiskit/release-notes/0.20.md
+++ b/docs/api/qiskit/release-notes/0.20.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.20 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.20
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.20 release notes

--- a/docs/api/qiskit/release-notes/0.21.md
+++ b/docs/api/qiskit/release-notes/0.21.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.21 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.21
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.21 release notes

--- a/docs/api/qiskit/release-notes/0.22.md
+++ b/docs/api/qiskit/release-notes/0.22.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.22 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.22
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.22 release notes

--- a/docs/api/qiskit/release-notes/0.23.md
+++ b/docs/api/qiskit/release-notes/0.23.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.23 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.23
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.23 release notes

--- a/docs/api/qiskit/release-notes/0.24.md
+++ b/docs/api/qiskit/release-notes/0.24.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.24 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.24
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.24 release notes

--- a/docs/api/qiskit/release-notes/0.25.md
+++ b/docs/api/qiskit/release-notes/0.25.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.25 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.25
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.25 release notes

--- a/docs/api/qiskit/release-notes/0.26.md
+++ b/docs/api/qiskit/release-notes/0.26.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.26 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.26
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.26 release notes

--- a/docs/api/qiskit/release-notes/0.27.md
+++ b/docs/api/qiskit/release-notes/0.27.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.27 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.27
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.27 release notes

--- a/docs/api/qiskit/release-notes/0.28.md
+++ b/docs/api/qiskit/release-notes/0.28.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.28 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.28
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.28 release notes

--- a/docs/api/qiskit/release-notes/0.29.md
+++ b/docs/api/qiskit/release-notes/0.29.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.29 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.29
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.29 release notes

--- a/docs/api/qiskit/release-notes/0.30.md
+++ b/docs/api/qiskit/release-notes/0.30.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.30 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.30
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.30 release notes

--- a/docs/api/qiskit/release-notes/0.31.md
+++ b/docs/api/qiskit/release-notes/0.31.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.31 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.31
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.31 release notes

--- a/docs/api/qiskit/release-notes/0.32.md
+++ b/docs/api/qiskit/release-notes/0.32.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.32 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.32
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.32 release notes

--- a/docs/api/qiskit/release-notes/0.33.md
+++ b/docs/api/qiskit/release-notes/0.33.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.33 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.33
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.33 release notes

--- a/docs/api/qiskit/release-notes/0.34.md
+++ b/docs/api/qiskit/release-notes/0.34.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.34 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.34
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.34 release notes

--- a/docs/api/qiskit/release-notes/0.35.md
+++ b/docs/api/qiskit/release-notes/0.35.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.35 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.35
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.35 release notes

--- a/docs/api/qiskit/release-notes/0.36.md
+++ b/docs/api/qiskit/release-notes/0.36.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.36 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.36
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.36 release notes

--- a/docs/api/qiskit/release-notes/0.37.md
+++ b/docs/api/qiskit/release-notes/0.37.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.37 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.37
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.37 release notes

--- a/docs/api/qiskit/release-notes/0.38.md
+++ b/docs/api/qiskit/release-notes/0.38.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.38 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.38
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.38 release notes

--- a/docs/api/qiskit/release-notes/0.39.md
+++ b/docs/api/qiskit/release-notes/0.39.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.39 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.39
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.39 release notes

--- a/docs/api/qiskit/release-notes/0.40.md
+++ b/docs/api/qiskit/release-notes/0.40.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.40 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.40
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.40 release notes

--- a/docs/api/qiskit/release-notes/0.41.md
+++ b/docs/api/qiskit/release-notes/0.41.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.41 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.41
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.41 release notes

--- a/docs/api/qiskit/release-notes/0.42.md
+++ b/docs/api/qiskit/release-notes/0.42.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.42 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.42
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.42 release notes

--- a/docs/api/qiskit/release-notes/0.43.md
+++ b/docs/api/qiskit/release-notes/0.43.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.43 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.43
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.43 release notes

--- a/docs/api/qiskit/release-notes/0.44.md
+++ b/docs/api/qiskit/release-notes/0.44.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.44 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.44
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.44 release notes

--- a/docs/api/qiskit/release-notes/0.45.md
+++ b/docs/api/qiskit/release-notes/0.45.md
@@ -1,7 +1,7 @@
 ---
 title: Qiskit 0.45 release notes
 description: Changes made in Qiskit 0.45
-in_page_toc_max_heading_level: 2
+in_page_toc_max_heading_level: 3
 ---
 
 <span id="release-notes" />

--- a/docs/api/qiskit/release-notes/0.46.md
+++ b/docs/api/qiskit/release-notes/0.46.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.46 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.46
+in_page_toc_max_heading_level: 3
 ---
 # Qiskit 0.46 release notes
   

--- a/docs/api/qiskit/release-notes/0.5.md
+++ b/docs/api/qiskit/release-notes/0.5.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.5 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.5
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.5 release notes

--- a/docs/api/qiskit/release-notes/0.6.md
+++ b/docs/api/qiskit/release-notes/0.6.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.6 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.6
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.6 release notes

--- a/docs/api/qiskit/release-notes/0.7.md
+++ b/docs/api/qiskit/release-notes/0.7.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.7 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.7
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.7 release notes

--- a/docs/api/qiskit/release-notes/0.8.md
+++ b/docs/api/qiskit/release-notes/0.8.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.8 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.8
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.8 release notes

--- a/docs/api/qiskit/release-notes/0.9.md
+++ b/docs/api/qiskit/release-notes/0.9.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 0.9 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 0.9
+in_page_toc_max_heading_level: 4
 ---
 
 # Qiskit 0.9 release notes

--- a/docs/api/qiskit/release-notes/1.0.md
+++ b/docs/api/qiskit/release-notes/1.0.md
@@ -1,6 +1,7 @@
 ---
 title: Qiskit 1.0 release notes
-description: New features and bug fixes
+description: Changes made in Qiskit 1.0
+in_page_toc_max_heading_level: 3
 ---
 # Qiskit 1.0 release notes
   

--- a/scripts/lib/api/addFrontMatter.ts
+++ b/scripts/lib/api/addFrontMatter.ts
@@ -45,12 +45,7 @@ ${markdown}
       const descriptionSuffix = pkg.hasSeparateReleaseNotes
         ? `in ${pkg.title}${versionStr}`
         : `to ${pkg.title}`;
-
-      let maxHeadingLevel = 2;
-      if (pkg.name == "qiskit") {
-        maxHeadingLevel = +pkg.versionWithoutPatch >= 0.45 ? 3 : 4;
-      }
-
+      const maxHeadingLevel = pkg.name == "qiskit" ? 3 : 2;
       result.markdown = `---
 title: ${pkg.title}${versionStr} release notes
 description: Changes made ${descriptionSuffix}

--- a/scripts/lib/api/addFrontMatter.ts
+++ b/scripts/lib/api/addFrontMatter.ts
@@ -45,10 +45,16 @@ ${markdown}
       const descriptionSuffix = pkg.hasSeparateReleaseNotes
         ? `in ${pkg.title}${versionStr}`
         : `to ${pkg.title}`;
+
+      let maxHeadingLevel = 2;
+      if (pkg.name == "qiskit") {
+        maxHeadingLevel = +pkg.versionWithoutPatch >= 0.45 ? 3 : 4;
+      }
+
       result.markdown = `---
 title: ${pkg.title}${versionStr} release notes
 description: Changes made ${descriptionSuffix}
-in_page_toc_max_heading_level: 2
+in_page_toc_max_heading_level: ${maxHeadingLevel}
 ---
 
 ${markdown}


### PR DESCRIPTION
Closes #941

This PR sets the `in_page_toc_max_heading_level` to 4 for legacy versions of qiskit (< 0.45) and to 3 for 0.45+ versions. It also changes the description of all the release notes to match the one we are using in the API generation script: `Changes made in Qiskit {version}`

Given that we don't regenerate legacy release notes using the script, we can set the `in_page_toc_max_heading_level` to 3 for all qiskit versions and 2 for the rest of the APIs.

The changes to the latest release note were done by removing the file and regenerating the 1.0.1 version. The rest of the files we manually updated.