### PR TITLE
Fix sequence of operations in `conversionPipeline.ts`

### DIFF
--- a/scripts/lib/api/conversionPipeline.ts
+++ b/scripts/lib/api/conversionPipeline.ts
@@ -62,12 +62,14 @@ export async function runConversionPipeline(
     maybeObjectsInv,
     initialResults,
   );
+
+  // Warning: the sequence of operations often matters.
   await writeMarkdownResults(pkg, docsBaseFolder, results);
   await copyImages(pkg, htmlPath, publicBaseFolder, results);
   await maybeObjectsInv?.write(pkg.outputDir(publicBaseFolder));
+  await maybeUpdateReleaseNotesFolder(pkg, markdownPath);
   await writeTocFile(pkg, markdownPath, results);
   await writeVersionFile(pkg, markdownPath);
-  await maybeUpdateReleaseNotesFolder(pkg, markdownPath);
 }
 
 async function determineFilePaths(


### PR DESCRIPTION
This PR fixes the order of the operations we are doing in `conversionPipeline.ts`. The important change is to call `maybeUpdateReleaseNotesFolder` before `writeTocFile`. This is because, in the former, we call to `addNewReleaseNotes`, which modifies the `_toc.json` file that we write in the latter.