### PR TITLE
Call Qiskit API docs "Qiskit SDK"

### DIFF
--- a/docs/api/qiskit/0.19/_toc.json
+++ b/docs/api/qiskit/0.19/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.24/_toc.json
+++ b/docs/api/qiskit/0.24/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.25/_toc.json
+++ b/docs/api/qiskit/0.25/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.26/_toc.json
+++ b/docs/api/qiskit/0.26/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.27/_toc.json
+++ b/docs/api/qiskit/0.27/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.28/_toc.json
+++ b/docs/api/qiskit/0.28/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.29/_toc.json
+++ b/docs/api/qiskit/0.29/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.30/_toc.json
+++ b/docs/api/qiskit/0.30/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.31/_toc.json
+++ b/docs/api/qiskit/0.31/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.32/_toc.json
+++ b/docs/api/qiskit/0.32/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.33/_toc.json
+++ b/docs/api/qiskit/0.33/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.35/_toc.json
+++ b/docs/api/qiskit/0.35/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.36/_toc.json
+++ b/docs/api/qiskit/0.36/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.37/_toc.json
+++ b/docs/api/qiskit/0.37/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.38/_toc.json
+++ b/docs/api/qiskit/0.38/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.39/_toc.json
+++ b/docs/api/qiskit/0.39/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.40/_toc.json
+++ b/docs/api/qiskit/0.40/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.41/_toc.json
+++ b/docs/api/qiskit/0.41/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.42/_toc.json
+++ b/docs/api/qiskit/0.42/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.43/_toc.json
+++ b/docs/api/qiskit/0.43/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.44/_toc.json
+++ b/docs/api/qiskit/0.44/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.45/_toc.json
+++ b/docs/api/qiskit/0.45/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/0.46/_toc.json
+++ b/docs/api/qiskit/0.46/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/_toc.json
+++ b/docs/api/qiskit/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/docs/api/qiskit/dev/_toc.json
+++ b/docs/api/qiskit/dev/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit",
+  "title": "Qiskit SDK",
   "children": [
     {
       "title": "qiskit",

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -75,7 +75,7 @@ export class Pkg {
       const releaseNoteEntries = await findLegacyReleaseNotes(name);
       return new Pkg({
         ...args,
-        title: "Qiskit",
+        title: "Qiskit SDK",
         name: "qiskit",
         githubSlug: "qiskit/qiskit",
         hasSeparateReleaseNotes: true,


### PR DESCRIPTION
This is to better clarify the word "Qiskit". This changes what shows up in the left ToC.

Change was generated with `rg '"title": "Qiskit",' -l | xargs sd '"title": "Qiskit",' '"title": "Qiskit SDK",'`