### PR TITLE
Update api-html-artifacts.json

### DIFF
--- a/scripts/api-html-artifacts.json
+++ b/scripts/api-html-artifacts.json
@@ -33,7 +33,8 @@
     "0.7": "https://ibm.box.com/shared/static/t2vuik7bqboata3i34r4a83baabo95xn.zip"
   },
   "qiskit-ibm-runtime": {
-    "dev": "https://ibm.box.com/shared/static/j4o6bvkmfndk9ib9h5wp2u3sprj9n6tv.zip",
+    "dev": "https://ibm.box.com/shared/static/pbq3c1ba7uyj6wl4e9kil3bsa2dnd2x8.zip",
+    "0.21": "https://ibm.box.com/shared/static/p5nc95ypavdaq3sk8g1ebm3h4bc1a846.zip",
     "0.20": "https://ibm.box.com/shared/static/0bcr09epud50i3czdx791iagumrf5bjz.zip",
     "0.19": "https://ibm.box.com/shared/static/ojpnzc71aex4d8itnktwbp9m7l15nazs.zip",
     "0.18": "https://ibm.box.com/shared/static/rbjdfogq8t1a4tquw1bh6gy4qdcv521v.zip",


### PR DESCRIPTION
This PR updates the Box artifacts links for runtime to the ones used on https://github.com/Qiskit/documentation/pull/986