### PR TITLE
Refactor `htmlToMd.test.ts`

### DIFF
--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -21,188 +21,51 @@ const DEFAULT_ARGS = {
   releaseNotesTitle: "My Quantum release notes",
 };
 
+async function toMd(html: string, withMetadata: boolean = false) {
+  const result = await sphinxHtmlToMarkdown({
+    fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
+    html,
+    ...DEFAULT_ARGS,
+  });
+  return withMetadata ? result : result.markdown;
+}
+
 describe("sphinxHtmlToMarkdown", () => {
-  test("remove .html extension from relative links", async () => {
-    expect(
-      await toMd(`<div
-  role='main'
-  class='main-content'
-  itemscope='itemscope'
-  itemtype='http://schema.org/Article'
->
-  <article itemprop='articleBody' id='pytorch-article' class='pytorch-article'>
-    <section id='qiskit-ibm-runtime-api-reference'>
-      <h1>
-        qiskit-ibm-runtime API reference<a
-        class='headerlink'
-        href='#qiskit-ibm-runtime-api-reference'
-        title='Permalink to this heading'
-      >¶</a
-      >
-      </h1>
-      <div class='toctree-wrapper compound'>
-        <ul>
-          <li class='toctree-l1'>
-            <a class='reference internal' href='runtime_service.html'
-            >Qiskit Runtime (<code
-              class='xref py py-mod docutils literal notranslate'
-            ><span class='pre'>qiskit_ibm_runtime</span></code
-            >)</a
-            >
-          </li>
-          <li class='toctree-l1'>
-            <a class='reference internal' href='options.html'
-            >Primitive options (<code
-              class='xref py py-mod docutils literal notranslate'
-            ><span class='pre'>qiskit_ibm_runtime.options</span></code
-            >)</a
-            >
-          </li>
-        </ul>
-      </div>
-    </section>
-  </article>
-</div>`),
-    ).toMatchInlineSnapshot(`
-      "<span id="qiskit-ibm-runtime-api-reference" />
-
-      # qiskit-ibm-runtime API reference
-
-      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
-      *   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
-      "
-    `);
-  });
-
-  test("remove permalink", async () => {
-    expect(
-      await toMd(`<article role="main">
-        <section id="qiskit-ibm-runtime-api-reference">
-          <h1>qiskit-ibm-runtime API reference<a class="headerlink" href="#qiskit-ibm-runtime-api-reference" title="Link to this heading">#</a></h1>
-         <div class="toctree-wrapper compound">
-           <ul>
-             <li class="toctree-l1"><a class="reference internal" href="runtime_service.html">Qiskit Runtime (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime</span></code>)</a></li>
-             <li class="toctree-l1"><a class="reference internal" href="options.html">Primitive options (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.options</span></code>)</a></li>
-           </ul>
-         </div>
-       </section>
-    </article>`),
-    ).toMatchInlineSnapshot(`
-      "<span id="qiskit-ibm-runtime-api-reference" />
-
-      # qiskit-ibm-runtime API reference
-
-      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
-      *   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
-      "
-    `);
-  });
-
-  test("remove download links", async () => {
-    expect(
-      await toMd(`<div
-  role='main'
-  class='main-content'
-  itemscope='itemscope'
-  itemtype='http://schema.org/Article'
->
-  <p>(<a class="reference download internal" download="" href="../_downloads/366189d70d6a05b2c91f442d20ba6114/qiskit-circuit-QuantumCircuit-1.py"><code class="xref download docutils literal notranslate"><span class="pre">Source</span> <span class="pre">code</span></code></a>)</p>
-</div>
-`),
-    ).toMatchInlineSnapshot(`""`);
-  });
-
   test("handle tabs", async () => {
     expect(
       await toMd(`<div role='main'>
-  <details
-    class='sd-sphinx-override sd-dropdown sd-card sd-mb-3 sd-fade-in-slide-down'
-  >
-    <summary class='sd-summary-title sd-card-header'>
-      Account initialization
-      <div class='sd-summary-down docutils'>
-        <svg
-          version='1.1'
-          width='1.5em'
-          height='1.5em'
-          class='sd-octicon sd-octicon-chevron-down'
-          viewBox='0 0 24 24'
-          aria-hidden='true'
-        >
-          <path
-            fill-rule='evenodd'
-            d='M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z'
-          ></path>
-        </svg>
-      </div>
-      <div class='sd-summary-up docutils'>
-        <svg
-          version='1.1'
-          width='1.5em'
-          height='1.5em'
-          class='sd-octicon sd-octicon-chevron-up'
-          viewBox='0 0 24 24'
-          aria-hidden='true'
-        >
-          <path
-            fill-rule='evenodd'
-            d='M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z'
-          ></path>
-        </svg>
-      </div>
-    </summary>
-    <div class='sd-summary-content sd-card-body docutils'>
-      <blockquote>
-        <div>
-          <p class='sd-card-text'>
-            You need to initialize your account before you can start using the
-            Qiskit Runtime service. This is done by initializing a
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.QiskitRuntimeService.html#qiskit_ibm_runtime.QiskitRuntimeService'
-              title='qiskit_ibm_runtime.QiskitRuntimeService'
-            ><code class='xref py py-class docutils literal notranslate'
-            ><span class='pre'>QiskitRuntimeService</span></code
-            ></a
-            >
-            instance with your account credentials. If you don’t want to pass in
-            the credentials each time, you can use the
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.QiskitRuntimeService.save_account.html#qiskit_ibm_runtime.QiskitRuntimeService.save_account'
-              title='qiskit_ibm_runtime.QiskitRuntimeService.save_account'
-            ><code class='xref py py-meth docutils literal notranslate'
-            ><span class='pre'
-            >QiskitRuntimeService.save_account()</span
-            ></code
-            ></a
-            >
-            method to save the credentials on disk.
-          </p>
-          <p class='sd-card-text'>
-            Qiskit Runtime is available on both IBM Cloud and IBM Quantum, and
-            you can specify
-            <code class='docutils literal notranslate'
-            ><span class='pre'>channel=&quot;ibm_cloud&quot;</span></code
-            >
-            for IBM Cloud and
-            <code class='docutils literal notranslate'
-            ><span class='pre'>channel=&quot;ibm_quantum&quot;</span></code
-            >
-            for IBM Quantum. The default is IBM Cloud.
-          </p>
+      <details
+        class='sd-sphinx-override sd-dropdown sd-card sd-mb-3 sd-fade-in-slide-down'
+      >
+        <summary class='sd-summary-title sd-card-header'>
+          Account initialization
+        </summary>
+        <div class='sd-summary-content sd-card-body docutils'>
+          <blockquote>
+            <div>
+              <p class='sd-card-text'>
+                You need to initialize your account before you can start using the
+                Qiskit Runtime service. This is done by initializing a
+                <a
+                  class='reference internal'
+                  href='../stubs/qiskit_ibm_runtime.QiskitRuntimeService.html#qiskit_ibm_runtime.QiskitRuntimeService'
+                  title='qiskit_ibm_runtime.QiskitRuntimeService'
+                ><code class='xref py py-class docutils literal notranslate'
+                ><span class='pre'>QiskitRuntimeService</span></code
+                ></a
+                >
+                instance with your account credentials.
+              </p>
+            </div>
+          </blockquote>
         </div>
-      </blockquote>
+      </details>
     </div>
-  </details>
-</div>
 `),
     ).toMatchInlineSnapshot(`
               "### Account initialization
 
-              You need to initialize your account before you can start using the Qiskit Runtime service. This is done by initializing a [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance with your account credentials. If you don’t want to pass in the credentials each time, you can use the [\`QiskitRuntimeService.save_account()\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService.save_account#qiskit_ibm_runtime.QiskitRuntimeService.save_account "qiskit_ibm_runtime.QiskitRuntimeService.save_account") method to save the credentials on disk.
-
-              Qiskit Runtime is available on both IBM Cloud and IBM Quantum, and you can specify \`channel="ibm_cloud"\` for IBM Cloud and \`channel="ibm_quantum"\` for IBM Quantum. The default is IBM Cloud.
+              You need to initialize your account before you can start using the Qiskit Runtime service. This is done by initializing a [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance with your account credentials.
               "
           `);
   });
@@ -210,203 +73,53 @@ describe("sphinxHtmlToMarkdown", () => {
   test("handle tables", async () => {
     expect(
       await toMd(`
-<div role='main'>
-  <table class='autosummary longtable docutils align-default'>
-    <tbody>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.QiskitRuntimeService.html#qiskit_ibm_runtime.QiskitRuntimeService'
-              title='qiskit_ibm_runtime.QiskitRuntimeService'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>QiskitRuntimeService</span></code
-              ></a
-            >([channel, auth, token, ...])
-          </p>
-        </td>
-        <td><p>Class for interacting with the Qiskit Runtime service.</p></td>
-      </tr>
-      <tr class='row-even'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.Estimator.html#qiskit_ibm_runtime.Estimator'
-              title='qiskit_ibm_runtime.Estimator'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>Estimator</span></code
-              ></a
-            >([circuits, observables, ...])
-          </p>
-        </td>
-        <td>
-          <p>
-            Class for interacting with Qiskit Runtime Estimator primitive
-            service.
-          </p>
-        </td>
-      </tr>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.Sampler.html#qiskit_ibm_runtime.Sampler'
-              title='qiskit_ibm_runtime.Sampler'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>Sampler</span></code
-              ></a
-            >([circuits, parameters, service, ...])
-          </p>
-        </td>
-        <td>
-          <p>
-            Class for interacting with Qiskit Runtime Sampler primitive service.
-          </p>
-        </td>
-      </tr>
-      <tr class='row-even'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.Session.html#qiskit_ibm_runtime.Session'
-              title='qiskit_ibm_runtime.Session'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>Session</span></code
-              ></a
-            >([service, backend, max_time])
-          </p>
-        </td>
-        <td><p>Class for creating a flexible Qiskit Runtime session.</p></td>
-      </tr>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.IBMBackend.html#qiskit_ibm_runtime.IBMBackend'
-              title='qiskit_ibm_runtime.IBMBackend'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>IBMBackend</span></code
-              ></a
-            >(configuration, service, api_client)
-          </p>
-        </td>
-        <td><p>Backend class interfacing with an IBM Quantum backend.</p></td>
-      </tr>
-      <tr class='row-even'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.RuntimeJob.html#qiskit_ibm_runtime.RuntimeJob'
-              title='qiskit_ibm_runtime.RuntimeJob'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>RuntimeJob</span></code
-              ></a
-            >(backend, api_client, ...[, ...])
-          </p>
-        </td>
-        <td><p>Representation of a runtime program execution.</p></td>
-      </tr>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.RuntimeProgram.html#qiskit_ibm_runtime.RuntimeProgram'
-              title='qiskit_ibm_runtime.RuntimeProgram'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>RuntimeProgram</span></code
-              ></a
-            >(program_name, program_id, ...)
-          </p>
-        </td>
-        <td><p>Class representing program metadata.</p></td>
-      </tr>
-      <tr class='row-even'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.ParameterNamespace.html#qiskit_ibm_runtime.ParameterNamespace'
-              title='qiskit_ibm_runtime.ParameterNamespace'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>ParameterNamespace</span></code
-              ></a
-            >(parameters)
-          </p>
-        </td>
-        <td><p>A namespace for program parameters with validation.</p></td>
-      </tr>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.RuntimeOptions.html#qiskit_ibm_runtime.RuntimeOptions'
-              title='qiskit_ibm_runtime.RuntimeOptions'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>RuntimeOptions</span></code
-              ></a
-            >([backend, image, log_level, ...])
-          </p>
-        </td>
-        <td>
-          <p>Class for representing generic runtime execution options.</p>
-        </td>
-      </tr>
-      <tr class='row-even'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.RuntimeEncoder.html#qiskit_ibm_runtime.RuntimeEncoder'
-              title='qiskit_ibm_runtime.RuntimeEncoder'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>RuntimeEncoder</span></code
-              ></a
-            >(*[, skipkeys, ensure_ascii, ...])
-          </p>
-        </td>
-        <td><p>JSON Encoder used by runtime service.</p></td>
-      </tr>
-      <tr class='row-odd'>
-        <td>
-          <p>
-            <a
-              class='reference internal'
-              href='../stubs/qiskit_ibm_runtime.RuntimeDecoder.html#qiskit_ibm_runtime.RuntimeDecoder'
-              title='qiskit_ibm_runtime.RuntimeDecoder'
-              ><code class='xref py py-obj docutils literal notranslate'
-                ><span class='pre'>RuntimeDecoder</span></code
-              ></a
-            >(*args, **kwargs)
-          </p>
-        </td>
-        <td><p>JSON Decoder used by runtime service.</p></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+      <div role='main'>
+      <table class='autosummary longtable docutils align-default'>
+        <tbody>
+          <tr class='row-odd'>
+            <td>
+              <p>
+                <a
+                  class='reference internal'
+                  href='../stubs/qiskit_ibm_runtime.QiskitRuntimeService.html#qiskit_ibm_runtime.QiskitRuntimeService'
+                  title='qiskit_ibm_runtime.QiskitRuntimeService'
+                  ><code class='xref py py-obj docutils literal notranslate'
+                    ><span class='pre'>QiskitRuntimeService</span></code
+                  ></a
+                >([channel, auth, token, ...])
+              </p>
+            </td>
+            <td><p>Class for interacting with the Qiskit Runtime service.</p></td>
+          </tr>
+          <tr class='row-even'>
+            <td>
+              <p>
+                <a
+                  class='reference internal'
+                  href='../stubs/qiskit_ibm_runtime.Estimator.html#qiskit_ibm_runtime.Estimator'
+                  title='qiskit_ibm_runtime.Estimator'
+                  ><code class='xref py py-obj docutils literal notranslate'
+                    ><span class='pre'>Estimator</span></code
+                  ></a
+                >([circuits, observables, ...])
+              </p>
+            </td>
+            <td>
+              <p>
+                Class for interacting with Qiskit Runtime Estimator primitive
+                service.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     `),
     ).toMatchInlineSnapshot(`
               "|                                                                                                                                                                                            |                                                                        |
               | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
               | [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\\[channel, auth, token, ...]) | Class for interacting with the Qiskit Runtime service.                 |
               | [\`Estimator\`](../stubs/qiskit_ibm_runtime.Estimator#qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\\[circuits, observables, ...])                                            | Class for interacting with Qiskit Runtime Estimator primitive service. |
-              | [\`Sampler\`](../stubs/qiskit_ibm_runtime.Sampler#qiskit_ibm_runtime.Sampler "qiskit_ibm_runtime.Sampler")(\\[circuits, parameters, service, ...])                                            | Class for interacting with Qiskit Runtime Sampler primitive service.   |
-              | [\`Session\`](../stubs/qiskit_ibm_runtime.Session#qiskit_ibm_runtime.Session "qiskit_ibm_runtime.Session")(\\[service, backend, max\\_time])                                                   | Class for creating a flexible Qiskit Runtime session.                  |
-              | [\`IBMBackend\`](../stubs/qiskit_ibm_runtime.IBMBackend#qiskit_ibm_runtime.IBMBackend "qiskit_ibm_runtime.IBMBackend")(configuration, service, api\\_client)                                  | Backend class interfacing with an IBM Quantum backend.                 |
-              | [\`RuntimeJob\`](../stubs/qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")(backend, api\\_client, ...\\[, ...])                                    | Representation of a runtime program execution.                         |
-              | [\`RuntimeProgram\`](../stubs/qiskit_ibm_runtime.RuntimeProgram#qiskit_ibm_runtime.RuntimeProgram "qiskit_ibm_runtime.RuntimeProgram")(program\\_name, program\\_id, ...)                      | Class representing program metadata.                                   |
-              | [\`ParameterNamespace\`](../stubs/qiskit_ibm_runtime.ParameterNamespace#qiskit_ibm_runtime.ParameterNamespace "qiskit_ibm_runtime.ParameterNamespace")(parameters)                           | A namespace for program parameters with validation.                    |
-              | [\`RuntimeOptions\`](../stubs/qiskit_ibm_runtime.RuntimeOptions#qiskit_ibm_runtime.RuntimeOptions "qiskit_ibm_runtime.RuntimeOptions")(\\[backend, image, log\\_level, ...])                   | Class for representing generic runtime execution options.              |
-              | [\`RuntimeEncoder\`](../stubs/qiskit_ibm_runtime.RuntimeEncoder#qiskit_ibm_runtime.RuntimeEncoder "qiskit_ibm_runtime.RuntimeEncoder")(\\*\\[, skipkeys, ensure\\_ascii, ...])                  | JSON Encoder used by runtime service.                                  |
-              | [\`RuntimeDecoder\`](../stubs/qiskit_ibm_runtime.RuntimeDecoder#qiskit_ibm_runtime.RuntimeDecoder "qiskit_ibm_runtime.RuntimeDecoder")(\\*args, \\*\\*kwargs)                                   | JSON Decoder used by runtime service.                                  |
               "
           `);
   });
@@ -473,415 +186,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
           `);
   });
 
-  test("convert source links", async () => {
-    expect(
-      (
-        await sphinxHtmlToMarkdown({
-          html: `<div role='main'>
-<span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
-</div>
-`,
-          fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
-          ...DEFAULT_ARGS,
-        })
-      ).markdown,
-    ).toMatchInlineSnapshot(`
-              "IBMBackend.control\\_channel(*qubits*)[\\[source\\]](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py)
-              "
-          `);
-  });
-
-  test("convert class signature headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-<h1>Estimator<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
-  <dl class='py class'>
-    <dt class='sig sig-object py' id='qiskit_ibm_runtime.Sampler'>
-      <em class='property'
-      ><span class='pre'>class</span><span class='w'> </span></em
-      ><span class='sig-name descname'><span class='pre'>Sampler</span></span
-    ><span class='sig-paren'>(</span
-    ><em class='sig-param'
-    ><span class='n'><span class='pre'>circuits</span></span
-    ><span class='o'><span class='pre'>=</span></span
-    ><span class='default_value'><span class='pre'>None</span></span></em
-    >,
-      <em class='sig-param'
-      ><span class='n'><span class='pre'>parameters</span></span
-      ><span class='o'><span class='pre'>=</span></span
-      ><span class='default_value'><span class='pre'>None</span></span></em
-      >,
-      <em class='sig-param'
-      ><span class='n'><span class='pre'>service</span></span
-      ><span class='o'><span class='pre'>=</span></span
-      ><span class='default_value'><span class='pre'>None</span></span></em
-      >,
-      <em class='sig-param'
-      ><span class='n'><span class='pre'>session</span></span
-      ><span class='o'><span class='pre'>=</span></span
-      ><span class='default_value'><span class='pre'>None</span></span></em
-      >,
-      <em class='sig-param'
-      ><span class='n'><span class='pre'>options</span></span
-      ><span class='o'><span class='pre'>=</span></span
-      ><span class='default_value'><span class='pre'>None</span></span></em
-      >,
-      <em class='sig-param'
-      ><span class='n'><span class='pre'>skip_transpilation</span></span
-      ><span class='o'><span class='pre'>=</span></span
-      ><span class='default_value'><span class='pre'>False</span></span></em
-      ><span class='sig-paren'>)</span
-    ><a
-      class='reference internal'
-      href='../_modules/qiskit_ibm_runtime/sampler.html#Sampler'
-    ><span class='viewcode-link'><span class='pre'>[source]</span></span></a
-    ><a
-      class='headerlink'
-      href='#qiskit_ibm_runtime.Sampler'
-      title='Permalink to this definition'
-    >¶</a
-    >
-    </dt>
-    <dd>
-      <p>
-        Class for interacting with Qiskit Runtime Sampler primitive service.
-      </p>
-    </dd>
-  </dl>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "# Estimator
-
-      <span id="qiskit_ibm_runtime.Sampler" />
-
-      \`Sampler(circuits=None, parameters=None, service=None, session=None, options=None, skip_transpilation=False) \`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/sampler.py "view source code")
-
-      Class for interacting with Qiskit Runtime Sampler primitive service.
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_runtime.Sampler",
-          "apiType": "class",
-        },
-      }
-    `);
-  });
-
-  test("convert class property headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-<h1>Estimator.circuits<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
-  <dl class='py property'>
-    <dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.circuits'>
-      <em class='property'
-      ><span class='pre'>property</span><span class='w'> </span></em
-      ><span class='sig-prename descclassname'
-    ><span class='pre'>Estimator.</span></span
-    ><span class='sig-name descname'><span class='pre'>circuits</span></span
-    ><em class='property'
-    ><span class='p'><span class='pre'>:</span></span
-    ><span class='w'> </span><span class='pre'>tuple</span
-    ><span class='p'><span class='pre'>[</span></span
-    ><span class='pre'>qiskit.circuit.quantumcircuit.QuantumCircuit</span
-    ><span class='p'><span class='pre'>,</span></span
-    ><span class='w'> </span
-    ><span class='p'><span class='pre'>...</span></span
-    ><span class='p'><span class='pre'>]</span></span></em
-    ><a
-      class='headerlink'
-      href='#qiskit_ibm_runtime.Estimator.circuits'
-      title='Permalink to this definition'
-    >¶</a
-    >
-    </dt>
-    <dd><p>Quantum circuits that represents quantum states.</p></dd>
-  </dl>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "# circuits
-
-      <span id="qiskit_ibm_runtime.Estimator.circuits" />
-
-      \`tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]\`
-
-      Quantum circuits that represents quantum states.
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_runtime.Estimator.circuits",
-          "apiType": "property",
-        },
-      }
-    `);
-  });
-
-  test("convert class method headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-<h1>Estimator.run<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
-  <dl class='py method'>
-<dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.run'>
-<span class='sig-prename descclassname'><span class='pre'>Estimator.</span></span><span class='sig-name descname'><span class='pre'>run</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>circuits</span></span></em>, <em class='sig-param'><span class='n'><span class='pre'>observables</span></span></em>, <em class='sig-param'><span class='n'><span class='pre'>parameter_values</span></span><span class='o'><span class='pre'>=</span></span><span class='default_value'><span class='pre'>None</span></span></em>, <em class='sig-param'><span class='o'><span class='pre'>**</span></span><span class='n'><span class='pre'>kwargs</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/estimator.html#Estimator.run'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.Estimator.run' title='Permalink to this definition'>¶</a></dt>
-<dd><p>Submit a request to the estimator primitive program.</p></dd></dl>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "# run
-
-      <span id="qiskit_ibm_runtime.Estimator.run" />
-
-      \`Estimator.run(circuits, observables, parameter_values=None, **kwargs)\`
-
-      Submit a request to the estimator primitive program.
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_runtime.Estimator.run",
-          "apiType": "method",
-        },
-      }
-    `);
-  });
-
-  test("convert class attributes headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-<h1>EnvironmentOptions.callback<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
-<dl class='py attribute'>
-<dt class='sig sig-object py' id='qiskit_ibm_runtime.options.EnvironmentOptions.callback'>
-<span class='sig-prename descclassname'><span class='pre'>EnvironmentOptions.</span></span><span class='sig-name descname'><span class='pre'>callback</span></span><em class='property'><span class='p'><span class='pre'>:</span></span><span class='w'> </span><span class='pre'>Optional</span><span class='p'><span class='pre'>[</span></span><span class='pre'>Callable</span><span class='p'><span class='pre'>]</span></span></em><em class='property'><span class='w'> </span><span class='p'><span class='pre'>=</span></span><span class='w'> </span><span class='pre'>None</span></em><a class='headerlink' href='#qiskit_ibm_runtime.options.EnvironmentOptions.callback' title='Permalink to this definition'>¶</a></dt>
-<dd></dd></dl>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "# callback
-
-      <span id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" />
-
-      \`Optional[Callable] = None\`
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_runtime.options.EnvironmentOptions.callback",
-          "apiType": "attribute",
-        },
-      }
-    `);
-  });
-
-  test("convert method and attributes to titles", async () => {
-    expect(
-      (
-        await toMdWithMeta(
-          `<div role='main'>
-<p class='rubric'>Methods</p>
-</div>
-`,
-        )
-      ).markdown,
-    ).toMatchInlineSnapshot(`
-              "## Methods
-              "
-          `);
-  });
-
-  test("convert functions headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-  <section id="job-monitor">
-<h1>job_monitor<a class="headerlink" href="#job-monitor" title="Permalink to this heading">¶</a></h1>
-<dl class="py function">
-<dt class="sig sig-object py" id="qiskit_ibm_provider.job.job_monitor">
-<span class="sig-name descname"><span class="pre">job_monitor</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">job</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">interval=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">output=&lt;_io.TextIOWrapper</span> <span class="pre">name='&lt;stdout&gt;'</span> <span class="pre">mode='w'</span> <span class="pre">encoding='utf-8'&gt;</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit_ibm_provider/job/job_monitor.html#job_monitor"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_provider.job.job_monitor" title="Permalink to this definition">¶</a></dt>
-<dd><p>Monitor the status of an <code class="docutils literal notranslate"><span class="pre">IBMJob</span></code> instance.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters<span class="colon">:</span></dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>job</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">IBMJob</span></code>) – Job to monitor.</p></li>
-<li><p><strong>interval</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Optional</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code>]) – Time interval between status queries.</p></li>
-<li><p><strong>output</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">TextIO</span></code>) – The file like object to write status messages to.
-By default this is sys.stdout.</p></li>
-</ul>
-</dd>
-<dt class="field-even">Return type<span class="colon">:</span></dt>
-<dd class="field-even"><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">None</span></code></p>
-</dd>
-</dl>
-</dd></dl>
-
-</section>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "<span id="job-monitor" />
-
-      # job\\_monitor
-
-      <span id="qiskit_ibm_provider.job.job_monitor" />
-
-      \`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/job_monitor.py "view source code")
-
-      Monitor the status of an \`IBMJob\` instance.
-
-      **Parameters**
-
-      *   **job** (\`IBMJob\`) – Job to monitor.
-      *   **interval** (\`Optional\`\\[\`float\`]) – Time interval between status queries.
-      *   **output** (\`TextIO\`) – The file like object to write status messages to. By default this is sys.stdout.
-
-      **Return type**
-
-      \`None\`
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_provider.job.job_monitor",
-          "apiType": "function",
-        },
-      }
-    `);
-  });
-
-  test("convert exception headings", async () => {
-    expect(
-      await toMdWithMeta(`<div role='main'>
-             <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
-
-  <section id="ibmjoberror">
-<h1>IBMJobError<a class="headerlink" href="#ibmjoberror" title="Permalink to this heading">¶</a></h1>
-<dl class="py exception">
-<dt class="sig sig-object py" id="qiskit_ibm_provider.job.IBMJobError">
-<em class="property"><span class="pre">exception</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">IBMJobError</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">*</span></span><span class="n"><span class="pre">message</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit_ibm_provider/job/exceptions.html#IBMJobError"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_provider.job.IBMJobError" title="Permalink to this definition">¶</a></dt>
-<dd><p>Base class for errors raised by the job modules.</p>
-<p>Set the error message.</p>
-</dd></dl>
-
-</section>
-
-
-             </article>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "<span id="ibmjoberror" />
-
-      # IBMJobError
-
-      <span id="qiskit_ibm_provider.job.IBMJobError" />
-
-      \`IBMJobError(*message)\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/exceptions.py "view source code")
-
-      Base class for errors raised by the job modules.
-
-      Set the error message.
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_provider.job.IBMJobError",
-          "apiType": "exception",
-        },
-      }
-    `);
-  });
-
-  test("convert class method with a problematic output", async () => {
-    // The problem is generated in this page
-    // https://qiskit.org/ecosystem/ibm-provider/stubs/qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state.html#qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state
-    expect(
-      await toMdWithMeta(`<div role='main'>
-  <h1>IBMCircuitJob.wait_for_final_state<a class='headerlink' href='#ibmcircuitjob-wait-for-final-state'
-                                           title='Permalink to this heading'>¶</a></h1>
-  <dl class='py method'>
-    <dt class='sig sig-object py' id='qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state'>
-      <span class='sig-prename descclassname'><span class='pre'>IBMCircuitJob.</span></span><span
-      class='sig-name descname'><span class='pre'>wait_for_final_state</span></span><span class='sig-paren'>(</span><em
-      class='sig-param'><span class='n'><span class='pre'>timeout</span></span><span class='o'><span
-      class='pre'>=</span></span><span class='default_value'><span class='pre'>None</span></span></em><span
-      class='sig-paren'>)</span><a class='reference internal'
-                                   href='../_modules/qiskit_ibm_provider/job/ibm_circuit_job.html#IBMCircuitJob.wait_for_final_state'><span
-      class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink'
-                                                                           href='#qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state'
-                                                                           title='Permalink to this definition'>¶</a>
-    </dt>
-    <dd>
-      <dl class='simple'>
-        <dt>Use the websocket server to wait for the final the state of a job. The server</dt>
-        <dd><p>will remain open if the job is still running and the connection will be terminated
-          once the job completes. Then update and return the status of the job.</p>
-        </dd>
-      </dl>
-      <dl class='field-list simple'>
-        <dt class='field-odd'>Parameters<span class='colon'>:</span></dt>
-        <dd class='field-odd'><p><strong>timeout</strong> (<code
-          class='xref py py-data docutils literal notranslate'><span class='pre'>Optional</span></code>[<code
-          class='xref py py-class docutils literal notranslate'><span class='pre'>float</span></code>]) – Seconds to
-          wait for the job. If <code class='docutils literal notranslate'><span class='pre'>None</span></code>, wait
-          indefinitely.</p>
-        </dd>
-        <dt class='field-even'>Raises<span class='colon'>:</span></dt>
-        <dd class='field-even'><p><a class='reference internal'
-                                     href='qiskit_ibm_provider.job.IBMJobTimeoutError.html#qiskit_ibm_provider.job.IBMJobTimeoutError'
-                                     title='qiskit_ibm_provider.job.IBMJobTimeoutError'><strong>IBMJobTimeoutError</strong></a>
-          – If the job does not complete within given timeout.</p>
-        </dd>
-        <dt class='field-odd'>Return type<span class='colon'>:</span></dt>
-        <dd class='field-odd'><p><code class='xref py py-obj docutils literal notranslate'><span class='pre'>None</span></code>
-        </p>
-        </dd>
-      </dl>
-    </dd>
-  </dl>
-</div>
-      `),
-    ).toMatchInlineSnapshot(`
-      {
-        "images": [],
-        "isReleaseNotes": false,
-        "markdown": "# wait\\_for\\_final\\_state
-
-      <span id="qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state" />
-
-      \`IBMCircuitJob.wait_for_final_state(timeout=None)\`
-
-      ## Use the websocket server to wait for the final the state of a job. The server
-
-      will remain open if the job is still running and the connection will be terminated once the job completes. Then update and return the status of the job.
-
-      **Parameters**
-
-      **timeout** (\`Optional\`\\[\`float\`]) – Seconds to wait for the job. If \`None\`, wait indefinitely.
-
-      **Raises**
-
-      [**IBMJobTimeoutError**](qiskit_ibm_provider.job.IBMJobTimeoutError#qiskit_ibm_provider.job.IBMJobTimeoutError "qiskit_ibm_provider.job.IBMJobTimeoutError") – If the job does not complete within given timeout.
-
-      **Return type**
-
-      \`None\`
-      ",
-        "meta": {
-          "apiName": "qiskit_ibm_provider.job.IBMCircuitJob.wait_for_final_state",
-          "apiType": "method",
-        },
-      }
-    `);
-  });
-
-  test("convert inline methods", async () => {
+  test("convert method and attributes to titles and handle inlined methods", async () => {
     expect(
       await toMd(`
       <div role="main">
@@ -917,8 +222,7 @@ bits.</p>
 </dd>
 </dl>
 </dd></dl>
-
-      </div>
+ </div>
       `),
     ).toMatchInlineSnapshot(`
       "# DAGCircuit
@@ -1013,72 +317,6 @@ bits.</p>
       Modules related to Qiskit Runtime IBM Client.
       "
     `);
-  });
-
-  test("transform inline math", async () => {
-    expect(
-      await toMd(`
-<div role='main'>
-<table>
-<tbody>
-<tr class="row-even"><td><p><a class="reference internal" href="../stubs/qiskit.circuit.library.GlobalPhaseGate.html#qiskit.circuit.library.GlobalPhaseGate" title="qiskit.circuit.library.GlobalPhaseGate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">GlobalPhaseGate</span></code></a>(phase[, label])</p></td>
-<td><p>The global phase gate (<span class="math notranslate nohighlight">\\(e^{i\\theta}\\)</span>).</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-        `),
-    ).toMatchInlineSnapshot(`
-        "|                                                                                                                                                                       |                                        |
-        | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-        | [\`GlobalPhaseGate\`](../stubs/qiskit.circuit.library.GlobalPhaseGate#qiskit.circuit.library.GlobalPhaseGate "qiskit.circuit.library.GlobalPhaseGate")(phase\\[, label]) | The global phase gate ($e^{i\\theta}$). |
-        "
-      `);
-  });
-
-  test("transform block math", async () => {
-    expect(
-      await toMd(`
-<div role='main'>
-<div class="math notranslate nohighlight">
-\\[\\begin{split}CCX q_0, q_1, q_2 =
-    I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
-   \\begin{pmatrix}
-        1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
-        0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
-        0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
-        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1\\\\
-        0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0\\\\
-        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0\\\\
-        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0\\\\
-        0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0
-    \\end{pmatrix}\\end{split}\\]</div>
-
-<div class="math notranslate nohighlight">
-\\[x = \\sum_{i=0}^{n-1} 2^i q_i,\\]</div>
-</div>
-        `),
-    ).toMatchInlineSnapshot(`
-        "$$
-        \\begin{split}CCX q_0, q_1, q_2 =
-            I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
-           \\begin{pmatrix}
-                1 & 0 & 0 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 1 & 0 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 0 & 1 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 0 & 0 & 1\\\\
-                0 & 0 & 0 & 0 & 1 & 0 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 1 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 0 & 1 & 0\\\\
-                0 & 0 & 0 & 1 & 0 & 0 & 0 & 0
-            \\end{pmatrix}\\end{split}
-        $$
-
-        $$
-        x = \\sum_{i=0}^{n-1} 2^i q_i,
-        $$
-        "
-      `);
   });
 
   test("transform admonitions", async () => {
@@ -1229,7 +467,7 @@ bits.</p>
 
   test("preserve span with ids", async () => {
     expect(
-      await toMd(`<div role='main'>
+      await toMd(`
   <div role='main' class='main-content' itemscope='itemscope' itemtype='http://schema.org/Article'>
     <article itemprop='articleBody' id='pytorch-article' class='pytorch-article'>
 
@@ -1268,22 +506,7 @@ bits.</p>
     `);
   });
 
-  test("merge contiguous emphasis", async () => {
-    expect(
-      await toMd(`
-      <div role="main">
-
-        <li><p><strong>gate</strong> (<em>Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]</em>) – Gate information.</p></li>
-
-      </div>
-    `),
-    ).toMatchInlineSnapshot(`
-      "*   **gate** (*Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]*) – Gate information.
-      "
-    `);
-  });
-
-  test("remove spaces from emphashis boundaries", async () => {
+  test("merge contiguous emphasis removing spaces", async () => {
     expect(
       await toMd(`
       <div role="main">
@@ -1305,14 +528,6 @@ bits.</p>
     <p>Transpilation is the process of rewriting a given input circuit to match
 the topology of a specific quantum device, and/or to optimize the circuit
 for execution on present day noisy quantum systems.</p>
-<p>Most circuits must undergo a series of transformations that make them compatible with
-a given target device, and optimize them to reduce the effects of noise on the
-resulting outcomes.  Rewriting quantum circuits to match hardware constraints and
-optimizing for performance can be far from trivial.  The flow of logic in the rewriting
-tool chain need not be linear, and can often have iterative sub-loops, conditional
-branches, and other complex behaviors. That being said, the standard
-compilation flow follows the structure given below:</p>
-<img alt="../_images/transpiling_core_steps.png" src="../_images/transpiling_core_steps.png" />
 <br><p>Qiskit has four pre-built transpilation pipelines available here:
 </p>
 </div>
@@ -1320,127 +535,564 @@ compilation flow follows the structure given below:</p>
     ).toMatchInlineSnapshot(`
       "Transpilation is the process of rewriting a given input circuit to match the topology of a specific quantum device, and/or to optimize the circuit for execution on present day noisy quantum systems.
 
-      Most circuits must undergo a series of transformations that make them compatible with a given target device, and optimize them to reduce the effects of noise on the resulting outcomes. Rewriting quantum circuits to match hardware constraints and optimizing for performance can be far from trivial. The flow of logic in the rewriting tool chain need not be linear, and can often have iterative sub-loops, conditional branches, and other complex behaviors. That being said, the standard compilation flow follows the structure given below:
-
-      ![../\\_images/transpiling\\_core\\_steps.png](/images/qiskit/transpiling_core_steps.png)
-
       Qiskit has four pre-built transpilation pipelines available here:
       "
     `);
   });
-});
 
-test("identify release notes", async () => {
-  expect(
-    await sphinxHtmlToMarkdown({
-      html: `
-          <div role="main">
-          <h1>Release Notes<a class="headerlink" href="#release-notes" title="Link to this heading">#</a></h1>
-          <section id="release-notes-0-14-0">
-          <span id="id1"></span><h2>0.14.0<a class="headerlink" href="#release-notes-0-14-0" title="Link to this heading">#</a></h2>
-          <section id="new-features">
-          <span id="release-notes-0-14-0-new-features"></span><h3>New Features<a class="headerlink" href="#new-features" title="Link to this heading">#</a></h3>
-          <ul class="simple">
-          <li><p>There is a new class, <code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.Batch</span></code> that currently works
-          the same way as <a class="reference internal" href="stubs/qiskit_ibm_runtime.Session.html#qiskit_ibm_runtime.Session" title="qiskit_ibm_runtime.Session"><code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.Session</span></code></a> but will later be updated 
-          to better support submitting multiple jobs at once.</p></li>
-          </ul>
-          `,
-      fileName: "release_notes.html",
-      ...DEFAULT_ARGS,
-    }),
-  ).toMatchInlineSnapshot(`
-{
-  "images": [],
-  "isReleaseNotes": true,
-  "markdown": "# My Quantum release notes
-
-<span id="release-notes-0-14-0" />
-
-<span id="id1" />
-
-## 0.14.0
-
-<span id="new-features" />
-
-<span id="release-notes-0-14-0-new-features" />
-
-### New Features
-
-*   There is a new class, \`qiskit_ibm_runtime.Batch\` that currently works the same way as [\`qiskit_ibm_runtime.Session\`](stubs/qiskit_ibm_runtime.Session#qiskit_ibm_runtime.Session \"qiskit_ibm_runtime.Session\") but will later be updated to better support submitting multiple jobs at once.
-",
-  "meta": {},
-}
-`);
-});
-
-// This test checks that the conversion to markdown is correct when we have a <dt class=sig-object"> tag
-// without id. For more information: https://github.com/Qiskit/documentation/issues/485
-test("test dt tag without id", async () => {
-  expect(
-    await toMd(`
-    <div role="main">
-    <p>In addition to the public abstract methods, subclasses should also implement the following
-    private methods:</p>
-    <dl class="py method">
-    <dt class="sig sig-object py">
-    <em class="property"><span class="pre">classmethod</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">_default_options</span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit/providers/basicaer/qasm_simulator.html#QasmSimulatorPy._default_options"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
-    <dd><p>Return the default options</p>
-    <p>This method will return a <a class="reference internal" href="qiskit.providers.Options.html#qiskit.providers.Options" title="qiskit.providers.Options"><code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit.providers.Options</span></code></a>
-    subclass object that will be used for the default options. These
-    should be the default parameters to use for the options of the
-    backend.</p>
-    <dl class="field-list simple">
-    <dt class="field-odd">Returns<span class="colon">:</span></dt>
-    <dd class="field-odd"><p><dl class="simple">
-    <dt>A options object with</dt><dd><p>default values set</p>
-    </dd>
-    </dl>
-    </p>
-    </dd>
-    <dt class="field-even">Return type<span class="colon">:</span></dt>
-    <dd class="field-even"><p><a class="reference internal" href="qiskit.providers.Options.html#qiskit.providers.Options" title="qiskit.providers.Options">qiskit.providers.Options</a></p>
-    </dd>
-    </dl>
-    </dd></dl>
-    </div>
-`),
-  ).toMatchInlineSnapshot(`
-  "In addition to the public abstract methods, subclasses should also implement the following private methods:
-  
-  \`classmethod _default_options()\`
-  
-  Return the default options
-  
-  This method will return a [\`qiskit.providers.Options\`](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options") subclass object that will be used for the default options. These should be the default parameters to use for the options of the backend.
-  
-  **Returns**
-  
-  **A options object with**
-  
-  default values set
-  
-  **Return type**
-  
-  [qiskit.providers.Options](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options")
-  "
-  `);
-});
-
-async function toMd(html: string) {
-  return (
-    await sphinxHtmlToMarkdown({
-      fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
-      html,
-      ...DEFAULT_ARGS,
-    })
-  ).markdown;
-}
-
-async function toMdWithMeta(html: string) {
-  return await sphinxHtmlToMarkdown({
-    fileName: "stubs/qiskit_ibm_runtime.Sampler.html",
-    html,
-    ...DEFAULT_ARGS,
+  // This test checks that the conversion to markdown is correct when we have a <dt class=sig-object"> tag
+  // without id. For more information: https://github.com/Qiskit/documentation/issues/485
+  test("test dt tag without id", async () => {
+    expect(
+      await toMd(`
+      <div role="main">
+      <p>In addition to the public abstract methods, subclasses should also implement the following
+      private methods:</p>
+      <dl class="py method">
+      <dt class="sig sig-object py">
+      <em class="property"><span class="pre">classmethod</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">_default_options</span></span><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit/providers/basicaer/qasm_simulator.html#QasmSimulatorPy._default_options"><span class="viewcode-link"><span class="pre">[source]</span></span></a></dt>
+      <dd><p>Return the default options</p>
+      <p>This method will return a <a class="reference internal" href="qiskit.providers.Options.html#qiskit.providers.Options" title="qiskit.providers.Options"><code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit.providers.Options</span></code></a>
+      subclass object that will be used for the default options. These
+      should be the default parameters to use for the options of the
+      backend.</p>
+      <dl class="field-list simple">
+      <dt class="field-odd">Returns<span class="colon">:</span></dt>
+      <dd class="field-odd"><p><dl class="simple">
+      <dt>A options object with</dt><dd><p>default values set</p>
+      </dd>
+      </dl>
+      </p>
+      </dd>
+      <dt class="field-even">Return type<span class="colon">:</span></dt>
+      <dd class="field-even"><p><a class="reference internal" href="qiskit.providers.Options.html#qiskit.providers.Options" title="qiskit.providers.Options">qiskit.providers.Options</a></p>
+      </dd>
+      </dl>
+      </dd></dl>
+      </div>
+  `),
+    ).toMatchInlineSnapshot(`
+    "In addition to the public abstract methods, subclasses should also implement the following private methods:
+    
+    \`classmethod _default_options()\`
+    
+    Return the default options
+    
+    This method will return a [\`qiskit.providers.Options\`](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options") subclass object that will be used for the default options. These should be the default parameters to use for the options of the backend.
+    
+    **Returns**
+    
+    **A options object with**
+    
+    default values set
+    
+    **Return type**
+    
+    [qiskit.providers.Options](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options")
+    "
+    `);
   });
-}
+
+  // ------------------------------------------------------------------
+  // Handle math expressions
+  // ------------------------------------------------------------------
+
+  test("transform inline math", async () => {
+    expect(
+      await toMd(`
+<div role='main'>
+<table>
+<tbody>
+<tr class="row-even"><td><p><a class="reference internal" href="../stubs/qiskit.circuit.library.GlobalPhaseGate.html#qiskit.circuit.library.GlobalPhaseGate" title="qiskit.circuit.library.GlobalPhaseGate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">GlobalPhaseGate</span></code></a>(phase[, label])</p></td>
+<td><p>The global phase gate (<span class="math notranslate nohighlight">\\(e^{i\\theta}\\)</span>).</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+        `),
+    ).toMatchInlineSnapshot(`
+        "|                                                                                                                                                                       |                                        |
+        | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+        | [\`GlobalPhaseGate\`](../stubs/qiskit.circuit.library.GlobalPhaseGate#qiskit.circuit.library.GlobalPhaseGate "qiskit.circuit.library.GlobalPhaseGate")(phase\\[, label]) | The global phase gate ($e^{i\\theta}$). |
+        "
+      `);
+  });
+
+  test("transform block math", async () => {
+    expect(
+      await toMd(`
+<div role='main'>
+<div class="math notranslate nohighlight">
+\\[\\begin{split}CCX q_0, q_1, q_2 =
+    I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
+   \\begin{pmatrix}
+        1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
+        0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
+        0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0\\\\
+        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1\\\\
+        0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0\\\\
+        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0\\\\
+        0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 0 &amp; 1 &amp; 0\\\\
+        0 &amp; 0 &amp; 0 &amp; 1 &amp; 0 &amp; 0 &amp; 0 &amp; 0
+    \\end{pmatrix}\\end{split}\\]</div>
+
+<div class="math notranslate nohighlight">
+\\[x = \\sum_{i=0}^{n-1} 2^i q_i,\\]</div>
+</div>
+        `),
+    ).toMatchInlineSnapshot(`
+        "$$
+        \\begin{split}CCX q_0, q_1, q_2 =
+            I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
+           \\begin{pmatrix}
+                1 & 0 & 0 & 0 & 0 & 0 & 0 & 0\\\\
+                0 & 1 & 0 & 0 & 0 & 0 & 0 & 0\\\\
+                0 & 0 & 1 & 0 & 0 & 0 & 0 & 0\\\\
+                0 & 0 & 0 & 0 & 0 & 0 & 0 & 1\\\\
+                0 & 0 & 0 & 0 & 1 & 0 & 0 & 0\\\\
+                0 & 0 & 0 & 0 & 0 & 1 & 0 & 0\\\\
+                0 & 0 & 0 & 0 & 0 & 0 & 1 & 0\\\\
+                0 & 0 & 0 & 1 & 0 & 0 & 0 & 0
+            \\end{pmatrix}\\end{split}
+        $$
+
+        $$
+        x = \\sum_{i=0}^{n-1} 2^i q_i,
+        $$
+        "
+      `);
+  });
+
+  // ------------------------------------------------------------------
+  // transform links
+  // ------------------------------------------------------------------
+
+  test("remove .html extension from relative links", async () => {
+    expect(
+      await toMd(`<div
+  role='main'
+  class='main-content'
+  itemscope='itemscope'
+  itemtype='http://schema.org/Article'
+>
+  <article itemprop='articleBody' id='pytorch-article' class='pytorch-article'>
+    <section id='qiskit-ibm-runtime-api-reference'>
+      <h1>
+        qiskit-ibm-runtime API reference<a
+        class='headerlink'
+        href='#qiskit-ibm-runtime-api-reference'
+        title='Permalink to this heading'
+      >¶</a
+      >
+      </h1>
+      <div class='toctree-wrapper compound'>
+        <ul>
+          <li class='toctree-l1'>
+            <a class='reference internal' href='runtime_service.html'
+            >Qiskit Runtime (<code
+              class='xref py py-mod docutils literal notranslate'
+            ><span class='pre'>qiskit_ibm_runtime</span></code
+            >)</a
+            >
+          </li>
+        </ul>
+      </div>
+    </section>
+  </article>
+</div>`),
+    ).toMatchInlineSnapshot(`
+      "<span id="qiskit-ibm-runtime-api-reference" />
+
+      # qiskit-ibm-runtime API reference
+
+      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
+      "
+    `);
+  });
+
+  test("remove permalink", async () => {
+    expect(
+      await toMd(`<article role="main">
+        <section id="qiskit-ibm-runtime-api-reference">
+          <h1>qiskit-ibm-runtime API reference<a class="headerlink" href="#qiskit-ibm-runtime-api-reference" title="Link to this heading">#</a></h1>
+         <div class="toctree-wrapper compound">
+           <ul>
+             <li class="toctree-l1"><a class="reference internal" href="runtime_service.html">Qiskit Runtime (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime</span></code>)</a></li>
+             <li class="toctree-l1"><a class="reference internal" href="options.html">Primitive options (<code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.options</span></code>)</a></li>
+           </ul>
+         </div>
+       </section>
+    </article>`),
+    ).toMatchInlineSnapshot(`
+      "<span id="qiskit-ibm-runtime-api-reference" />
+
+      # qiskit-ibm-runtime API reference
+
+      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
+      *   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
+      "
+    `);
+  });
+
+  test("remove download links", async () => {
+    expect(
+      await toMd(`<div
+  role='main'
+  class='main-content'
+  itemscope='itemscope'
+  itemtype='http://schema.org/Article'
+>
+  <p>(<a class="reference download internal" download="" href="../_downloads/366189d70d6a05b2c91f442d20ba6114/qiskit-circuit-QuantumCircuit-1.py"><code class="xref download docutils literal notranslate"><span class="pre">Source</span> <span class="pre">code</span></code></a>)</p>
+</div>
+`),
+    ).toMatchInlineSnapshot(`""`);
+  });
+
+  test("convert source links", async () => {
+    expect(
+      await toMd(`<div role='main'>
+<span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
+</div>`),
+    ).toMatchInlineSnapshot(`
+              "IBMBackend.control\\_channel(*qubits*)[\\[source\\]](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py)
+              "
+          `);
+  });
+
+  // ------------------------------------------------------------------
+  // apiType headings conversion
+  // ------------------------------------------------------------------
+
+  test("convert class signature headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+    <h1>Estimator<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
+      <dl class='py class'>
+        <dt class='sig sig-object py' id='qiskit_ibm_runtime.Sampler'>
+          <em class='property'
+          ><span class='pre'>class</span><span class='w'> </span></em
+          ><span class='sig-name descname'><span class='pre'>SamplerExample</span></span
+        ><span class='sig-paren'>(</span
+        ><em class='sig-param'
+        ><span class='n'><span class='pre'>circuits</span></span
+        ><span class='o'><span class='pre'>=</span></span
+        ><span class='default_value'><span class='pre'>None</span></span></em
+        >,
+          <em class='sig-param'
+          ><span class='n'><span class='pre'>parameters</span></span
+          ><span class='o'><span class='pre'>=</span></span
+          ><span class='default_value'><span class='pre'>None</span></span></em
+          ><span class='sig-paren'>)</span
+        ><a
+          class='reference internal'
+          href='../_modules/qiskit_ibm_runtime/sampler.html#Sampler'
+        ><span class='viewcode-link'><span class='pre'>[source]</span></span></a
+        ><a
+          class='headerlink'
+          href='#qiskit_ibm_runtime.Sampler'
+          title='Permalink to this definition'
+        >¶</a
+        >
+        </dt>
+        <dd>
+          <p>
+            Class for interacting with Qiskit Runtime Sampler primitive service.
+          </p>
+        </dd>
+      </dl>
+    </div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "# Estimator
+
+    <span id="qiskit_ibm_runtime.Sampler" />
+
+    \`SamplerExample(circuits=None, parameters=None) \`[GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/sampler.py "view source code")
+
+    Class for interacting with Qiskit Runtime Sampler primitive service.
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_runtime.Sampler",
+        "apiType": "class",
+      },
+    }
+  `);
+  });
+
+  test("convert class property headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+<h1>Estimator.circuits<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
+<dl class='py property'>
+  <dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.circuits'>
+    <em class='property'
+    ><span class='pre'>property</span><span class='w'> </span></em
+    ><span class='sig-prename descclassname'
+  ><span class='pre'>Estimator.</span></span
+  ><span class='sig-name descname'><span class='pre'>circuits</span></span
+  ><em class='property'
+  ><span class='p'><span class='pre'>:</span></span
+  ><span class='w'> </span><span class='pre'>tuple</span
+  ><span class='p'><span class='pre'>[</span></span
+  ><span class='pre'>qiskit.circuit.quantumcircuit.QuantumCircuit</span
+  ><span class='p'><span class='pre'>,</span></span
+  ><span class='w'> </span
+  ><span class='p'><span class='pre'>...</span></span
+  ><span class='p'><span class='pre'>]</span></span></em
+  ><a
+    class='headerlink'
+    href='#qiskit_ibm_runtime.Estimator.circuits'
+    title='Permalink to this definition'
+  >¶</a
+  >
+  </dt>
+  <dd><p>Quantum circuits that represents quantum states.</p></dd>
+</dl>
+</div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "# circuits
+
+    <span id="qiskit_ibm_runtime.Estimator.circuits" />
+
+    \`tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]\`
+
+    Quantum circuits that represents quantum states.
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_runtime.Estimator.circuits",
+        "apiType": "property",
+      },
+    }
+  `);
+  });
+
+  test("convert class method headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+<h1>Estimator.run<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
+<dl class='py method'>
+<dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.run'>
+<span class='sig-prename descclassname'><span class='pre'>Estimator.</span></span><span class='sig-name descname'><span class='pre'>run</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>circuits</span></span></em>, <em class='sig-param'><span class='n'><span class='pre'>observables</span></span></em>, <em class='sig-param'><span class='n'><span class='pre'>parameter_values</span></span><span class='o'><span class='pre'>=</span></span><span class='default_value'><span class='pre'>None</span></span></em>, <em class='sig-param'><span class='o'><span class='pre'>**</span></span><span class='n'><span class='pre'>kwargs</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/estimator.html#Estimator.run'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.Estimator.run' title='Permalink to this definition'>¶</a></dt>
+<dd><p>Submit a request to the estimator primitive program.</p></dd></dl>
+</div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "# run
+
+    <span id="qiskit_ibm_runtime.Estimator.run" />
+
+    \`Estimator.run(circuits, observables, parameter_values=None, **kwargs)\`
+
+    Submit a request to the estimator primitive program.
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_runtime.Estimator.run",
+        "apiType": "method",
+      },
+    }
+  `);
+  });
+
+  test("convert class attributes headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+<h1>EnvironmentOptions.callback<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
+<dl class='py attribute'>
+<dt class='sig sig-object py' id='qiskit_ibm_runtime.options.EnvironmentOptions.callback'>
+<span class='sig-prename descclassname'><span class='pre'>EnvironmentOptions.</span></span><span class='sig-name descname'><span class='pre'>callback</span></span><em class='property'><span class='p'><span class='pre'>:</span></span><span class='w'> </span><span class='pre'>Optional</span><span class='p'><span class='pre'>[</span></span><span class='pre'>Callable</span><span class='p'><span class='pre'>]</span></span></em><em class='property'><span class='w'> </span><span class='p'><span class='pre'>=</span></span><span class='w'> </span><span class='pre'>None</span></em><a class='headerlink' href='#qiskit_ibm_runtime.options.EnvironmentOptions.callback' title='Permalink to this definition'>¶</a></dt>
+<dd></dd></dl>
+</div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "# callback
+
+    <span id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" />
+
+    \`Optional[Callable] = None\`
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_runtime.options.EnvironmentOptions.callback",
+        "apiType": "attribute",
+      },
+    }
+  `);
+  });
+
+  test("convert functions headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+<section id="job-monitor">
+<h1>job_monitor<a class="headerlink" href="#job-monitor" title="Permalink to this heading">¶</a></h1>
+<dl class="py function">
+<dt class="sig sig-object py" id="qiskit_ibm_provider.job.job_monitor">
+<span class="sig-name descname"><span class="pre">job_monitor</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">job</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">interval=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">output=&lt;_io.TextIOWrapper</span> <span class="pre">name='&lt;stdout&gt;'</span> <span class="pre">mode='w'</span> <span class="pre">encoding='utf-8'&gt;</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit_ibm_provider/job/job_monitor.html#job_monitor"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_provider.job.job_monitor" title="Permalink to this definition">¶</a></dt>
+<dd><p>Monitor the status of an <code class="docutils literal notranslate"><span class="pre">IBMJob</span></code> instance.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>job</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">IBMJob</span></code>) – Job to monitor.</p></li>
+<li><p><strong>interval</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Optional</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">float</span></code>]) – Time interval between status queries.</p></li>
+<li><p><strong>output</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">TextIO</span></code>) – The file like object to write status messages to.
+By default this is sys.stdout.</p></li>
+</ul>
+</dd>
+<dt class="field-even">Return type<span class="colon">:</span></dt>
+<dd class="field-even"><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">None</span></code></p>
+</dd>
+</dl>
+</dd></dl>
+
+</section>
+</div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "<span id="job-monitor" />
+
+    # job\\_monitor
+
+    <span id="qiskit_ibm_provider.job.job_monitor" />
+
+    \`job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/job_monitor.py "view source code")
+
+    Monitor the status of an \`IBMJob\` instance.
+
+    **Parameters**
+
+    *   **job** (\`IBMJob\`) – Job to monitor.
+    *   **interval** (\`Optional\`\\[\`float\`]) – Time interval between status queries.
+    *   **output** (\`TextIO\`) – The file like object to write status messages to. By default this is sys.stdout.
+
+    **Return type**
+
+    \`None\`
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_provider.job.job_monitor",
+        "apiType": "function",
+      },
+    }
+  `);
+  });
+
+  test("convert exception headings", async () => {
+    expect(
+      await toMd(
+        `<div role='main'>
+<article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
+<section id="ibmjoberror">
+<h1>IBMJobError<a class="headerlink" href="#ibmjoberror" title="Permalink to this heading">¶</a></h1>
+<dl class="py exception">
+<dt class="sig sig-object py" id="qiskit_ibm_provider.job.IBMJobError">
+<em class="property"><span class="pre">exception</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">IBMJobError</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="o"><span class="pre">*</span></span><span class="n"><span class="pre">message</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit_ibm_provider/job/exceptions.html#IBMJobError"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_provider.job.IBMJobError" title="Permalink to this definition">¶</a></dt>
+<dd><p>Base class for errors raised by the job modules.</p>
+<p>Set the error message.</p>
+</dd></dl>
+</section>
+</article>
+</div>
+`,
+        true,
+      ),
+    ).toMatchInlineSnapshot(`
+    {
+      "images": [],
+      "isReleaseNotes": false,
+      "markdown": "<span id="ibmjoberror" />
+
+    # IBMJobError
+
+    <span id="qiskit_ibm_provider.job.IBMJobError" />
+
+    \`IBMJobError(*message)\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/exceptions.py "view source code")
+
+    Base class for errors raised by the job modules.
+
+    Set the error message.
+    ",
+      "meta": {
+        "apiName": "qiskit_ibm_provider.job.IBMJobError",
+        "apiType": "exception",
+      },
+    }
+  `);
+  });
+
+  // ------------------------------------------------------------------
+  // Release notes HTML to markdown
+  // ------------------------------------------------------------------
+
+  test("identify release notes", async () => {
+    expect(
+      await sphinxHtmlToMarkdown({
+        html: `
+            <div role="main">
+            <h1>Release Notes<a class="headerlink" href="#release-notes" title="Link to this heading">#</a></h1>
+            <section id="release-notes-0-14-0">
+            <span id="id1"></span><h2>0.14.0<a class="headerlink" href="#release-notes-0-14-0" title="Link to this heading">#</a></h2>
+            <section id="new-features">
+            <span id="release-notes-0-14-0-new-features"></span><h3>New Features<a class="headerlink" href="#new-features" title="Link to this heading">#</a></h3>
+            <ul class="simple">
+            <li><p>There is a new class, <code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.Batch</span></code> that currently works
+            the same way as <a class="reference internal" href="stubs/qiskit_ibm_runtime.Session.html#qiskit_ibm_runtime.Session" title="qiskit_ibm_runtime.Session"><code class="xref py py-class docutils literal notranslate"><span class="pre">qiskit_ibm_runtime.Session</span></code></a> but will later be updated 
+            to better support submitting multiple jobs at once.</p></li>
+            </ul>
+            `,
+        fileName: "release_notes.html",
+        ...DEFAULT_ARGS,
+      }),
+    ).toMatchInlineSnapshot(`
+  {
+    "images": [],
+    "isReleaseNotes": true,
+    "markdown": "# My Quantum release notes
+
+  <span id="release-notes-0-14-0" />
+
+  <span id="id1" />
+
+  ## 0.14.0
+
+  <span id="new-features" />
+
+  <span id="release-notes-0-14-0-new-features" />
+
+  ### New Features
+
+  *   There is a new class, \`qiskit_ibm_runtime.Batch\` that currently works the same way as [\`qiskit_ibm_runtime.Session\`](stubs/qiskit_ibm_runtime.Session#qiskit_ibm_runtime.Session \"qiskit_ibm_runtime.Session\") but will later be updated to better support submitting multiple jobs at once.
+  ",
+    "meta": {},
+  }
+  `);
+  });
+});


### PR DESCRIPTION
### Summary

Part of  #845

This PR refactors the `htmlToMd.test.ts` test file.

### Changes

- Three tests were removed
  1. `merge contiguous emphasis` was merged with `remove spaces from emphasis boundaries`. They were using the same HTML but only adding spaces
  2. `convert method and attributes to titles`. This test was incomplete and it's implicitly checked at `convert inline methods`.
  3. `convert class method with a problematic output`. The test wasn't checking anything related to the script behavior. The problematic output is due to a bad HTML that should be fixed in the original repo.

- Input HTML trimmed for some tests. We were using long inputs to test certain behaviors that don't need it. For example, we were testing the transformation of a table with 11 entries when the same test could use 2 or 3.

- Some tests have been organized into sections to easily find them scanning the file. These sections can be found at the end of the test file leaving the uncategorized tests at the beginning.

- We were using two helper functions for the tests named `toMd` and `toMdWithMeta` with the only difference that in the first one, we returned the markdown attribute of the transformation instead of the whole object. I merged these two functions with an extra argument to specify when we need to return the metadata.