### PR TITLE
Create more sections for `htmlToMd.test.ts` and merge tests

### DIFF
--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -186,115 +186,6 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
           `);
   });
 
-  test("convert method and attributes to titles and handle inlined methods", async () => {
-    expect(
-      await toMd(`
-      <div role="main">
-
-<h1>DAGCircuit<a class="headerlink" href="#dagcircuit" title="Permalink to this heading">#</a></h1>
-<dl class="py class">
-<dt class="sig sig-object py" id="qiskit.dagcircuit.DAGCircuit">
-<em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">qiskit.dagcircuit.</span></span><span class="sig-name descname"><span class="pre">DAGCircuit</span></span><a class="reference internal" href="../_modules/qiskit/dagcircuit/dagcircuit.html#DAGCircuit"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit.dagcircuit.DAGCircuit" title="Permalink to this definition">#</a></dt>
-<dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
-<p>Quantum circuit as a directed acyclic graph.</p>
-<p>There are 3 types of nodes in the graph: inputs, outputs, and operations.
-The nodes are connected by directed edges that correspond to qubits and
-bits.</p>
-<p>Create an empty circuit.</p>
-<p class="rubric">Attributes</p>
-
-<p class="rubric">Methods</p>
-<dl class="py method">
-<dt class="sig sig-object py" id="qiskit.dagcircuit.DAGCircuit.add_calibration">
-<span class="sig-name descname"><span class="pre">add_calibration</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">gate</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">qubits</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">schedule</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">params</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit/dagcircuit/dagcircuit.html#DAGCircuit.add_calibration"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit.dagcircuit.DAGCircuit.add_calibration" title="Permalink to this definition">#</a></dt>
-<dd><p>Register a low-level, custom pulse definition for the given gate.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters<span class="colon">:</span></dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>gate</strong> (<em>Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]</em>) – Gate information.</p></li>
-<li><p><strong>qubits</strong> (<em>Union</em><em>[</em><em>int</em><em>, </em><em>Tuple</em><em>[</em><em>int</em><em>]</em><em>]</em>) – List of qubits to be measured.</p></li>
-<li><p><strong>schedule</strong> (<a class="reference internal" href="qiskit.pulse.Schedule.html#qiskit.pulse.Schedule" title="qiskit.pulse.Schedule"><em>Schedule</em></a>) – Schedule information.</p></li>
-<li><p><strong>params</strong> (<em>Optional</em><em>[</em><em>List</em><em>[</em><em>Union</em><em>[</em><em>float</em><em>, </em><a class="reference internal" href="qiskit.circuit.Parameter.html#qiskit.circuit.Parameter" title="qiskit.circuit.Parameter"><em>Parameter</em></a><em>]</em><em>]</em><em>]</em>) – A list of parameters.</p></li>
-</ul>
-</dd>
-<dt class="field-even">Raises<span class="colon">:</span></dt>
-<dd class="field-even"><p><strong>Exception</strong> – if the gate is of type string and params is None.</p>
-</dd>
-</dl>
-</dd></dl>
- </div>
-      `),
-    ).toMatchInlineSnapshot(`
-      "# DAGCircuit
-
-      <span id="qiskit.dagcircuit.DAGCircuit" />
-
-      \`qiskit.dagcircuit.DAGCircuit\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py "view source code")
-
-      Bases: \`object\`
-
-      Quantum circuit as a directed acyclic graph.
-
-      There are 3 types of nodes in the graph: inputs, outputs, and operations. The nodes are connected by directed edges that correspond to qubits and bits.
-
-      Create an empty circuit.
-
-      ## Attributes
-
-      ## Methods
-
-      ### add\\_calibration
-
-      <span id="qiskit.dagcircuit.DAGCircuit.add_calibration" />
-
-      \`add_calibration(gate, qubits, schedule, params=None)\`
-
-      Register a low-level, custom pulse definition for the given gate.
-
-      **Parameters**
-
-      *   **gate** (*Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]*) – Gate information.
-      *   **qubits** (*Union\\[int, Tuple\\[int]]*) – List of qubits to be measured.
-      *   **schedule** ([*Schedule*](qiskit.pulse.Schedule#qiskit.pulse.Schedule "qiskit.pulse.Schedule")) – Schedule information.
-      *   **params** (*Optional\\[List\\[Union\\[float,* [*Parameter*](qiskit.circuit.Parameter#qiskit.circuit.Parameter "qiskit.circuit.Parameter")*]]]*) – A list of parameters.
-
-      **Raises**
-
-      **Exception** – if the gate is of type string and params is None.
-      "
-    `);
-  });
-
-  test("transform dl, dd, dt elements", async () => {
-    expect(
-      await toMd(`<div role='main'>
-  <dl>
-    <dt class='field-even'>Return type<span class='colon'>:</span></dt>
-    <dd class='field-even'><p><a class='reference internal'
-                                 href='qiskit_ibm_runtime.RuntimeJob.html#qiskit_ibm_runtime.RuntimeJob'
-                                 title='qiskit_ibm_runtime.RuntimeJob'>RuntimeJob</a></p>
-    </dd>
-    <dt class='field-odd'>Returns<span class='colon'>:</span></dt>
-    <dd class='field-odd'><p>Submitted job.
-      The result of the job is an instance of <code
-        class='xref py py-class docutils literal notranslate'><span class='pre'>qiskit.primitives.EstimatorResult</span></code>.
-    </p>
-    </dd>
-  </dl>
-</div>
-`),
-    ).toMatchInlineSnapshot(`
-        "## Return type
-
-        [RuntimeJob](qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")
-
-        ## Returns
-
-        Submitted job. The result of the job is an instance of \`qiskit.primitives.EstimatorResult\`.
-        "
-      `);
-  });
-
   test("remove () around module titles", async () => {
     expect(
       await toMd(`<div role='main'>
@@ -317,152 +208,6 @@ bits.</p>
       Modules related to Qiskit Runtime IBM Client.
       "
     `);
-  });
-
-  test("transform admonitions", async () => {
-    expect(
-      await toMd(`<div role='main'>
-  <div class='admonition note'>
-    <p class='admonition-title'>Note</p>
-    <p>To use these tools locally, you’ll need to install the
-      additional dependencies for the visualization functions:</p>
-  </div>
-
-  <div class='admonition warning'>
-    <p class='admonition-title'>Warning</p>
-    <p>This is a warning</p>
-  </div>
-
-  <div class='admonition important'>
-    <p class='admonition-title'>Important</p>
-    <p>The global phase gate (<span class="math notranslate nohighlight">\\(e^{i\\theta}\\)</span>).</p>
-  </div>
-</div>
-        `),
-    ).toMatchInlineSnapshot(`
-        "<Admonition title="Note" type="note">
-          To use these tools locally, you’ll need to install the additional dependencies for the visualization functions:
-        </Admonition>
-
-        <Admonition title="Warning" type="caution">
-          This is a warning
-        </Admonition>
-
-        <Admonition title="Important" type="danger">
-          The global phase gate ($e^{i\\theta}$).
-        </Admonition>
-        "
-      `);
-  });
-
-  test("parse inline attributes section", async () => {
-    expect(
-      await toMd(`<div role='main'>
-
-  <section id='quantumcircuit'>
-    <h1>QuantumCircuit<a class='headerlink' href='#quantumcircuit' title='Permalink to this heading'>¶</a></h1>
-    <dl class='py class'>
-      <dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit'>
-        QuantumCircuit(*regs, name=None, global_phase=0, metadata=None)
-      </dt>
-      <dd><p>Bases: <code class='xref py py-class docutils literal notranslate'><span class='pre'>object</span></code>
-      </p>
-        <p>Create a new circuit.</p>
-
-        <p class='rubric'>Attributes</p>
-        <dl class='py attribute'>
-          <dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit.ancillas'>
-            <span class='sig-name descname'><span class='pre'>ancillas</span></span><a class='headerlink'
-                                                                                       href='#qiskit.circuit.QuantumCircuit.ancillas'
-                                                                                       title='Permalink to this definition'>¶</a>
-          </dt>
-          <dd><p>Returns a list of ancilla bits in the order that the registers were added.</p>
-
-          </dd>
-
-          <dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit.foo'>
-            foo = re.compile('')
-          </dt>
-          <dd>Foo has a default value
-          </dd>
-
-          <dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit.bar'>
-            bar : Object
-          </dt>
-          <dd>Bar has a type</dd>
-
-          <dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit.foobar'>
-            bar : Object = re.compile('')
-          </dt>
-          <dd>Bar has a type and a defualt value</dd>
-        </dl>
-</div>
-        `),
-    ).toMatchInlineSnapshot(`
-      "<span id="quantumcircuit" />
-
-      # QuantumCircuit
-
-      <span id="qiskit.circuit.QuantumCircuit" />
-
-      \`QuantumCircuit(*regs, name=None, global_phase=0, metadata=None)\`
-
-      Bases: \`object\`
-
-      Create a new circuit.
-
-      ## Attributes
-
-      <span id="qiskit.circuit.QuantumCircuit.ancillas" />
-
-      ### ancillas
-
-      Returns a list of ancilla bits in the order that the registers were added.
-
-      <span id="qiskit.circuit.QuantumCircuit.ancillas" />
-
-      ### foo
-
-      \`= re.compile('')\`
-
-      Foo has a default value
-
-      <span id="qiskit.circuit.QuantumCircuit.ancillas" />
-
-      ### bar
-
-      \`Object\`
-
-      Bar has a type
-
-      <span id="qiskit.circuit.QuantumCircuit.ancillas" />
-
-      ### bar
-
-      \`Object\`
-
-      \`= re.compile('')\`
-
-      Bar has a type and a defualt value
-      "
-    `);
-  });
-
-  test("parse deprecations warnings", async () => {
-    expect(
-      await toMd(`
-      <div role="main">
-      <div class="deprecated">
-<p><span class="versionmodified deprecated">Deprecated since version 0.23.0: </span>The method <code class="docutils literal notranslate"><span class="pre">qiskit.circuit.quantumregister.QuantumRegister.qasm()</span></code> is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.</p>
-</div>
-      </div>
-      `),
-    ).toMatchInlineSnapshot(`
-        "<Admonition title="Deprecated since version 0.23.0" type="danger">
-          The method \`qiskit.circuit.quantumregister.QuantumRegister.qasm()\` is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.
-        </Admonition>
-        "
-      `);
   });
 
   test("preserve span with ids", async () => {
@@ -510,9 +255,7 @@ bits.</p>
     expect(
       await toMd(`
       <div role="main">
-
         <li><p><strong>gate</strong> (<em> Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]   </em>) – Gate information.</p></li>
-
       </div>
     `),
     ).toMatchInlineSnapshot(`
@@ -540,9 +283,138 @@ for execution on present day noisy quantum systems.</p>
     `);
   });
 
-  // This test checks that the conversion to markdown is correct when we have a <dt class=sig-object"> tag
-  // without id. For more information: https://github.com/Qiskit/documentation/issues/485
-  test("test dt tag without id", async () => {
+  // ------------------------------------------------------------------
+  // Transform methods and attributes
+  // ------------------------------------------------------------------
+
+  test("handle inlined methods and attributes", async () => {
+    expect(
+      await toMd(`
+      <div role="main">
+
+<h1>DAGCircuit<a class="headerlink" href="#dagcircuit" title="Permalink to this heading">#</a></h1>
+<dl class="py class">
+<dt class="sig sig-object py" id="qiskit.dagcircuit.DAGCircuit">
+<em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">qiskit.dagcircuit.</span></span><span class="sig-name descname"><span class="pre">DAGCircuit</span></span><a class="reference internal" href="../_modules/qiskit/dagcircuit/dagcircuit.html#DAGCircuit"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit.dagcircuit.DAGCircuit" title="Permalink to this definition">#</a></dt>
+<dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
+<p>Quantum circuit as a directed acyclic graph.</p>
+<p>There are 3 types of nodes in the graph: inputs, outputs, and operations.
+The nodes are connected by directed edges that correspond to qubits and
+bits.</p>
+<p>Create an empty circuit.</p>
+<p class="rubric">Attributes</p>
+<dl class='py attribute'>
+<dt class='sig sig-object py' id='qiskit.circuit.QuantumCircuit.ancillas'>
+  <span class='sig-name descname'><span class='pre'>ancillas</span></span><a class='headerlink'
+                                                                             href='#qiskit.circuit.QuantumCircuit.ancillas'
+                                                                             title='Permalink to this definition'>¶</a>
+</dt>
+<dd><p>Returns a list of ancilla bits in the order that the registers were added.</p></dd>
+</dl>
+<p class="rubric">Methods</p>
+<dl class="py method">
+<dt class="sig sig-object py" id="qiskit.dagcircuit.DAGCircuit.add_calibration">
+<span class="sig-name descname"><span class="pre">add_calibration</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">gate</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">qubits</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">schedule</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">params</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit/dagcircuit/dagcircuit.html#DAGCircuit.add_calibration"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit.dagcircuit.DAGCircuit.add_calibration" title="Permalink to this definition">#</a></dt>
+<dd><p>Register a low-level, custom pulse definition for the given gate.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Parameters<span class="colon">:</span></dt>
+<dd class="field-odd"><ul class="simple">
+<li><p><strong>gate</strong> (<em>Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]</em>) – Gate information.</p></li>
+<li><p><strong>qubits</strong> (<em>Union</em><em>[</em><em>int</em><em>, </em><em>Tuple</em><em>[</em><em>int</em><em>]</em><em>]</em>) – List of qubits to be measured.</p></li>
+<li><p><strong>schedule</strong> (<a class="reference internal" href="qiskit.pulse.Schedule.html#qiskit.pulse.Schedule" title="qiskit.pulse.Schedule"><em>Schedule</em></a>) – Schedule information.</p></li>
+<li><p><strong>params</strong> (<em>Optional</em><em>[</em><em>List</em><em>[</em><em>Union</em><em>[</em><em>float</em><em>, </em><a class="reference internal" href="qiskit.circuit.Parameter.html#qiskit.circuit.Parameter" title="qiskit.circuit.Parameter"><em>Parameter</em></a><em>]</em><em>]</em><em>]</em>) – A list of parameters.</p></li>
+</ul>
+</dd>
+<dt class="field-even">Raises<span class="colon">:</span></dt>
+<dd class="field-even"><p><strong>Exception</strong> – if the gate is of type string and params is None.</p>
+</dd>
+</dl>
+</dd></dl>
+ </div>
+      `),
+    ).toMatchInlineSnapshot(`
+      "# DAGCircuit
+
+      <span id="qiskit.dagcircuit.DAGCircuit" />
+
+      \`qiskit.dagcircuit.DAGCircuit\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py "view source code")
+
+      Bases: \`object\`
+
+      Quantum circuit as a directed acyclic graph.
+
+      There are 3 types of nodes in the graph: inputs, outputs, and operations. The nodes are connected by directed edges that correspond to qubits and bits.
+
+      Create an empty circuit.
+
+      ## Attributes
+
+      <span id="qiskit.circuit.QuantumCircuit.ancillas" />
+
+      ### ancillas
+
+      Returns a list of ancilla bits in the order that the registers were added.
+
+      ## Methods
+
+      ### add\\_calibration
+
+      <span id="qiskit.dagcircuit.DAGCircuit.add_calibration" />
+
+      \`add_calibration(gate, qubits, schedule, params=None)\`
+
+      Register a low-level, custom pulse definition for the given gate.
+
+      **Parameters**
+
+      *   **gate** (*Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]*) – Gate information.
+      *   **qubits** (*Union\\[int, Tuple\\[int]]*) – List of qubits to be measured.
+      *   **schedule** ([*Schedule*](qiskit.pulse.Schedule#qiskit.pulse.Schedule "qiskit.pulse.Schedule")) – Schedule information.
+      *   **params** (*Optional\\[List\\[Union\\[float,* [*Parameter*](qiskit.circuit.Parameter#qiskit.circuit.Parameter "qiskit.circuit.Parameter")*]]]*) – A list of parameters.
+
+      **Raises**
+
+      **Exception** – if the gate is of type string and params is None.
+      "
+    `);
+  });
+
+  // ------------------------------------------------------------------
+  // transform description HTML tags
+  // ------------------------------------------------------------------
+
+  test("transform dl, dd, dt elements", async () => {
+    expect(
+      await toMd(`<div role='main'>
+  <dl>
+    <dt class='field-even'>Return type<span class='colon'>:</span></dt>
+    <dd class='field-even'><p><a class='reference internal'
+                                 href='qiskit_ibm_runtime.RuntimeJob.html#qiskit_ibm_runtime.RuntimeJob'
+                                 title='qiskit_ibm_runtime.RuntimeJob'>RuntimeJob</a></p>
+    </dd>
+    <dt class='field-odd'>Returns<span class='colon'>:</span></dt>
+    <dd class='field-odd'><p>Submitted job.
+      The result of the job is an instance of <code
+        class='xref py py-class docutils literal notranslate'><span class='pre'>qiskit.primitives.EstimatorResult</span></code>.
+    </p>
+    </dd>
+  </dl>
+</div>
+`),
+    ).toMatchInlineSnapshot(`
+        "## Return type
+
+        [RuntimeJob](qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")
+
+        ## Returns
+
+        Submitted job. The result of the job is an instance of \`qiskit.primitives.EstimatorResult\`.
+        "
+      `);
+  });
+
+  // For more information: https://github.com/Qiskit/documentation/issues/485
+  test("dt sig-object tags without id", async () => {
     expect(
       await toMd(`
       <div role="main">
@@ -591,6 +463,63 @@ for execution on present day noisy quantum systems.</p>
     [qiskit.providers.Options](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options")
     "
     `);
+  });
+
+  // ------------------------------------------------------------------
+  // transform admonitions
+  // ------------------------------------------------------------------
+
+  test("transform admonitions", async () => {
+    expect(
+      await toMd(`<div role='main'>
+  <div class='admonition note'>
+    <p class='admonition-title'>Note</p>
+    <p>To use these tools locally, you’ll need to install the
+      additional dependencies for the visualization functions:</p>
+  </div>
+
+  <div class='admonition warning'>
+    <p class='admonition-title'>Warning</p>
+    <p>This is a warning</p>
+  </div>
+
+  <div class='admonition important'>
+    <p class='admonition-title'>Important</p>
+    <p>The global phase gate (<span class="math notranslate nohighlight">\\(e^{i\\theta}\\)</span>).</p>
+  </div>
+</div>
+        `),
+    ).toMatchInlineSnapshot(`
+        "<Admonition title="Note" type="note">
+          To use these tools locally, you’ll need to install the additional dependencies for the visualization functions:
+        </Admonition>
+
+        <Admonition title="Warning" type="caution">
+          This is a warning
+        </Admonition>
+
+        <Admonition title="Important" type="danger">
+          The global phase gate ($e^{i\\theta}$).
+        </Admonition>
+        "
+      `);
+  });
+
+  test("parse deprecations warnings", async () => {
+    expect(
+      await toMd(`
+      <div role="main">
+      <div class="deprecated">
+<p><span class="versionmodified deprecated">Deprecated since version 0.23.0: </span>The method <code class="docutils literal notranslate"><span class="pre">qiskit.circuit.quantumregister.QuantumRegister.qasm()</span></code> is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.</p>
+</div>
+      </div>
+      `),
+    ).toMatchInlineSnapshot(`
+        "<Admonition title="Deprecated since version 0.23.0" type="danger">
+          The method \`qiskit.circuit.quantumregister.QuantumRegister.qasm()\` is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.
+        </Admonition>
+        "
+      `);
   });
 
   // ------------------------------------------------------------------

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -361,7 +361,7 @@ bits.</p>
   });
 
   // ------------------------------------------------------------------
-  // transform description HTML tags
+  // Transform description HTML tags
   // ------------------------------------------------------------------
 
   test("transform dl, dd, dt elements", async () => {
@@ -447,7 +447,7 @@ bits.</p>
   });
 
   // ------------------------------------------------------------------
-  // transform admonitions
+  // Transform admonitions
   // ------------------------------------------------------------------
 
   test("transform admonitions", async () => {
@@ -574,7 +574,7 @@ bits.</p>
   });
 
   // ------------------------------------------------------------------
-  // transform links
+  // Transform links
   // ------------------------------------------------------------------
 
   test("remove .html extension from relative links", async () => {

--- a/scripts/lib/api/htmlToMd.test.ts
+++ b/scripts/lib/api/htmlToMd.test.ts
@@ -124,7 +124,7 @@ describe("sphinxHtmlToMarkdown", () => {
           `);
   });
 
-  test("handle <", async () => {
+  test("handle special characters: `<` and `{`", async () => {
     expect(
       await toMd(`
     <div role='main'>
@@ -132,34 +132,15 @@ describe("sphinxHtmlToMarkdown", () => {
 &lt;<a class='reference external' href='https://qiskit.org/documentation/apidoc/providers_models.html'>https://qiskit.org/documentation/apidoc/providers_models.html</a>&gt;</p>
 </p></li>
 
-<dl class="py class">
-<dt class="sig sig-object py" id="qiskit_ibm_runtime.options.Options">
-<em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">Options</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">optimization_level=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">resilience_level=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">max_execution_time=None</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">transpilation=&lt;factory&gt;</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">resilience=&lt;factory&gt;</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">execution=&lt;factory&gt;</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">environment=&lt;factory&gt;</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">simulator=&lt;factory&gt;</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/qiskit_ibm_runtime/options/options.html#Options"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#qiskit_ibm_runtime.options.Options" title="Permalink to this definition">¶</a></dt>
-</dl>
-
-    </div>
-    `),
-    ).toMatchInlineSnapshot(`
-      "For the full list of backend attributes, see the IBMBackend class documentation \\<[https://qiskit.org/documentation/apidoc/providers\\_models.html](https://qiskit.org/documentation/apidoc/providers_models.html)>
-
-      <span id="qiskit_ibm_runtime.options.Options" />
-
-      \`Options(optimization_level=None, resilience_level=None, max_execution_time=None, transpilation=<factory>, resilience=<factory>, execution=<factory>, environment=<factory>, simulator=<factory>)\` [GitHub](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/options/options.py "view source code")
-      "
-    `);
-  });
-
-  test("handle {", async () => {
-    expect(
-      await toMd(`
-    <div role='main'>
 <p><strong>basis_fidelity</strong> (<em>dict</em><em> | </em><em>float</em>) – available strengths and fidelity of each.
 Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or
 (2) a single float f, interpreted as {pi: f, pi/2: f/2, pi/3: f/3}.</p>
     </div>
     `),
     ).toMatchInlineSnapshot(`
-      "**basis\\_fidelity** (*dict | float*) – available strengths and fidelity of each. Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or (2) a single float f, interpreted as \\{pi: f, pi/2: f/2, pi/3: f/3}.
+      "For the full list of backend attributes, see the IBMBackend class documentation \\<[https://qiskit.org/documentation/apidoc/providers\\_models.html](https://qiskit.org/documentation/apidoc/providers_models.html)>
+
+      **basis\\_fidelity** (*dict | float*) – available strengths and fidelity of each. Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or (2) a single float f, interpreted as \\{pi: f, pi/2: f/2, pi/3: f/3}.
       "
     `);
   });


### PR DESCRIPTION
### Summary

Part of  #845

This PR creates more sections for the `htmlToMd.test.ts` and merges some tests.

### Changes

- Merged `parse inline attributes section` and `convert method and attributes to titles and handle inlined methods` into `handle inlined methods and attributes`
- Merged `handle <` and `handle {` into `handle special characters: < and {`.
- Created three new sections to classify some tests:
  1. Transform methods and attributes
  2. transform description HTML tags
  3. transform admonitions