### PR TITLE
update the blog link on the start/index page

### DIFF
--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -36,8 +36,9 @@ Join other users in our quantum community to share ideas and see what others are
 
 - Join our [Slack channel](https://ibm.co/joinqiskitslack)
 - Follow us on [LinkedIn](https://www.linkedin.com/showcase/ibm-quantum/)
-- Start contributing at [GitHub](https://github.com/qiskit)
-- Find us on [YouTube](https://www.youtube.com/qiskit) and [Medium](https://medium.com/qiskit)
+- Start contributing to our [GitHub](https://github.com/qiskit)
+- Find us on [YouTube](https://www.youtube.com/qiskit)
+- Stay up-to-date with our [blog](https://www.ibm.com/quantum/blog?topic=qiskit)
 
 
 ## Next steps


### PR DESCRIPTION
Point [here](https://www.ibm.com/quantum/blog?topic=qiskit) instead of to Medium.