### PR TITLE
Split `generateToc` into helper functions

### DIFF
--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -139,4 +139,49 @@ describe("generateToc", () => {
       }
     `);
   });
+
+  test("generate a toc without modules", () => {
+    const toc = generateToc(Pkg.mock({}), [
+      {
+        meta: { apiType: "class", apiName: "Sampler" },
+        url: "/docs/qiskit_ibm_runtime.Sampler",
+      },
+      {
+        meta: { apiType: "method", apiName: "Sampler.run" },
+        url: "/docs/qiskit_ibm_runtime.Sampler.run",
+      },
+      {
+        meta: { apiType: "class", apiName: "Estimator" },
+        url: "/docs/qiskit_ibm_runtime.Estimator",
+      },
+      {
+        meta: { apiType: "class" },
+        url: "/docs/qiskit_ibm_runtime.NoName",
+      },
+      {
+        meta: { apiType: "class", apiName: "Options" },
+        url: "docs/qiskit_ibm_runtime.options.Options",
+      },
+      {
+        meta: {
+          apiType: "function",
+          apiName: "runSomething",
+        },
+        url: "docs/qiskit_ibm_runtime.runSomething",
+      },
+    ]);
+
+    expect(toc).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "title": "Release notes",
+            "url": "/api/my-quantum-project/release-notes",
+          },
+        ],
+        "collapsed": true,
+        "title": "My Quantum Project",
+      }
+    `);
+  });
 });

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -15,6 +15,12 @@ import { describe, expect, test } from "@jest/globals";
 import { generateToc } from "./generateToc";
 import { Pkg } from "./Pkg";
 
+const DEFAULT_ARGS = {
+  markdown: "",
+  images: [],
+  isReleaseNotes: false,
+};
+
 describe("generateToc", () => {
   test("generate a toc", () => {
     const toc = generateToc(Pkg.mock({}), [
@@ -24,6 +30,7 @@ describe("generateToc", () => {
           apiName: "qiskit_ibm_runtime",
         },
         url: "/docs/runtime",
+        ...DEFAULT_ARGS,
       },
       {
         meta: {
@@ -31,26 +38,32 @@ describe("generateToc", () => {
           apiName: "qiskit_ibm_runtime.options",
         },
         url: "/docs/options",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class", apiName: "Sampler" },
         url: "/docs/qiskit_ibm_runtime.Sampler",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "method", apiName: "Sampler.run" },
         url: "/docs/qiskit_ibm_runtime.Sampler.run",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class", apiName: "Estimator" },
         url: "/docs/qiskit_ibm_runtime.Estimator",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class" },
         url: "/docs/qiskit_ibm_runtime.NoName",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class", apiName: "Options" },
         url: "docs/qiskit_ibm_runtime.options.Options",
+        ...DEFAULT_ARGS,
       },
       {
         meta: {
@@ -58,6 +71,7 @@ describe("generateToc", () => {
           apiName: "runSomething",
         },
         url: "docs/qiskit_ibm_runtime.runSomething",
+        ...DEFAULT_ARGS,
       },
       {
         meta: {
@@ -65,6 +79,7 @@ describe("generateToc", () => {
           apiName: "qiskit_ibm_runtime.single",
         },
         url: "/docs/single",
+        ...DEFAULT_ARGS,
       },
     ]);
 
@@ -104,11 +119,13 @@ describe("generateToc", () => {
       }),
       [
         {
+          ...DEFAULT_ARGS,
           meta: {
             apiType: "module",
             apiName: "qiskit_ibm_runtime",
           },
           url: "/docs/runtime/qiskit_ibm_runtime",
+          isReleaseNotes: true,
         },
       ],
     );
@@ -145,22 +162,27 @@ describe("generateToc", () => {
       {
         meta: { apiType: "class", apiName: "Sampler" },
         url: "/docs/qiskit_ibm_runtime.Sampler",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "method", apiName: "Sampler.run" },
         url: "/docs/qiskit_ibm_runtime.Sampler.run",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class", apiName: "Estimator" },
         url: "/docs/qiskit_ibm_runtime.Estimator",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class" },
         url: "/docs/qiskit_ibm_runtime.NoName",
+        ...DEFAULT_ARGS,
       },
       {
         meta: { apiType: "class", apiName: "Options" },
         url: "docs/qiskit_ibm_runtime.options.Options",
+        ...DEFAULT_ARGS,
       },
       {
         meta: {
@@ -168,6 +190,7 @@ describe("generateToc", () => {
           apiName: "runSomething",
         },
         url: "docs/qiskit_ibm_runtime.runSomething",
+        ...DEFAULT_ARGS,
       },
     ]);
 

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -13,7 +13,7 @@
 import { Dictionary, isEmpty, keyBy, keys, orderBy } from "lodash";
 
 import { getLastPartFromFullIdentifier } from "../stringUtils";
-import { Metadata } from "./Metadata";
+import { HtmlToMdResultWithUrl } from "./HtmlToMdResult";
 import { Pkg } from "./Pkg";
 
 export type TocEntry = {
@@ -35,10 +35,7 @@ function nestModule(id: string): boolean {
   return id.split(".").length > 2;
 }
 
-export function generateToc(
-  pkg: Pkg,
-  results: Array<{ meta: Metadata; url: string }>,
-): Toc {
+export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
   const [modules, items] = getModulesAndItems(results);
   const tocModules = generateTocModules(modules);
   const tocModulesByTitle = keyBy(tocModules, (toc) => toc.title);
@@ -60,11 +57,8 @@ export function generateToc(
 }
 
 function getModulesAndItems(
-  results: Array<{ meta: Metadata; url: string }>,
-): [
-  Array<{ meta: Metadata; url: string }>,
-  Array<{ meta: Metadata; url: string }>,
-] {
+  results: HtmlToMdResultWithUrl[],
+): [HtmlToMdResultWithUrl[], HtmlToMdResultWithUrl[]] {
   const resultsWithName = results.filter(
     (result) => !isEmpty(result.meta.apiName),
   );
@@ -82,9 +76,7 @@ function getModulesAndItems(
   return [modules, items];
 }
 
-function generateTocModules(
-  modules: Array<{ meta: Metadata; url: string }>,
-): TocEntry[] {
+function generateTocModules(modules: HtmlToMdResultWithUrl[]): TocEntry[] {
   return modules.map(
     (module): TocEntry => ({
       title: module.meta.apiName!,
@@ -95,7 +87,7 @@ function generateTocModules(
 }
 
 function addItemsToModules(
-  items: Array<{ meta: Metadata; url: string }>,
+  items: HtmlToMdResultWithUrl[],
   tocModulesByTitle: Dictionary<TocEntry>,
   tocModuleTitles: string[],
 ) {

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { isEmpty, keyBy, keys, orderBy } from "lodash";
+import { Dictionary, isEmpty, keyBy, keys, orderBy } from "lodash";
 
 import { getLastPartFromFullIdentifier } from "../stringUtils";
 import { Metadata } from "./Metadata";
@@ -39,7 +39,32 @@ export function generateToc(
   pkg: Pkg,
   results: Array<{ meta: Metadata; url: string }>,
 ): Toc {
-  const releaseNotesUrl = `/api/${pkg.name}/release-notes`;
+  const [modules, items] = getModulesAndItems(results);
+  const tocModules = generateTocModules(modules);
+  const tocModulesByTitle = keyBy(tocModules, (toc) => toc.title);
+  const tocModuleTitles = keys(tocModulesByTitle);
+
+  addItemsToModules(items, tocModulesByTitle, tocModuleTitles);
+  const nestedTocModules = getNestedTocModulesSorted(
+    tocModules,
+    tocModulesByTitle,
+    tocModuleTitles,
+  );
+  generateOverviewPage(tocModules);
+
+  return {
+    title: pkg.title,
+    children: [...nestedTocModules, generateReleaseNotesEntries(pkg)],
+    collapsed: true,
+  };
+}
+
+function getModulesAndItems(
+  results: Array<{ meta: Metadata; url: string }>,
+): [
+  Array<{ meta: Metadata; url: string }>,
+  Array<{ meta: Metadata; url: string }>,
+] {
   const resultsWithName = results.filter(
     (result) => !isEmpty(result.meta.apiName),
   );
@@ -54,76 +79,89 @@ export function generateToc(
       result.meta.apiType === "exception",
   );
 
-  const tocChildren: Toc["children"] = [];
+  return [modules, items];
+}
 
-  if (modules.length > 0) {
-    const tocModules = modules.map(
-      (module): TocEntry => ({
-        title: module.meta.apiName!,
-        // Remove the final /index from the url
-        url: module.url.replace(/\/index$/, ""),
-      }),
+function generateTocModules(
+  modules: Array<{ meta: Metadata; url: string }>,
+): TocEntry[] {
+  return modules.map(
+    (module): TocEntry => ({
+      title: module.meta.apiName!,
+      // Remove the final /index from the url
+      url: module.url.replace(/\/index$/, ""),
+    }),
+  );
+}
+
+function addItemsToModules(
+  items: Array<{ meta: Metadata; url: string }>,
+  tocModulesByTitle: Dictionary<TocEntry>,
+  tocModuleTitles: string[],
+) {
+  for (const item of items) {
+    if (!item.meta.apiName) continue;
+    const itemModuleTitle = findClosestParentModules(
+      item.meta.apiName,
+      tocModuleTitles,
     );
-    const tocModulesByTitle = keyBy(tocModules, (toc) => toc.title);
-    const tocModuleTitles = keys(tocModulesByTitle);
 
-    // Add items to modules
-    for (const item of items) {
-      if (!item.meta.apiName) continue;
-      const itemModuleTitle = findClosestParentModules(
-        item.meta.apiName,
-        tocModuleTitles,
-      );
-      const itemModule = itemModuleTitle
-        ? tocModulesByTitle[itemModuleTitle]
-        : undefined;
-      if (itemModule) {
-        if (!itemModule.children) itemModule.children = [];
-        const itemTocEntry: TocEntry = {
-          title: getLastPartFromFullIdentifier(item.meta.apiName!),
-          url: item.url,
-        };
-        itemModule.children.push(itemTocEntry);
-      }
+    if (itemModuleTitle) {
+      const itemModule = tocModulesByTitle[itemModuleTitle];
+      if (!itemModule.children) itemModule.children = [];
+      const itemTocEntry: TocEntry = {
+        title: getLastPartFromFullIdentifier(item.meta.apiName!),
+        url: item.url,
+      };
+      itemModule.children.push(itemTocEntry);
+    }
+  }
+}
+
+function getNestedTocModulesSorted(
+  tocModules: TocEntry[],
+  tocModulesByTitle: Dictionary<TocEntry>,
+  tocModuleTitles: string[],
+): TocEntry[] {
+  const nestedTocModules: TocEntry[] = [];
+
+  for (const tocModule of tocModules) {
+    if (!nestModule(tocModule.title)) {
+      nestedTocModules.push(tocModule);
+      continue;
     }
 
-    // Nest modules
-    const nestedTocModules: TocEntry[] = [];
-    for (const tocModule of tocModules) {
-      if (!nestModule(tocModule.title)) {
-        nestedTocModules.push(tocModule);
-        continue;
-      }
+    const parentModuleTitle = findClosestParentModules(
+      tocModule.title,
+      tocModuleTitles,
+    );
 
-      const parentModuleTitle = findClosestParentModules(
-        tocModule.title,
-        tocModuleTitles,
-      );
-      const parentModule = parentModuleTitle
-        ? tocModulesByTitle[parentModuleTitle]
-        : undefined;
-      if (parentModule) {
-        if (!parentModule.children) parentModule.children = [];
-        parentModule.children.push(tocModule);
-      } else {
-        nestedTocModules.push(tocModule);
-      }
+    if (parentModuleTitle) {
+      const parentModule = tocModulesByTitle[parentModuleTitle];
+      if (!parentModule.children) parentModule.children = [];
+      parentModule.children.push(tocModule);
+    } else {
+      nestedTocModules.push(tocModule);
     }
-
-    // Sort children and create overview page
-    for (const tocModule of tocModules) {
-      if (tocModule.children && tocModule.children.length > 0) {
-        tocModule.children = [
-          { title: "Overview", url: tocModule.url },
-          ...orderEntriesByChildrenAndTitle(tocModule.children),
-        ];
-        delete tocModule.url;
-      }
-    }
-
-    tocChildren.push(...orderEntriesByTitle(nestedTocModules));
   }
 
+  return orderEntriesByTitle(nestedTocModules);
+}
+
+function generateOverviewPage(tocModules: TocEntry[]): void {
+  for (const tocModule of tocModules) {
+    if (tocModule.children && tocModule.children.length > 0) {
+      tocModule.children = [
+        { title: "Overview", url: tocModule.url },
+        ...orderEntriesByChildrenAndTitle(tocModule.children),
+      ];
+      delete tocModule.url;
+    }
+  }
+}
+
+function generateReleaseNotesEntries(pkg: Pkg) {
+  const releaseNotesUrl = `/api/${pkg.name}/release-notes`;
   const releaseNotesEntry: TocEntry = {
     title: "Release notes",
   };
@@ -132,13 +170,8 @@ export function generateToc(
   } else {
     releaseNotesEntry.url = releaseNotesUrl;
   }
-  tocChildren.push(releaseNotesEntry);
 
-  return {
-    title: pkg.title,
-    children: tocChildren,
-    collapsed: true,
-  };
+  return releaseNotesEntry;
 }
 
 function findClosestParentModules(


### PR DESCRIPTION
This PR refactors the `generateToc.ts` script splitting out the `generateToc` function into some helper functions. It also removes the if condition to check if the length of the modules is greater than 0 because it's not necessary.

The PR added a test to check the latter, and it was tested regenerating every qiskit and provider versions.