### PR TITLE
Future proof pages render check for new Patterns folders

### DIFF
--- a/scripts/commands/checkPagesRender.ts
+++ b/scripts/commands/checkPagesRender.ts
@@ -159,32 +159,27 @@ async function determineFilePaths(args: Arguments): Promise<string[]> {
   }
 
   if (args.nonApi) {
-    globs.push(
-      "docs/support.mdx",
-      "docs/{build,run,start,transpile,verify}/*.{ipynb,md,mdx}",
-      "docs/api/migration-guides/**/*.{ipynb,md,mdx}",
-    );
+    globs.push("docs/**/*.{ipynb,md,mdx}");
   }
-  if (args.currentApis) {
-    globs.push(
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/*.{ipynb,md,mdx}",
-    );
-  }
-  if (args.historicalApis) {
-    globs.push(
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*.{ipynb,md,mdx}",
-    );
-  }
-  if (args.devApis) {
-    globs.push(
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*.{ipynb,md,mdx}",
-    );
-  }
-  if (args.qiskitReleaseNotes) {
-    globs.push("docs/api/qiskit/release-notes/*.{ipynb,md,mdx}");
-  }
-  if (args.translations) {
-    globs.push("translations/**/*.{ipynb,md,mdx}");
+
+  for (const [isIncluded, glob] of [
+    [
+      args.currentApis,
+      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/*.{md,mdx}",
+    ],
+    [
+      args.historicalApis,
+      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*.{md,mdx}",
+    ],
+    [
+      args.devApis,
+      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*.{md,mdx}",
+    ],
+    [args.qiskitReleaseNotes, "docs/api/qiskit/release-notes/*.{md,mdx}"],
+    [args.translations, "translations/**/*.{ipynb,md,mdx}"],
+  ]) {
+    const prefix = isIncluded ? "" : "!";
+    globs.push(`${prefix}${glob}`);
   }
   return globby(globs);
 }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/998. Before this PR, new folders like `docs/analyze` would not be included in `npm run check:pages-render -- --non-api`.