### PR TITLE
Add API entries to allowed urls

### DIFF
--- a/scripts/commands/checkOrphanPages.ts
+++ b/scripts/commands/checkOrphanPages.ts
@@ -178,26 +178,28 @@ function apiDocsIgnores(): string[] {
     "0.46/",
   ];
 
-  return versions.flatMap((vers) => [
-    `/api/qiskit-ibm-runtime/${vers}index`,
-    `/api/qiskit-ibm-provider/${vers}index`,
-    `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Estimator`,
-    `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Sampler`,
-    `/api/qiskit/${vers}aer`,
-    `/api/qiskit/${vers}aqua`,
-    `/api/qiskit/${vers}ibmq-provider`,
-    `/api/qiskit/${vers}ibmq_jupyter`,
-    `/api/qiskit/${vers}ibmq_visualization`,
-    `/api/qiskit/${vers}qiskit.aqua.aqua_globals`,
-    `/api/qiskit/${vers}qiskit.optimization.INFINITY`,
-    `/api/qiskit/${vers}qiskit.quantum_info.two_qubit_cnot_decompose`,
-    `/api/qiskit/${vers}qiskit.utils.algorithm_globals`,
-    `/api/qiskit/${vers}parallel`,
-    `/api/qiskit/${vers}transpiler_builtin_plugins`,
+  return [
+    ...versions.flatMap((vers) => [
+      `/api/qiskit-ibm-runtime/${vers}index`,
+      `/api/qiskit-ibm-provider/${vers}index`,
+      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Estimator`,
+      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Sampler`,
+      `/api/qiskit/${vers}aer`,
+      `/api/qiskit/${vers}aqua`,
+      `/api/qiskit/${vers}ibmq-provider`,
+      `/api/qiskit/${vers}ibmq_jupyter`,
+      `/api/qiskit/${vers}ibmq_visualization`,
+      `/api/qiskit/${vers}qiskit.aqua.aqua_globals`,
+      `/api/qiskit/${vers}qiskit.optimization.INFINITY`,
+      `/api/qiskit/${vers}qiskit.quantum_info.two_qubit_cnot_decompose`,
+      `/api/qiskit/${vers}qiskit.utils.algorithm_globals`,
+      `/api/qiskit/${vers}parallel`,
+      `/api/qiskit/${vers}transpiler_builtin_plugins`,
+    ]),
     `/api/qiskit/0.19/index`,
     `/api/qiskit/dev/qiskit.primitives.BaseEstimator`,
     `/api/qiskit/dev/qiskit.primitives.BaseSampler`,
-  ]);
+  ];
 }
 
 main().then(() => process.exit());

--- a/scripts/commands/checkOrphanPages.ts
+++ b/scripts/commands/checkOrphanPages.ts
@@ -28,9 +28,10 @@ interface Arguments {
 }
 
 const ALLOWED_ORPHAN_URLS = new Set([
+  ...apiDocsIgnores(),
+  "/run/circuit-execution",
   "/api/qiskit/qiskit.primitives.BaseEstimator",
   "/api/qiskit/qiskit.primitives.BaseSampler",
-  "/run/circuit-execution",
 ]);
 
 const readArgs = (): Arguments => {
@@ -74,6 +75,7 @@ async function main() {
       ),
     );
   }
+  console.log("\n Allowed Orphans are: \n", ALLOWED_ORPHAN_URLS);
   if (orphanPages.length > 0) {
     console.error(
       "\n There are some orphaned pages!  These files need a home: \n",
@@ -121,6 +123,7 @@ async function determineTocFiles(args: Arguments): Promise<string[]> {
     globs.push(
       "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/_toc.json",
     );
+    ``;
   }
   return await globby(globs);
 }
@@ -137,6 +140,69 @@ function collectTocFileContents(children: TocEntry[]): string[] {
     }
   }
   return urls;
+}
+
+function apiDocsIgnores(): string[] {
+  const versions = [
+    "",
+    "dev/",
+    "0.7/",
+    "0.8/",
+    "0.9/",
+    "0.14/",
+    "0.15/",
+    "0.16/",
+    "0.17/",
+    "0.18/",
+    "0.19/",
+    "0.20/",
+    "0.24/",
+    "0.25/",
+    "0.26/",
+    "0.27/",
+    "0.28/",
+    "0.29/",
+    "0.30/",
+    "0.31/",
+    "0.32/",
+    "0.33/",
+    "0.35/",
+    "0.36/",
+    "0.37/",
+    "0.38/",
+    "0.39/",
+    "0.40/",
+    "0.41/",
+    "0.42/",
+    "0.43/",
+    "0.44/",
+    "0.45/",
+    "0.46/",
+  ];
+
+  return flattenDeep([
+    versions.map((vers) => [
+      `/api/qiskit-ibm-runtime/${vers}index`,
+      `/api/qiskit-ibm-provider/${vers}index`,
+      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Estimator`,
+      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Sampler`,
+      `/api/qiskit/${vers}aer`,
+      `/api/qiskit/${vers}aqua`,
+      `/api/qiskit/${vers}ibmq-provider`,
+      `/api/qiskit/${vers}ibmq_jupyter`,
+      `/api/qiskit/${vers}ibmq_visualization`,
+      `/api/qiskit/${vers}qiskit.aqua.aqua_globals`,
+      `/api/qiskit/${vers}qiskit.optimization.INFINITY`,
+      `/api/qiskit/${vers}qiskit.quantum_info.two_qubit_cnot_decompose`,
+      `/api/qiskit/${vers}qiskit.utils.algorithm_globals`,
+      `/api/qiskit/${vers}parallel`,
+      `/api/qiskit/${vers}transpiler_builtin_plugins`,
+    ]),
+    `/api/qiskit/0.19/index`,
+    `/api/qiskit/dev/qiskit.primitives.BaseEstimator`,
+    `/api/qiskit/dev/qiskit.primitives.BaseSampler`,
+    `/api/qiskit/dev/qiskit.primitives.BaseSampler`,
+  ]);
 }
 
 main().then(() => process.exit());

--- a/scripts/commands/checkOrphanPages.ts
+++ b/scripts/commands/checkOrphanPages.ts
@@ -75,7 +75,6 @@ async function main() {
       ),
     );
   }
-  console.log("\n Allowed Orphans are: \n", ALLOWED_ORPHAN_URLS);
   if (orphanPages.length > 0) {
     console.error(
       "\n There are some orphaned pages!  These files need a home: \n",
@@ -123,7 +122,6 @@ async function determineTocFiles(args: Arguments): Promise<string[]> {
     globs.push(
       "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/_toc.json",
     );
-    ``;
   }
   return await globby(globs);
 }
@@ -180,27 +178,24 @@ function apiDocsIgnores(): string[] {
     "0.46/",
   ];
 
-  return flattenDeep([
-    versions.map((vers) => [
-      `/api/qiskit-ibm-runtime/${vers}index`,
-      `/api/qiskit-ibm-provider/${vers}index`,
-      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Estimator`,
-      `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Sampler`,
-      `/api/qiskit/${vers}aer`,
-      `/api/qiskit/${vers}aqua`,
-      `/api/qiskit/${vers}ibmq-provider`,
-      `/api/qiskit/${vers}ibmq_jupyter`,
-      `/api/qiskit/${vers}ibmq_visualization`,
-      `/api/qiskit/${vers}qiskit.aqua.aqua_globals`,
-      `/api/qiskit/${vers}qiskit.optimization.INFINITY`,
-      `/api/qiskit/${vers}qiskit.quantum_info.two_qubit_cnot_decompose`,
-      `/api/qiskit/${vers}qiskit.utils.algorithm_globals`,
-      `/api/qiskit/${vers}parallel`,
-      `/api/qiskit/${vers}transpiler_builtin_plugins`,
-    ]),
+  return versions.flatMap((vers) => [
+    `/api/qiskit-ibm-runtime/${vers}index`,
+    `/api/qiskit-ibm-provider/${vers}index`,
+    `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Estimator`,
+    `/api/qiskit-ibm-runtime/${vers}qiskit_ibm_runtime.Sampler`,
+    `/api/qiskit/${vers}aer`,
+    `/api/qiskit/${vers}aqua`,
+    `/api/qiskit/${vers}ibmq-provider`,
+    `/api/qiskit/${vers}ibmq_jupyter`,
+    `/api/qiskit/${vers}ibmq_visualization`,
+    `/api/qiskit/${vers}qiskit.aqua.aqua_globals`,
+    `/api/qiskit/${vers}qiskit.optimization.INFINITY`,
+    `/api/qiskit/${vers}qiskit.quantum_info.two_qubit_cnot_decompose`,
+    `/api/qiskit/${vers}qiskit.utils.algorithm_globals`,
+    `/api/qiskit/${vers}parallel`,
+    `/api/qiskit/${vers}transpiler_builtin_plugins`,
     `/api/qiskit/0.19/index`,
     `/api/qiskit/dev/qiskit.primitives.BaseEstimator`,
-    `/api/qiskit/dev/qiskit.primitives.BaseSampler`,
     `/api/qiskit/dev/qiskit.primitives.BaseSampler`,
   ]);
 }


### PR DESCRIPTION
Closes #1014 

In the interest of readability, the list of allowed urls includes pages that don't exist.  There is a small risk of a false positive if there are any new pages that get added to the api docs of the same name which should actually be checked against their toc instead of ignored.