### PR TITLE
Complete OpenQASM 2 interoperation guide

### DIFF
--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -8,18 +8,26 @@ description: How to convert code between OpenQASM 2 and the Qiskit SDK.
 
 The Qiskit SDK provides some tools for converting between OpenQASM representations of quantum programs, and the [QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit) class.
 
+<span id="import"></span>
 ## Import an OpenQASM 2 program into Qiskit
 
-Currently two high-level functions are available for importing from OpenQASM 2 into Qiskit. These functions are `qasm2.load()`, which takes a file name, and `qasm2.loads()`, which takes the program itself as a string. 
+There are two functions that import OpenQASM 2 programs into Qiskit.
+These are [`qasm2.load()`](../api/qiskit/qasm2#load), which takes a filename, and [`qasm2.loads()`](../api/qiskit/qasm2#loads), which takes the OpenQASM 2 program as a string.
 
 ```python
 import qiskit.qasm2
-qiskit.qasm2.load(filename, *, include_path=('.',), include_input_directory='append', custom_instructions=(), custom_classical=(), strict=False)
+
+qiskit.qasm2.load(filename, include_path=('.',), include_input_directory='append', custom_instructions=(), custom_classical=(), strict=False)
+qiskit.qasm2.loads(program, include_path=('.',), custom_instructions=(), custom_classical=(), strict=False)
 ```
 
-See the [OpenQASM 2 Qiskit API](/api/qiskit/qasm2) for more information. 
+See the [OpenQASM 2 Qiskit API](/api/qiskit/qasm2) for more information.
 
-### Example: import an OpenQASM 2 program as a string
+### Importing simple programs
+
+For most OpenQASM 2 programs, you can simply use `qasm2.load` and `qasm2.loads` with a single argument.
+
+#### Example: import an OpenQASM 2 program as a string
 
 Use `qasm2.loads()` to import an OpenQASM 2 program as a string into a QuantumCircuit:
 
@@ -42,7 +50,7 @@ circuit.draw()
 
 ![output](/images/build/qasm2.png)
 
-### Example: import an OpenQASM 2 program from a file
+#### Example: import an OpenQASM 2 program from a file
 
 Use `load()` to import an OpenQASM 2 program from a file into a QuantumCircuit:
 
@@ -51,63 +59,179 @@ import qiskit.qasm2
 circuit = qiskit.qasm2.load("myfile.qasm")
 ```
 
+
 <span id="custom-instructions"></span>
-## Custom quantum instructions
+### Linking OpenQASM 2 gates with Qiskit gates
 
-You can extend the quantum components of the OpenQASM 2 language by passing an iterable of information on custom instructions as the argument `custom_instructions`. In files that have compatible definitions for these instructions, the given constructor will be used in place of whatever other handling `qiskit.qasm2` would have done.  You cannot provide a custom instruction that has a different number of parameters or qubits from a defined instruction in a parsed program. Each element of the argument iterable should be a particular data class as follows:
+By default, Qiskit's OpenQASM 2 importer treats the include file `"qelib1.inc"` as a *de facto* standard library.
+The importer treats this file as containing precisely the gates it is described to contain in [the original paper defining OpenQASM 2](https://arxiv.org/abs/1707.03429).
+Qiskit will use the built-in gates in [the circuit library](../api/qiskit/circuit_library) to represent the gates in `"qelib1.inc"`.
+Gates defined in the program by manual OpenQASM 2 `gate` statements will, by default, be constructed as custom [Qiskit `Gate` subclasses](../api/qiskit/qiskit.circuit.Gate).
 
-#### `qiskit.qasm2.CustomInstruction(name, num_params, num_qubits, constructor, builtin=False)`
+You can tell the importer to use specific [`Gate`](../api/qiskit/qiskit.circuit.Gate) classes for given `gate` statements it encounters.
+You can also use this mechanism to treat additional gate names as "built in", that is, not requiring an explicit definition.
+Qiskit will typically be more efficient if you can tell it which gate classes it should use for `gate` statements outside of `"qelib1.inc"`.
 
-The CustomInstruction class gives information about a custom instruction that should be defined during the parse.
+<Admonition type="warning">
+As of Qiskit 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
+This means that the default settings of the importer might not be able to import a program exported by our importer.
+See [the specific example on working with the legacy exporter](#import-legacy) for how to resolve this problem.
 
-The `constructor` field should be a callable object with signature `*args -> Instruction`, where each of the `num_params` args is a floating-point value. Most of the built-in Qiskit gate classes have this form.
+This discrepancy is legacy behavior of Qiskit, and [we are planning to fix it in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
+</Admonition>
 
-The `builtin` field is optional. If set to `true`, the instruction will be defined and available within the parsing, even if there is no definition in any included OpenQASM 2 file. Instructions marked as `builtin` do not require an opaque or gate declaration, but they will silently ignore a compatible declaration.
+To pass information about a custom instruction to the OpenQASM 2 importer, you use [the `qasm2.CustomInstruction` class](../api/qiskit/qasm2#qiskit.qasm2.CustomInstruction).
+This has four required pieces of information, in order:
 
-### Example: use custom quantum instructions
+* the **name** of the gate, used in the OpenQASM 2 program
+* the **number of angle parameters** that the gate takes
+* the **number of qubits** that the gate acts on
+* the Python **constructor** class or function for the gate, which should take the gate parameters (but not qubits) as individual arguments
 
-Use `qasm2.loads()` to import an OpenQASM 2 program as a string into a QuantumCircuit, but use a custom quantum instruction.  Sometimes you might  want to influence the gate objects that the importer emits for given named instructions. Gates that are defined by the statement `include "qelib1.inc"` are automatically associated with a suitable Qiskit circuit-library gate, but you can extend this:
+If the importer encounters a `gate` definition that matches a given custom instruction, it will use that custom information to reconstruct the gate object.
+If a `gate` statement is encountered that matches the `name` of a custom instruction, but does not match both the number of parameters and the number of qubits, the importer will raise a [`QASM2ParseError`](../api/qiskit/qasm2#qasm2parseerror), to indicate the mismatch between the supplied information and program.
+
+In addition, a fifth argument `builtin` can be optionally set to `True` to make the gate automatically available within the OpenQASM 2 program, even if it is not explicitly defined.
+If the importer does encounter an explicit `gate` definition for a built-in custom instruction, it will accept it silently.
+As before, if an explicit definition of the same name is not compatible with the provided custom instruction, a [`QASM2ParseError`](../api/qiskit/qasm2#qasm2parseerror) will be raised.
+This is useful for compatibility with older OpenQASM 2 exporters, and with certain other quantum platforms that treat the "basis gates" of their hardware as being built-in instructions.
+
+Qiskit provides a data attribute for working with OpenQASM 2 programs produced by legacy versions of [Qiskit's OpenQASM 2 exporting capabilities](#export).
+This is [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility), which can be given as the `custom_instructions` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm2#loads).
+
+
+<span id="import-legacy"></span>
+#### Example: import a program created by Qiskit's legacy exporter
+
+This OpenQASM 2 program uses gates that are not in the original version of `"qelib1.inc"` without declaring them, but are standard gates in Qiskit's library.
+You can use [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility) to easily tell the importer to use the same set of gates that Qiskit's OpenQASM 2 exporter used to use.
 
 ```python
-from qiskit.circuit import Gate
 from qiskit import qasm2
 
-class MyGate(Gate):
-    def __init__(self, theta):
-        super().__init__("my", 2, [theta])
+program = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
 
-class Builtin(Gate):
-    def __init__(self):
-        super().__init__("builtin", 1, [])
+    qreg q[4];
+    creg c[4];
 
-program = '''
-    opaque my(theta) q1, q2;
-    qreg q[2];
-    my(0.5) q[0], q[1];
-    builtin q[0];
-    '''
-customs = [
-    qasm2.CustomInstruction(name="my", num_params=1, num_qubits=2, constructor=MyGate),
-    # Setting 'builtin=True' means the instruction doesn't require a declaration to be usable.
-    qasm2.CustomInstruction("builtin", 0, 1, Builtin, builtin=True),
-]
-circuit = qasm2.loads(program, custom_instructions=customs)
+    h q[0];
+    cx q[0], q[1];
+
+    // 'rxx' is not actually in `qelib1.inc`,
+    // but Qiskit used to behave as if it were.
+    rxx(0.75) q[2], q[3];
+
+    measure q -> c;
+"""
+circuit = qasm2.loads(
+    program,
+    custom_instructions=qasm2.LEGACY_CUSTOM_INSTRUCTIONS,
+)
 ```
 
+
+#### Example: use a particular gate class when importing an OpenQASM 2 program
+
+Qiskit cannot, in general, verify if the definition in an OpenQASM 2 `gate` statement corresponds exactly to a Qiskit standard-library gate.
+Rather than guessing, Qiskit will simply use a custom gate using the precise definition supplied.
+This can be less efficient that using one of the built-in standard gates, or a user-defined custom gate.
+You can manually `gate` statements with particular classes.
+
+```python
+from qiskit import qasm2
+from qiskit.circuit import Gate
+from qiskit.circuit.library import RZXGate
+
+# Define a custom gate that takes one qubit and two angles.
+class MyGate(Gate):
+    def __init__(self, theta, phi):
+        super().__init__("my", 1, [theta, phi])
+
+custom_instructions = [
+    # Link the OpenQASM 2 name 'my' with our custom gate.
+    qasm2.CustomInstruction("my", 2, 1, MyGate),
+    # Link the OpenQASM 2 name 'rzx' with Qiskit's
+    # built-in RZXGate.
+    qasm2.CustomInstruction("rzx", 1, 2, RZXGate),
+]
+
+program = """
+    OPENQASM 2.0;
+
+    gate my(theta, phi) q {
+        U(theta / 2, phi, -theta / 2) q;
+    }
+    gate rzx(theta) a, b {
+        // It doesn't matter what definition is
+        // supplied, if the parameters match;
+        // Qiskit will still use `RZXGate`.
+    }
+
+    qreg q[2];
+    my(0.25, 0.125) q[0];
+    rzx(pi) q[0], q[1];
+"""
+
+circuit = qasm2.loads(
+    program,
+    custom_instructions=custom_instructions,
+)
+```
+
+#### Example: define a new built-in gate in an OpenQASM 2 program
+
+If the argument `builtin=True` is set, a custom gate does not need to have an associated definition.
+
+```python
+from qiskit import qasm2
+from qiskit.circuit import Gate
+
+# Define a custom gate that takes one qubit and two angles.
+class MyGate(Gate):
+    def __init__(self, theta, phi):
+        super().__init__("my", 1, [theta, phi])
+
+custom_instructions = [
+    qasm2.CustomInstruction("my", 2, 1, MyGate, builtin=True),
+]
+
+program = """
+    OPENQASM 2.0;
+    qreg q[1];
+
+    my(0.25, 0.125) q[0];
+"""
+
+circuit = qasm2.loads(
+    program,
+    custom_instructions=custom_instructions,
+)
+```
+
+
 <span id="custom-classical"></span>
-## Custom classical functions
+### Defining custom classical functions
 
-You can extend the processing done to classical expressions (arguments to gates) by passing an iterable to the argument `custom_classical`. This needs the name (a valid OpenQASM 2 identifier), the number of parameters it takes (num_params), and a Python callable that implements the function. The Python callable must be able to accept `num_params` positional floating-point arguments, and must return a float or integer (which will be converted to a float). Built-in functions cannot be overridden. 
+OpenQASM 2 includes some built-in classical functions that can be used in gate arguments.
+You can extend the language with more functions by using the `custom_classical` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm3#loads), with the [`qasm2.CustomClassical`](../api/qiskit/qasm2#qiskit.qasm2.CustomClassical) class.
 
-#### `qiskit.qasm2.CustomClassical`
+To define a custom classical function, you must supply:
 
-The `CustomClassical` class gives information about a custom classical function that should be defined in mathematical expressions.
+* the *name* of the function as it appears in the OpenQASM 2 program
+* the number of floating-point arguments it accepts
+* a callable Python object that evaluates the function
 
-The given `callable` must be a Python function that takes `num_params` floats, and returns a float. The `name` is the identifier that refers to it in the OpenQASM 2 program. This cannot clash with any defined gates.
+All defined custom classical functions are treated as built in to the OpenQASM 2 language by the importer.
+There is no official way within the OpenQASM 2 language to define new functions; this is a Qiskit extension.
 
-### Example: use custom classical instructions
 
-Use `qasm2.loads()` to import an OpenQASM 2 program as a string into a QuantumCircuit, but use a custom classical instruction.  You can add new classical functions used during the description of arguments to gates, both in the main body of the program (which come out constant-folded) and within the bodies of defined gates (which are computed on demand). Here we provide a Python version of `atan2(y, x)`, which mathematically is $\atan(y/x)$, but correctly handles angle quadrants and infinities, and a custom `add_one` function:
+#### Example: use custom classical instructions
+
+Here we provide two custom classical functions.
+The first is simple, and just adds one to its input.
+The second is the function ``math.atan2``, which represents the mathematical operation $\arctan(y/x)$ in a quadrant-aware manner.
 
 ```python
 import math
@@ -116,7 +240,7 @@ import qiskit.qasm2
 program = '''
     include "qelib1.inc";
     qreg q[2];
-    rx(atan2(pi, 3 + add_one(0.2))) q[0];
+    rx(arctan(pi, 3 + add_one(0.2))) q[0];
     cx q[0], q[1];
 '''
 
@@ -124,20 +248,55 @@ def add_one(x):
     return x + 1
 
 customs = [
-    # `atan2` takes two parameters, and `math.atan2` implements it.
-    qasm2.CustomClassical("atan2", 2, math.atan2),
     # Our `add_one` takes only one parameter.
     qasm2.CustomClassical("add_one", 1, add_one),
+    # `arctan` takes two parameters, and `math.atan2` implements it.
+    qasm2.CustomClassical("atan2", 2, math.atan2),
 ]
 circuit = qasm2.loads(program, custom_classical=customs)
 ```
 
 <span id="strict"></span>
-## Strict mode
+### Strict mode
 
-By default, this parser is a little bit more relaxed than the official specification. It allows trailing commas in parameter lists; unnecessary (empty-statement) semicolons; the `OPENQASM 2.0;` version statement to be omitted; and a couple of other quality-of-life improvements without emitting any errors. However, you can use the "letter-of-the-spec" mode with `strict=True`.
+By default, this parser is a little bit more relaxed than the official specification.
+It allows trailing commas in parameter lists; unnecessary (empty-statement) semicolons; the `OPENQASM 2.0;` version statement to be omitted; and a couple of other quality-of-life improvements without emitting any errors.
+However, you can use the "letter-of-the-spec" mode with `strict=True`.
 
-## Next steps 
+
+<span id="export"></span>
+## Export a Qiskit circuit to OpenQASM 2
+
+Qiskit can also export a [`QuantumCircuit`](../api/qiskit/qiskit.circuit.QuantumCircuit) to OpenQASM 2.
+You use the function [`qasm2.dump()`](../api/qiskit/qasm2#dump) to write to a file, and [`qasm2.dumps()`](../api/qiskit/qasm2#dumps) to write to a string.
+These functions currently have a very simple interface: they accept a circuit, and, only in the case of [`qasm2.dump()`](../api/qiskit/qasm2#dump), a location to write the output to.
+
+<Admonition type="warning">
+Qiskit's OpenQASM 2 exporter still assumes a legacy, non-standard version of the `"qelib1.inc"` include file.
+[We are planning to fix this in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, you should use [the example above for how to tell the importer about the legacy gates](#import-legacy).
+</Admonition>
+
+
+### Example: export a circuit to OpenQASM 2
+
+```python
+from qiskit import QuantumCircuit, qasm2
+
+# Define any circuit.
+circuit = QuantumCircuit(2, 2)
+circuit.h(0)
+circuit.cx(0, 1)
+circuit.measure([0, 1], [0, 1])
+
+# Export to a string.
+program = qasm2.dumps(circuit)
+
+# Export to a file.
+qasm2.dump(circuit, "my_file.qasm")
+```
+
+
+## Next steps
 
 <Admonition type="tip" title="Recommendations">
     - Learn how to generate OpenQASM code in the [Explore gates and circuits with the Quantum Composer](https://learning.quantum.ibm.com/tutorial/explore-gates-and-circuits-with-the-quantum-composer) tutorial.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -70,7 +70,7 @@ Gates defined in the program by manual OpenQASM 2 `gate` statements will, by def
 
 You can tell the importer to use specific [`Gate`](../api/qiskit/qiskit.circuit.Gate) classes for the given `gate` statements it encounters.
 You can also use this mechanism to treat additional gate names as "built-in", that is, not requiring an explicit definition.
-Qiskit will typically be more efficient if you can tell it which gate classes it should use for `gate` statements outside of `"qelib1.inc"`.
+If you specify which gate classes to use for `gate` statements outside of `"qelib1.inc"`, the resulting circuit will typically be more efficient to work with.
 
 <Admonition type="warning">
 As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -80,7 +80,7 @@ See [the specific example on working with the legacy exporter](#import-legacy) t
 This discrepancy is legacy behavior of Qiskit, and [it will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
 </Admonition>
 
-To pass information about a custom instruction to the OpenQASM 2 importer, you use [the `qasm2.CustomInstruction` class](../api/qiskit/qasm2#qiskit.qasm2.CustomInstruction).
+To pass information about a custom instruction to the OpenQASM 2 importer, use [the `qasm2.CustomInstruction` class](../api/qiskit/qasm2#qiskit.qasm2.CustomInstruction).
 This has four required pieces of information, in order:
 
 * the **name** of the gate, used in the OpenQASM 2 program

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -135,7 +135,7 @@ circuit = qasm2.loads(
 #### Example: use a particular gate class when importing an OpenQASM 2 program
 
 Qiskit cannot, in general, verify if the definition in an OpenQASM 2 `gate` statement corresponds exactly to a Qiskit standard-library gate.
-Rather than guessing, Qiskit will simply use a custom gate using the precise definition supplied.
+Instead, Qiskit chooses a custom gate using the precise definition supplied.
 This can be less efficient that using one of the built-in standard gates, or a user-defined custom gate.
 You can manually define `gate` statements with particular classes.
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -100,7 +100,7 @@ Qiskit provides a data attribute for working with OpenQASM 2 programs produced b
 This is [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility), which can be given as the `custom_instructions` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm2#loads).
 
 
-<span id="import-legacy"></span>
+<span id="qasm2-import-legacy"></span>
 #### Example: import a program created by Qiskit's legacy exporter
 
 This OpenQASM 2 program uses gates that are not in the original version of `"qelib1.inc"` without declaring them, but are standard gates in Qiskit's library.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -77,7 +77,7 @@ As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circu
 This means that the default settings of the importer might not be able to import a program exported by our importer.
 See [the specific example on working with the legacy exporter](#import-legacy) to resolve this problem.
 
-This discrepancy is legacy behavior of Qiskit, and [we are planning to fix it in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
+This discrepancy is legacy behavior of Qiskit, and [it will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
 </Admonition>
 
 To pass information about a custom instruction to the OpenQASM 2 importer, you use [the `qasm2.CustomInstruction` class](../api/qiskit/qasm2#qiskit.qasm2.CustomInstruction).

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -273,7 +273,7 @@ These functions currently have a very simple interface: they accept a circuit an
 
 <Admonition type="warning">
 Qiskit's OpenQASM 2 exporter still assumes a legacy, non-standard version of the `"qelib1.inc"` include file.
-[We are planning to fix this in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, you should use [the example above for how to tell the importer about the legacy gates](#qasm2-import-legacy).
+[This will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, use [the example above for how to tell the importer about the legacy gates](#qasm2-import-legacy).
 </Admonition>
 
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -273,7 +273,7 @@ These functions currently have a very simple interface: they accept a circuit an
 
 <Admonition type="warning">
 Qiskit's OpenQASM 2 exporter still assumes a legacy, non-standard version of the `"qelib1.inc"` include file.
-[This will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, use [the example above for how to tell the importer about the legacy gates](#qasm2-import-legacy).
+[This will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the meantime, if you need to re-import an OpenQASM 2 program created with Qiskit, use [the example above for how to tell the importer about the legacy gates](#qasm2-import-legacy).
 </Admonition>
 
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -68,7 +68,7 @@ The importer treats this file as containing precisely the gates it is described 
 Qiskit will use the built-in gates in [the circuit library](../api/qiskit/circuit_library) to represent the gates in `"qelib1.inc"`.
 Gates defined in the program by manual OpenQASM 2 `gate` statements will, by default, be constructed as custom [Qiskit `Gate` subclasses](../api/qiskit/qiskit.circuit.Gate).
 
-You can tell the importer to use specific [`Gate`](../api/qiskit/qiskit.circuit.Gate) classes for given `gate` statements it encounters.
+You can tell the importer to use specific [`Gate`](../api/qiskit/qiskit.circuit.Gate) classes for the given `gate` statements it encounters.
 You can also use this mechanism to treat additional gate names as "built in", that is, not requiring an explicit definition.
 Qiskit will typically be more efficient if you can tell it which gate classes it should use for `gate` statements outside of `"qelib1.inc"`.
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -61,7 +61,7 @@ circuit = qiskit.qasm2.load("myfile.qasm")
 
 
 <span id="custom-instructions"></span>
-### Linking OpenQASM 2 gates with Qiskit gates
+### Link OpenQASM 2 gates with Qiskit gates
 
 By default, Qiskit's OpenQASM 2 importer treats the include file `"qelib1.inc"` as a *de facto* standard library.
 The importer treats this file as containing precisely the gates it is described to contain in [the original paper defining OpenQASM 2](https://arxiv.org/abs/1707.03429).

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -273,7 +273,7 @@ These functions currently have a very simple interface: they accept a circuit, a
 
 <Admonition type="warning">
 Qiskit's OpenQASM 2 exporter still assumes a legacy, non-standard version of the `"qelib1.inc"` include file.
-[We are planning to fix this in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, you should use [the example above for how to tell the importer about the legacy gates](#import-legacy).
+[We are planning to fix this in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737), but in the mean time, if you need to re-import an OpenQASM 2 program created with Qiskit, you should use [the example above for how to tell the importer about the legacy gates](#qasm2-import-legacy).
 </Admonition>
 
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -69,7 +69,7 @@ Qiskit will use the built-in gates in [the circuit library](../api/qiskit/circui
 Gates defined in the program by manual OpenQASM 2 `gate` statements will, by default, be constructed as custom [Qiskit `Gate` subclasses](../api/qiskit/qiskit.circuit.Gate).
 
 You can tell the importer to use specific [`Gate`](../api/qiskit/qiskit.circuit.Gate) classes for the given `gate` statements it encounters.
-You can also use this mechanism to treat additional gate names as "built in", that is, not requiring an explicit definition.
+You can also use this mechanism to treat additional gate names as "built-in", that is, not requiring an explicit definition.
 Qiskit will typically be more efficient if you can tell it which gate classes it should use for `gate` statements outside of `"qelib1.inc"`.
 
 <Admonition type="warning">

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -223,7 +223,7 @@ To define a custom classical function, you must supply:
 * The number of floating-point arguments it accepts
 * A callable Python object that evaluates the function
 
-All defined custom classical functions are treated as built in to the OpenQASM 2 language by the importer.
+All defined custom classical functions are treated as built-in to the OpenQASM 2 language by the importer.
 There is no official way within the OpenQASM 2 language to define new functions; this is a Qiskit extension.
 
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -83,10 +83,10 @@ This discrepancy is legacy behavior of Qiskit, and [it will be resolved in a lat
 To pass information about a custom instruction to the OpenQASM 2 importer, use [the `qasm2.CustomInstruction` class](../api/qiskit/qasm2#qiskit.qasm2.CustomInstruction).
 This has four required pieces of information, in order:
 
-* the **name** of the gate, used in the OpenQASM 2 program
-* the **number of angle parameters** that the gate takes
-* the **number of qubits** that the gate acts on
-* the Python **constructor** class or function for the gate, which should take the gate parameters (but not qubits) as individual arguments
+* The **name** of the gate, used in the OpenQASM 2 program
+* The **number of angle parameters** that the gate takes
+* The **number of qubits** that the gate acts on
+* The Python **constructor** class or function for the gate, which takes the gate parameters (but not qubits) as individual arguments
 
 If the importer encounters a `gate` definition that matches a given custom instruction, it will use that custom information to reconstruct the gate object.
 If a `gate` statement is encountered that matches the `name` of a custom instruction, but does not match both the number of parameters and the number of qubits, the importer will raise a [`QASM2ParseError`](../api/qiskit/qasm2#qasm2parseerror), to indicate the mismatch between the supplied information and program.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -23,7 +23,7 @@ qiskit.qasm2.loads(program, include_path=('.',), custom_instructions=(), custom_
 
 See the [OpenQASM 2 Qiskit API](/api/qiskit/qasm2) for more information.
 
-### Importing simple programs
+### Import simple programs
 
 For most OpenQASM 2 programs, you can simply use `qasm2.load` and `qasm2.loads` with a single argument.
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -75,7 +75,7 @@ Qiskit will typically be more efficient if you can tell it which gate classes it
 <Admonition type="warning">
 As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
 This means that the default settings of the importer might not be able to import a program exported by our importer.
-See [the specific example on working with the legacy exporter](#import-legacy) to resolve this problem.
+See [the specific example on working with the legacy exporter](#qasm2-import-legacy) to resolve this problem.
 
 This discrepancy is legacy behavior of Qiskit, and [it will be resolved in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
 </Admonition>

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -73,7 +73,7 @@ You can also use this mechanism to treat additional gate names as "built-in", th
 If you specify which gate classes to use for `gate` statements outside of `"qelib1.inc"`, the resulting circuit will typically be more efficient to work with.
 
 <Admonition type="warning">
-As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
+As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#qasm2-export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
 This means that the default settings of the importer might not be able to import a program exported by our importer.
 See [the specific example on working with the legacy exporter](#qasm2-import-legacy) to resolve this problem.
 
@@ -96,7 +96,7 @@ If the importer does encounter an explicit `gate` definition for a built-in cust
 As before, if an explicit definition of the same name is not compatible with the provided custom instruction, a [`QASM2ParseError`](../api/qiskit/qasm2#qasm2parseerror) will be raised.
 This is useful for compatibility with older OpenQASM 2 exporters, and with certain other quantum platforms that treat the "basis gates" of their hardware as built-in instructions.
 
-Qiskit provides a data attribute for working with OpenQASM 2 programs produced by legacy versions of [Qiskit's OpenQASM 2 exporting capabilities](#export).
+Qiskit provides a data attribute for working with OpenQASM 2 programs produced by legacy versions of [Qiskit's OpenQASM 2 exporting capabilities](#qasm2-export).
 This is [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility), which can be given as the `custom_instructions` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm2#loads).
 
 
@@ -264,7 +264,7 @@ It allows trailing commas in parameter lists; unnecessary (empty-statement) semi
 However, you can use the "letter-of-the-spec" mode with `strict=True`.
 
 
-<span id="export"></span>
+<span id="qasm2-export"></span>
 ## Export a Qiskit circuit to OpenQASM 2
 
 Qiskit can also export a [`QuantumCircuit`](../api/qiskit/qiskit.circuit.QuantumCircuit) to OpenQASM 2.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -137,7 +137,7 @@ circuit = qasm2.loads(
 Qiskit cannot, in general, verify if the definition in an OpenQASM 2 `gate` statement corresponds exactly to a Qiskit standard-library gate.
 Rather than guessing, Qiskit will simply use a custom gate using the precise definition supplied.
 This can be less efficient that using one of the built-in standard gates, or a user-defined custom gate.
-You can manually `gate` statements with particular classes.
+You can manually define `gate` statements with particular classes.
 
 ```python
 from qiskit import qasm2

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -259,8 +259,8 @@ circuit = qasm2.loads(program, custom_classical=customs)
 <span id="strict"></span>
 ### Strict mode
 
-By default, this parser is a little bit more relaxed than the official specification.
-It allows trailing commas in parameter lists; unnecessary (empty-statement) semicolons; the `OPENQASM 2.0;` version statement to be omitted; and a couple of other quality-of-life improvements without emitting any errors.
+By default, this parser is more relaxed than the official specification.
+It allows trailing commas in parameter lists; unnecessary (empty-statement) semicolons; omission of the `OPENQASM 2.0;` version statement; and several other quality-of-life improvements without emitting any errors.
 However, you can use the "letter-of-the-spec" mode with `strict=True`.
 
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -104,7 +104,7 @@ This is [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatib
 #### Example: import a program created by Qiskit's legacy exporter
 
 This OpenQASM 2 program uses gates that are not in the original version of `"qelib1.inc"` without declaring them, but are standard gates in Qiskit's library.
-You can use [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility) to easily tell the importer to use the same set of gates that Qiskit's OpenQASM 2 exporter used to use.
+You can use [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility) to easily tell the importer to use the same set of gates that Qiskit's OpenQASM 2 exporter previously used.
 
 ```python
 from qiskit import qasm2

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -11,7 +11,7 @@ The Qiskit SDK provides some tools for converting between OpenQASM representatio
 <span id="qasm2-import"></span>
 ## Import an OpenQASM 2 program into Qiskit
 
-There are two functions that import OpenQASM 2 programs into Qiskit.
+Two functions import OpenQASM 2 programs into Qiskit.
 These are [`qasm2.load()`](../api/qiskit/qasm2#load), which takes a filename, and [`qasm2.loads()`](../api/qiskit/qasm2#loads), which takes the OpenQASM 2 program as a string.
 
 ```python

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -73,7 +73,7 @@ You can also use this mechanism to treat additional gate names as "built-in", th
 Qiskit will typically be more efficient if you can tell it which gate classes it should use for `gate` statements outside of `"qelib1.inc"`.
 
 <Admonition type="warning">
-As of Qiskit 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
+As of Qiskit SDK 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
 This means that the default settings of the importer might not be able to import a program exported by our importer.
 See [the specific example on working with the legacy exporter](#import-legacy) to resolve this problem.
 

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -212,7 +212,7 @@ circuit = qasm2.loads(
 
 
 <span id="custom-classical"></span>
-### Defining custom classical functions
+### Define custom classical functions
 
 OpenQASM 2 includes some built-in classical functions that can be used in gate arguments.
 You can extend the language with more functions by using the `custom_classical` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm3#loads), with the [`qasm2.CustomClassical`](../api/qiskit/qasm2#qiskit.qasm2.CustomClassical) class.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -6,7 +6,7 @@ description: How to convert code between OpenQASM 2 and the Qiskit SDK.
 
 # OpenQASM 2 and the Qiskit SDK
 
-The Qiskit SDK provides some tools for converting between OpenQASM representations of quantum programs, and the [QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit) class.
+The Qiskit SDK provides some tools for converting between OpenQASM representations of quantum programs, and the [QuantumCircuit](/api/qiskit/qiskit.circuit.QuantumCircuit) class.
 
 <span id="qasm2-import"></span>
 ## Import an OpenQASM 2 program into Qiskit

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -269,7 +269,7 @@ However, you can use the "letter-of-the-spec" mode with `strict=True`.
 
 Qiskit can also export a [`QuantumCircuit`](../api/qiskit/qiskit.circuit.QuantumCircuit) to OpenQASM 2.
 You use the function [`qasm2.dump()`](../api/qiskit/qasm2#dump) to write to a file, and [`qasm2.dumps()`](../api/qiskit/qasm2#dumps) to write to a string.
-These functions currently have a very simple interface: they accept a circuit, and, only in the case of [`qasm2.dump()`](../api/qiskit/qasm2#dump), a location to write the output to.
+These functions currently have a very simple interface: they accept a circuit and, only in the case of [`qasm2.dump()`](../api/qiskit/qasm2#dump), a location to write the output to.
 
 <Admonition type="warning">
 Qiskit's OpenQASM 2 exporter still assumes a legacy, non-standard version of the `"qelib1.inc"` include file.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -8,7 +8,7 @@ description: How to convert code between OpenQASM 2 and the Qiskit SDK.
 
 The Qiskit SDK provides some tools for converting between OpenQASM representations of quantum programs, and the [QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit) class.
 
-<span id="import"></span>
+<span id="qasm2-import"></span>
 ## Import an OpenQASM 2 program into Qiskit
 
 There are two functions that import OpenQASM 2 programs into Qiskit.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -94,7 +94,7 @@ If a `gate` statement is encountered that matches the `name` of a custom instruc
 In addition, a fifth argument `builtin` can be optionally set to `True` to make the gate automatically available within the OpenQASM 2 program, even if it is not explicitly defined.
 If the importer does encounter an explicit `gate` definition for a built-in custom instruction, it will accept it silently.
 As before, if an explicit definition of the same name is not compatible with the provided custom instruction, a [`QASM2ParseError`](../api/qiskit/qasm2#qasm2parseerror) will be raised.
-This is useful for compatibility with older OpenQASM 2 exporters, and with certain other quantum platforms that treat the "basis gates" of their hardware as being built-in instructions.
+This is useful for compatibility with older OpenQASM 2 exporters, and with certain other quantum platforms that treat the "basis gates" of their hardware as built-in instructions.
 
 Qiskit provides a data attribute for working with OpenQASM 2 programs produced by legacy versions of [Qiskit's OpenQASM 2 exporting capabilities](#export).
 This is [`qasm2.LEGACY_CUSTOM_INSTRUCTIONS`](../api/qiskit/qasm2#legacy-compatibility), which can be given as the `custom_instructions` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm2#loads).

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -75,7 +75,7 @@ Qiskit will typically be more efficient if you can tell it which gate classes it
 <Admonition type="warning">
 As of Qiskit 1.0, Qiskit's OpenQASM 2 *exporter* (see [Export a Qiskit circuit to OpenQASM 2](#export)) still behaves as if `"qelib1.inc"` has more gates than it really does.
 This means that the default settings of the importer might not be able to import a program exported by our importer.
-See [the specific example on working with the legacy exporter](#import-legacy) for how to resolve this problem.
+See [the specific example on working with the legacy exporter](#import-legacy) to resolve this problem.
 
 This discrepancy is legacy behavior of Qiskit, and [we are planning to fix it in a later release of Qiskit](https://github.com/Qiskit/qiskit/issues/10737).
 </Admonition>

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -219,9 +219,9 @@ You can extend the language with more functions by using the `custom_classical` 
 
 To define a custom classical function, you must supply:
 
-* the *name* of the function as it appears in the OpenQASM 2 program
-* the number of floating-point arguments it accepts
-* a callable Python object that evaluates the function
+* The *name* of the function as it appears in the OpenQASM 2 program
+* The number of floating-point arguments it accepts
+* A callable Python object that evaluates the function
 
 All defined custom classical functions are treated as built in to the OpenQASM 2 language by the importer.
 There is no official way within the OpenQASM 2 language to define new functions; this is a Qiskit extension.

--- a/docs/build/interoperate-qiskit-qasm2.mdx
+++ b/docs/build/interoperate-qiskit-qasm2.mdx
@@ -214,7 +214,7 @@ circuit = qasm2.loads(
 <span id="custom-classical"></span>
 ### Define custom classical functions
 
-OpenQASM 2 includes some built-in classical functions that can be used in gate arguments.
+OpenQASM 2 includes some built-in classical functions to use in gate arguments.
 You can extend the language with more functions by using the `custom_classical` argument to [`qasm2.load()`](../api/qiskit/qasm2#load) and [`qasm2.loads()`](../api/qiskit/qasm3#loads), with the [`qasm2.CustomClassical`](../api/qiskit/qasm2#qiskit.qasm2.CustomClassical) class.
 
 To define a custom classical function, you must supply:


### PR DESCRIPTION
This finishes off the guide to interoperation with OpenQASM 2, including more tutorial-like versions of how to work with custom quantum and classical instructions, specific instructions on how to import programs created by the (to-be-fixed) exporter, and how to export programs to OpenQASM 2.

Close #240.