### PR TITLE
Inline `qiskit/gh-actions`

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -19,7 +19,11 @@ on:
         default: "Preview"
         required: true
         type: string
-
+    secrets:
+      ibmcloud_account:
+        required: true
+      ibmcloud_api_key:
+        required: true
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -49,7 +53,7 @@ jobs:
           ibmcloud plugin install -f container-registry
       - name: Authenticate with IBM Cloud CLI
         run: |
-          ibmcloud login -g "Quantum Community" -r "us-south" -c "${{ secrets.IBMCLOUD_ACCOUNT }}" --apikey "${{ secrets.IBMCLOUD_API_KEY }}"
+          ibmcloud login -g "Quantum Community" -r "us-south" -c "${{ secrets.ibmcloud_account }}" --apikey "${{ secrets.ibmcloud_api_key }}"
       - name: Remove previous Docker image (if exists)
         run: |
           ibmcloud cr region-set global
@@ -63,7 +67,7 @@ jobs:
         with:
           registry: icr.io
           username: iamapikey
-          password: ${{ secrets.IBMCLOUD_API_KEY }}
+          password: ${{ secrets.ibmcloud_api_key }}
       - name: Build and push to IBM registry
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
-          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/$qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: GH deployment status (start)
         id: gh_deployment

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -91,7 +91,7 @@ jobs:
           ibmcloud ce app ${{ steps.ce_command_choice.outputs.command }} \
             --name "${{ env.APP_NAME }}" \
             --image "${{ env.DOCKER_IMAGE_TAG }}" \
-            --registry-secret code_engine_registry_secret \
+            --registry-secret "ibm-container-registry" \
             --port 3000 \
             --cpu 0.25 \
             --memory 0.5G \

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -28,9 +28,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Set env variables
+      - name: Set PREVIEW_TAG
+        run: echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Set APP_NAME and DOCKER_IMAGE_TAG
         run: |
-          echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_TAG=icr.io/community-digital/qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
     inputs:
       env_name:
-        default: 'Preview'
+        default: "Preview"
         required: true
         type: string
 

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -16,7 +16,6 @@ on:
   workflow_call:
     inputs:
       env_name:
-        default: "Preview"
         required: true
         type: string
     secrets:

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -1,0 +1,107 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+name: Docker image deployment process in IBM Cloud Code Engine
+
+on:
+  workflow_call:
+    inputs:
+      env_name:
+        default: 'Preview'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env variables
+        run: |
+          echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/$qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - name: GH deployment status (start)
+        id: gh_deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: ${{ inputs.env_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Setup IBM Cloud CLI
+        run: |
+          curl -o IBM_Cloud_CLI_2.20.0_amd64.tar.gz -L https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.20.0/IBM_Cloud_CLI_2.20.0_amd64.tar.gz
+          tar xvf IBM_Cloud_CLI_2.20.0_amd64.tar.gz
+          sh Bluemix_CLI/install
+          ibmcloud --version
+          ibmcloud config --check-version=false
+          ibmcloud plugin install -f code-engine
+          ibmcloud plugin install -f container-registry
+      - name: Authenticate with IBM Cloud CLI
+        run: |
+          ibmcloud login -g "Quantum Community" -r "us-south" -c "${{ secrets.IBMCLOUD_ACCOUNT }}" --apikey "${{ secrets.IBMCLOUD_API_KEY }}"
+      - name: Remove previous Docker image (if exists)
+        run: |
+          ibmcloud cr region-set global
+          if ibmcloud cr image-list | grep "qiskit-docs-preview" | grep "${{ env.PREVIEW_TAG }}" ; then
+            ibmcloud cr image-rm "${{ env.DOCKER_IMAGE_TAG }}"
+          else
+            echo "no image to remove"
+          fi
+      - name: Log-in into IBM Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: icr.io
+          username: iamapikey
+          password: ${{ secrets.IBMCLOUD_API_KEY }}
+      - name: Build and push to IBM registry
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ env.DOCKER_IMAGE_TAG }}
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
+          cache-to: type=inline
+      - name: Determine Code Engine project and app status
+        id: ce_command_choice
+        run: |
+          ibmcloud ce project select -n "qiskit-docs-preview"
+          if ibmcloud ce app list -q | grep "${{ env.APP_NAME }}" ; then
+            echo "command=update" >> $GITHUB_OUTPUT
+          else
+            echo "command=create" >> $GITHUB_OUTPUT
+          fi
+      - name: Create a new preview application in Code Engine
+        id: ce_app_creation
+        run: |
+          ibmcloud ce app ${{ steps.ce_command_choice.outputs.command }} \
+            --name "${{ env.APP_NAME }}" \
+            --image "${{ env.DOCKER_IMAGE_TAG }}" \
+            --registry-secret code_engine_registry_secret \
+            --port 3000 \
+            --cpu 0.25 \
+            --memory 0.5G \
+            --min 1
+          echo "preview_url=$(\
+            ibmcloud ce app get --name "${{ env.APP_NAME }}" --output url
+          )" >> $GITHUB_OUTPUT
+      - name: GH deployment status (finish)
+        uses: bobheadxi/deployments@v1
+        if: always()
+        with:
+          step: finish
+          token: ${{ github.token }}
+          env: ${{ steps.gh_deployment.outputs.env }}
+          status: ${{ job.status }}
+          override: false
+          deployment_id: ${{ steps.gh_deployment.outputs.deployment_id }}
+          env_url: ${{ steps.ce_app_creation.outputs.preview_url }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
-          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/$qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
       - name: Install IBM Cloud CLI
         run: |
           curl -o IBM_Cloud_CLI_2.20.0_amd64.tar.gz -L https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.20.0/IBM_Cloud_CLI_2.20.0_amd64.tar.gz

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -30,23 +30,42 @@ jobs:
     if: |
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    uses: ./github/workflows/code-engine-preview.yml
     with:
-      code_engine_project: qiskit-docs-preview
-      docker_image_name: qiskit-docs-preview
-      docker_image_port: "3000"
-    secrets:
-      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+      env_name: Preview
 
   teardown:
     if: |
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-cleanup.yml@main
-    with:
-      code_engine_project: qiskit-docs-preview
-      docker_image_name: qiskit-docs-preview
-    secrets:
-      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env variables
+        run: |
+          echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=icr.io/community-digital/$qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
+      - name: Install IBM Cloud CLI
+        run: |
+          curl -o IBM_Cloud_CLI_2.20.0_amd64.tar.gz -L https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.20.0/IBM_Cloud_CLI_2.20.0_amd64.tar.gz
+          tar xvf IBM_Cloud_CLI_2.20.0_amd64.tar.gz
+          sh Bluemix_CLI/install
+          ibmcloud --version
+          ibmcloud config --check-version=false
+          ibmcloud plugin install -f code-engine
+          ibmcloud plugin install -f container-registry
+      - name: Authenticate with IBM Cloud CLI
+        run: |
+          ibmcloud login -g "Quantum Community" -r "us-south" -c "${{ secrets.ibmcloud_account }}" --apikey "${{ secrets.ibmcloud_api_key }}"
+      - name: Remove Code Engine preview application
+        run: |
+          ibmcloud ce project select -n qiskit-docs-preview
+          ibmcloud ce application delete \
+            --name "${{ env.APP_NAME }}" \
+            --wait \
+            --ignore-not-found \
+            --force
+      - name: Remove Docker image
+        run: |
+          ibmcloud cr region-set global
+          ibmcloud cr image-rm "${{ env.DOCKER_IMAGE_TAG }}"

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -43,9 +43,10 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Set env variables
+      - name: Set PREVIEW_TAG
+        run: echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Set APP_NAME and DOCKER_IMAGE_TAG
         run: |
-          echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "APP_NAME=qiskit-docs-preview-${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_TAG=icr.io/community-digital/qiskit-docs-preview:${{ env.PREVIEW_TAG }}" >> $GITHUB_ENV
       - name: Install IBM Cloud CLI

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -33,6 +33,9 @@ jobs:
     uses: ./.github/workflows/code-engine-preview.yml
     with:
       env_name: Preview
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
 
   teardown:
     if: |

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -30,7 +30,7 @@ jobs:
     if: |
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./github/workflows/code-engine-preview.yml
+    uses: ./.github/workflows/code-engine-preview.yml
     with:
       env_name: Preview
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,3 +28,6 @@ jobs:
     uses: ./.github/workflows/code-engine-preview.yml
     with:
       env_name: Staging
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,6 +25,6 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'Qiskit'
-    uses: ./github/workflows/code-engine-preview.yml
+    uses: ./.github/workflows/code-engine-preview.yml
     with:
       env_name: Staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,12 +25,6 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'Qiskit'
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    uses: ./github/workflows/code-engine-preview.yml
     with:
-      code_engine_project: qiskit-docs-preview
-      docker_image_name: qiskit-docs-preview
-      docker_image_port: "3000"
       env_name: Staging
-    secrets:
-      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,6 +6,7 @@ in_page_toc_max_heading_level: 2
 
 ---
 
+
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,7 +6,6 @@ in_page_toc_max_heading_level: 2
 
 ---
 
-
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 


### PR DESCRIPTION
This is the only repository still using https://github.com/Qiskit/gh-actions, so we can inline its logic and then archive the repository. That allows us to make the workflow file less generic and remove some indirection. It simplifies the overall infrastructure.

I think PR previews might have been broken for a while, but I want to address this in a follow up. https://github.com/Qiskit/documentation/issues/1034