### PR TITLE
Add default posarg to tox.ini

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -6,4 +6,4 @@ ipykernel~=6.29.2
 qiskit[all]~=1.0
 qiskit-aer~=0.13.1
 qiskit-ibm-runtime~=0.19.1
-squeaky==0.6.0
+squeaky==0.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
 commands = python scripts/nb-tester/test-notebook.py {posargs}
 
 [testenv:lint]
-commands = squeaky --check --no-advice {posargs}
+commands = squeaky --check --no-advice {posargs:docs/}
 
 [testenv:fix]
-commands = squeaky {posargs}
+commands = squeaky {posargs:docs/}


### PR DESCRIPTION
The linting instructions are actually lies as they you should run `tox -e fix` but this doesn't work unless you pass the files as a posarg. This PR bumps the version of Squeaky to one that supports recursive searching and sets a default posarg of `docs/` so writers can just run `tox -e fix` to clean everything.
