### PR TITLE
Update instructions for preview now that there's a home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,9 @@ npm install
 
 ## Preview the docs locally
 
-Run `./start` in your terminal, then open http://localhost:3000/start in your browser.
+Run `./start` in your terminal, then open http://localhost:3000 in your browser.
 
-The local preview does not include the initial index page and the top nav bar from docs.quantum.ibm.com. Therefore, you must directly navigate in the URL to the folder that you want:
-
-- http://localhost:3000/build
-- http://localhost:3000/start
-- http://localhost:3000/run
-- http://localhost:3000/transpile
-- http://localhost:3000/verify
-- http://localhost:3000/api/qiskit
-- http://localhost:3000/api/qiskit-ibm-runtime
-- http://localhost:3000/api/qiskit-ibm-provider
-- http://localhost:3000/api/migration-guides
-
-For historical API versions, use URLs like http://localhost:3000/api/qiskit/0.44, i.e. put the desired version after the
-API name.
-
-For translations, put the language code in front of the URL, like http://localhost:3000/es/start or http://localhost:3000/fr/start. You can find the language codes by looking in the `translations/` folder.
+The preview application does not include the top nav bar. Instead, navigate to the folder you want with the links in the home page. You can return to the home page at any time by clicking "IBM Quantum Documentation Preview" in the top-left of the header.
 
 Warning: `./start` does not check if there is a new version of the docs application available. Run `docker pull qiskit/documentation` to update to the latest version of the app.
 

--- a/start
+++ b/start
@@ -26,8 +26,10 @@ def translation_volume_mounts() -> Iterator[str]:
     Docker complains that the volume is already mounted when we mount the `/docs` folder. So, instead
     we need to be more specific to mount each language's folder.
     """
-    for folder in PWD.glob("translations/*"):
-        yield from ["-v", f"{folder}:/home/node/app/docs/{folder.name}"]
+    for path in PWD.glob("translations/*"):
+        if not path.is_dir():
+            continue
+        yield from ["-v", f"{path}:/home/node/app/docs/{path.name}"]
 
 
 def main() -> None:


### PR DESCRIPTION
The recently released Preview docker image now has a home page, so `localhost:3000` no longer 404s. It acts like a table of contents.

![image](https://github.com/Qiskit/documentation/assets/14852634/4153cbc1-aaa0-4e1e-9d39-5b0cd9a1c7ef)


(Users need to run `docker pull qiskit/documentation` to pull in this change.)