### PR TITLE
Fix pages render check

### DIFF
--- a/scripts/commands/checkPagesRender.ts
+++ b/scripts/commands/checkPagesRender.ts
@@ -134,7 +134,7 @@ function pathToUrl(path: string): string {
 async function validateDockerRunning(): Promise<void> {
   try {
     const response = await fetch(`http://localhost:${PORT}`);
-    if (response.status !== 404) {
+    if (response.status !== 200) {
       console.error(
         "Failed to access http://localhost:3000. Have you started the Docker server with `./start`? " +
           "Refer to the README for instructions.",


### PR DESCRIPTION
Missed in https://github.com/Qiskit/documentation/pull/1054. `localhost:3000` should now be a 200, not 404.