### PR TITLE
Update artifact shared links for runtime 0.22 and dev

### DIFF
--- a/scripts/api-html-artifacts.json
+++ b/scripts/api-html-artifacts.json
@@ -33,8 +33,8 @@
     "0.7": "https://ibm.box.com/shared/static/t2vuik7bqboata3i34r4a83baabo95xn.zip"
   },
   "qiskit-ibm-runtime": {
-    "dev": "https://ibm.box.com/shared/static/uuhaszyozocq3190tpjnwprd4wil0a3z.zip",
-    "0.22": "https://ibm.box.com/shared/static/d7tduhbog53f33f8ej0utmbzh3110hhp.zip",
+    "dev": "https://ibm.box.com/shared/static/y6zyxlu2hm7xu84z4ijivi5ic9impuua.zip",
+    "0.22": "https://ibm.box.com/shared/static/97jzr5seqpevhnepyslx8xol5fcbm2aq.zip",
     "0.21": "https://ibm.box.com/shared/static/p5nc95ypavdaq3sk8g1ebm3h4bc1a846.zip",
     "0.20": "https://ibm.box.com/shared/static/0bcr09epud50i3czdx791iagumrf5bjz.zip",
     "0.19": "https://ibm.box.com/shared/static/ojpnzc71aex4d8itnktwbp9m7l15nazs.zip",


### PR DESCRIPTION
The links expired in Box and I created two new ones









