### PR TITLE
Link checker: use the non-greedy quantifier to parse anchors

### DIFF
--- a/scripts/lib/links/extractLinks.test.ts
+++ b/scripts/lib/links/extractLinks.test.ts
@@ -62,6 +62,14 @@ test("parseAnchors()", () => {
   ##### Header 2
 
   ## \`code-header\`
+
+  <Function id="mdx.component.testId" name="testId" signature="testId">
+    Convert to dictionary.
+
+    **Return type**
+
+    \`Dict\`
+  </Function>
   `);
   expect(result).toEqual(
     new Set([
@@ -70,6 +78,7 @@ test("parseAnchors()", () => {
       "#code-header",
       "#this-is-a-hardcoded-anchor",
       "#another_span",
+      "#mdx.component.testId",
     ]),
   );
 });

--- a/scripts/lib/links/extractLinks.ts
+++ b/scripts/lib/links/extractLinks.ts
@@ -51,7 +51,7 @@ export function parseAnchors(markdown: string): Set<string> {
   // Anchors generated from markdown titles.
   const mdAnchors = markdownLinkExtractor(markdown).anchors;
   // Anchors from HTML id tags.
-  const idAnchors = markdown.match(/(?<=id=")(.*)(?=")/gm) || [];
+  const idAnchors = markdown.match(/(?<=id=")(.+?)(?=")/gm) || [];
   return new Set([...mdAnchors, ...idAnchors.map((id) => `#${id}`)]);
 }
 


### PR DESCRIPTION
This small PR changes the regex used in the link checker to parse the anchors for a non-greedy version of it. After regenerating the API docs with the mdx components, our link checker wasn't able to detect the id from them that we previously had as `<span>` tags.

The problem was how the script was searching for the ids. In the the following screenshots, we can see the change introduced here.

**Before**

![Captura desde 2024-03-27 17-27-06](https://github.com/Qiskit/documentation/assets/47946624/d1896d55-2a94-4992-8ec3-c52234aefd6a)

**After**
![Captura desde 2024-03-27 17-39-51](https://github.com/Qiskit/documentation/assets/47946624/0b063a3e-9ef6-4d5f-a775-cf53497339ec)

More information on the non-greedy quantifier here: https://www.ibm.com/docs/en/netcoolomnibus/8.1?topic=library-minimal-non-greedy-quantifiers

To see that it fixed the issue, this change was applied to ##1094, #1101, and #1102 
