### PR TITLE
Revert "Work around Reno release notes issue with Runtime (#980)"

### DIFF
--- a/scripts/lib/api/conversionPipeline.ts
+++ b/scripts/lib/api/conversionPipeline.ts
@@ -191,10 +191,6 @@ async function handleReleaseNotesFile(
   // When the release notes are a single file, only use them if this is the latest version rather
   // than a historical release.
   if (!pkg.hasSeparateReleaseNotes) {
-    // Deal with Reno issue: https://github.com/Qiskit/documentation/issues/978
-    if (pkg.name === "qiskit-ibm-runtime") {
-      result.markdown = result.markdown.replace("# HACK FOR RENO ISSUE", "");
-    }
     return pkg.isLatest();
   }
 


### PR DESCRIPTION
This reverts commit 3f151c3df9012b5ce5f2fbc08bf745487ba4e313.

Instead, we fixed by switching Runtime to Towncrier.