### PR TITLE
Present circuit basics before circuit library

### DIFF
--- a/docs/build/_toc.json
+++ b/docs/build/_toc.json
@@ -10,12 +10,12 @@
       "title": "Build circuits with the Qiskit SDK",
       "children": [
         {
-          "title": "Circuit library",
-          "url": "/build/circuit-library"
-        },
-        {
           "title": "Construct circuits",
           "url": "/build/circuit-construction"
+        },
+        {
+          "title": "Circuit library",
+          "url": "/build/circuit-library"
         },
         {
           "title": "Visualize circuits",


### PR DESCRIPTION
The circuit basics page is introductory, such as defining what a circuit is. It makes more sense to present before the circuit library. That follows our Qiskit 101 presentation structure.