### PR TITLE
Upload artifacts from cron job

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -29,8 +29,8 @@ jobs:
           instance: "client-enablement/documentation/qiskit-documenta"
 
       - name: Execute notebooks
-        timeout-minutes: 10
-        run: tox -- --write
+        timeout-minutes: 330
+        run: tox -- --write --only-submit-jobs
 
       - name: Detect changed notebooks
         id: changed-notebooks

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -29,8 +29,8 @@ jobs:
           instance: "client-enablement/documentation/qiskit-documenta"
 
       - name: Execute notebooks
-        timeout-minutes: 330
-        run: tox -- --write --only-submit-jobs
+        timeout-minutes: 10
+        run: tox -- --write
 
       - name: Detect changed notebooks
         id: changed-notebooks

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -29,7 +29,23 @@ jobs:
           instance: "client-enablement/documentation/qiskit-documenta"
 
       - name: Execute notebooks
-        run: tox -- --only-submit-jobs
+        timeout-minutes: 330
+        run: tox -- --write --only-submit-jobs
+
+      - name: Detect changed notebooks
+        id: changed-notebooks
+        if: "!cancelled()"
+        run: |
+          echo "CHANGED_NOTEBOOKS<<EOF" >> $GITHUB_OUTPUT
+          echo "$(git diff --name-only)" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Upload executed notebooks
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: Executed notebooks
+          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS }}
 
   make_issue:
     name: Make issue on failure

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -29,7 +29,7 @@ jobs:
           instance: "client-enablement/documentation/qiskit-documenta"
 
       - name: Execute notebooks
-        timeout-minutes: 330
+        timeout-minutes: 350
         run: tox -- --write --only-submit-jobs
 
       - name: Detect changed notebooks
@@ -37,7 +37,7 @@ jobs:
         if: "!cancelled()"
         run: |
           echo "CHANGED_NOTEBOOKS<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git diff --name-only)" >> $GITHUB_OUTPUT
+          git diff --name-only >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload executed notebooks


### PR DESCRIPTION
We run notebooks that submit jobs twice a month to check they don't raise errors, but we currently throw away the results. This PR uploads the executed notebooks as an artifact so we can inspect the outputs and update the files in this repo with more recent output.

See https://github.com/Qiskit/documentation/actions/runs/8645293171 for an example of this working.