### PR TITLE
Execute notebooks in parallel

### DIFF
--- a/scripts/nb-tester/test-notebook.py
+++ b/scripts/nb-tester/test-notebook.py
@@ -266,11 +266,11 @@ if __name__ == "__main__":
     start_time = datetime.now()
     print("Executing notebooks:")
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(filtered_paths)) as executor:
-        results = executor.map(
+        results = list(executor.map(
             partial(execute_notebook, args=args),
             filtered_paths,
             chunksize=1
-        )
+        ))
     print("Checking for trailing jobs...")
     results.append(cancel_trailing_jobs(start_time))
     if not all(results):

--- a/scripts/nb-tester/test-notebook.py
+++ b/scripts/nb-tester/test-notebook.py
@@ -11,7 +11,7 @@
 # been altered from the originals.
 
 import argparse
-import multiprocessing
+import concurrent.futures
 import sys
 import warnings
 import textwrap
@@ -265,8 +265,8 @@ if __name__ == "__main__":
     # Execute notebooks
     start_time = datetime.now()
     print("Executing notebooks:")
-    with multiprocessing.Pool(len(filtered_paths)) as pool:
-        results = pool.map(
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(filtered_paths)) as executor:
+        results = executor.map(
             partial(execute_notebook, args=args),
             filtered_paths,
             chunksize=1


### PR DESCRIPTION
Executes notebooks in parallel. This should help when executing many notebooks that submit jobs as they'll all submit their jobs immediately and begin queueing in parallel.

### Screenshots
<details><summary>Standard run</summary>
<img width="785" alt="Screenshot 2024-04-16 at 13 15 20" src="https://github.com/Qiskit/documentation/assets/36071638/0f6e7497-86f1-4321-9515-a88ea9b9b7e3">
</details>
<details><summary>Standard run (with errors)</summary>
<img width="808" alt="Screenshot 2024-04-16 at 13 07 59" src="https://github.com/Qiskit/documentation/assets/36071638/7fbfc60a-187b-4a40-97aa-6209fe061488">
</details>
<details><summary>Running notebooks that submit jobs</summary>
<img width="785" alt="Screenshot 2024-04-16 at 13 10 44" src="https://github.com/Qiskit/documentation/assets/36071638/822582f0-9abc-436e-9f4a-67e68fd61473">
<img width="1747" alt="Screenshot 2024-04-16 at 13 09 41" src="https://github.com/Qiskit/documentation/assets/36071638/9e26f963-9aa0-4226-8df1-cd87be84393b">
</details>
