### PR TITLE
Indicate IBM Provider is deprecated in left navbar

### DIFF
--- a/docs/api/qiskit-ibm-provider/0.10/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.10/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit IBM Provider",
+  "title": "Qiskit IBM Provider (deprecated)",
   "children": [
     {
       "title": "qiskit_ibm_provider",
@@ -211,4 +211,3 @@
   ],
   "collapsed": true
 }
-

--- a/docs/api/qiskit-ibm-provider/0.7/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.7/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit IBM Provider",
+  "title": "Qiskit IBM Provider (deprecated)",
   "children": [
     {
       "title": "qiskit_ibm_provider",

--- a/docs/api/qiskit-ibm-provider/0.8/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.8/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit IBM Provider",
+  "title": "Qiskit IBM Provider (deprecated)",
   "children": [
     {
       "title": "qiskit_ibm_provider",

--- a/docs/api/qiskit-ibm-provider/0.9/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.9/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit IBM Provider",
+  "title": "Qiskit IBM Provider (deprecated)",
   "children": [
     {
       "title": "qiskit_ibm_provider",

--- a/docs/api/qiskit-ibm-provider/_toc.json
+++ b/docs/api/qiskit-ibm-provider/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit IBM Provider",
+  "title": "Qiskit IBM Provider (deprecated)",
   "children": [
     {
       "title": "qiskit_ibm_provider",

--- a/docs/api/qiskit-ibm-provider/release-notes.mdx
+++ b/docs/api/qiskit-ibm-provider/release-notes.mdx
@@ -1,12 +1,12 @@
 ---
-title: Qiskit IBM Provider release notes
-description: Changes made to Qiskit IBM Provider
+title: Qiskit IBM Provider (deprecated) release notes
+description: Changes made to Qiskit IBM Provider (deprecated)
 in_page_toc_max_heading_level: 2
 ---
 
 <span id="release-notes" />
 
-# Qiskit IBM Provider 0.11 release notes
+# Qiskit IBM Provider (deprecated) 0.11 release notes
 
 <span id="release-notes-0-11-0" />
 

--- a/docs/api/qiskit-ibm-provider/release-notes.mdx
+++ b/docs/api/qiskit-ibm-provider/release-notes.mdx
@@ -6,7 +6,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="release-notes" />
 
-# Qiskit IBM Provider (deprecated) 0.11 release notes
+# Qiskit IBM Provider (deprecated) release notes
 
 <span id="release-notes-0-11-0" />
 

--- a/docs/api/qiskit-ibm-runtime/release-notes.mdx
+++ b/docs/api/qiskit-ibm-runtime/release-notes.mdx
@@ -6,7 +6,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="qiskit-runtime-ibm-client-release-notes" />
 
-# Qiskit Runtime IBM Client 0.23 release notes
+# Qiskit Runtime IBM Client release notes
 
 <span id="id1" />
 

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -162,6 +162,13 @@ export class Pkg {
     return this.name !== "qiskit" || +this.versionWithoutPatch >= 0.45;
   }
 
+  releaseNotesTitle(): string {
+    const versionStr = this.hasSeparateReleaseNotes
+      ? ` ${this.versionWithoutPatch}`
+      : "";
+    return `${this.title}${versionStr} release notes`;
+  }
+
   /**
    * Returns a function that takes in a fileName like `qiskit_ibm_provider/job/exceptions` and returns the
    * stable GitHub URL to the file for this package's version.

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -97,7 +97,7 @@ export class Pkg {
     if (name === "qiskit-ibm-provider") {
       return new Pkg({
         ...args,
-        title: "Qiskit IBM Provider",
+        title: "Qiskit IBM Provider (deprecated)",
         name: "qiskit-ibm-provider",
         githubSlug: "qiskit/qiskit-ibm-provider",
         hasSeparateReleaseNotes: false,

--- a/scripts/lib/api/conversionPipeline.ts
+++ b/scripts/lib/api/conversionPipeline.ts
@@ -112,7 +112,7 @@ async function convertFilesToMarkdown(
       fileName: file,
       determineGithubUrl: pkg.determineGithubUrlFn(),
       imageDestination: pkg.outputDir("/images"),
-      releaseNotesTitle: `${pkg.title} ${pkg.versionWithoutPatch} release notes`,
+      releaseNotesTitle: pkg.releaseNotesTitle(),
     });
 
     // Avoid creating an empty markdown file for HTML files without content


### PR DESCRIPTION
We're also changing other parts of the UI like the API dropdown in the top nav bar. This will change the left ToC here:

<img width="326" alt="Screenshot 2024-04-18 at 10 49 23 AM" src="https://github.com/Qiskit/documentation/assets/14852634/4e357344-b1e2-44c6-93e9-179f5e99723b">

This PR also removes the version number from the H1 for the release notes for Runtime and Provider to no longer have the version number in them. That didn't make sense to do because they're the same release notes for all versions.