### PR TITLE
Reorganise "Save jobs" page

### DIFF
--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "IBM Quantum automatically stores results from every job for you to retrieve at a later date. Use this feature to continue quantum programs across kernel restarts and review past results. You can get the ID of a job programmatically through its `job_id` method, or you can see all your submitted jobs and their IDs through the [Jobs dashboard](https://quantum.ibm.com/jobs).\n",
     "\n",
-    "Once you have the job ID, use the `QiskitRuntimeService.jobs` method to retrieve it."
+    "To find a job programatically, use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method. The following cell finds any jobs submitted in the last day. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
    ]
   },
   {
@@ -31,7 +31,10 @@
     {
      "data": {
       "text/plain": [
-       "PrimitiveResult([PubResult(data=DataBin(meas=BitArray(<shape=(), num_shots=10, num_bits=2>)), metadata={'circuit_metadata': {}})], metadata={'version': 2})"
+       "[<RuntimeJob('cogiau7imm49f6et38a0', 'sampler')>,\n",
+       " <RuntimeJob('crgja91qzd5000886v60', 'sampler')>,\n",
+       " <RuntimeJob('cogi9gftcirtooeunfe0', 'sampler')>,\n",
+       " <RuntimeJob('cogi8qqai5rk2r0u9bu0', 'sampler')>]"
       ]
      },
      "execution_count": 1,
@@ -40,11 +43,13 @@
     }
    ],
    "source": [
+    "import datetime\n",
     "from qiskit_ibm_runtime import QiskitRuntimeService\n",
     "\n",
+    "one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)\n",
+    "\n",
     "service = QiskitRuntimeService()\n",
-    "retrieved_job = service.job(\"cogiau7imm49f6et38a0\")\n",
-    "retrieved_job.result()"
+    "service.jobs(created_after=one_day_ago)"
    ]
   },
   {
@@ -52,11 +57,20 @@
    "id": "9aae5f5a-a543-493c-9bc5-5682ba846ab5",
    "metadata": {},
    "source": [
-    "### Programmatically find jobs\n",
+    "You can also select by backend, job state, session, and more. For more information, see [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) in the API documentation.\n",
     "\n",
-    "If you don't have a job ID and want to find it programmatically rather than visiting the [Jobs dashboard](https://quantum.ibm.com/jobs), you can use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method.\n",
-    "\n",
-    "The following cell finds any jobs submitted in the last hour. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
+    "Once you have the job ID, use the [`QiskitRuntimeService.job`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#job) method to retrieve it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get ID of last job for demonstration\n",
+    "job_id = service.jobs()[0].job_id()\n",
+    "print(job_id)"
    ]
   },
   {
@@ -80,19 +94,8 @@
     }
    ],
    "source": [
-    "import datetime\n",
-    "one_hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)\n",
-    "\n",
-    "service = QiskitRuntimeService()\n",
-    "service.jobs(created_after=one_hour_ago)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60405a95-8d79-4ece-9f36-47299cfa3311",
-   "metadata": {},
-   "source": [
-    "You can also select by backend, job state, session, and more. For more information, see [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) in the API documentation."
+    "retrieved_job = service.job(job_id)\n",
+    "retrieved_job.result()"
    ]
   },
   {

--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "IBM Quantum automatically stores results from every job for you to retrieve at a later date. Use this feature to continue quantum programs across kernel restarts and review past results. You can get the ID of a job programmatically through its `job_id` method, or you can see all your submitted jobs and their IDs through the [Jobs dashboard](https://quantum.ibm.com/jobs).\n",
     "\n",
-    "To find a job programatically, use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method. The following cell finds any jobs submitted in the last day. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
+    "To find a job programatically, use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method. By default, this returns the most recent jobs, but you can also filter jobs by backend name, creation date, and more. The following cell finds any jobs submitted in the last year. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
    ]
   },
   {
@@ -46,10 +46,11 @@
     "import datetime\n",
     "from qiskit_ibm_runtime import QiskitRuntimeService\n",
     "\n",
-    "one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)\n",
+    "three_months_ago = datetime.datetime.now() - datetime.timedelta(days=90)\n",
     "\n",
     "service = QiskitRuntimeService()\n",
-    "service.jobs(created_after=one_day_ago)"
+    "jobs_in_last_three_months = service.jobs(created_after=three_months_ago)\n",
+    "jobs_in_last_three_months[:3]  # show first three jobs"
    ]
   },
   {
@@ -77,7 +78,7 @@
     }
    ],
    "source": [
-    "# Get ID of last job for demonstration.\n",
+    "# Get ID of most recent job for demonstration.\n",
     "# This will not work if you've never submitted a job.\n",
     "job_id = service.jobs()[0].job_id()\n",
     "print(job_id)"

--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "IBM Quantum automatically stores results from every job for you to retrieve at a later date. Use this feature to continue quantum programs across kernel restarts and review past results. You can get the ID of a job programmatically through its `job_id` method, or you can see all your submitted jobs and their IDs through the [Jobs dashboard](https://quantum.ibm.com/jobs).\n",
     "\n",
-    "To find a job programatically, use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method. By default, this returns the most recent jobs, but you can also filter jobs by backend name, creation date, and more. The following cell finds any jobs submitted in the last year. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
+    "To find a job programatically, use the [`QiskitRuntimeService.jobs`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#jobs) method. By default, this returns the most recent jobs, but you can also filter jobs by backend name, creation date, and more. The following cell finds any jobs submitted in the last three months. The `created_after` argument must be a [`datetime.datetime`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime) object."
    ]
   },
   {

--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -64,9 +64,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
+   "id": "43d0f06e-f97f-4c19-b242-02cb0bd420a9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cogiau7imm49f6et38a0\n"
+     ]
+    }
+   ],
    "source": [
     "# Get ID of last job for demonstration\n",
     "job_id = service.jobs()[0].job_id()\n",
@@ -75,20 +84,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "90133394-3259-487f-96b2-3b50e0274064",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<RuntimeJob('cogiau7imm49f6et38a0', 'sampler')>,\n",
-       " <RuntimeJob('crgja91qzd5000886v60', 'sampler')>,\n",
-       " <RuntimeJob('cogi9gftcirtooeunfe0', 'sampler')>,\n",
-       " <RuntimeJob('cogi8qqai5rk2r0u9bu0', 'sampler')>]"
+       "PrimitiveResult([PubResult(data=DataBin(meas=BitArray(<shape=(), num_shots=10, num_bits=2>)), metadata={'circuit_metadata': {}})], metadata={'version': 2})"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -110,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "3a3ff817-01c1-47e8-94c6-1ecf2215ef7c",
    "metadata": {},
    "outputs": [],
@@ -131,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "316aa6f7-faee-4a05-a7b4-02d7bee4d58a",
    "metadata": {},
    "outputs": [
@@ -150,7 +156,7 @@
        "       [3]], dtype=uint8)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "eae94b73-157b-4751-8dd3-add4cc9efec6",
    "metadata": {
     "tags": [

--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -77,7 +77,8 @@
     }
    ],
    "source": [
-    "# Get ID of last job for demonstration\n",
+    "# Get ID of last job for demonstration.\n",
+    "# This will not work if you've never submitted a job.\n",
     "job_id = service.jobs()[0].job_id()\n",
     "print(job_id)"
    ]

--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -33,8 +33,7 @@
       "text/plain": [
        "[<RuntimeJob('cogiau7imm49f6et38a0', 'sampler')>,\n",
        " <RuntimeJob('crgja91qzd5000886v60', 'sampler')>,\n",
-       " <RuntimeJob('cogi9gftcirtooeunfe0', 'sampler')>,\n",
-       " <RuntimeJob('cogi8qqai5rk2r0u9bu0', 'sampler')>]"
+       " <RuntimeJob('cogi9gftcirtooeunfe0', 'sampler')>]"
       ]
      },
      "execution_count": 1,


### PR DESCRIPTION
This page originally submitted a simple job using the cloud simulator as a demonstration. Since the simulators are being deprecated, #1160 removed the job-submitting step and hardcoded the `job_id` into the notebook. This was a bad idea because it means the notebook breaks if not run with my IBM Quantum account.

This PR reorganises the page to get `job_id` programatically first. This lets us avoid hardcoding the `job_id` in the notebook, which means we can run the notebook with any IBM account that has submitted at least one job.
