### PR TITLE
Change how we specify Python versions for testing

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.8"
         cache: "pip"
 
     - name: Install Python packages

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-env_list = py311
+env_list = py3
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
We currently test everything with Python 3.11, but this is a problem as not all writers have it available on their system. We also want to make sure our docs work with as many versions of Python as possible.

This PR allows writers to test their docs with any version of Python, and sets CI to test with Python 3.8 (the minimum version that Qiskit supports).
