### PR TITLE
Fix Python version in CI

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
         cache: "pip"
 
     - name: Install Python packages


### PR DESCRIPTION
Fixes https://github.com/Qiskit/documentation/pull/1207. We use `list[str]` in type hints rather than `List[str]`, which was only added in Python 3.9. So it broke CI.

Python 3.9 is fine as a floor, given that Python 3.12 is newest.