### PR TITLE
Remove tabs from "Plot quantum states"

### DIFF
--- a/docs/verify/plot-quantum-states.ipynb
+++ b/docs/verify/plot-quantum-states.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "$$\\rho = \\sum_k p_k |\\psi_k\\rangle\\langle \\psi_k |.$$\n",
     "\n",
-    "Qiskit represents quantum states through the `Statevector` and `DensityMatrix` classes and provides many visualization functions. Click through the tabs following the code cell to see how Qiskit's different visualization functions plot the following quantum state."
+    "Qiskit represents quantum states through the `Statevector` and `DensityMatrix` classes and provides many visualization functions. See the sections after the following the code cell to see how Qiskit's different visualization functions plot the following quantum state."
    ]
   },
   {
@@ -59,8 +59,7 @@
    "id": "3a89d7cd-7eb2-499e-a9a4-e1921aa57284",
    "metadata": {},
    "source": [
-    "<Tabs>\n",
-    "<TabItem value=\"LaTeX\" label=\"LaTeX\">\n",
+    "## LaTeX state visualization\n",
     "\n",
     "While not technically a \"plot\", Qiskit can render LaTeX representations of both `Statevector` and `DensityMatrix` objects that display nicely in Jupyter notebooks. These follow the standard mathematical conventions for writing down quantum states. Read more in [Basics of quantum information: Single systems](https://learning.quantum.ibm.com/course/basics-of-quantum-information/single-systems#quantum-state-vectors).\n",
     "\n",
@@ -131,8 +130,7 @@
    "source": [
     "You can also replace `\"latex\"` with `\"latex_source\"` to get the raw LaTeX string.\n",
     "\n",
-    "</TabItem>\n",
-    "<TabItem value=\"City\" label=\"City\">\n",
+    "## City state visualization\n",
     "\n",
     "This plot displays the real and imaginary parts of each density matrix element in two three-dimensional bar charts.  It's called a \"city\" plot because the bars resemble skyscrapers in a city. The state we're plotting has the following density matrix.\n",
     "\n",
@@ -193,8 +191,7 @@
    "source": [
     "See the [API documentation](/api/qiskit/qiskit.visualization.plot_state_city) for more information.\n",
     "\n",
-    "</TabItem>\n",
-    "<TabItem value=\"Hinton\" label=\"Hinton\">\n",
+    "## Hinton state visualization\n",
     "\n",
     "This plot is very similar to the \"city\" plot, but the magnitude of each element is represented by the size of a square rather than the height of a bar. White squares represent elements with positive values, and black squares represent elements with negative values. The state we're plotting has the following density matrix.\n",
     "\n",
@@ -255,8 +252,7 @@
    "source": [
     "See the [API documentation](/api/qiskit/qiskit.visualization.plot_state_hinton) for more information.\n",
     "\n",
-    "</TabItem>\n",
-    "<TabItem value=\"Pauli vector\" label=\"Pauli vector\">\n",
+    "## Pauli vector state visualization\n",
     "\n",
     "An observable is a way of measuring a quantum state such that the possible measurement outcomes are real numbers. The expected value of the outcome is also known as the expectation value of the observable on that state, and it can be thought of as the average of infinitely many observations of that state.\n",
     "\n",
@@ -345,8 +341,7 @@
    "source": [
     "See the [API documentation](/api/qiskit/qiskit.visualization.plot_state_paulivec) for more information.\n",
     "\n",
-    "</TabItem>\n",
-    "<TabItem value=\"QSphere\" label=\"QSphere\">\n",
+    "## QSphere state visualization\n",
     "\n",
     "The \"QSphere\" is a Qiskit-unique view of a quantum state in which the amplitude and phase of each element in a statevector is plotted on the surface of a sphere. The thickness of each dot represents the amplitude, and the color represents the phase. For mixed states it will show a sphere for each component."
    ]
@@ -423,8 +418,7 @@
     "\n",
     "See the [API documentation](/api/qiskit/qiskit.visualization.plot_state_qsphere) for more information.\n",
     "\n",
-    "</TabItem>\n",
-    "<TabItem value=\"Bloch multivector\" label=\"Bloch multivector\">\n",
+    "## Bloch multivector state visualization\n",
     "\n",
     "The Bloch vector of a qubit state is its expectation value in the X, Y, and Z Pauli observables mapped to the X, Y, and Z axes in three-dimensional space. This plot projects multi-qubit quantum states onto the single-qubit space and plots each qubit on a Bloch sphere. This visualization only shows the expectation values of individual qubits. It can't show correlations between qubits and so can't fully describe entangled quantum states."
    ]
@@ -460,10 +454,7 @@
    "id": "90407fe1-8226-41ef-8275-73ede8f5613d",
    "metadata": {},
    "source": [
-    "See the [API documentation](/api/qiskit/qiskit.visualization.plot_bloch_multivector) for more information.\n",
-    "\n",
-    "</TabItem>\n",
-    "</Tabs>"
+    "See the [API documentation](/api/qiskit/qiskit.visualization.plot_bloch_multivector) for more information."
    ]
   },
   {


### PR DESCRIPTION
This page wrapped code blocks in `<TabItem>` tags to include them in the tab component. This looks nice but unfortunately relied on some implementation details of how the notebook is converted to the web page, which is something we want to avoid.

This PR removes the tabs and uses headings instead to unblock publishing the page while we work on a more robust solution.
