### PR TITLE
Switch to new Docker image for staging/PR builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,6 @@
 
 FROM icr.io/quantum-computing/iqp-channel-docs-dev:hostname-experiment
 
-# Debug https://github.com/vercel/next.js/issues/53171
-ENV HOSTNAME 0.0.0.0
-
 COPY docs/ /home/node/app/docs
 COPY translations/ /home/node/app/docs
 COPY public/ /home/node/app/packages/web/public/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@
 #   2. ❯ docker run --rm -p 3000:3000 -t qiskit-docs-preview
 #   3. Open up http://localhost:3000
 
-FROM icr.io/quantum-computing/iqp-channel-docs-dev:next13.4
+FROM icr.io/quantum-computing/iqp-channel-docs-dev:hostname-experiment
+
+# Debug https://github.com/vercel/next.js/issues/53171
+ENV HOSTNAME 0.0.0.0
 
 COPY docs/ /home/node/app/docs
 COPY translations/ /home/node/app/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@
 #   2. ❯ docker run --rm -p 3000:3000 -t qiskit-docs-preview
 #   3. Open up http://localhost:3000
 
-FROM icr.io/quantum-computing/iqp-channel-docs-dev:hostname-experiment
+FROM icr.io/quantum-computing/iqp-channel-docs-dev:latest
 
 COPY docs/ /home/node/app/docs
 COPY translations/ /home/node/app/docs

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,8 +6,6 @@ in_page_toc_max_heading_level: 2
 
 ---
 
-# Force CI
-
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,6 +6,8 @@ in_page_toc_max_heading_level: 2
 
 ---
 
+# Force CI
+
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 


### PR DESCRIPTION
We use a new approach in closed source that sets `ENV HOSTNAME 0.0.0.0` in the Dockerfile to work around https://github.com/vercel/next.js/issues/53171 breaking IBM Code Engine with IPv6.