### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   execute:
     name: Execute notebooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   execute:
     name: Execute notebooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Testing notebooks that require linux dependencies is broken due to https://github.com/orgs/community/discussions/120966.

This PR unblocks CI by following the suggestion to pin the Ubuntu version.
