### PR TITLE
Remove simulator from "Get backend information"

### DIFF
--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "# Initialize your account\n",
     "from qiskit_ibm_runtime import QiskitRuntimeService\n",
-    "service = QiskitRuntimeService()\n",
+    "service = QiskitRuntimeService(instance=\"ibm-q/open/main\")\n",
     "\n",
     "service.backends()"
    ]
@@ -83,7 +83,7 @@
     }
    ],
    "source": [
-    "service.backend(\"ibmq_qasm_simulator\")"
+    "service.backend(\"ibm_kyoto\")"
    ]
   },
   {

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -127,7 +127,7 @@
    "id": "6de23dcc-c2ba-4338-b1e8-4086ed653240",
    "metadata": {},
    "source": [
-    "Use these keyword arguments to filter by any attribute in backend configuration or status. A similar method is [`QiskitRuntimeService.least_busy()`](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#least_busy), which takes the same filters as `backends()` but returns the backend that matches the filters and has the least number of jobs pending in the queue:"
+    "Use these keyword arguments to filter by any attribute in backend configuration ([JSON schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json)) or status ([JSON schema](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_status_schema.json)). A similar method is [`QiskitRuntimeService.least_busy()`](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#least_busy), which takes the same filters as `backends()` but returns the backend that matches the filters and has the least number of jobs pending in the queue:"
    ]
   },
   {

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "You can also filter the available backends by their properties. For more general filters, you can make advanced functions using a lambda function. Refer to the [API documentation](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends) for more details.\n",
     "\n",
-    "Let’s try getting only backends that fit these criteria:\n",
+    "The following code only returns backends that fit these criteria:\n",
     "\n",
     "*   Are real quantum devices (`simulator=False`)\n",
     "*   Are currently operational (`operational=True`)\n",
@@ -127,7 +127,7 @@
    "id": "6de23dcc-c2ba-4338-b1e8-4086ed653240",
    "metadata": {},
    "source": [
-    "A similar method is [`QiskitRuntimeService.least_busy()`](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#least_busy), which takes the same filters as `backends()` but returns the backend that matches the filters and has the least number of jobs pending in the queue:"
+    "Use these keyword arguments to filter by any attribute in backend configuration or status. A similar method is [`QiskitRuntimeService.least_busy()`](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#least_busy), which takes the same filters as `backends()` but returns the backend that matches the filters and has the least number of jobs pending in the queue:"
    ]
   },
   {

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "You can also filter the available backends by their properties. For more general filters, you can make advanced functions using a lambda function. Refer to the [API documentation](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends) for more details.\n",
     "\n",
-    "The following code only returns backends that fit these criteria:\n",
+    "The following code returns only backends that fit these criteria:\n",
     "\n",
     "*   Are real quantum devices (`simulator=False`)\n",
     "*   Are currently operational (`operational=True`)\n",

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "## Filter backends\n",
     "\n",
-    "You can also filter the available backends by their properties. For more general filters, you can make advanced functions using a lambda function. Refer to the [API documentation](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends) for more details.\n",
+    "You can also filter the available backends by their properties. For more general filters, set the `filters` argument to a function that accepts a backend object and returns `True` if it meets your criteria. Refer to the [API documentation](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends) for more details.\n",
     "\n",
     "The following code returns only backends that fit these criteria:\n",
     "\n",

--- a/docs/run/get-backend-information.ipynb
+++ b/docs/run/get-backend-information.ipynb
@@ -29,19 +29,15 @@
     {
      "data": {
       "text/plain": [
-       "[<IBMBackend('ibm_cairo')>,\n",
-       " <IBMBackend('ibm_hanoi')>,\n",
-       " <IBMBackend('ibmq_kolkata')>,\n",
-       " <IBMBackend('ibm_sherbrooke')>,\n",
-       " <IBMBackend('ibm_brisbane')>,\n",
-       " <IBMBackend('ibm_nazca')>,\n",
-       " <IBMBackend('ibm_cusco')>,\n",
-       " <IBMBackend('ibm_torino')>,\n",
-       " <IBMBackend('ibmq_mumbai')>,\n",
+       "[<IBMBackend('simulator_statevector')>,\n",
        " <IBMBackend('ibm_kyoto')>,\n",
-       " <IBMBackend('ibmq_qasm_simulator')>,\n",
-       " <IBMBackend('ibm_algiers')>,\n",
-       " <IBMBackend('ibm_osaka')>]"
+       " <IBMBackend('ibm_sherbrooke')>,\n",
+       " <IBMBackend('simulator_mps')>,\n",
+       " <IBMBackend('simulator_extended_stabilizer')>,\n",
+       " <IBMBackend('simulator_stabilizer')>,\n",
+       " <IBMBackend('ibm_brisbane')>,\n",
+       " <IBMBackend('ibm_osaka')>,\n",
+       " <IBMBackend('ibmq_qasm_simulator')>]"
       ]
      },
      "execution_count": 1,
@@ -74,7 +70,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMBackend('ibmq_qasm_simulator')>"
+       "<IBMBackend('ibm_kyoto')>"
       ]
      },
      "execution_count": 2,
@@ -111,17 +107,9 @@
     {
      "data": {
       "text/plain": [
-       "[<IBMBackend('ibm_cairo')>,\n",
-       " <IBMBackend('ibm_hanoi')>,\n",
-       " <IBMBackend('ibmq_kolkata')>,\n",
+       "[<IBMBackend('ibm_kyoto')>,\n",
        " <IBMBackend('ibm_sherbrooke')>,\n",
        " <IBMBackend('ibm_brisbane')>,\n",
-       " <IBMBackend('ibm_nazca')>,\n",
-       " <IBMBackend('ibm_cusco')>,\n",
-       " <IBMBackend('ibm_torino')>,\n",
-       " <IBMBackend('ibmq_mumbai')>,\n",
-       " <IBMBackend('ibm_kyoto')>,\n",
-       " <IBMBackend('ibm_algiers')>,\n",
        " <IBMBackend('ibm_osaka')>]"
       ]
      },
@@ -151,7 +139,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMBackend('ibm_cairo')>"
+       "<IBMBackend('simulator_statevector')>"
       ]
      },
      "execution_count": 4,
@@ -234,7 +222,7 @@
     {
      "data": {
       "text/plain": [
-       "IBMQubitProperties(t1=0.00017890738300219413, t2=2.6687259977252058e-05, frequency=4908622971.84939, anharmonicity=-308028796.19250304)"
+       "IBMQubitProperties(t1=0.00022166953697436856, t2=2.71364838264149e-05, frequency=4908399363.66221, anharmonicity=-308028796.19250304)"
       ]
      },
      "execution_count": 6,
@@ -265,7 +253,7 @@
     {
      "data": {
       "text/plain": [
-       "InstructionProperties(duration=6.6e-07, error=0.01598506240188205, calibration=Schedule ecr)"
+       "InstructionProperties(duration=6.6e-07, error=0.02131754555943946, calibration=Schedule ecr)"
       ]
      },
      "execution_count": 7,
@@ -294,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "InstructionProperties(duration=1.4e-06, error=0.16620000000000001, calibration=Schedule measure)"
+       "InstructionProperties(duration=1.4e-06, error=0.18920000000000003, calibration=Schedule measure)"
       ]
      },
      "execution_count": 8,


### PR DESCRIPTION
This notebook explicitly requested a simulator backend, which doesn't work with our testing provider. They'll also be removed soon, so the best fix is to use a real device instead.

I've also changed the instance to the open provider so users see the same list of backends.

---

Fixes #1228.
