### PR TITLE
Fix url in Get started with primitives

### DIFF
--- a/docs/run/primitives-get-started.mdx
+++ b/docs/run/primitives-get-started.mdx
@@ -241,7 +241,7 @@ print(f"  > Metadata: {result.metadata[0]}")
 
 The `Sampler` primitive can be run with any provider by using [`qiskit.primitives.BackendSampler`](../api/qiskit/qiskit.primitives.BackendSampler). Likewise, the `Estimator` primitive can be run with any provider using [`qiskit.primitives.BackendEstimator`](../api/qiskit/qiskit.primitives.BackendEstimator). Equivalent implementations in V2 are coming soon.   
   
-Some providers implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#providers) for more details).
+Some providers implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#provider) for more details).
 
 ### Example: BackendEstimator
 


### PR DESCRIPTION
Broken link needs updating