### PR TITLE
Flatten left table of contents for Runtime and Provider

### DIFF
--- a/docs/api/qiskit-ibm-provider/0.10/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.10/_toc.json
@@ -109,56 +109,46 @@
     },
     {
       "title": "qiskit_ibm_provider.transpiler",
+      "url": "/api/qiskit-ibm-provider/0.10/ibm_transpiler"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes",
+      "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-provider/0.10/ibm_transpiler"
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_provider.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-provider/0.7/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.7/_toc.json
@@ -109,56 +109,46 @@
     },
     {
       "title": "qiskit_ibm_provider.transpiler",
+      "url": "/api/qiskit-ibm-provider/0.7/ibm_transpiler"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes",
+      "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-provider/0.7/ibm_transpiler"
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_provider.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-provider/0.8/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.8/_toc.json
@@ -109,56 +109,46 @@
     },
     {
       "title": "qiskit_ibm_provider.transpiler",
+      "url": "/api/qiskit-ibm-provider/0.8/ibm_transpiler"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes",
+      "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-provider/0.8/ibm_transpiler"
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_provider.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-provider/0.9/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.9/_toc.json
@@ -109,56 +109,46 @@
     },
     {
       "title": "qiskit_ibm_provider.transpiler",
+      "url": "/api/qiskit-ibm-provider/0.9/ibm_transpiler"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes",
+      "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-provider/0.9/ibm_transpiler"
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_provider.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-provider/_toc.json
+++ b/docs/api/qiskit-ibm-provider/_toc.json
@@ -109,56 +109,46 @@
     },
     {
       "title": "qiskit_ibm_provider.transpiler",
+      "url": "/api/qiskit-ibm-provider/ibm_transpiler"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes",
+      "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-provider/ibm_transpiler"
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_provider.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/0.18/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.18/_toc.json
@@ -454,56 +454,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/0.18/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/0.18/transpiler"
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/0.19/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.19/_toc.json
@@ -454,56 +454,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/0.19/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/0.19/transpiler"
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/0.20/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.20/_toc.json
@@ -454,56 +454,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/0.20/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/0.20/transpiler"
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/0.21/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.21/_toc.json
@@ -546,56 +546,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/0.21/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/0.21/transpiler"
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/0.22/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.22/_toc.json
@@ -546,56 +546,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/0.22/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/0.22/transpiler"
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -550,56 +550,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/transpiler"
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/docs/api/qiskit-ibm-runtime/dev/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/dev/_toc.json
@@ -550,56 +550,46 @@
     },
     {
       "title": "qiskit_ibm_runtime.transpiler",
+      "url": "/api/qiskit-ibm-runtime/dev/transpiler"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes",
+      "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
+      "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.basis"
+    },
+    {
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Overview",
-          "url": "/api/qiskit-ibm-runtime/dev/transpiler"
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling"
         },
         {
-          "title": "qiskit_ibm_runtime.transpiler.passes",
-          "children": [
-            {
-              "title": "Overview",
-              "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.basis",
-              "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.basis"
-            },
-            {
-              "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
-              "children": [
-                {
-                  "title": "Overview",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling"
-                },
-                {
-                  "title": "ALAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
-                },
-                {
-                  "title": "ASAPScheduleAnalysis",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
-                },
-                {
-                  "title": "BlockBasePadder",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
-                },
-                {
-                  "title": "DynamicCircuitInstructionDurations",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
-                },
-                {
-                  "title": "PadDelay",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
-                },
-                {
-                  "title": "PadDynamicalDecoupling",
-                  "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
-                }
-              ]
-            }
-          ]
+          "title": "ALAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis"
+        },
+        {
+          "title": "ASAPScheduleAnalysis",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis"
+        },
+        {
+          "title": "BlockBasePadder",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder"
+        },
+        {
+          "title": "DynamicCircuitInstructionDurations",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations"
+        },
+        {
+          "title": "PadDelay",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay"
+        },
+        {
+          "title": "PadDynamicalDecoupling",
+          "url": "/api/qiskit-ibm-runtime/dev/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling"
         }
       ]
     },

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -35,6 +35,7 @@ export class Pkg {
   readonly versionWithoutPatch: string;
   readonly type: PackageType;
   readonly releaseNoteEntries: ReleaseNoteEntry[];
+  readonly nestModulesInToc: boolean;
 
   static VALID_NAMES = ["qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider"];
 
@@ -47,6 +48,7 @@ export class Pkg {
     versionWithoutPatch: string;
     type: PackageType;
     releaseNoteEntries: ReleaseNoteEntry[];
+    nestModulesInToc: boolean;
   }) {
     this.name = kwargs.name;
     this.title = kwargs.title;
@@ -56,6 +58,7 @@ export class Pkg {
     this.versionWithoutPatch = kwargs.versionWithoutPatch;
     this.type = kwargs.type;
     this.releaseNoteEntries = kwargs.releaseNoteEntries;
+    this.nestModulesInToc = kwargs.nestModulesInToc;
   }
 
   static async fromArgs(
@@ -80,6 +83,7 @@ export class Pkg {
         githubSlug: "qiskit/qiskit",
         hasSeparateReleaseNotes: true,
         releaseNoteEntries,
+        nestModulesInToc: true,
       });
     }
 
@@ -91,6 +95,7 @@ export class Pkg {
         githubSlug: "qiskit/qiskit-ibm-runtime",
         hasSeparateReleaseNotes: false,
         releaseNoteEntries: [],
+        nestModulesInToc: false,
       });
     }
 
@@ -102,6 +107,7 @@ export class Pkg {
         githubSlug: "qiskit/qiskit-ibm-provider",
         hasSeparateReleaseNotes: false,
         releaseNoteEntries: [],
+        nestModulesInToc: false,
       });
     }
 
@@ -117,6 +123,7 @@ export class Pkg {
     versionWithoutPatch?: string;
     type?: PackageType;
     releaseNoteEntries?: ReleaseNoteEntry[];
+    nestModulesInToc?: boolean;
   }): Pkg {
     return new Pkg({
       name: kwargs.name ?? "my-quantum-project",
@@ -127,6 +134,7 @@ export class Pkg {
       versionWithoutPatch: kwargs.versionWithoutPatch ?? "0.1",
       type: kwargs.type ?? "latest",
       releaseNoteEntries: kwargs.releaseNoteEntries ?? [],
+      nestModulesInToc: kwargs.nestModulesInToc ?? false,
     });
   }
 

--- a/scripts/lib/api/conversionPipeline.test.ts
+++ b/scripts/lib/api/conversionPipeline.test.ts
@@ -60,6 +60,7 @@ test("qiskit-sphinx-theme", async () => {
     versionWithoutPatch: "0.1",
     type: "latest",
     releaseNoteEntries: [],
+    nestModulesInToc: false,
   });
   const markdownFolder = pkg.outputDir(docsBaseFolder);
 

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, test } from "@jest/globals";
 
-import { generateToc, nestModule } from "./generateToc";
+import { generateToc } from "./generateToc";
 import { Pkg } from "./Pkg";
 
 const DEFAULT_ARGS = {
@@ -20,11 +20,6 @@ const DEFAULT_ARGS = {
   images: [],
   isReleaseNotes: false,
 };
-
-test("nestModule", () => {
-  expect(nestModule("project.module")).toEqual(false);
-  expect(nestModule("project.module.submodule")).toEqual(true);
-});
 
 describe("generateToc", () => {
   test("generate a basic toc", () => {

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -22,14 +22,8 @@ const DEFAULT_ARGS = {
 };
 
 test("nestModule", () => {
-  const nestingDisabled = Pkg.mock({ nestModulesInToc: false });
-  const nestingEnabled = Pkg.mock({ nestModulesInToc: true });
-  expect(nestModule(nestingDisabled, "project.module")).toEqual(false);
-  expect(nestModule(nestingDisabled, "project.module.submodule")).toEqual(
-    false,
-  );
-  expect(nestModule(nestingEnabled, "project.module")).toEqual(false);
-  expect(nestModule(nestingEnabled, "project.module.submodule")).toEqual(true);
+  expect(nestModule("project.module")).toEqual(false);
+  expect(nestModule("project.module.submodule")).toEqual(true);
 });
 
 describe("generateToc", () => {

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -29,7 +29,12 @@ type Toc = {
   collapsed: boolean;
 };
 
-function nestModule(id: string): boolean {
+export function nestModule(pkg: Pkg, id: string): boolean {
+  // Most packages don't nest submodules because there module list is so small,
+  // so it's more useful to show them all and have less nesting.
+  if (!pkg.nestModulesInToc) {
+    return false;
+  }
   // For example, nest `qiskit.algorithms.submodule`, but
   // not `qiskit.algorithms` which should be top-level.
   return id.split(".").length > 2;
@@ -43,6 +48,7 @@ export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
 
   addItemsToModules(items, tocModulesByTitle, tocModuleTitles);
   const nestedTocModules = getNestedTocModulesSorted(
+    pkg,
     tocModules,
     tocModulesByTitle,
     tocModuleTitles,
@@ -111,6 +117,7 @@ function addItemsToModules(
 }
 
 function getNestedTocModulesSorted(
+  pkg: Pkg,
   tocModules: TocEntry[],
   tocModulesByTitle: Dictionary<TocEntry>,
   tocModuleTitles: string[],
@@ -118,7 +125,7 @@ function getNestedTocModulesSorted(
   const nestedTocModules: TocEntry[] = [];
 
   for (const tocModule of tocModules) {
-    if (!nestModule(tocModule.title)) {
+    if (!nestModule(pkg, tocModule.title)) {
       nestedTocModules.push(tocModule);
       continue;
     }

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -117,7 +117,7 @@ function getNestedTocModulesSorted(
   tocModulesByTitle: Dictionary<TocEntry>,
   tocModuleTitles: string[],
 ): TocEntry[] {
-  // Most packages don't nest submodules because there module list is so small,
+  // Most packages don't nest submodules because their module list is so small,
   // so it's more useful to show them all and have less nesting.
   if (!pkg.nestModulesInToc) {
     return orderEntriesByTitle(tocModules);

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -29,12 +29,7 @@ type Toc = {
   collapsed: boolean;
 };
 
-export function nestModule(pkg: Pkg, id: string): boolean {
-  // Most packages don't nest submodules because there module list is so small,
-  // so it's more useful to show them all and have less nesting.
-  if (!pkg.nestModulesInToc) {
-    return false;
-  }
+export function nestModule(id: string): boolean {
   // For example, nest `qiskit.algorithms.submodule`, but
   // not `qiskit.algorithms` which should be top-level.
   return id.split(".").length > 2;
@@ -122,10 +117,15 @@ function getNestedTocModulesSorted(
   tocModulesByTitle: Dictionary<TocEntry>,
   tocModuleTitles: string[],
 ): TocEntry[] {
-  const nestedTocModules: TocEntry[] = [];
+  // Most packages don't nest submodules because there module list is so small,
+  // so it's more useful to show them all and have less nesting.
+  if (!pkg.nestModulesInToc) {
+    return orderEntriesByTitle(tocModules);
+  }
 
+  const nestedTocModules: TocEntry[] = [];
   for (const tocModule of tocModules) {
-    if (!nestModule(pkg, tocModule.title)) {
+    if (!nestModule(tocModule.title)) {
       nestedTocModules.push(tocModule);
       continue;
     }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1212. As explained there, this is because:

1. Qiskit SDK is getting a bigger revamp in https://github.com/Qiskit/documentation/issues/1211 and it will also flatten submodules, so we want to be consistent.
2. The module list is so short that it's useful to have the navbar be flatter. It makes things less crowded and more discoverable.

Note that some of the Runtime provider pages aren't very useful...I opened https://github.com/Qiskit/documentation/issues/1240 to track that.

For now, this is implemented as the `Pkg` constructor setting a boolean argument for whether modules should be nested or not. I'm coming up with an alternative—but similar factoring—while working on https://github.com/Qiskit/documentation/issues/1211. This PR is ~prework.

<img width="253" alt="Screenshot 2024-04-24 at 4 02 34 PM" src="https://github.com/Qiskit/documentation/assets/14852634/2bbbaa7f-e187-4170-b2c5-02273e340b07">

<img width="257" alt="Screenshot 2024-04-24 at 4 02 10 PM" src="https://github.com/Qiskit/documentation/assets/14852634/53816ee2-f7ee-4d1d-90a5-64d7795fd776">
