### PR TITLE
Remove duplicate entries in Migration Guides ToC

### DIFF
--- a/docs/api/migration-guides/_toc.json
+++ b/docs/api/migration-guides/_toc.json
@@ -65,19 +65,6 @@
         ]
       },
       {
-        "title": "Qiskit Runtime 0.20 changes",
-        "children": [
-          {
-            "title": "V2 primitives",
-            "url": "/api/migration-guides/v2-primitives"
-          },
-          {
-            "title": "qiskit_ibm_provider to qiskit_ibm_runtime",
-            "url": "/api/migration-guides/qiskit-runtime-from-provider"
-          }
-        ]
-      },
-      {
         "title": "Qiskit 0.44 changes",
         "children": [
           {

--- a/docs/api/migration-guides/index.mdx
+++ b/docs/api/migration-guides/index.mdx
@@ -12,7 +12,7 @@ These migration guides help you more effectively use Qiskit and Qiskit Runtime:
    * [Qiskit 1.0 packaging changes](/api/migration-guides/qiskit-1.0-installation)
    * [Qiskit 1.0 feature changes](/api/migration-guides/qiskit-1.0-features)
 * [Migrate to the Qiskit Runtime V2 primitives](/api/migration-guides/v2-primitives)
-* [How to use Qiskit Runtime Sessions](/api/migration-guides/sessions)
+* [Qiskit Runtime execution mode changes](/api/migration-guides/sessions)
 * Migrate to Qiskit Runtime
    * [Overview](./qiskit-runtime)
    * [Migrate from `qiskit-ibmq-provider`](./qiskit-runtime-from-ibmq-provider)

--- a/docs/api/migration-guides/index.mdx
+++ b/docs/api/migration-guides/index.mdx
@@ -12,6 +12,7 @@ These migration guides help you more effectively use Qiskit and Qiskit Runtime:
    * [Qiskit 1.0 packaging changes](/api/migration-guides/qiskit-1.0-installation)
    * [Qiskit 1.0 feature changes](/api/migration-guides/qiskit-1.0-features)
 * [Migrate to the Qiskit Runtime V2 primitives](/api/migration-guides/v2-primitives)
+* [How to use Qiskit Runtime Sessions](/api/migratino-guides/sessions)
 * Migrate to Qiskit Runtime
    * [Overview](./qiskit-runtime)
    * [Migrate from `qiskit-ibmq-provider`](./qiskit-runtime-from-ibmq-provider)

--- a/docs/api/migration-guides/index.mdx
+++ b/docs/api/migration-guides/index.mdx
@@ -12,7 +12,7 @@ These migration guides help you more effectively use Qiskit and Qiskit Runtime:
    * [Qiskit 1.0 packaging changes](/api/migration-guides/qiskit-1.0-installation)
    * [Qiskit 1.0 feature changes](/api/migration-guides/qiskit-1.0-features)
 * [Migrate to the Qiskit Runtime V2 primitives](/api/migration-guides/v2-primitives)
-* [How to use Qiskit Runtime Sessions](/api/migratino-guides/sessions)
+* [How to use Qiskit Runtime Sessions](/api/migration-guides/sessions)
 * Migrate to Qiskit Runtime
    * [Overview](./qiskit-runtime)
    * [Migrate from `qiskit-ibmq-provider`](./qiskit-runtime-from-ibmq-provider)


### PR DESCRIPTION
* `/api/migration-guides/v2-primitives` is already in the ToC as a top-level entry called "Migrate to the Qiskit Runtime V2 primitives"
* `/api/migration-guides/qiskit-runtime-from-provider` is already in the section `Migrate to Qiskit Runtime`, but under the new URL `qiskit-runtime-from-ibm-provider`

I think it was a bad merge conflict to duplicate the entries in the new Runtime 0.20 section.