### PR TITLE
Falcon processors retirement on 30 April

### DIFF
--- a/docs/run/retired-systems.mdx
+++ b/docs/run/retired-systems.mdx
@@ -15,9 +15,9 @@ The following IBM Quantum&trade; systems have been retired. For the full list of
 
 | System name       | Qubit count | Retirement date (Year - month - day) |
 | ----------------- | ----------- | --------------- |
-| ibmq_algiers      | **27**      | 2024-04-30      |
-| ibmq_cairo        | **27**      | 2024-04-30      |
-| ibmq_hanoi        | **27**      | 2024-04-30      |
+| ibm_algiers       | **27**      | 2024-04-30      |
+| ibm_cairo         | **27**      | 2024-04-30      |
+| ibm_hanoi         | **27**      | 2024-04-30      |
 | ibmq_kolkata      | **27**      | 2024-04-01      |
 | ibmq_mumbai       | **27**      | 2024-04-01      |
 | ibm_ithaca        | **65**      | 2024-01-24      |

--- a/docs/run/retired-systems.mdx
+++ b/docs/run/retired-systems.mdx
@@ -15,6 +15,9 @@ The following IBM Quantum&trade; systems have been retired. For the full list of
 
 | System name       | Qubit count | Retirement date (Year - month - day) |
 | ----------------- | ----------- | --------------- |
+| ibmq_algiers      | **27**      | 2024-04-30      |
+| ibmq_cairo        | **27**      | 2024-04-30      |
+| ibmq_hanoi        | **27**      | 2024-04-30      |
 | ibmq_kolkata      | **27**      | 2024-04-01      |
 | ibmq_mumbai       | **27**      | 2024-04-01      |
 | ibm_ithaca        | **65**      | 2024-01-24      |


### PR DESCRIPTION
Algiers, Cairo, and Hanoi (27-qubit systems) to be retired on 30 April. Add to retired systems page.