### PR TITLE
Refactor generateToc.ts to not use dictionary type

### DIFF
--- a/scripts/lib/stringUtils.test.ts
+++ b/scripts/lib/stringUtils.test.ts
@@ -18,6 +18,7 @@ import {
   removeSuffix,
   getLastPartFromFullIdentifier,
   capitalize,
+  hasPrefix,
 } from "./stringUtils";
 
 test("removePart()", () => {
@@ -54,4 +55,12 @@ test("getLastPartFromFullIdentifier", () => {
 test("capitalize()", () => {
   const input = "hello world!";
   expect(capitalize(input)).toEqual("Hello world!");
+});
+
+test("hasPrefix()", () => {
+  expect(hasPrefix("abc", ["a", "z"])).toBe(true);
+  expect(hasPrefix("abc", ["x", "z"])).toBe(false);
+  expect(hasPrefix("abc", ["x", "a"])).toBe(true);
+  expect(hasPrefix("abc", [])).toBe(false);
+  expect(hasPrefix("abc", ["abc"])).toBe(true);
 });

--- a/scripts/lib/stringUtils.ts
+++ b/scripts/lib/stringUtils.ts
@@ -42,3 +42,7 @@ export function getLastPartFromFullIdentifier(fullIdentifierName: string) {
 export function capitalize(text: string) {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
+
+export function hasPrefix(text: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => text.startsWith(prefix));
+}


### PR DESCRIPTION
Prework for https://github.com/Qiskit/documentation/pull/1256. It was confusing how we pass both `tocModules: TocEntry[]` and `tocModulesByTitle: Dictionary<TocEntry>`. It wasn't clear how those values relate, and `Dictionary` is an under-documented API by Lodash.

Also adds `hasPrefix`, which we will need in https://github.com/Qiskit/documentation/pull/1256.