### PR TITLE
url change for serverless

### DIFF
--- a/docs/api/migration-guides/qiskit-runtime-use-case.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-use-case.mdx
@@ -269,4 +269,4 @@ result = backend.run(isa_circuit, shots=10, meas_level=1, meas_return="avg").res
 
 ## Upload, view, or delete custom prototype programs
 
-This function has been replaced with Quantum Serverless patterns.  For instructions to migrate, see [Converting from Qiskit Runtime Programs.](https://qiskit-extensions.github.io/quantum-serverless/migration/migration_from_qiskit_runtime_programs.html)
+This function has been replaced with Quantum Serverless patterns.  For instructions to migrate, see [Converting from Qiskit Runtime Programs.](https://qiskit-extensions.github.io/qiskit-serverless/migration/migration_from_qiskit_runtime_programs.html)

--- a/docs/run/quantum-serverless.mdx
+++ b/docs/run/quantum-serverless.mdx
@@ -7,7 +7,7 @@ description: How to run quantum computing workloads remotely using Quantum Serve
 
 Premium users can build, deploy, and run their workloads remotely on classical compute made available through the IBM Quantum&trade; Platform.
 
-Try out the tutorials in [IBM Quantum Learning](https://learning.quantum.ibm.com/catalog/tutorials?topics=qiskit-patterns) (note: these are accessible in the Premium Plan once you have logged into your IBM Quantum account) and explore more of the features of Quantum Serverless in the [documentation](https://qiskit-extensions.github.io/quantum-serverless/).
+Try out the tutorials in [IBM Quantum Learning](https://learning.quantum.ibm.com/catalog/tutorials?topics=qiskit-patterns) (note: these are accessible in the Premium Plan once you have logged into your IBM Quantum account) and explore more of the features of Quantum Serverless in the [documentation](https://qiskit-extensions.github.io/qiskit-serverless/).
 
 
 <Admonition type="note">
@@ -83,7 +83,7 @@ print(result)
 save_result(result[0].data.evs)
 ```
 
-Please refer to our guides on how to configure your pattern to [accept input arguments](https://qiskit-extensions.github.io/quantum-serverless/getting_started/basic/02_arguments_and_results.html) and [handle external python dependencies](https://qiskit-extensions.github.io/quantum-serverless/getting_started/basic/03_dependencies.html).
+Please refer to our guides on how to configure your pattern to [accept input arguments](https://qiskit-extensions.github.io/qiskit-serverless/getting_started/basic/02_arguments_and_results.html) and [handle external python dependencies](https://qiskit-extensions.github.io/qiskit-serverless/getting_started/basic/03_dependencies.html).
 
 After creating a workflow, authenticate to the `IBMServerlessProvider` with your IBM Quantum token, which can be obtained from your [IBM Quantum account](https://quantum.ibm.com/account), and upload the script.
 
@@ -119,7 +119,7 @@ job.result()
 
 ## Migration guide
 
-Qiskit Runtime custom programs can be easily migrated to Quantum Serverless via this [migration guide](https://qiskit-extensions.github.io/quantum-serverless/migration/migration_from_qiskit_runtime_programs.html).
+Qiskit Runtime custom programs can be easily migrated to Quantum Serverless via this [migration guide](https://qiskit-extensions.github.io/qiskit-serverless/migration/migration_from_qiskit_runtime_programs.html).
 
 ## Resource management (alpha)
 


### PR DESCRIPTION
The github.io URL has changed from quantum-serverless to qiskit-serverless, and there is no redirect.

https://qiskit-extensions.github.io/quantum-serverless/ -> https://qiskit-extensions.github.io/qiskit-serverless/

Update the URLs in our docs