### PR TITLE
Remove unused ToC nesting mechanism

### DIFF
--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -40,7 +40,6 @@ export class Pkg {
   readonly versionWithoutPatch: string;
   readonly type: PackageType;
   readonly releaseNotesConfig: ReleaseNotesConfig;
-  readonly nestModulesInToc: boolean;
   readonly tocGrouping?: TocGrouping;
 
   static VALID_NAMES = ["qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider"];
@@ -53,7 +52,6 @@ export class Pkg {
     versionWithoutPatch: string;
     type: PackageType;
     releaseNotesConfig?: ReleaseNotesConfig;
-    nestModulesInToc?: boolean;
     tocGrouping?: TocGrouping;
   }) {
     this.name = kwargs.name;
@@ -64,7 +62,6 @@ export class Pkg {
     this.type = kwargs.type;
     this.releaseNotesConfig =
       kwargs.releaseNotesConfig ?? new ReleaseNotesConfig({});
-    this.nestModulesInToc = kwargs.nestModulesInToc ?? false;
     this.tocGrouping = kwargs.tocGrouping;
   }
 
@@ -124,7 +121,6 @@ export class Pkg {
     versionWithoutPatch?: string;
     type?: PackageType;
     releaseNotesConfig?: ReleaseNotesConfig;
-    nestModulesInToc?: boolean;
     tocGrouping?: TocGrouping;
   }): Pkg {
     return new Pkg({
@@ -135,7 +131,6 @@ export class Pkg {
       versionWithoutPatch: kwargs.versionWithoutPatch ?? "0.1",
       type: kwargs.type ?? "latest",
       releaseNotesConfig: kwargs.releaseNotesConfig,
-      nestModulesInToc: kwargs.nestModulesInToc ?? false,
       tocGrouping: kwargs.tocGrouping ?? undefined,
     });
   }

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -120,62 +120,6 @@ describe("generateToc", () => {
     });
   });
 
-  test("TOC with nested submodules", () => {
-    const toc = generateToc(Pkg.mock({ nestModulesInToc: true }), [
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project",
-        },
-        url: "/api/my-quantum-project",
-        ...DEFAULT_ARGS,
-      },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.options",
-        },
-        url: "/api/my-quantum-project/options",
-        ...DEFAULT_ARGS,
-      },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.options.submodule",
-        },
-        url: "/api/my-quantum-project/my_quantum_project.options.submodule",
-        ...DEFAULT_ARGS,
-      },
-    ]);
-    expect(toc).toEqual({
-      children: [
-        {
-          title: "my_quantum_project",
-          url: "/api/my-quantum-project",
-        },
-        {
-          children: [
-            {
-              title: "Module overview",
-              url: "/api/my-quantum-project/options",
-            },
-            {
-              title: "my_quantum_project.options.submodule",
-              url: "/api/my-quantum-project/my_quantum_project.options.submodule",
-            },
-          ],
-          title: "my_quantum_project.options",
-        },
-        {
-          title: "Release notes",
-          url: "/api/my-quantum-project/release-notes",
-        },
-      ],
-      collapsed: true,
-      title: "My Quantum Project",
-    });
-  });
-
   test("TOC with grouped modules", () => {
     // This ordering is intentional.
     const topLevelEntries: TocGroupingEntry[] = [

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -30,12 +30,6 @@ type Toc = {
   collapsed: boolean;
 };
 
-function nestModule(id: string): boolean {
-  // For example, nest `qiskit.algorithms.submodule`, but
-  // not `qiskit.algorithms` which should be top-level.
-  return id.split(".").length > 2;
-}
-
 export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
   const [modules, items] = getModulesAndItems(results);
   const tocModules = generateTocModules(modules);
@@ -46,32 +40,24 @@ export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
 
   addItemsToModules(items, tocModulesByTitle, tocModuleTitles);
 
-  let orderedModules;
-  if (pkg.tocGrouping) {
-    orderedModules = groupAndSortModules(pkg.tocGrouping, tocModulesByTitle);
-  } else if (pkg.nestModulesInToc) {
-    orderedModules = getNestedTocModulesSorted(
-      tocModulesByTitle,
-      tocModuleTitles,
-    );
-  } else {
-    orderedModules = sortAndTruncateModules(tocModules);
-  }
+  const orderedEntries = pkg.tocGrouping
+    ? groupAndSortModules(pkg.tocGrouping, tocModulesByTitle)
+    : sortAndTruncateModules(tocModules);
 
   generateOverviewPage(tocModules);
-  const maybeIndexPage = ensureIndexPage(pkg, orderedModules);
+  const maybeIndexPage = ensureIndexPage(pkg, orderedEntries);
   if (maybeIndexPage) {
-    orderedModules.unshift(maybeIndexPage);
+    orderedEntries.unshift(maybeIndexPage);
   }
 
   const maybeReleaseNotes = generateReleaseNotesEntry(pkg);
   if (maybeReleaseNotes) {
-    orderedModules.push(maybeReleaseNotes);
+    orderedEntries.push(maybeReleaseNotes);
   }
 
   return {
     title: pkg.title,
-    children: orderedModules,
+    children: orderedEntries,
     collapsed: true,
   };
 }
@@ -191,39 +177,6 @@ function groupAndSortModules(
     }
   });
   return result;
-}
-
-/** Nest modules so that only top-level modules like qiskit.circuit are at the top
- * and submodules like qiskit.circuit.library are nested.
- *
- * This function sorts alphabetically at every level.
- */
-function getNestedTocModulesSorted(
-  tocModulesByTitle: Map<string, TocEntry>,
-  tocModuleTitles: string[],
-): TocEntry[] {
-  const nestedTocModules: TocEntry[] = [];
-  for (const tocModule of tocModulesByTitle.values()) {
-    if (!nestModule(tocModule.title)) {
-      nestedTocModules.push(tocModule);
-      continue;
-    }
-
-    const parentModuleTitle = findClosestParentModules(
-      tocModule.title,
-      tocModuleTitles,
-    );
-
-    if (parentModuleTitle) {
-      const parentModule = tocModulesByTitle.get(parentModuleTitle) as TocEntry;
-      if (!parentModule.children) parentModule.children = [];
-      parentModule.children.push(tocModule);
-    } else {
-      nestedTocModules.push(tocModule);
-    }
-  }
-
-  return orderEntriesByTitle(nestedTocModules);
 }
 
 /** Sorts all modules and truncates the package name, e.g. `qiskit_ibm_runtime.options` -> `...options`.


### PR DESCRIPTION
Thanks to https://github.com/Qiskit/documentation/issues/1213, we no longer nest submodules in the left ToC. We don't plan to nest again in the future because it limits discoverability of modules and results in too deep of nesting.