### PR TITLE
Add missing header - class without id

### DIFF
--- a/docs/api/qiskit/0.19/logging.mdx
+++ b/docs/api/qiskit/0.19/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")()            | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()      | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.3/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.3/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.24/logging.mdx
+++ b/docs/api/qiskit/0.24/logging.mdx
@@ -24,9 +24,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.5/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.5/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.25/logging.mdx
+++ b/docs/api/qiskit/0.25/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.26/logging.mdx
+++ b/docs/api/qiskit/0.26/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.27/logging.mdx
+++ b/docs/api/qiskit/0.27/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.28/logging.mdx
+++ b/docs/api/qiskit/0.28/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.29/logging.mdx
+++ b/docs/api/qiskit/0.29/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.30/logging.mdx
+++ b/docs/api/qiskit/0.30/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.31/logging.mdx
+++ b/docs/api/qiskit/0.31/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.32/logging.mdx
+++ b/docs/api/qiskit/0.32/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.6/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.33/logging.mdx
+++ b/docs/api/qiskit/0.33/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.35/logging.mdx
+++ b/docs/api/qiskit/0.35/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.

--- a/docs/api/qiskit/0.36/logging.mdx
+++ b/docs/api/qiskit/0.36/logging.mdx
@@ -22,9 +22,9 @@ python_api_name: qiskit.ignis.logging
 | [`IgnisLogging`](qiskit.ignis.logging.IgnisLogging "qiskit.ignis.logging.IgnisLogging")(\[log\_config\_path]) | Singleton class to configure file logging via IgnisLogger |
 | [`IgnisLogReader`](qiskit.ignis.logging.IgnisLogReader "qiskit.ignis.logging.IgnisLogReader")()               | Class to read from Ignis log files                        |
 
-###
+### IgnisLogger
 
-<Class github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
+<Class id="qiskit.ignis.logging.IgnisLogger" github="https://github.com/qiskit-community/qiskit-ignis/tree/stable/0.7/qiskit/ignis/logging/ignis_logging.py" signature="IgnisLogger(name, level=0)">
   A logger class for Ignis
 
   IgnisLogger is a like any other `logging.Logger` object except it has an additional method, [`log_to_file()`](qiskit.ignis.logging.IgnisLogger#log_to_file "qiskit.ignis.logging.IgnisLogger.log_to_file"), used to log data in the form of key:value pairs to a log file. Logging configuration is performed via a configuration file and is handled by IgnisLogging.


### PR DESCRIPTION
This PR adds the header of a class that was missing its id. The id was manually fixed in Box by modifying the HTML, and this is the regeneration as a follow-up of #1283 