### PR TITLE
Deduplicate `generateApiComponents` dispatch table entries

### DIFF
--- a/scripts/lib/api/generateApiComponents.ts
+++ b/scripts/lib/api/generateApiComponents.ts
@@ -86,18 +86,29 @@ function prepareProps(
   apiType: ApiType,
   id: string,
 ): ComponentProps {
+  const prepClassOrException = () =>
+    prepareClassOrExceptionProps($, $child, $dl, githubSourceLink, id);
+  const prepFunction = () =>
+    prepareFunctionProps($, $child, $dl, githubSourceLink, id);
+  const prepMethod = () =>
+    prepareMethodProps($, $child, $dl, priorApiType, githubSourceLink, id);
+  const prepAttributeOrProperty = () =>
+    prepareAttributeOrPropertyProps(
+      $,
+      $child,
+      $dl,
+      priorApiType,
+      githubSourceLink,
+      id,
+    );
+
   const preparePropsPerApiType: Record<string, () => ComponentProps> = {
-    class: () =>
-      prepareClassOrExceptionProps($, $child, $dl, githubSourceLink, id),
-    property: () =>
-      prepareAttributeProps($, $child, $dl, priorApiType, githubSourceLink, id),
-    method: () =>
-      prepareMethodProps($, $child, $dl, priorApiType, githubSourceLink, id),
-    attribute: () =>
-      prepareAttributeProps($, $child, $dl, priorApiType, githubSourceLink, id),
-    function: () => prepareFunctionProps($, $child, $dl, id, githubSourceLink),
-    exception: () =>
-      prepareClassOrExceptionProps($, $child, $dl, githubSourceLink, id),
+    class: prepClassOrException,
+    exception: prepClassOrException,
+    property: prepAttributeOrProperty,
+    method: prepMethod,
+    attribute: prepAttributeOrProperty,
+    function: prepFunction,
   };
 
   const githubSourceLink = prepareGitHubLink($child, apiType === "method");
@@ -173,7 +184,7 @@ function prepareMethodProps(
   return props;
 }
 
-function prepareAttributeProps(
+function prepareAttributeOrPropertyProps(
   $: CheerioAPI,
   $child: Cheerio<any>,
   $dl: Cheerio<any>,
@@ -233,8 +244,8 @@ function prepareFunctionProps(
   $: CheerioAPI,
   $child: Cheerio<any>,
   $dl: Cheerio<any>,
-  id: string,
   githubSourceLink: string | undefined,
+  id: string,
 ): ComponentProps {
   const props = {
     id,

--- a/scripts/lib/api/generateApiComponents.ts
+++ b/scripts/lib/api/generateApiComponents.ts
@@ -106,8 +106,8 @@ function prepareProps(
     class: prepClassOrException,
     exception: prepClassOrException,
     property: prepAttributeOrProperty,
-    method: prepMethod,
     attribute: prepAttributeOrProperty,
+    method: prepMethod,
     function: prepFunction,
   };
 


### PR DESCRIPTION
This PR refactors the dispatch table used to prepare the props of each API component in order to simplify the `generateApiComponents.ts` script. The functions for "functions" and "methods" cannot be merged trivially because they check in different ways the `isDedicatedPage` prop. Using the same method for that gives us false positives on pages like [this](https://docs.quantum.ibm.com/api/qiskit/0.36/execute). Moreover, functions don't need any header in those cases.

Thanks @Eric-Arellano for the idea on #1283 