### PR TITLE
Fix API docs script to tolerate empty docs folder

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -128,10 +128,9 @@ async function prepareSphinxFolder(pkg: Pkg, args: Arguments): Promise<string> {
 
 async function deleteExistingMarkdown(pkg: Pkg): Promise<void> {
   const markdownDir = pkg.outputDir("docs");
-  if (pkg.isLatest() || (await pathExists(markdownDir))) {
-    console.log(
-      `Deleting existing markdown for ${pkg.name}:${pkg.versionWithoutPatch}`,
-    );
-    await rmFilesInFolder(markdownDir);
-  }
+  if (!(await pathExists(markdownDir))) return;
+  console.log(
+    `Deleting existing markdown for ${pkg.name}:${pkg.versionWithoutPatch}`,
+  );
+  await rmFilesInFolder(markdownDir);
 }

--- a/scripts/lib/fs.ts
+++ b/scripts/lib/fs.ts
@@ -33,5 +33,5 @@ export async function pathExists(path: string) {
  * Assumes the folder exists, but it's fine if it's empty.
  */
 export async function rmFilesInFolder(dir: string): Promise<void> {
-await $`find ${dir} -maxdepth 1 -type f -path "${dir}/*" | xargs rm -f {}`.quiet();
+  await $`find ${dir} -maxdepth 1 -type f -path "${dir}/*" | xargs rm -f {}`.quiet();
 }

--- a/scripts/lib/fs.ts
+++ b/scripts/lib/fs.ts
@@ -13,6 +13,8 @@
 import fs from "fs/promises";
 import path from "path";
 
+import { $ } from "zx/core";
+
 export function getRoot() {
   return path.normalize(`${__dirname}/../../`);
 }

--- a/scripts/lib/fs.ts
+++ b/scripts/lib/fs.ts
@@ -33,14 +33,5 @@ export async function pathExists(path: string) {
  * Assumes the folder exists, but it's fine if it's empty.
  */
 export async function rmFilesInFolder(dir: string): Promise<void> {
-  const dirMembers = await fs.readdir(dir);
-  await Promise.all(
-    dirMembers.map(async (member) => {
-      const fp = path.join(dir, member);
-      const stat = await fs.stat(fp);
-      if (stat.isFile()) {
-        await fs.unlink(fp);
-      }
-    }),
-  );
+await $`find ${dir} -maxdepth 1 -type f -path "${dir}/*" | xargs rm -f {}`.quiet();
 }


### PR DESCRIPTION
This was getting in the way of adding the new qiskit-transpiler-service docs, since its folder is empty. This also was a problem when rerunning the script if the folder had been previously deleted without having restored the deleted files before the rerun.