### PR TITLE
Add Qiskit Transpiler Service Client docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ You can regenerate all API docs versions following these steps:
 
 1. Create a dedicated branch for the regeneration other than `main` using `git checkout -b <branch-name>`.
 2. Ensure there are no pending changes by running `git status` and creating a new commit for them if necessary.
-3. Run `npm run regen-apis` to regenerate all API docs versions for `qiskit`, `qiskit-ibm-provider`, and `qiskit-ibm-runtime`.
+3. Run `npm run regen-apis` to regenerate all API docs versions for `qiskit`, `qiskit-ibm-provider`, `qiskit-ibm-runtime`, and `qiskit-transpiler-service`.
 
 Each regenerated version will be saved as a distinct commit. If the changes are too large for one single PR, consider splitting it up into multiple PRs by using `git cherry-pick` or `git rebase -i` so each PR only has the commits it wants to target.
 
@@ -332,7 +332,7 @@ If you only want to regenerate the latest stable minor release of each package, 
 
 Alternatively, you can also regenerate one specific version:
 
-1. Choose which documentation you want to generate (`qiskit`, `qiskit-ibm-provider`, or `qiskit-ibm-runtime`) and its version.
+1. Choose which documentation you want to generate (`qiskit`, `qiskit-ibm-provider`, `qiskit-ibm-runtime`, or `qiskit-transpiler-service`) and its version.
 2. Run `npm run gen-api -- -p <pkg-name> -v <version>`,
    e.g. `npm run gen-api -- -p qiskit -v 0.45.0`
 
@@ -346,7 +346,7 @@ In this case, no commit will be automatically created.
 
 This is useful when new docs content is published, usually corresponding to new releases or hotfixes for content issues. If you're generating a patch release, also see the below subsection for additional steps.
 
-1. Choose which documentation you want to generate (`qiskit`, `qiskit-ibm-provider`, or `qiskit-ibm-runtime`) and its version.
+1. Choose which documentation you want to generate (`qiskit`, `qiskit-ibm-provider`, `qiskit-ibm-runtime`, or `qiskit-transpiler-service`) and its version.
 2. Determine the full version, such as by looking at https://github.com/Qiskit/qiskit/releases
 3. Download a CI artifact with the project's documentation. To find this:
    1. Pull up the CI runs for the stable commit that you want to build docs from. This should not be from a Pull Request

--- a/docs/api/qiskit-transpiler-service/_package.json
+++ b/docs/api/qiskit-transpiler-service/_package.json
@@ -1,0 +1,4 @@
+{
+  "name": "qiskit-transpiler-service",
+  "version": "0.3.0"
+}

--- a/docs/api/qiskit-transpiler-service/_toc.json
+++ b/docs/api/qiskit-transpiler-service/_toc.json
@@ -1,0 +1,40 @@
+{
+  "title": "Qiskit Transpiler Service Client",
+  "children": [
+    {
+      "title": "API index",
+      "url": "/api/qiskit-transpiler-service"
+    },
+    {
+      "title": "qiskit_transpiler_service.ai",
+      "children": [
+        {
+          "title": "Module overview",
+          "url": "/api/qiskit-transpiler-service/ai"
+        },
+        {
+          "title": "AIRouting",
+          "url": "/api/qiskit-transpiler-service/qiskit_transpiler_service.ai.AIRouting"
+        }
+      ]
+    },
+    {
+      "title": "qiskit_transpiler_service.transpiler_service",
+      "children": [
+        {
+          "title": "Module overview",
+          "url": "/api/qiskit-transpiler-service/transpiler_service"
+        },
+        {
+          "title": "TranspilerService",
+          "url": "/api/qiskit-transpiler-service/qiskit_transpiler_service.transpiler_service.TranspilerService"
+        }
+      ]
+    },
+    {
+      "title": "qiskit_transpiler_service.utils",
+      "url": "/api/qiskit-transpiler-service/utils"
+    }
+  ],
+  "collapsed": true
+}

--- a/docs/api/qiskit-transpiler-service/ai.mdx
+++ b/docs/api/qiskit-transpiler-service/ai.mdx
@@ -1,0 +1,24 @@
+---
+title: ai
+description: API reference for qiskit_transpiler_service.ai
+in_page_toc_min_heading_level: 2
+python_api_type: module
+python_api_name: qiskit_transpiler_service.ai
+---
+
+<span id="ai-qiskit-transpiler-service-ai" />
+
+<span id="module-qiskit_transpiler_service.ai" />
+
+# AI
+
+<span id="module-qiskit_transpiler_service.ai" />
+
+`qiskit_transpiler_service.ai`
+
+## Classes
+
+|                                                                                                                    |   |
+| ------------------------------------------------------------------------------------------------------------------ | - |
+| [`AIRouting`](qiskit_transpiler_service.ai.AIRouting "qiskit_transpiler_service.ai.AIRouting")(\*args, \*\*kwargs) |   |
+

--- a/docs/api/qiskit-transpiler-service/index.mdx
+++ b/docs/api/qiskit-transpiler-service/index.mdx
@@ -1,0 +1,5 @@
+# qiskit-transpiler-service API reference
+
+*   [AI (`qiskit_transpiler_service.ai`)](ai)
+*   [Qiskit Transpiler Service (`qiskit_transpiler_service.transpiler_service`)](transpiler_service)
+*   [Utilities (`qiskit_transpiler_service.utils`)](utils)

--- a/docs/api/qiskit-transpiler-service/qiskit_transpiler_service.ai.AIRouting.mdx
+++ b/docs/api/qiskit-transpiler-service/qiskit_transpiler_service.ai.AIRouting.mdx
@@ -1,0 +1,94 @@
+---
+title: AIRouting
+description: API reference for qiskit_transpiler_service.ai.AIRouting
+in_page_toc_min_heading_level: 1
+python_api_type: class
+python_api_name: qiskit_transpiler_service.ai.AIRouting
+---
+
+# AIRouting
+
+<Class id="qiskit_transpiler_service.ai.AIRouting" isDedicatedPage={true} signature="qiskit_transpiler_service.ai.AIRouting(*args, **kwargs)">
+  Bases: [`TransformationPass`](/api/qiskit/qiskit.transpiler.TransformationPass "(in Qiskit v1.0)")
+
+  ## Attributes
+
+  ### is\_analysis\_pass
+
+  <Attribute id="qiskit_transpiler_service.ai.AIRouting.is_analysis_pass">
+    Check if the pass is an analysis pass.
+
+    If the pass is an AnalysisPass, that means that the pass can analyze the DAG and write the results of that analysis in the property set. Modifications on the DAG are not allowed by this kind of pass.
+  </Attribute>
+
+  ### is\_transformation\_pass
+
+  <Attribute id="qiskit_transpiler_service.ai.AIRouting.is_transformation_pass">
+    Check if the pass is a transformation pass.
+
+    If the pass is a TransformationPass, that means that the pass can manipulate the DAG, but cannot modify the property set (but it can be read).
+  </Attribute>
+
+  ## Methods
+
+  ### execute
+
+  <Function id="qiskit_transpiler_service.ai.AIRouting.execute" signature="execute(passmanager_ir: Any, state: PassManagerState, callback: Callable | None = None) → tuple[Any, PassManagerState]">
+    Execute optimization task for input Qiskit IR.
+
+    **Parameters**
+
+    *   **passmanager\_ir** – Qiskit IR to optimize.
+    *   **state** – State associated with workflow execution by the pass manager itself.
+    *   **callback** – A callback function which is caller per execution of optimization task.
+
+    **Returns**
+
+    Optimized Qiskit IR and state of the workflow.
+  </Function>
+
+  ### name
+
+  <Function id="qiskit_transpiler_service.ai.AIRouting.name" signature="name() → str">
+    Name of the pass.
+  </Function>
+
+  ### run
+
+  <Function id="qiskit_transpiler_service.ai.AIRouting.run" signature="run(dag)">
+    Run the AIRouting pass on dag.
+
+    **Parameters**
+
+    **dag** (*DAGCircuit*) – the directed acyclic graph to be mapped.
+
+    **Returns**
+
+    A dag mapped to be compatible with the coupling\_map.
+
+    **Return type**
+
+    DAGCircuit
+
+    **Raises**
+
+    *   **TranspilerError** – if the coupling map or the layout are not
+    *   **compatible with the DAG**\*\*, or \*\***if the coupling\_map=None** –
+  </Function>
+
+  ### update\_status
+
+  <Function id="qiskit_transpiler_service.ai.AIRouting.update_status" signature="update_status(state: PassManagerState, run_state: RunState) → PassManagerState">
+    Update workflow status.
+
+    **Parameters**
+
+    *   **state** – Pass manager state to update.
+    *   **run\_state** – Completion status of current task.
+
+    **Returns**
+
+    Updated pass manager state.
+  </Function>
+</Class>
+

--- a/docs/api/qiskit-transpiler-service/qiskit_transpiler_service.transpiler_service.TranspilerService.mdx
+++ b/docs/api/qiskit-transpiler-service/qiskit_transpiler_service.transpiler_service.TranspilerService.mdx
@@ -1,0 +1,20 @@
+---
+title: TranspilerService
+description: API reference for qiskit_transpiler_service.transpiler_service.TranspilerService
+in_page_toc_min_heading_level: 1
+python_api_type: class
+python_api_name: qiskit_transpiler_service.transpiler_service.TranspilerService
+---
+
+# TranspilerService
+
+<Class id="qiskit_transpiler_service.transpiler_service.TranspilerService" isDedicatedPage={true} signature="qiskit_transpiler_service.transpiler_service.TranspilerService(optimization_level: int, ai: bool = True, coupling_map: List[List[int]] | None = None, backend_name: str | None = None, qiskit_transpile_options: dict | None = None, ai_layout_mode: str | None = None)">
+  Bases: [`object`](https://docs.python.org/3/library/functions.html#object "(in Python v3.12)")
+
+  ## Methods
+
+  ### run
+
+  <Function id="qiskit_transpiler_service.transpiler_service.TranspilerService.run" signature="run(circuits: List[str | QuantumCircuit] | str | QuantumCircuit)" />
+</Class>
+

--- a/docs/api/qiskit-transpiler-service/transpiler_service.mdx
+++ b/docs/api/qiskit-transpiler-service/transpiler_service.mdx
@@ -1,0 +1,24 @@
+---
+title: transpiler_service
+description: API reference for qiskit_transpiler_service.transpiler_service
+in_page_toc_min_heading_level: 2
+python_api_type: module
+python_api_name: qiskit_transpiler_service.transpiler_service
+---
+
+<span id="qiskit-transpiler-service-qiskit-transpiler-service-transpiler-service" />
+
+<span id="module-qiskit_transpiler_service.transpiler_service" />
+
+# Qiskit Transpiler Service
+
+<span id="module-qiskit_transpiler_service.transpiler_service" />
+
+`qiskit_transpiler_service.transpiler_service`
+
+## Classes
+
+|                                                                                                                                                                                         |   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | - |
+| [`TranspilerService`](qiskit_transpiler_service.transpiler_service.TranspilerService "qiskit_transpiler_service.transpiler_service.TranspilerService")(optimization\_level\[, ai, ...]) |   |
+

--- a/docs/api/qiskit-transpiler-service/utils.mdx
+++ b/docs/api/qiskit-transpiler-service/utils.mdx
@@ -1,0 +1,30 @@
+---
+title: utils
+description: API reference for qiskit_transpiler_service.utils
+in_page_toc_min_heading_level: 2
+python_api_type: module
+python_api_name: qiskit_transpiler_service.utils
+---
+
+<span id="utilities-qiskit-transpiler-service-utils" />
+
+<span id="module-qiskit_transpiler_service.utils" />
+
+# Utilities
+
+<span id="module-qiskit_transpiler_service.utils" />
+
+`qiskit_transpiler_service.utils`
+
+## Functions
+
+### create\_random\_linear\_function
+
+<Function id="qiskit_transpiler_service.utils.create_random_linear_function" signature="qiskit_transpiler_service.utils.create_random_linear_function(n_qubits: int, seed: int = 123) → LinearFunction" />
+
+### get\_metrics
+
+<Function id="qiskit_transpiler_service.utils.get_metrics" signature="qiskit_transpiler_service.utils.get_metrics(qc: QuantumCircuit) → dict[str, int]">
+  Returns a dict with metrics from a QuantumCircuit
+</Function>
+

--- a/public/api/qiskit-transpiler-service/objects.inv
+++ b/public/api/qiskit-transpiler-service/objects.inv
@@ -1,0 +1,6 @@
+# Sphinx inventory version 2
+# Project: Qiskit Transpiler Service
+# Version: 
+# The remainder of this file is compressed using zlib.
+xÚ­T;oÂ0Şù–Ú†P76¤.lô5GÆ9è©‰ü ğïk'%ºD—³¿‡ÏwŞ¢şAÅ¥Î1iP;rdùa–f±M€MÇ§2Y0Ø^…óÅ{fÊ'	×šMA¥aÂ(<‚ùÎb²ÆÓ	JÖBqÉ“ƒvAîãD¹1
+W†¬Û¢¹Å@±e©”Ìäƒ6ºÈÈf$Oï*{#«(+ïñ0²†Ícn Ò†«ïQ;'èÑUGÕñşe>Ú©³	n/Ó&º#õY¥>j¡şI'1=jå†Î¡Ğõv”»—DŸºÈĞj[l…ßFn9ÎÒ(A	\Ek+…ŸNO]ÅÓ#9…u&rEP(ôEcœ	=v½6ñÌÅ¾İß|Á†×ZrTAQÆ°o¢ËD	jppêÉùrÁ¬APÑt4oƒ³cõ­`õ…±So¹ñú åE6DËÄ—û¢AĞ×x‹­£Á…Z\¶:	_ÂIQ‘Wg-ì~ÚØ•Ÿ„†QE½B¤‰% 1µ2—Hï

--- a/scripts/api-html-artifacts.json
+++ b/scripts/api-html-artifacts.json
@@ -45,5 +45,8 @@
     "0.16": "https://ibm.box.com/shared/static/xbtjc270jc2uu3s8tp7tqn8o9pckl37i.zip",
     "0.15": "https://ibm.box.com/shared/static/u9yqn2ya75cigotxsgl8zqaaqllzuudb.zip",
     "0.14": "https://ibm.box.com/shared/static/t37e7jjsi0hii4j3xoorwpwso5m03jqn.zip"
+  },
+  "qiskit-transpiler-service": {
+    "0.3": "https://ibm.box.com/shared/static/qiskfdazhq1dpxcl9b627x9yi60gncb4.zip"
   }
 }

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -52,7 +52,12 @@ export class Pkg {
   readonly releaseNotesConfig: ReleaseNotesConfig;
   readonly tocConfig: TocConfig;
 
-  static VALID_NAMES = ["qiskit", "qiskit-ibm-runtime", "qiskit-ibm-provider"];
+  static VALID_NAMES = [
+    "qiskit",
+    "qiskit-ibm-runtime",
+    "qiskit-ibm-provider",
+    "qiskit-transpiler-service",
+  ];
 
   constructor(kwargs: {
     name: string;
@@ -119,6 +124,16 @@ export class Pkg {
         name: "qiskit-ibm-provider",
         githubSlug: "qiskit/qiskit-ibm-provider",
         tocConfig: new TocConfig({ truncate: true }),
+      });
+    }
+
+    if (name === "qiskit-transpiler-service") {
+      return new Pkg({
+        ...args,
+        title: "Qiskit Transpiler Service Client",
+        name: "qiskit-transpiler-service",
+        githubSlug: undefined,
+        releaseNotesConfig: new ReleaseNotesConfig({ enabled: false }),
       });
     }
 


### PR DESCRIPTION
Docs for https://pypi.org/project/qiskit-transpiler-service/.

These docs are not ready to go live to production yet. But we can safely merge them in this repository to unblock infrastructure work in closed source. We won't have closed source sync over these files until we get the final okay from the transpiler service team.