### PR TITLE
Make generic scripts for new projects

### DIFF
--- a/scripts/commands/checkInternalLinks.ts
+++ b/scripts/commands/checkInternalLinks.ts
@@ -16,6 +16,7 @@ import { globby } from "globby";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
+import { Pkg } from "../lib/api/Pkg";
 import { pathExists } from "../lib/fs";
 import { File } from "../lib/links/InternalLink";
 import { FileBatch } from "../lib/links/FileBatch";
@@ -185,10 +186,9 @@ async function determineCurrentDocsFileBatch(
   ];
 
   if (!args.currentApis) {
-    toCheck.push(
-      "!{public,docs}/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/*",
-    );
-    toLoad.push("docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/*");
+    const projects = Pkg.VALID_NAMES.join(",");
+    toCheck.push(`!{public,docs}/api/{${projects}}/*`);
+    toLoad.push(`docs/api/{${projects}}/*`);
   }
 
   if (args.qiskitReleaseNotes) {
@@ -222,16 +222,11 @@ async function determineCurrentDocsFileBatch(
 async function determineDevFileBatches(): Promise<FileBatch[]> {
   const projects: [string, string[]][] = [
     ["qiskit", QISKIT_GLOBS_TO_LOAD],
-    ["qiskit-ibm-provider", PROVIDER_GLOBS_TO_LOAD],
     ["qiskit-ibm-runtime", RUNTIME_GLOBS_TO_LOAD],
   ];
 
   const result = [];
   for (const [project, toLoad] of projects) {
-    if (!(await pathExists(`docs/api/${project}/dev`))) {
-      continue;
-    }
-
     const fileBatch = await FileBatch.fromGlobs(
       [`docs/api/${project}/dev/*`, `public/api/${project}/dev/objects.inv`],
       toLoad,

--- a/scripts/commands/checkMetadata.ts
+++ b/scripts/commands/checkMetadata.ts
@@ -106,7 +106,7 @@ async function determineFiles(args: Arguments): Promise<[string[], string[]]> {
 }
 
 function isApi(filePath: string): boolean {
-  const apiFolders = Pkg.VALID_NAMES.map((pkg) => `/api/${pkg}`);
+  const apiFolders = Pkg.VALID_NAMES.map((pkg) => `/api/${pkg}/`);
   return apiFolders.some((urlPath) => filePath.startsWith(urlPath));
 }
 

--- a/scripts/commands/checkMetadata.ts
+++ b/scripts/commands/checkMetadata.ts
@@ -17,6 +17,8 @@ import { hideBin } from "yargs/helpers";
 import grayMatter from "gray-matter";
 import { globby } from "globby";
 
+import { Pkg } from "../lib/api/Pkg";
+
 interface Arguments {
   [x: string]: unknown;
   apis: boolean;
@@ -91,8 +93,8 @@ async function determineFiles(args: Arguments): Promise<[string[], string[]]> {
   const mdGlobs = ["docs/**/*.mdx"];
   const notebookGlobs = ["docs/**/*.ipynb"];
   if (!args.apis) {
-    const apiIgnore =
-      "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/**/*";
+    const projects = Pkg.VALID_NAMES.join(",");
+    const apiIgnore = `!docs/api/{${projects}}/**/*`;
     mdGlobs.push(apiIgnore);
     notebookGlobs.push(apiIgnore);
   }
@@ -104,11 +106,8 @@ async function determineFiles(args: Arguments): Promise<[string[], string[]]> {
 }
 
 function isApi(filePath: string): boolean {
-  return (
-    filePath.includes("/api/qiskit/") ||
-    filePath.includes("/api/qiskit-ibm-runtime/") ||
-    filePath.includes("/api/qiskit-ibm-provider/")
-  );
+  const apiFolders = Pkg.VALID_NAMES.map((pkg) => `/api/${pkg}`);
+  return apiFolders.some((urlPath) => filePath.startsWith(urlPath));
 }
 
 function handleErrors(mdErrors: string[], notebookErrors: string[]): void {

--- a/scripts/commands/checkOrphanPages.ts
+++ b/scripts/commands/checkOrphanPages.ts
@@ -110,14 +110,10 @@ async function determineTocFiles(args: Arguments): Promise<string[]> {
     globs.push("docs/api/*/_toc.json");
   }
   if (args.devApis) {
-    globs.push(
-      "docs/api/{qiskit,qiskit-ibm-runtime,qiskit-ibm-provider}/dev/_toc.json",
-    );
+    globs.push("docs/api/*/dev/_toc.json");
   }
   if (args.historicalApis) {
-    globs.push(
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/_toc.json",
-    );
+    globs.push("docs/api/*/[0-9]*/_toc.json");
   }
   return await globby(globs);
 }

--- a/scripts/commands/checkPagesRender.ts
+++ b/scripts/commands/checkPagesRender.ts
@@ -17,6 +17,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
 import { zxMain } from "../lib/zx";
+import { Pkg } from "../lib/api/Pkg";
 
 const PORT = 3000;
 
@@ -162,19 +163,11 @@ async function determineFilePaths(args: Arguments): Promise<string[]> {
     globs.push("docs/**/*.{ipynb,mdx}");
   }
 
+  const allProjects = Pkg.VALID_NAMES.join(",");
   for (const [isIncluded, glob] of [
-    [
-      args.currentApis,
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/*.mdx",
-    ],
-    [
-      args.historicalApis,
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*.mdx",
-    ],
-    [
-      args.devApis,
-      "docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*.mdx",
-    ],
+    [args.currentApis, `docs/api/{${allProjects}}/*.mdx`],
+    [args.historicalApis, "docs/api/*/[0-9]*/*.mdx"],
+    [args.devApis, "docs/api/*/dev/*.mdx"],
     [args.qiskitReleaseNotes, "docs/api/qiskit/release-notes/*.mdx"],
     [args.translations, "translations/**/*.{ipynb,mdx}"],
   ]) {

--- a/scripts/commands/convertApiDocsToHistorical.ts
+++ b/scripts/commands/convertApiDocsToHistorical.ts
@@ -11,25 +11,21 @@
 // that they have been altered from the originals.
 
 import { $ } from "zx";
-import { zxMain } from "../lib/zx";
 import { globby } from "globby";
-import { pathExists, getRoot } from "../lib/fs";
 import { readFile, writeFile } from "fs/promises";
 import { mkdirp } from "mkdirp";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import transformLinks from "transform-markdown-links";
 
+import { pathExists, getRoot } from "../lib/fs";
+import { zxMain } from "../lib/zx";
+import { Pkg } from "../lib/api/Pkg";
+
 interface Arguments {
   [x: string]: unknown;
   package: string;
 }
-
-const PACKAGES: string[] = [
-  "qiskit-ibm-runtime",
-  "qiskit-ibm-provider",
-  "qiskit",
-];
 
 const readArgs = (): Arguments => {
   return yargs(hideBin(process.argv))
@@ -37,7 +33,7 @@ const readArgs = (): Arguments => {
     .option("package", {
       alias: "p",
       type: "string",
-      choices: PACKAGES,
+      choices: Pkg.VALID_NAMES,
       demandOption: true,
       description: "Which package to convert",
     })
@@ -47,7 +43,7 @@ const readArgs = (): Arguments => {
 zxMain(async () => {
   const args = readArgs();
 
-  const pkgName = PACKAGES.find((pkgName) => pkgName === args.package);
+  const pkgName = Pkg.VALID_NAMES.find((pkgName) => pkgName === args.package);
   if (pkgName === undefined) {
     throw new Error(`Unrecognized package: ${args.package}`);
   }


### PR DESCRIPTION
Unblocks https://github.com/Qiskit/documentation/pull/1317

Context: we can't use `api/*` for globs because it would match against `api/migration-guides`.