### PR TITLE
Add note reminding to pull changes to requirements.txt into inner-source

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -1,5 +1,7 @@
 # We pin to exact versions for a more reproducible and
-# stable build.
+# stable build. Make sure to update the commit hash in
+# the inner-source repo after updating this file.
+
 qiskit[all]~=1.0
 qiskit-aer~=0.14.0.1
 qiskit-ibm-runtime~=0.23.0


### PR DESCRIPTION
The inner-source repo uses this requirements file too, but we pin to a commit to avoid unintentionally breaking CI. This note reminds maintainers to update the commit in the inner-source repo after they update this file.