### PR TITLE
Make issue when weekly checks fail

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -57,3 +57,29 @@ jobs:
           npm run check:external-links --
           'docs/**/*.{md,mdx,ipynb}'
           '!docs/api/qiskit/[0-9]*/*'
+
+  make_issue:
+    name: Make issue on failure
+    needs: [external-link-checker, pages-render]
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `Today's scheduled extended checks failed.
+
+            Please [check the logs](https://github.com/Qiskit/documentation/actions/runs/${{ github.run_id }}/).
+
+            > [!NOTE]
+            > This issue was created by a GitHub action.
+            `
+
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Extended checks failed",
+              body: message,
+              assignees: ["frankharkins", "Eric-Arellano", "arnaucasau"]
+            })


### PR DESCRIPTION
Closes #547. This PR makes a new issue whenever the weekly checks fail. We decided to create a new issue rather than reopening / commenting. This reduces code complexity and lets us reuse the code from `.github/workflows/learning-uploader-test.yml`.
