### PR TITLE
Ignore local testing warnings when testing with fake backend

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -33,6 +33,7 @@ from squeaky import clean_notebook
 
 # If not submitting jobs, we mock the real backend by prepending this to each notebook
 MOCKING_CODE = """\
+import warnings
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.fake_provider import FakeKyoto
 
@@ -40,6 +41,9 @@ def patched_least_busy(self, *args, **kwarg):
   return FakeKyoto()
 
 QiskitRuntimeService.least_busy = patched_least_busy
+
+warnings.filterwarnings("ignore", message="Options {.*} have no effect in local testing mode.")
+warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
 """
 
 @dataclass


### PR DESCRIPTION
When we use the fake backend to test code examples, we can get the following warnings ([example](https://github.com/Qiskit/documentation/actions/runs/8991252592/job/24698420154?pr=1307#step:7:74)).

```
Cell 24:
 │ /home/runner/work/documentation/documentation/.tox/py3/lib/python3.9/site-
 │ packages/qiskit_ibm_runtime/session.py:157: UserWarning: Session is not
 │ supported in local testing mode or when using a simulator.
 │   warnings.warn(

Cell 28:
 │ /home/runner/work/documentation/documentation/.tox/py3/lib/python3.9/site-
 │ packages/qiskit_ibm_runtime/fake_provider/local_service.py:243:
 │ UserWarning: Options {'default_shots': 10000, 'dynamical_decoupling':
 │ {'enable': True}} have no effect in local testing mode.
 │   warnings.warn(f"Options {options_copy} have no effect in local testing
 │ mode.")
 ```

 This PR ignores those specific warnings when the patch is enabled so they don't break CI.
