### PR TITLE
Prettier ignore mypy_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tsconfig.tsbuildinfo
 /.out/
 /.sphinx-artifacts/
 poetry.lock
+
+.mypy_cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 docs
 translations
 scripts/lib/api/testdata
+.mypy_cache


### PR DESCRIPTION
If people run MyPy in the repo, they'll have the folder `.mypy_cache` which Prettier will format and Git will try to add.