### PR TITLE
Add option to use arbitrary Sphinx HTML artifact folder

### DIFF
--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -67,7 +67,7 @@ const readArgs = (): Arguments => {
       implies: "skip-download",
       normalize: true,
       description:
-        "Skip downloading the the artifact from Box and instead use a given directory as the root of the Sphinx HTML output.",
+        "Skip downloading the artifact from Box and instead use the given directory as the root of the Sphinx HTML output.",
     })
     .parseSync();
 };

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -26,6 +26,7 @@ interface Arguments {
   historical: boolean;
   dev: boolean;
   skipDownload: boolean;
+  sphinxArtifactFolder?: string;
 }
 
 const readArgs = (): Arguments => {
@@ -60,6 +61,14 @@ const readArgs = (): Arguments => {
       description:
         "Rather than downloading the artifact from Box, reuse what is already downloaded. This can save time, but it risks using an outdated version of the docs.",
     })
+    .option("sphinx-artifact-folder", {
+      alias: "sphinx-output",
+      type: "string",
+      implies: "skip-download",
+      normalize: true,
+      description:
+        "Skip downloading the the artifact from Box and instead use a given directory as the root of the Sphinx HTML output.",
+    })
     .parseSync();
 };
 
@@ -85,12 +94,7 @@ zxMain(async () => {
   await deleteExistingMarkdown(pkg);
 
   console.log(`Run pipeline for ${pkg.name}:${pkg.versionWithoutPatch}`);
-  await runConversionPipeline(
-    `${sphinxArtifactFolder}/artifact`,
-    "docs",
-    "public",
-    pkg,
-  );
+  await runConversionPipeline(sphinxArtifactFolder, "docs", "public", pkg);
 });
 
 function determineMinorVersion(args: Arguments): string {
@@ -112,6 +116,14 @@ function determineMinorVersion(args: Arguments): string {
 }
 
 async function prepareSphinxFolder(pkg: Pkg, args: Arguments): Promise<string> {
+  if (args.sphinxArtifactFolder) {
+    if (!(await pathExists(args.sphinxArtifactFolder))) {
+      throw new Error(
+        `Explicit artifact path '${args.sphinxArtifactFolder}' does not exist.`,
+      );
+    }
+    return args.sphinxArtifactFolder;
+  }
   const sphinxArtifactFolder = pkg.sphinxArtifactFolder();
   if (
     args.skipDownload &&
@@ -123,7 +135,7 @@ async function prepareSphinxFolder(pkg: Pkg, args: Arguments): Promise<string> {
   } else {
     await downloadSphinxArtifact(pkg, sphinxArtifactFolder);
   }
-  return sphinxArtifactFolder;
+  return `${sphinxArtifactFolder}/artifact`;
 }
 
 async function deleteExistingMarkdown(pkg: Pkg): Promise<void> {

--- a/scripts/commands/updateApiDocs.ts
+++ b/scripts/commands/updateApiDocs.ts
@@ -62,7 +62,7 @@ const readArgs = (): Arguments => {
         "Rather than downloading the artifact from Box, reuse what is already downloaded. This can save time, but it risks using an outdated version of the docs.",
     })
     .option("sphinx-artifact-folder", {
-      alias: "sphinx-output",
+      alias: "a",
       type: "string",
       implies: "skip-download",
       normalize: true,


### PR DESCRIPTION
This adds a `--sphinx-artifact-folder` (alias `--sphinx-output`) option to manually specify the root of the Sphinx HTML output for a given package.  This implies `--skip-download`.  This is convenient for local API-docs development of the targetted packages, since I can use their regular docs-build processes and then just point `gen-api` at the right place without needing to copy anything into special folders.

For example, I've locally been using Sphinx as normal in Qiskit, then running
```bash
npm run gen-api -- -p qiskit -v 1.2.0 -a /path/to/docs/_build/html
```
to have the script directly target the Sphinx files without copying them.

I made the magic `/artifact` suffix a bit more local, rather than spread between two functions for two reasons:
1. it's easier to reason about magic that's only local.
2. if the `/artifact` is _always_ appended by `zxMain` outside of the control of `prepareSphinxFolder`, it defeated the main purpose of this option.