### PR TITLE
Use generic backend for testing

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -35,10 +35,10 @@ from squeaky import clean_notebook
 MOCKING_CODE = """\
 import warnings
 from qiskit_ibm_runtime import QiskitRuntimeService
-from qiskit_ibm_runtime.fake_provider import FakeKyoto
+from qiskit.providers.fake_provider import GenericBackendV2
 
 def patched_least_busy(self, *args, **kwarg):
-  return FakeKyoto()
+  return GenericBackendV2(num_qubits=5, control_flow=True)
 
 QiskitRuntimeService.least_busy = patched_least_busy
 
@@ -164,7 +164,7 @@ async def execute_notebook(path: Path, args: argparse.Namespace, config: Config)
     """
     is_patched = not args.submit_jobs and matches(path, config.notebooks_that_submit_jobs)
     if is_patched:
-        print(f"▶️ Executing {path} (with least_busy patched to return FakeKyoto)")
+        print(f"▶️ Executing {path} (with least_busy patched to return fake backend)")
     else:
         print(f"▶️ Executing {path}")
     possible_exceptions = (


### PR DESCRIPTION
Running notebooks with the `FakeKyoto` backend was occassionally taking a very long time (see https://github.com/Qiskit/documentation/pull/1307#issuecomment-2099165171). We believe this is due to some notebooks taking advantage of the large number of qubits it supports.

This PR switches to Qiskit's `GenericBackendV2`. This should be much faster and gives us more fine-grained control over the test backend properties.
