### PR TITLE
add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .tox/
 docs/.gitkeep
 .envrc
+.python-version
 latex_error.log
 
 .ipynb_checkpoints/


### PR DESCRIPTION
Used by https://github.com/pyenv/pyenv-virtualenv.