### PR TITLE
Revert truncation of Runtime left ToC

### DIFF
--- a/docs/api/qiskit-ibm-provider/0.10/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.10/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...job",
+      "title": "qiskit_ibm_provider.job",
       "children": [
         {
           "title": "Module overview",
@@ -108,23 +108,23 @@
       ]
     },
     {
-      "title": "...jupyter",
+      "title": "qiskit_ibm_provider.jupyter",
       "url": "/api/qiskit-ibm-provider/0.10/ibm_jupyter"
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_provider.transpiler",
       "url": "/api/qiskit-ibm-provider/0.10/ibm_transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_provider.transpiler.passes",
       "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-provider/0.10/qiskit_ibm_provider.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "title": "...utils",
+      "title": "qiskit_ibm_provider.utils",
       "children": [
         {
           "title": "Module overview",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "title": "...visualization",
+      "title": "qiskit_ibm_provider.visualization",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-provider/0.7/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.7/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...job",
+      "title": "qiskit_ibm_provider.job",
       "children": [
         {
           "title": "Module overview",
@@ -108,23 +108,23 @@
       ]
     },
     {
-      "title": "...jupyter",
+      "title": "qiskit_ibm_provider.jupyter",
       "url": "/api/qiskit-ibm-provider/0.7/ibm_jupyter"
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_provider.transpiler",
       "url": "/api/qiskit-ibm-provider/0.7/ibm_transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_provider.transpiler.passes",
       "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-provider/0.7/qiskit_ibm_provider.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "title": "...utils",
+      "title": "qiskit_ibm_provider.utils",
       "children": [
         {
           "title": "Module overview",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "title": "...visualization",
+      "title": "qiskit_ibm_provider.visualization",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-provider/0.8/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.8/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...job",
+      "title": "qiskit_ibm_provider.job",
       "children": [
         {
           "title": "Module overview",
@@ -108,23 +108,23 @@
       ]
     },
     {
-      "title": "...jupyter",
+      "title": "qiskit_ibm_provider.jupyter",
       "url": "/api/qiskit-ibm-provider/0.8/ibm_jupyter"
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_provider.transpiler",
       "url": "/api/qiskit-ibm-provider/0.8/ibm_transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_provider.transpiler.passes",
       "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-provider/0.8/qiskit_ibm_provider.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "title": "...utils",
+      "title": "qiskit_ibm_provider.utils",
       "children": [
         {
           "title": "Module overview",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "title": "...visualization",
+      "title": "qiskit_ibm_provider.visualization",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-provider/0.9/_toc.json
+++ b/docs/api/qiskit-ibm-provider/0.9/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...job",
+      "title": "qiskit_ibm_provider.job",
       "children": [
         {
           "title": "Module overview",
@@ -108,23 +108,23 @@
       ]
     },
     {
-      "title": "...jupyter",
+      "title": "qiskit_ibm_provider.jupyter",
       "url": "/api/qiskit-ibm-provider/0.9/ibm_jupyter"
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_provider.transpiler",
       "url": "/api/qiskit-ibm-provider/0.9/ibm_transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_provider.transpiler.passes",
       "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-provider/0.9/qiskit_ibm_provider.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "title": "...utils",
+      "title": "qiskit_ibm_provider.utils",
       "children": [
         {
           "title": "Module overview",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "title": "...visualization",
+      "title": "qiskit_ibm_provider.visualization",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-provider/_toc.json
+++ b/docs/api/qiskit-ibm-provider/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...job",
+      "title": "qiskit_ibm_provider.job",
       "children": [
         {
           "title": "Module overview",
@@ -108,23 +108,23 @@
       ]
     },
     {
-      "title": "...jupyter",
+      "title": "qiskit_ibm_provider.jupyter",
       "url": "/api/qiskit-ibm-provider/ibm_jupyter"
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_provider.transpiler",
       "url": "/api/qiskit-ibm-provider/ibm_transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_provider.transpiler.passes",
       "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_provider.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-provider/qiskit_ibm_provider.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_provider.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "title": "...utils",
+      "title": "qiskit_ibm_provider.utils",
       "children": [
         {
           "title": "Module overview",
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "title": "...visualization",
+      "title": "qiskit_ibm_provider.visualization",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.14/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.14/_toc.json
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.15/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.15/_toc.json
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.16/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.16/_toc.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.17/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.17/_toc.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.18/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.18/_toc.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -424,7 +424,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -457,19 +457,19 @@
       ]
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_runtime.transpiler",
       "url": "/api/qiskit-ibm-runtime/0.18/transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-runtime/0.18/qiskit_ibm_runtime.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.19/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.19/_toc.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -424,7 +424,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -457,19 +457,19 @@
       ]
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_runtime.transpiler",
       "url": "/api/qiskit-ibm-runtime/0.19/transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-runtime/0.19/qiskit_ibm_runtime.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.20/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.20/_toc.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -424,7 +424,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -457,19 +457,19 @@
       ]
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_runtime.transpiler",
       "url": "/api/qiskit-ibm-runtime/0.20/transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-runtime/0.20/qiskit_ibm_runtime.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.21/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.21/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -476,7 +476,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -549,19 +549,19 @@
       ]
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_runtime.transpiler",
       "url": "/api/qiskit-ibm-runtime/0.21/transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-runtime/0.21/qiskit_ibm_runtime.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/0.22/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.22/_toc.json
@@ -63,7 +63,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -476,7 +476,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -549,19 +549,19 @@
       ]
     },
     {
-      "title": "...transpiler",
+      "title": "qiskit_ibm_runtime.transpiler",
       "url": "/api/qiskit-ibm-runtime/0.22/transpiler"
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes"
     },
     {
-      "title": "...transpiler.passes.basis",
+      "title": "qiskit_ibm_runtime.transpiler.passes.basis",
       "url": "/api/qiskit-ibm-runtime/0.22/qiskit_ibm_runtime.transpiler.passes.basis"
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -67,7 +67,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -480,7 +480,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -553,7 +553,7 @@
       ]
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "children": [
         {
           "title": "Module overview",
@@ -566,7 +566,7 @@
       ]
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/docs/api/qiskit-ibm-runtime/dev/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/dev/_toc.json
@@ -67,7 +67,7 @@
       ]
     },
     {
-      "title": "...fake_provider",
+      "title": "qiskit_ibm_runtime.fake_provider",
       "children": [
         {
           "title": "Module overview",
@@ -480,7 +480,7 @@
       ]
     },
     {
-      "title": "...options",
+      "title": "qiskit_ibm_runtime.options",
       "children": [
         {
           "title": "Module overview",
@@ -553,7 +553,7 @@
       ]
     },
     {
-      "title": "...transpiler.passes",
+      "title": "qiskit_ibm_runtime.transpiler.passes",
       "children": [
         {
           "title": "Module overview",
@@ -566,7 +566,7 @@
       ]
     },
     {
-      "title": "...transpiler.passes.scheduling",
+      "title": "qiskit_ibm_runtime.transpiler.passes.scheduling",
       "children": [
         {
           "title": "Module overview",

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -27,16 +27,6 @@ export class ReleaseNotesConfig {
   }
 }
 
-export class TocConfig {
-  readonly truncate: boolean;
-  readonly tocGrouping?: TocGrouping;
-
-  constructor(kwargs: { truncate?: boolean; tocGrouping?: TocGrouping }) {
-    this.truncate = kwargs.truncate ?? false;
-    this.tocGrouping = kwargs.tocGrouping;
-  }
-}
-
 type PackageType = "latest" | "historical" | "dev";
 
 /**
@@ -50,7 +40,7 @@ export class Pkg {
   readonly versionWithoutPatch: string;
   readonly type: PackageType;
   readonly releaseNotesConfig: ReleaseNotesConfig;
-  readonly tocConfig: TocConfig;
+  readonly tocGrouping?: TocGrouping;
 
   static VALID_NAMES = [
     "qiskit",
@@ -67,7 +57,7 @@ export class Pkg {
     versionWithoutPatch: string;
     type: PackageType;
     releaseNotesConfig?: ReleaseNotesConfig;
-    tocConfig?: TocConfig;
+    tocGrouping?: TocGrouping;
   }) {
     this.name = kwargs.name;
     this.title = kwargs.title;
@@ -77,7 +67,7 @@ export class Pkg {
     this.type = kwargs.type;
     this.releaseNotesConfig =
       kwargs.releaseNotesConfig ?? new ReleaseNotesConfig({});
-    this.tocConfig = kwargs.tocConfig ?? new TocConfig({});
+    this.tocGrouping = kwargs.tocGrouping;
   }
 
   static async fromArgs(
@@ -103,7 +93,7 @@ export class Pkg {
         releaseNotesConfig: new ReleaseNotesConfig({
           separatePagesVersions: releaseNoteEntries,
         }),
-        tocConfig: new TocConfig({ tocGrouping: QISKIT_TOC_GROUPING }),
+        tocGrouping: QISKIT_TOC_GROUPING,
       });
     }
 
@@ -113,7 +103,6 @@ export class Pkg {
         title: "Qiskit Runtime IBM Client",
         name: "qiskit-ibm-runtime",
         githubSlug: "qiskit/qiskit-ibm-runtime",
-        tocConfig: new TocConfig({ truncate: true }),
       });
     }
 
@@ -123,7 +112,6 @@ export class Pkg {
         title: "Qiskit IBM Provider (deprecated)",
         name: "qiskit-ibm-provider",
         githubSlug: "qiskit/qiskit-ibm-provider",
-        tocConfig: new TocConfig({ truncate: true }),
       });
     }
 
@@ -148,7 +136,7 @@ export class Pkg {
     versionWithoutPatch?: string;
     type?: PackageType;
     releaseNotesConfig?: ReleaseNotesConfig;
-    tocConfig?: TocConfig;
+    tocGrouping?: TocGrouping;
   }): Pkg {
     return new Pkg({
       name: kwargs.name ?? "my-quantum-project",
@@ -158,7 +146,7 @@ export class Pkg {
       versionWithoutPatch: kwargs.versionWithoutPatch ?? "0.1",
       type: kwargs.type ?? "latest",
       releaseNotesConfig: kwargs.releaseNotesConfig,
-      tocConfig: kwargs.tocConfig,
+      tocGrouping: kwargs.tocGrouping,
     });
   }
 

--- a/scripts/lib/api/generateToc.test.ts
+++ b/scripts/lib/api/generateToc.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, test } from "@jest/globals";
 
 import { generateToc } from "./generateToc";
-import { Pkg, ReleaseNotesConfig, TocConfig } from "./Pkg";
+import { Pkg, ReleaseNotesConfig } from "./Pkg";
 import type { TocGroupingEntry } from "./TocGrouping";
 
 const DEFAULT_ARGS = {
@@ -120,48 +120,6 @@ describe("generateToc", () => {
     });
   });
 
-  test("truncate module names", () => {
-    const toc = generateToc(
-      Pkg.mock({
-        tocConfig: new TocConfig({ truncate: true }),
-        releaseNotesConfig: new ReleaseNotesConfig({ enabled: false }),
-      }),
-      [
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project",
-          },
-          url: "/api/my-quantum-project",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project.options",
-          },
-          url: "/api/my-quantum-project/options",
-          ...DEFAULT_ARGS,
-        },
-      ],
-    );
-
-    expect(toc).toEqual({
-      children: [
-        {
-          title: "my_quantum_project",
-          url: "/api/my-quantum-project",
-        },
-        {
-          title: "...options",
-          url: "/api/my-quantum-project/options",
-        },
-      ],
-      collapsed: true,
-      title: "My Quantum Project",
-    });
-  });
-
   test("TOC with grouped modules", () => {
     // This ordering is intentional.
     const topLevelEntries: TocGroupingEntry[] = [
@@ -187,43 +145,40 @@ describe("generateToc", () => {
         module == "my_quantum_project.module" ? "Group 1" : "Group 2",
     };
 
-    const toc = generateToc(
-      Pkg.mock({ tocConfig: new TocConfig({ tocGrouping }) }),
-      [
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project",
-          },
-          url: "/api/my-quantum-project",
-          ...DEFAULT_ARGS,
+    const toc = generateToc(Pkg.mock({ tocGrouping }), [
+      {
+        meta: {
+          apiType: "module",
+          apiName: "my_quantum_project",
         },
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project.module",
-          },
-          url: "/api/my-quantum-project/my_quantum_project.module",
-          ...DEFAULT_ARGS,
+        url: "/api/my-quantum-project",
+        ...DEFAULT_ARGS,
+      },
+      {
+        meta: {
+          apiType: "module",
+          apiName: "my_quantum_project.module",
         },
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project.module.submodule",
-          },
-          url: "/api/my-quantum-project/my_quantum_project.module.submodule",
-          ...DEFAULT_ARGS,
+        url: "/api/my-quantum-project/my_quantum_project.module",
+        ...DEFAULT_ARGS,
+      },
+      {
+        meta: {
+          apiType: "module",
+          apiName: "my_quantum_project.module.submodule",
         },
-        {
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project.another",
-          },
-          url: "/api/my-quantum-project/my_quantum_project.another",
-          ...DEFAULT_ARGS,
+        url: "/api/my-quantum-project/my_quantum_project.module.submodule",
+        ...DEFAULT_ARGS,
+      },
+      {
+        meta: {
+          apiType: "module",
+          apiName: "my_quantum_project.another",
         },
-      ],
-    );
+        url: "/api/my-quantum-project/my_quantum_project.another",
+        ...DEFAULT_ARGS,
+      },
+    ]);
     expect(toc).toEqual({
       collapsed: true,
       title: "My Quantum Project",

--- a/scripts/lib/api/generateToc.ts
+++ b/scripts/lib/api/generateToc.ts
@@ -40,9 +40,9 @@ export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
 
   addItemsToModules(items, tocModulesByTitle, tocModuleTitles);
 
-  const orderedEntries = pkg.tocConfig.tocGrouping
-    ? groupAndSortModules(pkg.tocConfig.tocGrouping, tocModulesByTitle)
-    : sortAndMaybeTruncateModules(tocModules, pkg.tocConfig.truncate);
+  const orderedEntries = pkg.tocGrouping
+    ? groupAndSortModules(pkg.tocGrouping, tocModulesByTitle)
+    : orderEntriesByTitle(tocModules);
 
   generateOverviewPage(tocModules);
   const maybeIndexPage = ensureIndexPage(pkg, orderedEntries);
@@ -177,25 +177,6 @@ function groupAndSortModules(
     }
   });
   return result;
-}
-
-/** Sorts all modules and possibly truncates the package name, e.g. `qiskit_ibm_runtime.options` -> `...options`.
- *
- * Returns a flat list of modules without any nesting.
- */
-function sortAndMaybeTruncateModules(
-  entries: TocEntry[],
-  truncate: boolean,
-): TocEntry[] {
-  const sorted = orderEntriesByTitle(entries);
-  if (truncate) {
-    sorted.forEach((entry) => {
-      // E.g. qiskit_ibm_runtime.options -> ...options, but ignore
-      // qiskit_ibm_runtime without a `.`.
-      entry.title = entry.title.replace(/^[^.]+\./, "...");
-    });
-  }
-  return sorted;
 }
 
 /**


### PR DESCRIPTION
Reverts https://github.com/Qiskit/documentation/issues/1213. We've gotten mixed feedback about truncating the left table of contents. While it makes things less crowded, several people found it confusing. We'd rather aim for clarity with our docs, even if it's more verbose.