### PR TITLE
Ignore MPL cache warnings

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -31,9 +31,14 @@ from jupyter_client.manager import start_new_async_kernel
 from qiskit_ibm_runtime import QiskitRuntimeService
 from squeaky import clean_notebook
 
-# If not submitting jobs, we mock the real backend by prepending this to each notebook
-MOCKING_CODE = """\
+# We always run the following code in the kernel before running the notebook
+PRE_EXECUTE_CODE = """\
 import warnings
+warnings.filterwarnings("ignore", message="Matplotlib is building the font cache; this may take a moment.")
+"""
+
+# If not submitting jobs, we also run this code before notebook execution to mock the real backend
+MOCKING_CODE = """\
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit.providers.fake_provider import GenericBackendV2
 
@@ -235,6 +240,7 @@ async def _execute_notebook(filepath: Path, config: Config) -> nbformat.Notebook
         extra_arguments=["--InlineBackend.figure_format='svg'"],
     )
 
+    kernel.execute(PRE_EXECUTE_CODE, store_history=False)
     if config.should_patch(filepath):
         kernel.execute(MOCKING_CODE, store_history=False)
 


### PR DESCRIPTION
We occasionally see the following warnings when executing notebooks:

<img width="503" alt="Screenshot 2024-05-14 at 10 18 24" src="https://github.com/Qiskit/documentation/assets/36071638/74c174b0-68fc-4eb3-b64c-e77f2e00a5ca">

[See logs](https://github.com/Qiskit/documentation/actions/runs/9020672968/job/24786345632#step:7:90).

These warnings are harmless, out of our control, and break CI. This PR runs some code in the kernel before notebook execution to disable them.
