### PR TITLE
Fix MPL warning suppression

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -33,8 +33,8 @@ from squeaky import clean_notebook
 
 # We always run the following code in the kernel before running the notebook
 PRE_EXECUTE_CODE = """\
-import warnings
-warnings.filterwarnings("ignore", message="Matplotlib is building the font cache; this may take a moment.")
+import matplotlib
+matplotlib.set_loglevel("critical")
 """
 
 # If not submitting jobs, we also run this code before notebook execution to mock the real backend

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -34,6 +34,7 @@ from squeaky import clean_notebook
 # We always run the following code in the kernel before running the notebook
 PRE_EXECUTE_CODE = """\
 import matplotlib
+# See https://github.com/matplotlib/matplotlib/issues/23326#issuecomment-1164772708
 matplotlib.set_loglevel("critical")
 """
 


### PR DESCRIPTION
#1362 didn't work as Matplotlib emits warnings through the `logging` module rather than the `warnings` module. This follows advice (https://github.com/matplotlib/matplotlib/issues/23326#issuecomment-1164772708) to correctly suppress the warnings.
