### PR TITLE
Fix mocking code

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -40,6 +40,7 @@ matplotlib.set_loglevel("critical")
 
 # If not submitting jobs, we also run this code before notebook execution to mock the real backend
 MOCKING_CODE = """\
+import warnings
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit.providers.fake_provider import GenericBackendV2
 


### PR DESCRIPTION
Embarassingly, #1368 broke the mocking code as `warnings` was never imported. I didn't notice because `kernel.execute` doesn't report if the execution fails. I'm making a companion PR to catch this.
