### PR TITLE
Check for errors when executing initialization code

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -27,7 +27,7 @@ from typing import Iterator
 import nbclient
 import nbformat
 import tomli
-from jupyter_client.manager import start_new_async_kernel
+from jupyter_client.manager import start_new_async_kernel, AsyncKernelClient
 from qiskit_ibm_runtime import QiskitRuntimeService
 from squeaky import clean_notebook
 
@@ -225,7 +225,7 @@ async def execute_notebook(path: Path, config: Config) -> bool:
     print(f"✅ No problems in {path} (written)")
     return True
 
-async def _execute_in_kernel(kernel, code: str) -> None:
+async def _execute_in_kernel(kernel: AsyncKernelClient, code: str) -> None:
     """Execute code in kernel and raise if it fails"""
     response = await kernel.execute_interactive(code, store_history=False)
     if response.get("content", {}).get("status", "") == "error":


### PR DESCRIPTION
We run some code before notebook execution to silence some warnings and set up mock backends. At the moment, errors are ignored and the kernel continues, often leading to unexpected behaviour.

This PR explicitly checks for errors when running the initialization code and exits early if needed.
