### PR TITLE
Allow manually created class pages

### DIFF
--- a/scripts/lib/api/generateApiComponents.ts
+++ b/scripts/lib/api/generateApiComponents.ts
@@ -19,6 +19,7 @@ import remarkStringify from "remark-stringify";
 import { ApiType } from "./Metadata";
 import {
   getLastPartFromFullIdentifier,
+  removeSuffix,
   APOSTROPHE_HEX_CODE,
 } from "../stringUtils";
 
@@ -142,7 +143,10 @@ function prepareClassOrExceptionProps(
     modifiers,
   };
 
-  const pageHeading = $dl.siblings("h1").text();
+  let pageHeading = $dl.siblings("h1").text();
+  // Manually created class pages like Qiskit 1.1+'s `QuantumCircuit`
+  // sometimes have ' class' in their h1.
+  pageHeading = removeSuffix(pageHeading, " class");
   if (id.endsWith(pageHeading) && pageHeading != "") {
     // Page is already dedicated to the class
     return {


### PR DESCRIPTION
This unblocks https://github.com/Qiskit/qiskit/pull/12403. Without this PR, we incorrectly treat the class as inline, which means it gets the blue left bar and an h3 incorrectly added. 

Without this PR, our test to check that the ToC and index page are in sync also fails, even though things behave how we expect (https://github.com/Qiskit/qiskit/pull/12403#pullrequestreview-2056366501)