### PR TITLE
External link checker: Add an HTTP header for the auth for GitHub

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Check external links
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >
           npm run check:external-links --
           'docs/**/*.{md,mdx,ipynb}'

--- a/scripts/lib/links/ExternalLink.ts
+++ b/scripts/lib/links/ExternalLink.ts
@@ -65,7 +65,9 @@ function getHeaders(link: string) {
 
   if (link.startsWith("https://github.com")) {
     const ghToken = process.env.GITHUB_TOKEN;
-    headers["Authorization"] = ghToken ? `token ${ghToken}` : "";
+    if (ghToken) {
+      headers["Authorization"] = `token ${ghToken}`;
+    }
   }
 
   return headers;

--- a/scripts/lib/links/ExternalLink.ts
+++ b/scripts/lib/links/ExternalLink.ts
@@ -64,7 +64,8 @@ function getHeaders(link: string) {
   };
 
   if (link.startsWith("https://github.com")) {
-    headers["Authorization"] = process.env.GITHUB_TOKEN || "";
+    const ghToken = process.env.GITHUB_TOKEN;
+    headers["Authorization"] = ghToken ? `token ${ghToken}` : "";
   }
 
   return headers;

--- a/scripts/lib/links/ExternalLink.ts
+++ b/scripts/lib/links/ExternalLink.ts
@@ -37,7 +37,7 @@ export class ExternalLink {
     let error: string = "";
     try {
       const response = await fetch(this.value, {
-        headers: { "User-Agent": "qiskit-documentation-broken-links-finder" },
+        headers: getHeaders(this.value),
         method: "HEAD",
       });
       if (response.status >= 300) {
@@ -56,4 +56,16 @@ export class ExternalLink {
       .map((originFile) => `    ${originFile}`);
     return `❌ ${error}. Appears in:\n${fileList.join("\n")}`;
   }
+}
+
+function getHeaders(link: string) {
+  const headers: HeadersInit = {
+    "User-Agent": "qiskit-documentation-broken-links-finder",
+  };
+
+  if (link.startsWith("https://github.com")) {
+    headers["Authorization"] = process.env.GITHUB_TOKEN || "";
+  }
+
+  return headers;
 }


### PR DESCRIPTION
Part of #823

This PR adds a new HTTP header to the external link checker to set the auth for GitHub when we are checking GitHub links. The new header is only used for GitHub links following what we do in the closed-source repo.

In order to be able to get the environment variable from typescript with `process.env.GITHUB_TOKEN`, we need to define it in the workflows. In the case of running the script locally, the token could be undefined.