### PR TITLE
Allow overriding default number of qubits for mock backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,11 @@ four categories:
   resources. You _can_ interact with IBM Quantum to retrieve jobs and backend
   information.
 - `notebooks_that_submit_jobs`: Notebooks that submit jobs, but that are small
-  enough to run on a 5-qubit simulator. We will test these notebooks in CI by
-  patching `least_busy` to return a 5-qubit fake backend.
+  enough to run on a simulator. We will test these notebooks in CI by patching
+  `least_busy` to return a 5-qubit fake backend. If your notebook needs more
+  than five qubits, you can set a custom number of qubits for the mocked
+  backend by setting the `testing_qubits` attribute of the metadata to the
+  number you'd like.
 - `notebooks_no_mock`: For notebooks that can't be tested using the 5-qubit
   simulator patch. We skip testing these in CI and instead run them twice per
   month. Any notebooks with cells that take more than five minutes to run are

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -45,11 +45,11 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit.providers.fake_provider import GenericBackendV2
 
 def patched_least_busy(self, *args, **kwarg):
-  return GenericBackendV2(num_qubits=5, control_flow=True)
+  return GenericBackendV2(num_qubits={num_qubits}, control_flow=True)
 
 QiskitRuntimeService.least_busy = patched_least_busy
 
-warnings.filterwarnings("ignore", message="Options {.*} have no effect in local testing mode.")
+warnings.filterwarnings("ignore", message="Options {{.*}} have no effect in local testing mode.")
 warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
 """
 
@@ -250,7 +250,8 @@ async def _execute_notebook(filepath: Path, config: Config) -> nbformat.Notebook
 
     await _execute_in_kernel(kernel, PRE_EXECUTE_CODE)
     if config.should_patch(filepath):
-        await _execute_in_kernel(kernel, MOCKING_CODE)
+        num_qubits = nb.metadata.get("testing_qubits", 5)
+        await _execute_in_kernel(kernel, MOCKING_CODE.format(num_qubits=num_qubits))
 
     notebook_client = nbclient.NotebookClient(
         nb=nb,


### PR DESCRIPTION
For notebooks that don't care, we'd like to keep the number of qubits in the mock backend low as it speeds up execution time. However, some notebooks do require more qubits to test properly (see #1332). This PR allows setting the number of qubits needed in the notebook metadata.
