### PR TITLE
Add logic for the new Methods/Attributes section

### DIFF
--- a/scripts/lib/api/mergeClassMembers.ts
+++ b/scripts/lib/api/mergeClassMembers.ts
@@ -74,6 +74,12 @@ export async function mergeClassMembers(
                 return;
               }
 
+              // Historical versions of qiskit have a section header for all the methods and attributes.
+              // This section needs to be removed when we inline members.
+              if (attributesAndProps.length > 0 || methods.length > 0) {
+                removeMembersListSection(mdxClassElement);
+              }
+
               for (const node of mdxClassElement.children) {
                 await replaceMembersAfterTitle(
                   mdxClassElement,
@@ -166,4 +172,18 @@ async function parseMarkdownIncreasingHeading(
   const root = pipeline.parse(md);
   const changedTree = pipeline.run(root);
   return changedTree;
+}
+
+function removeMembersListSection(root: MdxJsxFlowElement) {
+  const headers = root.children.find(
+    (node) =>
+      node.type == "heading" &&
+      node.children.find(
+        (child) =>
+          child.type == "text" && child.value == "Member implementations",
+      ),
+  );
+  if (headers) {
+    root.children.splice(root.children.indexOf(headers), 1);
+  }
 }

--- a/scripts/lib/api/processHtml.ts
+++ b/scripts/lib/api/processHtml.ts
@@ -58,6 +58,7 @@ export async function processHtml(options: {
   processSimpleFieldLists($, $main);
   removeColonSpans($main);
   preserveMathBlockWhitespace($, $main);
+  maybeAddMembersListSection($, $main);
 
   const meta: Metadata = {};
   await processMembersAndSetMeta($, $main, meta);
@@ -347,6 +348,17 @@ export function preserveMathBlockWhitespace(
       const $el = $(el);
       $el.replaceWith(`<pre class="math">${$el.html()}</pre>`);
     });
+}
+
+export function maybeAddMembersListSection(
+  $: CheerioAPI,
+  $main: Cheerio<any>,
+): void {
+  const lastTable = $main.find("table").last();
+  const previousElement = lastTable.prev().text();
+  if (previousElement == "Attributes" || previousElement == "Methods") {
+    $(`<h2>Member implementations</h2>`).insertAfter(lastTable);
+  }
 }
 
 export function updateModuleHeadings(


### PR DESCRIPTION
Part of #1388 

This PR has an implementation of a fix consisting of searching in the page if there exists a table with an immediate header called "Methods" or "Attributes". In that case, we need to add a new section header after the last table that will serve as a section for all the methods and attributes sorted alphabetically.

This header has to be removed in the case where we substitute the tables afterward inlining the methods/attributes, and this could be done by searching inside the unified plugin of `mergeClassMembers.ts`.

**Todo:**

- Regenerate the docs with the change
- Following the approach of searching for a table doesn't work well for the pages with empty tables (look at #1404). In those cases, we have an extra header that is never removed because of how `mergeClassMembers.ts` works. If #1404 is fixed, I think the logic in the closed PR mentioned above should work as expected (It needs some testing though). 