### PR TITLE
Revert putting `(beta)` in Transpiler Service title

### DIFF
--- a/docs/api/qiskit-transpiler-service/_toc.json
+++ b/docs/api/qiskit-transpiler-service/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client (beta)",
+  "title": "Qiskit Transpiler Service Client",
   "children": [
     {
       "title": "API index",

--- a/scripts/lib/api/Pkg.ts
+++ b/scripts/lib/api/Pkg.ts
@@ -118,7 +118,7 @@ export class Pkg {
     if (name === "qiskit-transpiler-service") {
       return new Pkg({
         ...args,
-        title: "Qiskit Transpiler Service Client (beta)",
+        title: "Qiskit Transpiler Service Client",
         name: "qiskit-transpiler-service",
         githubSlug: undefined,
         releaseNotesConfig: new ReleaseNotesConfig({ enabled: false }),


### PR DESCRIPTION
We got updated instructions from leadership to remove this and instead have a banner saying that the API is experimental.