### PR TITLE
Remove mention of simulated results in CHSH tutorial

### DIFF
--- a/tutorials/chsh-inequality/chsh-inequality.ipynb
+++ b/tutorials/chsh-inequality/chsh-inequality.ipynb
@@ -432,7 +432,7 @@
    "id": "63e63853",
    "metadata": {},
    "source": [
-    "In the figure, the dashed lines delimit the classical bounds ($\\pm 2$) and the dash-dotted lines delimit the quantum bounds ($\\pm 2\\sqrt{2}$). You can see that there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
+    "In the figure, the lines and gray areas delimit the bounds; the outer-most (dash-dotted) lines delimit the quantum-bounds ($\\pm 2$), whereas the inner (dashed) lines delimit the classical bounds ($\\pm 2\\sqrt{2}$). You can see that there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
    ]
   },
   {

--- a/tutorials/chsh-inequality/chsh-inequality.ipynb
+++ b/tutorials/chsh-inequality/chsh-inequality.ipynb
@@ -432,7 +432,7 @@
    "id": "63e63853",
    "metadata": {},
    "source": [
-    "In the figure, the red dashed lines delimit the classical bounds ($\\pm 2$) and the dash-dotted blue lines delimit the quantum bounds ($\\pm 2\\sqrt{2}$). You can see that the experimental results resemble the general trend of the simulated results and there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
+    "In the figure, the dashed lines delimit the classical bounds ($\\pm 2$) and the dash-dotted lines delimit the quantum bounds ($\\pm 2\\sqrt{2}$). You can see that there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
    ]
   },
   {


### PR DESCRIPTION
First part of #1443 

Still need to figure out how to change the tags on the platform.  

- [ ]  The CHSH tutorial is tagged "scheduling", but there is no scheduling involved.