### PR TITLE
Fix broken link in configure-qiskit-local.mdx

### DIFF
--- a/docs/start/configure-qiskit-local.mdx
+++ b/docs/start/configure-qiskit-local.mdx
@@ -32,8 +32,8 @@ By default, this file is in `~/.qiskit/settings.conf` but the path can be overri
 - `circuit_mpl_style`: The default style sheet used for the mpl output system for the circuit drawer. Valid values are `default` or `bw`.
 - `circuit_mpl_style_path`: The paths to have the circuit drawer use to look for JSON style sheets when using the mpl output mode.
 - `state_drawer`: This is used to change the default system for the state visualization draw methods. Valid values are `repr`, `text`, `latex`, `latex_source`, `qsphere`, `hinton`, or `bloch`. When the output kwarg is not explicitly set on the [qiskit.quantum_info.DensityMatrix.draw](../api/qiskit/qiskit.quantum_info.DensityMatrix#densitymatrix) method, the specified output method is used.
-- `transpile_optimization_level: Change the default optimization level for [qiskit.compiler.transpile](../api/qiskit/compiler#circuit-and-pulse-compilation-functions) and [qiskit.execute.execute](../api/qiskit/execute#executing-experiments). Specify an integer 0-3.
-- `parallel`: Whether Python multiprocessing is enabled for operations that support running in parallel.  For example, transpilation of multiple [qiskit.circuit.QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit#quantumcircuit) objects. This setting can be overridden by the QISKIT_PARALLEL environment variable. Specify a boolean value.
+- `transpile_optimization_level`: Change the default optimization level for [qiskit.compiler.transpile](../api/qiskit/compiler#circuit-and-pulse-compilation-functions). Specify an integer 0-3.
+- `parallel`: Whether Python multiprocessing is enabled for operations that support running in parallel.  For example, transpilation of multiple [qiskit.circuit.QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit#quantumcircuit-class) objects. This setting can be overridden by the QISKIT_PARALLEL environment variable. Specify a boolean value.
 - `num_processes`: The maximum number of parallel processes to launch for parallel operations if parallel execution is enabled. This setting can be overridden by the QISKIT_NUM_PROCS environment variable. Specify an integer greater than 0. 
 
 <Admonition type="note">

--- a/scripts/commands/checkInternalLinks.ts
+++ b/scripts/commands/checkInternalLinks.ts
@@ -168,11 +168,11 @@ async function determineCurrentDocsFileBatch(
     "docs/**/*.{ipynb,mdx}",
     "public/api/*/objects.inv",
     // Ignore historical versions
-    "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*",
-    "!public/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/[0-9]*/*",
+    "!docs/api/*/[0-9]*/*",
+    "!public/api/*/[0-9]*/*",
     // Ignore dev version
-    "!docs/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*",
-    "!public/api/{qiskit,qiskit-ibm-provider,qiskit-ibm-runtime}/dev/*",
+    "!docs/api/*/dev/*",
+    "!public/api/*/dev/*",
     // Ignore Qiskit release notes
     "!docs/api/qiskit/release-notes/*",
   ];


### PR DESCRIPTION
The check broke because the missing ` messed up the markdown parser.