### PR TITLE
Clarify title for Qiskit SDK simulator page

### DIFF
--- a/docs/verify/_toc.json
+++ b/docs/verify/_toc.json
@@ -7,7 +7,7 @@
       "url": "/verify"
     },
     {
-      "title": "Exact simulation with Qiskit primitives",
+      "title": "Exact simulation with Qiskit SDK primitives",
       "url": "/verify/simulate-with-qiskit-primitives"
     },
     {

--- a/docs/verify/simulate-with-qiskit-primitives.mdx
+++ b/docs/verify/simulate-with-qiskit-primitives.mdx
@@ -1,10 +1,10 @@
 ---
-title: Exact simulation with Qiskit primitives
+title: Exact simulation with Qiskit SDK primitives
 description: How to perform exact simulation of quantum circuits using primitives in Qiskit.
 ---
-# Exact simulation with Qiskit primitives
+# Exact simulation with Qiskit SDK primitives
 
-The reference primitives in Qiskit perform local statevector simulations. These simulations do not support
+The reference primitives in the Qiskit SDK perform local statevector simulations. These simulations do not support
 modeling device noise, but are useful for quickly prototyping algorithms before looking into more advanced simulation
 techniques ([using Qiskit Aer](/verify/stabilizer-circuit-simulation)) or running on real devices ([Qiskit Runtime primitives](/run/primitives)).
 


### PR DESCRIPTION
We should clarify this is the Qiskit SDK. 

We don't change the URL because it will be redirected anyways soon to its new home in the `guides/` section, so it's not worth renaming yet.