### PR TITLE
Correct operator ordering

### DIFF
--- a/docs/start/hello-world.ipynb
+++ b/docs/start/hello-world.ipynb
@@ -151,7 +151,7 @@
    "metadata": {},
    "source": [
     "<Admonition type=\"note\" title=\"Operator Notation\">\n",
-    "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 0 and Z on qubit 1 together, and obtaining information about the correlation between qubit 0 and qubit 1. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
+    "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 1 and Z on qubit 0 together, and obtaining information about the correlation between qubit 1 and qubit 0. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
     "\n",
     "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1.\n",
     "</Admonition>"

--- a/docs/start/hello-world.ipynb
+++ b/docs/start/hello-world.ipynb
@@ -151,9 +151,9 @@
    "metadata": {},
    "source": [
     "<Admonition type=\"note\" title=\"Operator Notation\">\n",
-    "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 0 and Z on qubit 1 together, and obtaining information about the correlation between qubit 0 and qubit 1. Expectation values like this are also typically written as $\\langle Z_0 Z_1 \\rangle$.\n",
+    "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 0 and Z on qubit 1 together, and obtaining information about the correlation between qubit 0 and qubit 1. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
     "\n",
-    "If the state is entangled, then the measurement of $\\langle Z_0 Z_1 \\rangle$ should be 1.\n",
+    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1.\n",
     "</Admonition>"
    ]
   },


### PR DESCRIPTION
This fixes #1477 with the correct ordering of operators