### PR TITLE
Ignore slack archives link

### DIFF
--- a/scripts/lib/links/ignores.ts
+++ b/scripts/lib/links/ignores.ts
@@ -35,6 +35,7 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://auth.quantum-computing.ibm.com/api",
   "https://www.cs.tau.ac.il/~nogaa/PDFS/r.pdf",
   "http://www.satcompetition.org/2009/format-benchmarks2009.html",
+  "https://qiskit.slack.com/archives/C06KF8YHUAU",
   // StackOverflow rate limits us.
   "https://stackoverflow.com/",
   "https://stackoverflow.com/questions/1049722/what-is-2s-complement",


### PR DESCRIPTION
Closes #1478

The link checker complains about a Slack link that is not broken. This PR adds the link to the ignores.