### PR TITLE
Change index entry from patterns `_toc.json`

### DIFF
--- a/scripts/patterns-reorg/entries.py
+++ b/scripts/patterns-reorg/entries.py
@@ -34,32 +34,32 @@ from page_content import (
 # Workflow: Post-Process, Tool: Execution Modes (manage jobs)
 RETRIEVE_RESULTS_PAGE = Entry(
     "Retrieve and save results",
-    slug="save-jobs",
+    slug="/save-jobs",
     from_file="run/save-jobs.ipynb",
 )
 # Workflow: Post-process, Tool: Visualization
 VISUALIZE_RESULTS_PAGE = Entry(
     "Visualize results",
-    slug="visualize-results",
+    slug="/visualize-results",
     from_file="run/visualize-results.ipynb",
 )
 # Workflow: Map problem (build circuits), Tool: Visualization
 VISUALIZE_CIRCUITS_PAGE = Entry(
     "Visualize circuits",
-    slug="circuit-visualization",
+    slug="/circuit-visualization",
     from_file="build/circuit-visualization.ipynb",
 )
 # Workflow: Optimize for hardware (simulators), Tool: Visualization
 PLOT_QUANTUM_STATES_PAGE = Entry(
     "Plot quantum states",
-    slug="plot-quantum-states",
+    slug="/plot-quantum-states",
     from_file="verify/plot-quantum-states.ipynb",
 )
 
 # Note: not used in Workflow.
 SERVERLESS_PAGE = Entry(
     "Qiskit Serverless workloads",
-    slug="qiskit-serverless",
+    slug="/qiskit-serverless",
     from_file="run/quantum-serverless.mdx",
 )
 
@@ -69,32 +69,32 @@ SERVERLESS_PAGE = Entry(
 # ------------------------------------------------------------------------------
 
 GET_STARTED_CHILDREN = [
-    Entry("Introduction to Qiskit", slug="index", page_content=index_page_content()),
+    Entry("Introduction to Qiskit", slug="", page_content=index_page_content()),
     Entry(
         "Install",
         children=(
             Entry(
-                "Install Qiskit", slug="install-qiskit", from_file="start/install.mdx"
+                "Install Qiskit", slug="/install-qiskit", from_file="start/install.mdx"
             ),
             Entry(
                 "Set up an IBM Quantum channel",
-                slug="setup-channel",
+                slug="/setup-channel",
                 from_file="start/setup-channel.mdx",
             ),
         ),
     ),
-    Entry("Hello world", slug="hello-world", from_file="start/hello-world.ipynb"),
+    Entry("Hello world", slug="/hello-world", from_file="start/hello-world.ipynb"),
     Entry(
         "Advanced setup",
         children=(
             Entry(
                 "Install the Qiskit SDK from source",
-                slug="install-qiskit-source",
+                slug="/install-qiskit-source",
                 from_file="start/install-qiskit-source.mdx",
             ),
             Entry(
                 "Configure the Qiskit SDK locally",
-                slug="configure-qiskit-local",
+                slug="/configure-qiskit-local",
                 from_file="start/configure-qiskit-local.mdx",
             ),
         ),
@@ -107,33 +107,33 @@ CIRCUIT_CONSTRUCTION = (
         children=(
             Entry(
                 "Circuit library",
-                slug="circuit-library",
+                slug="/circuit-library",
                 from_file="build/circuit-library.ipynb",
             ),
             Entry(
                 "Construct circuits",
-                slug="circuit-construction",
+                slug="/circuit-construction",
                 from_file="build/circuit-construction.ipynb",
             ),
             VISUALIZE_CIRCUITS_PAGE,
             Entry(
                 "Classical feedforward and control flow",
-                slug="classical-feedforward-and-control-flow",
+                slug="/classical-feedforward-and-control-flow",
                 from_file="build/classical-feedforward-and-control-flow.ipynb",
             ),
             Entry(
                 "Synthesize unitary operators",
-                slug="unitary-synthesis",
+                slug="/unitary-synthesis",
                 from_file="build/unitary-synthesis.mdx",
             ),
             Entry(
                 "Bit-ordering in the Qiskit SDK",
-                slug="bit-ordering",
+                slug="/bit-ordering",
                 from_file="build/bit-ordering.mdx",
             ),
             Entry(
                 "Save circuits to disk",
-                slug="save-circuits",
+                slug="/save-circuits",
                 from_file="build/save-circuits.ipynb",
             ),
         ),
@@ -143,12 +143,12 @@ CIRCUIT_CONSTRUCTION = (
         children=(
             Entry(
                 "Operators module overview",
-                slug="operators-overview",
+                slug="/operators-overview",
                 from_file="build/operators-overview.ipynb",
             ),
             Entry(
                 "Specifying observables in the Pauli basis",
-                slug="specify-observables-pauli",
+                slug="/specify-observables-pauli",
                 from_file="build/specify-observables-pauli.mdx",
             ),
         ),
@@ -156,28 +156,28 @@ CIRCUIT_CONSTRUCTION = (
     Entry(
         "Other circuit building tools",
         children=(
-            Entry("Pulse schedules", slug="pulse", from_file="build/pulse.ipynb"),
+            Entry("Pulse schedules", slug="/pulse", from_file="build/pulse.ipynb"),
             Entry(
                 "OpenQASM",
                 children=(
                     Entry(
                         "Intro to OpenQASM",
-                        slug="introduction-to-qasm",
+                        slug="/introduction-to-qasm",
                         from_file="build/introduction-to-qasm.mdx",
                     ),
                     Entry(
                         "OpenQASM 2 and the Qiskit SDK",
-                        slug="interoperate-qiskit-qasm2",
+                        slug="/interoperate-qiskit-qasm2",
                         from_file="build/interoperate-qiskit-qasm2.mdx",
                     ),
                     Entry(
                         "OpenQASM 3 and the Qiskit SDK",
-                        slug="interoperate-qiskit-qasm3",
+                        slug="/interoperate-qiskit-qasm3",
                         from_file="build/interoperate-qiskit-qasm3.mdx",
                     ),
                     Entry(
                         "OpenQASM 3 feature table",
-                        slug="qasm-feature-table",
+                        slug="/qasm-feature-table",
                         from_file="build/qasm-feature-table.mdx",
                     ),
                     Entry(
@@ -196,17 +196,17 @@ TRANSPILER = (
         children=(
             Entry(
                 "Introduction to transpilation",
-                slug="transpile",
+                slug="/transpile",
                 from_file="transpile/index.mdx",
             ),
             Entry(
                 "Transpiler stages",
-                slug="transpiler-stages",
+                slug="/transpiler-stages",
                 from_file="transpile/transpiler-stages.ipynb",
             ),
             Entry(
                 "Transpile with pass managers",
-                slug="transpile-with-pass-managers",
+                slug="/transpile-with-pass-managers",
                 from_file="transpile/transpile-with-pass-managers.ipynb",
             ),
         ),
@@ -216,22 +216,22 @@ TRANSPILER = (
         children=(
             Entry(
                 "Default settings and configuration options",
-                slug="defaults-and-configuration-options",
+                slug="/defaults-and-configuration-options",
                 from_file="transpile/defaults-and-configuration-options.ipynb",
             ),
             Entry(
                 "Set optimization level",
-                slug="set-optimization",
+                slug="/set-optimization",
                 from_file="transpile/set-optimization.ipynb",
             ),
             Entry(
                 "Commonly used parameters for transpilation",
-                slug="common-parameters",
+                slug="/common-parameters",
                 from_file="transpile/common-parameters.ipynb",
             ),
             Entry(
                 "Represent quantum computers",
-                slug="representing-quantum-computers",
+                slug="/representing-quantum-computers",
                 from_file="transpile/representing_quantum_computers.ipynb",
             ),
         ),
@@ -241,27 +241,27 @@ TRANSPILER = (
         children=(
             Entry(
                 "Create a pass manager for dynamical decoupling",
-                slug="dynamical-decoupling-pass-manager",
+                slug="/dynamical-decoupling-pass-manager",
                 from_file="transpile/dynamical-decoupling-pass-manager.ipynb",
             ),
             Entry(
                 "Write a custom transpiler pass",
-                slug="custom-transpiler-pass",
+                slug="/custom-transpiler-pass",
                 from_file="transpile/custom-transpiler-pass.ipynb",
             ),
             Entry(
                 "Transpile against custom backends",
-                slug="custom-backend",
+                slug="/custom-backend",
                 from_file="transpile/custom-backend.ipynb",
             ),
             Entry(
                 "Install and use transpiler plugins",
-                slug="transpiler-plugins",
+                slug="/transpiler-plugins",
                 from_file="transpile/transpiler-plugins.ipynb",
             ),
             Entry(
                 "Create a transpiler plugin",
-                slug="create-a-transpiler-plugin",
+                slug="/create-a-transpiler-plugin",
                 from_file="transpile/create-a-transpiler-plugin.ipynb",
             ),
         ),
@@ -271,12 +271,12 @@ TRANSPILER = (
         children=(
             Entry(
                 "Transpile circuits remotely with the Qiskit transpiler service",
-                slug="qiskit-transpiler-service",
+                slug="/qiskit-transpiler-service",
                 from_file="transpile/qiskit-transpiler-service.mdx",
             ),
             Entry(
                 "AI transpiler passes",
-                slug="ai-transpiler-passes",
+                slug="/ai-transpiler-passes",
                 from_file="transpile/ai-transpiler-passes.mdx",
             ),
         ),
@@ -286,33 +286,33 @@ TRANSPILER = (
 SIMULATORS = (
     Entry(
         "Introduction to debugging tools",
-        slug="verify",
+        slug="/verify",
         from_file="verify/index.mdx",
     ),
     Entry(
         "Exact simulation with Qiskit SDK primitives",
-        slug="simulate-with-qiskit-sdk-primitives",
+        slug="/simulate-with-qiskit-sdk-primitives",
         from_file="verify/simulate-with-qiskit-primitives.mdx",
     ),
     Entry(
         "Exact and noisy simulation with Qiskit Aer primitives",
-        slug="simulate-with-qiskit-aer",
+        slug="/simulate-with-qiskit-aer",
         from_file="verify/simulate-with-qiskit-aer.ipynb",
     ),
     Entry(
         "Qiskit Runtime local testing mode",
-        slug="local-testing-mode",
+        slug="/local-testing-mode",
         from_file="verify/local-testing-mode.ipynb",
     ),
     Entry(
         "Build noise models",
-        slug="building-noise-models",
+        slug="/building-noise-models",
         from_file="verify/building_noise_models.ipynb",
     ),
     PLOT_QUANTUM_STATES_PAGE,
     Entry(
         "Efficient simulation of stabilizer circuits with Qiskit Aer primitives",
-        slug="stabilizer-circuit-simulation",
+        slug="/stabilizer-circuit-simulation",
         from_file="verify/stabilizer-circuit-simulation.ipynb",
     ),
 )
@@ -323,17 +323,17 @@ PRIMITIVES = (
         children=(
             Entry(
                 "Introduction to primitives",
-                slug="primitives",
+                slug="/primitives",
                 from_file="run/primitives.mdx",
             ),
             Entry(
                 "Get started with primitives",
-                slug="primitives-get-started",
+                slug="/primitives-get-started",
                 from_file="run/primitives-get-started.mdx",
             ),
             Entry(
                 "Primitives examples",
-                slug="primitives-examples",
+                slug="/primitives-examples",
                 from_file="run/primitives-examples.mdx",
             ),
         ),
@@ -343,17 +343,17 @@ PRIMITIVES = (
         children=(
             Entry(
                 "Configure runtime compilation",
-                slug="configure-runtime-compilation",
+                slug="/configure-runtime-compilation",
                 from_file="run/configure-runtime-compilation.mdx",
             ),
             Entry(
                 "Configure runtime error mitigation",
-                slug="configure-error-mitigation",
+                slug="/configure-error-mitigation",
                 from_file="run/configure-error-mitigation.mdx",
             ),
             Entry(
                 "Advanced runtime options",
-                slug="advanced-runtime-options",
+                slug="/advanced-runtime-options",
                 from_file="run/advanced-runtime-options.mdx",
             ),
         ),
@@ -365,22 +365,22 @@ MANAGE_JOBS_FOLDER = Entry(
     children=(
         Entry(
             "Monitor or cancel a job",
-            slug="monitor-job",
+            slug="/monitor-job",
             from_file="run/monitor-job.mdx",
         ),
         Entry(
             "Estimate job run time",
-            slug="estimate-job-run-time",
+            slug="/estimate-job-run-time",
             from_file="run/estimate-job-run-time.mdx",
         ),
         Entry(
             "Minimize job run time",
-            slug="minimize-time",
+            slug="/minimize-time",
             from_file="run/minimize-time.mdx",
         ),
         Entry(
             "Maximum execution time",
-            slug="max-execution-time",
+            slug="/max-execution-time",
             from_file="run/max-execution-time.mdx",
         ),
         RETRIEVE_RESULTS_PAGE,
@@ -390,82 +390,82 @@ MANAGE_JOBS_FOLDER = Entry(
 EXECUTION_MODES_CHILDREN = (
     Entry(
         "Introduction to execution modes",
-        slug="execution-modes-intro",
+        slug="/execution-modes-intro",
         from_file="run/execution-modes.mdx",
     ),
     Entry(
         "Introduction to sessions",
-        slug="sessions",
+        slug="/sessions",
         from_file="run/sessions.mdx",
     ),
     Entry(
         "Run jobs in a session",
-        slug="run-jobs-in-session",
+        slug="/run-jobs-in-session",
         from_file="run/run-jobs-in-session.mdx",
     ),
     Entry(
         "Run jobs in a batch",
-        slug="run-jobs-batch",
+        slug="/run-jobs-batch",
         from_file="run/run-jobs-batch.mdx",
     ),
     MANAGE_JOBS_FOLDER,
     Entry(
         "Execution modes FAQs",
-        slug="execution-modes-faq",
+        slug="/execution-modes-faq",
         from_file="run/execution-modes-faq.mdx",
     ),
 )
 
 SYSTEMS_CHILDREN = (
     Entry(
-        "Processor types", slug="processor-types", from_file="run/processor-types.mdx"
+        "Processor types", slug="/processor-types", from_file="run/processor-types.mdx"
     ),
     Entry(
         "System information",
-        slug="system-information",
+        slug="/system-information",
         from_file="run/system-information.mdx",
     ),
     Entry(
         "Get backend information with Qiskit",
-        slug="get-backend-information",
+        slug="/get-backend-information",
         from_file="run/get-backend-information.ipynb",
     ),
     Entry(
         "Native gates and operations",
-        slug="native-gates",
+        slug="/native-gates",
         from_file="run/native-gates.mdx",
     ),
     Entry(
-        "Retired systems", slug="retired-systems", from_file="run/retired-systems.mdx"
+        "Retired systems", slug="/retired-systems", from_file="run/retired-systems.mdx"
     ),
     Entry(
         "Hardware considerations and limitations for classical feedforward and control flow",
-        slug="dynamic-circuits-considerations",
+        slug="/dynamic-circuits-considerations",
         from_file="run/dynamic-circuits-considerations.ipynb",
     ),
-    Entry("Instances", slug="instances", from_file="run/instances.mdx"),
+    Entry("Instances", slug="/instances", from_file="run/instances.mdx"),
     Entry(
         "Fair-share scheduler",
-        slug="fair-share-queue",
+        slug="/fair-share-queue",
         from_file="run/fair-share-queue.mdx",
     ),
-    Entry("Manage cost", slug="manage-cost", from_file="run/manage-cost.mdx"),
+    Entry("Manage cost", slug="/manage-cost", from_file="run/manage-cost.mdx"),
 )
 
 PATTERNS_CHILDREN = (
     Entry(
         "Introduction to Qiskit Patterns",
-        slug="intro-to-patterns",
+        slug="/intro-to-patterns",
         page_content=patterns_index_content(),
     ),
     Entry(
         "Map problem to circuits",
-        slug="map-problem-to-circuits",
+        slug="/map-problem-to-circuits",
         page_content=map_content(entries_as_markdown_list(CIRCUIT_CONSTRUCTION)),
     ),
     Entry(
         "Optimize for hardware",
-        slug="optimize-for-hardware",
+        slug="/optimize-for-hardware",
         page_content=optimize_content(
             entries_as_markdown_list(
                 (
@@ -477,7 +477,7 @@ PATTERNS_CHILDREN = (
     ),
     Entry(
         "Execute on hardware",
-        slug="execute-on-hardware",
+        slug="/execute-on-hardware",
         page_content=execute_index_content(
             entries_as_markdown_list(
                 (
@@ -501,7 +501,7 @@ PATTERNS_CHILDREN = (
     ),
     Entry(
         "Post-process results",
-        slug="postprocess-results",
+        slug="/postprocess-results",
         page_content=postprocess_index_content(
             entries_as_markdown_list((RETRIEVE_RESULTS_PAGE, VISUALIZE_RESULTS_PAGE))
         ),

--- a/scripts/patterns-reorg/main.py
+++ b/scripts/patterns-reorg/main.py
@@ -37,7 +37,6 @@ def write_guides_dir() -> None:
         "children": [entry.to_json("guides") for entry in TOP_LEVEL_ENTRIES],
     }
     text = json.dumps(result, indent=2)
-    text = text.replace('"url": "/guides/index"', '"url": "/guides"')
     (folder_path / "_toc.json").write_text(text)
 
 

--- a/scripts/patterns-reorg/main.py
+++ b/scripts/patterns-reorg/main.py
@@ -37,6 +37,7 @@ def write_guides_dir() -> None:
         "children": [entry.to_json("guides") for entry in TOP_LEVEL_ENTRIES],
     }
     text = json.dumps(result, indent=2)
+    text = text.replace('"url": "/guides/index"', '"url": "/guides"')
     (folder_path / "_toc.json").write_text(text)
 
 

--- a/scripts/patterns-reorg/models.py
+++ b/scripts/patterns-reorg/models.py
@@ -63,7 +63,8 @@ class Entry:
             assert self.page_content is not None
             content = self.page_content
             extension = ".mdx"
-        Path(base_dir / f"{self.get_relative_path_from_slug()}{extension}").write_text(content)
+        dest = base_dir / f"{self.relative_path_from_slug()}{extension}"
+        dest.write_text(content)
 
     def relative_path_from_slug(self) -> str | None:
         if self.slug is None:

--- a/scripts/patterns-reorg/models.py
+++ b/scripts/patterns-reorg/models.py
@@ -65,7 +65,7 @@ class Entry:
             extension = ".mdx"
         Path(base_dir / f"{self.get_relative_path_from_slug()}{extension}").write_text(content)
 
-    def get_relative_path_from_slug(self):
+    def relative_path_from_slug(self) -> str | None:
         if self.slug is None:
             return
         return (self.slug if self.slug != "" else "/index").removeprefix("/")

--- a/scripts/patterns-reorg/models.py
+++ b/scripts/patterns-reorg/models.py
@@ -69,7 +69,9 @@ class Entry:
     def relative_path_from_slug(self) -> str | None:
         if self.slug is None:
             return
-        return (self.slug if self.slug != "" else "/index").removeprefix("/")
+        if self.slug == "":
+            return "index"
+        return self.slug.removeprefix("/")
 
 
 def entries_as_markdown_list(


### PR DESCRIPTION
This PR changes the patterns script to use '`"url": "/guides"`' instead of `"url": "/guides/index"'` for the index entry of the guides `_toc.json`. The PR doesn't modify the `entries.py` script to avoid having an empty slug.