### PR TITLE
Use internal links for new index page

### DIFF
--- a/scripts/patterns-reorg/page_content.py
+++ b/scripts/patterns-reorg/page_content.py
@@ -210,47 +210,47 @@ The Qiskit SDK (package name [`qiskit`](https://pypi.org/project/qiskit/)) is an
 Some of the most useful features of the Qiskit SDK include:
 
 ### Circuit building tools 
-([`qiskit.circuit`](https://docs.quantum.ibm.com/api/qiskit/circuit))
+([`qiskit.circuit`](/api/qiskit/circuit))
 For initializing and manipulating registers, circuits, instructions, gates, parameters, and control flow objects. 
 
 ### Circuit library 
-([`qiskit.circuit.library`](https://docs.quantum.ibm.com/api/qiskit/circuit_library)) 
+([`qiskit.circuit.library`](/api/qiskit/circuit_library)) 
 A vast range of circuits, instructions, and gates - key building blocks for circuit-based quantum computations.
 
 ### Quantum Information
-([`qiskit.quantum_info`](https://docs.quantum.ibm.com/api/qiskit/quantum_info))
+([`qiskit.quantum_info`](/api/qiskit/quantum_info))
 A toolkit for working with quantum states, operators and channels, using exact calculations (no sampling noise). Use this module to specify input observables and analyse fidelity of outputs from primitives queries.
 
 ### Transpiler 
-([`qiskit.transpiler`](https://docs.quantum.ibm.com/api/qiskit/transpiler))
+([`qiskit.transpiler`](/api/qiskit/transpiler))
 For transforming and adapting quantum circuits to suit specific device topology and/or optimizing for execution on real quantum systems.
 
 ### Primitives 
-([`qiskit.primitives`](https://docs.quantum.ibm.com/api/qiskit/primitives))
-The module that contains the base definitions and reference implementations of the `Sampler` and `Estimator` primitives, from which different quantum hardware providers can derive their own implementations. See more information about the Qiskit Runtime primitives [in the documentation](https://docs.quantum.ibm.com/run/primitives).
+([`qiskit.primitives`](/api/qiskit/primitives))
+The module that contains the base definitions and reference implementations of the `Sampler` and `Estimator` primitives, from which different quantum hardware providers can derive their own implementations. See more information about the Qiskit Runtime primitives [in the documentation](./primitives).
 
 
 ## Qiskit Runtime
 
-Qiskit Runtime is a cloud-based service for executing quantum computations on IBM Quantum&trade; hardware. The `qiskit-ibm-runtime` package is a client for that service, and is the successor to the Qiskit IBM Provider. The Qiskit Runtime service streamlines quantum computations and provides optimal implementations of the Qiskit primitives for IBM Quantum hardware. To get started with Qiskit Runtime primitives, visit the [documentation](https://docs.quantum.ibm.com/run/primitives-get-started). 
+Qiskit Runtime is a cloud-based service for executing quantum computations on IBM Quantum&trade; hardware. The `qiskit-ibm-runtime` package is a client for that service, and is the successor to the Qiskit IBM Provider. The Qiskit Runtime service streamlines quantum computations and provides optimal implementations of the Qiskit primitives for IBM Quantum hardware. To get started with Qiskit Runtime primitives, visit the [documentation](./get-started-with-primitives). 
 
-With Qiskit Runtime you can choose to run your quantum programs on IBM Quantum hardware through the IBM Quantum Platform or IBM Cloud&reg;. See more information on selecting an IBM Quantum channel [in the documentation](https://docs.quantum.ibm.com/start/setup-channel).
+With Qiskit Runtime you can choose to run your quantum programs on IBM Quantum hardware through the IBM Quantum Platform or IBM Cloud&reg;. See more information on selecting an IBM Quantum channel [in the documentation](./setup-channel).
 
-Qiskit Runtime is designed to use additional classical and quantum compute resources, including techniques such as error suppression and error mitigation, to return a higher-quality result from executing quantum circuits on quantum processors. Examples include dynamical decoupling for error suppression, and readout mitigation and zero-noise extrapolation (ZNE) for error mitigation. Learn how to configure these options on the [Configure error mitigation](https://docs.quantum.ibm.com/run/configure-error-mitigation) page.
+Qiskit Runtime is designed to use additional classical and quantum compute resources, including techniques such as error suppression and error mitigation, to return a higher-quality result from executing quantum circuits on quantum processors. Examples include dynamical decoupling for error suppression, and readout mitigation and zero-noise extrapolation (ZNE) for error mitigation. Learn how to configure these options on the [Configure error mitigation](./configure-error-mitigation) page.
 
 
-Qiskit Runtime also includes three types of execution modes for running your quantum program on IBM hardware: _Job_, _Session_, and _Batch_, each of which have different use cases and implications for the quantum job queue. A Job is a single query to a primitive that can be run over a specified number of shots. [Sessions](https://docs.quantum.ibm.com/run/sessions) allow you to efficiently run multiple jobs in iterative workloads on quantum computers. [Batch mode](https://docs.quantum.ibm.com/run/run-jobs-batch) allows you to submit all your jobs at once for parallel processing.
+Qiskit Runtime also includes three types of execution modes for running your quantum program on IBM hardware: _Job_, _Session_, and _Batch_, each of which have different use cases and implications for the quantum job queue. A Job is a single query to a primitive that can be run over a specified number of shots. [Sessions](./sessions) allow you to efficiently run multiple jobs in iterative workloads on quantum computers. [Batch mode](./run-jobs-batch) allows you to submit all your jobs at once for parallel processing.
 
 ### Is Qiskit Runtime open-source?
 The short answer is, _not all of it_. The Qiskit Runtime service software that handles the technicalities of running your quantum program on an IBM Quantum device (including any error mitigation and suppression) is **not** open-source. However, the Qiskit Runtime client (the interface for users to access the Qiskit Runtime service), the Qiskit SDK running on the server side, and some of the software used for error mitigation, **are** open-source.  To get involved with the Qiskit open-source efforts, visit our GitHub organization at [github.com/Qiskit](https://github.com/Qiskit) and [github.com/Qiskit-Extensions](https://github.com/Qiskit-Extensions/).
 
 
 ## Qiskit Serverless
-Creating utility-scale quantum applications generally requires a variety of compute resource requirements. Premium users can use Qiskit Serverless (package name `qiskit-serverless`) to easily submit quantum workflows for remote, managed execution. See more information [here](https://docs.quantum.ibm.com/run/quantum-serverless) about how to use this collection of tools.
+Creating utility-scale quantum applications generally requires a variety of compute resource requirements. Premium users can use Qiskit Serverless (package name `qiskit-serverless`) to easily submit quantum workflows for remote, managed execution. See more information [here](./qiskit-serverless) about how to use this collection of tools.
 
 
 ## Qiskit Transpiler as a Service
-The Qiskit transpiler service ([package name `qiskit-transpiler-service`](https://pypi.org/project/qiskit-transpiler-service/)) is a new experimental service that provides remote transpilation capabilities on the cloud to IBM Quantum Premium Plan users. In addition to the local Qiskit SDK transpiler capabilities, your transpilation tasks can benefit from both IBM Quantum cloud resources and AI-powered transpiler passes using this service. To learn more about how to integrate cloud-based transpilation into your Qiskit workflow you can [check out the documentation](https://docs.quantum.ibm.com/transpile/qiskit-transpiler-service).
+The Qiskit transpiler service ([package name `qiskit-transpiler-service`](https://pypi.org/project/qiskit-transpiler-service/)) is a new experimental service that provides remote transpilation capabilities on the cloud to IBM Quantum Premium Plan users. In addition to the local Qiskit SDK transpiler capabilities, your transpilation tasks can benefit from both IBM Quantum cloud resources and AI-powered transpiler passes using this service. To learn more about how to integrate cloud-based transpilation into your Qiskit workflow you can [check out the documentation](./qiskit-transpiler-service).
 
 
 ## The Qiskit Ecosystem
@@ -264,6 +264,6 @@ Some popular projects in the Qiskit ecosystem include:
 - **mthree** `mthree` - a package for implementing M3 (Matrix-free Measurement Mitigation), a measurement mitigation technique that solves for corrected measurement probabilities using a dimensionality reduction step followed by either direct LU factorization or a preconditioned iterative method that nominally converges in O(1) steps, and can be computed in parallel. Maintained by IBM Quantum.
 - **Qiskit TOQM** `qiskit-toqm` - a transpiler plugin for a routing method that uses the Time-Optimal Qubit Mapping (TOQM) algorithm. Maintained by IBM Quantum.
 
-You can find a catalogue of projects in the [Qiskit ecosystem page](https://qiskit.github.io/ecosystem/), as well as information about how to nominate your own project.
+You can find a catalog of projects in the [Qiskit ecosystem page](https://qiskit.github.io/ecosystem/), as well as information about how to nominate your own project.
 """
     )


### PR DESCRIPTION
We shouldn't be using external links in general.

This PR also updates to use the new `guides/` URLs. Note that we have some risk that the links we hardcode here diverge from our source of truth in `entries.py`. We can't have `page_content.py` load the final URLs from `entries.py` because it would result in a circular import. However, our link checker will complain if there are any divergences, so it should be fine.