### PR TITLE
Use `pull_request_target` for PR preview teardown

### DIFF
--- a/.github/workflows/preview-docs-teardown.yml
+++ b/.github/workflows/preview-docs-teardown.yml
@@ -1,0 +1,51 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# WARNING: This event type uses secrets even when triggered by an untrusted PR.
+# Do NOT checkout the PR or access any user-defined inputs (such as the title) as it could be untrusted.
+# For more information, see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+# This event type runs on the target branch (rather than a merge commit of the
+# target and PR branches), so you'll need to test it out in a fork.
+
+name: Preview teardown
+
+on:
+  pull_request:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "docs/**/*"
+      - "public/images/**/*"
+
+jobs:
+  teardown:
+    # Do not edit or modify the repo name condition; see warning above
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/set-up-ibm-cloud
+        id: set-up-cloud
+        with:
+          env_name: Preview
+          ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+          ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+      - name: Remove Code Engine preview application
+        run: |
+          ibmcloud ce project select -n qiskit-docs-preview
+          ibmcloud ce application delete \
+            --name "${{ steps.set-up-cloud.outputs.app_name }}" \
+            --wait \
+            --ignore-not-found \
+            --force

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -21,7 +21,7 @@ name: Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    paths: &changed-file-paths
+    paths:
       - "docs/**/*"
       - "public/images/**/*"
 
@@ -32,7 +32,9 @@ on:
   # the PR), so you'll need to test it out in a fork.
   pull_request_target:
     types: [closed]
-    paths: *changed-file-paths
+    paths:
+      - "docs/**/*"
+      - "public/images/**/*"
 
 jobs:
   setup:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -25,17 +25,6 @@ on:
       - "docs/**/*"
       - "public/images/**/*"
 
-  # WARNING: This event type uses secrets even when triggered by an untrusted PR.
-  # Do NOT checkout the PR or access any user-defined inputs (such as the title) as it could be untrusted.
-  # For more information, see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
-  # This event type runs on the _target_ branch (rather than a merge commit of
-  # the PR), so you'll need to test it out in a fork.
-  pull_request_target:
-    types: [closed]
-    paths:
-      - "docs/**/*"
-      - "public/images/**/*"
-
 jobs:
   setup:
     if: |
@@ -47,25 +36,3 @@ jobs:
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
       ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-
-  teardown:
-    if: |
-      github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/set-up-ibm-cloud
-        id: set-up-cloud
-        with:
-          env_name: Preview
-          ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-          ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-      - name: Remove Code Engine preview application
-        run: |
-          ibmcloud ce project select -n qiskit-docs-preview
-          ibmcloud ce application delete \
-            --name "${{ steps.set-up-cloud.outputs.app_name }}" \
-            --wait \
-            --ignore-not-found \
-            --force

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -20,10 +20,19 @@ name: Preview
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, closed]
-    paths:
+    types: [opened, reopened, synchronize]
+    paths: &changed-file-paths
       - "docs/**/*"
       - "public/images/**/*"
+
+  # WARNING: This event type uses secrets even when triggered by an untrusted PR.
+  # Do NOT checkout the PR or access any user-defined inputs (such as the title) as it could be untrusted.
+  # For more information, see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+  # This event type runs on the _target_ branch (rather than a merge commit of
+  # the PR), so you'll need to test it out in a fork.
+  pull_request_target:
+    types: [closed]
+    paths: *changed-file-paths
 
 jobs:
   setup:


### PR DESCRIPTION
Should fix 1034.

## Investigation

It seems PR previews _are_ being cleaned up correctly for _merged_ PRs; the teardown action is running, and the previews are no longer accessible after merging (see following screenshot as example).

<img width="300" alt="Screenshot 2024-06-07 at 13 35 48" src="https://github.com/Qiskit/documentation/assets/36071638/0066b309-9432-4213-81bd-1836521a8900">

It seems the problem is if a PR is closed but not merged (e.g. #1468, #1380, and #1289 still have active previews). I believe this is the reason: https://github.com/orgs/community/discussions/26657#discussioncomment-3252753.


## Solution

This PR tries to fix this by using the `pull_request_target` event to trigger teardowns. This should trigger correctly when PRs are closed.

We need to be careful with this event as it allows untrusted PRs to trigger events using secrets. Since this action runs on the target branch (rather than a merge commit of the target and PR branches), an untrusted user shouldn't be able to do anything malicious, but we need to make sure we **never** checkout the PR branch with this event type, or read any user-defined inputs (such as the PR title) as it could lead to an injection. I think this is unlikely, but I've left a warning in the action just in case.
