### PR TITLE
Explain why decompose is used

### DIFF
--- a/docs/build/unitary-synthesis.mdx
+++ b/docs/build/unitary-synthesis.mdx
@@ -59,7 +59,7 @@ circuit.draw("mpl")
 
 ![output](/images/build/unitary-synthesis/unitary_target-qiskit-1.0.svg)
 
-However, after re-synthesizing with the following code, it only needs a single CX gate.
+However, after re-synthesizing with the following code, it only needs a single CX gate. (Here we use the `QuantumCircuit.decompose()` method to better visualize the gates used to re-synthesize the unitary.)
 
 ```python 
 from qiskit.quantum_info import Operator


### PR DESCRIPTION
Closes #1439 
 
Decompose is basically only used here to visualize the circuit correctly. If it wasn't, it  just be an opaque block when calling `draw()`