### PR TITLE
Update "operators overview" page to highlight SparsePauliOp and split in-depth Operator coverage to separate page

### DIFF
--- a/docs/build/_toc.json
+++ b/docs/build/_toc.json
@@ -46,10 +46,14 @@
           "title": "Operators module overview",
           "url": "/build/operators-overview"
         },
-	{
-	  "title": "Specify observables in the Pauli basis",
-	  "url": "/build/specify-observables-pauli"
-	}
+        {
+          "title": "Specify observables in the Pauli basis",
+          "url": "/build/specify-observables-pauli"
+        },
+        {
+          "title": "The Operator class",
+          "url": "/build/operator-class"
+        }
       ]
     },
     {

--- a/docs/build/operator-class.ipynb
+++ b/docs/build/operator-class.ipynb
@@ -1,0 +1,709 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Operator class\n",
+    "\n",
+    "This page shows how to use the [`Operator`](/api/qiskit/qiskit.quantum_info.Operator) class. For a high-level overview of the class, see [Overview of operator classes](/build/operators-overview#operator)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qiskit.circuit import QuantumCircuit\n",
+    "from qiskit.circuit.library import CXGate, RXGate, XGate\n",
+    "from qiskit.quantum_info import Operator, Pauli, process_fidelity\n",
+    "from qiskit_aer import Aer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Converting classes to Operators\n",
+    "\n",
+    "Several other classes in Qiskit can be directly converted to an `Operator` object using the operator initialization method. For example:\n",
+    "\n",
+    "* `Pauli` objects\n",
+    "* `Gate` and `Instruction` objects\n",
+    "* `QuantumCircuit` objects\n",
+    "\n",
+    "Note that the last point means we can use the `Operator` class as a unitary simulator to compute the final unitary matrix for a quantum circuit, without having to call a simulator backend. If the circuit contains any unsupported operations, an exception will be raised. Unsupported operations are: measure, reset, conditional operations, or a gate that does not have a matrix definition or decomposition in terms of gate with matrix definitions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],\n",
+      "         input_dims=(2, 2), output_dims=(2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create an Operator from a Pauli object\n",
+    "\n",
+    "pauliXX = Pauli(\"XX\")\n",
+    "Operator(pauliXX)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j]],\n",
+      "         input_dims=(2, 2), output_dims=(2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create an Operator for a Gate object\n",
+    "Operator(CXGate())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[0.70710678+0.j        , 0.        -0.70710678j],\n",
+      "          [0.        -0.70710678j, 0.70710678+0.j        ]],\n",
+      "         input_dims=(2,), output_dims=(2,))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create an operator from a parameterized Gate object\n",
+    "Operator(RXGate(np.pi / 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.70710678+0.j,  0.70710678+0.j,  0.        +0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
+      "          [ 0.        +0.j,  0.        +0.j,  0.70710678+0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
+      "          [ 0.        +0.j,  0.        +0.j,  0.        +0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
+      "          ...,\n",
+      "          [ 0.        +0.j,  0.        +0.j,  0.        +0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
+      "          [ 0.        +0.j,  0.        +0.j,  0.70710678+0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
+      "          [ 0.70710678+0.j, -0.70710678+0.j,  0.        +0.j, ...,\n",
+      "            0.        +0.j,  0.        +0.j,  0.        +0.j]],\n",
+      "         input_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), output_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create an operator from a QuantumCircuit object\n",
+    "circ = QuantumCircuit(10)\n",
+    "circ.h(0)\n",
+    "for j in range(1, 10):\n",
+    "    circ.cx(j - 1, j)\n",
+    "\n",
+    "# Convert circuit to an operator by implicit unitary simulation\n",
+    "Operator(circ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Operators in circuits\n",
+    "\n",
+    "Unitary `Operators` can be directly inserted into a `QuantumCircuit` using the `QuantumCircuit.append` method. This converts the `Operator` into a `UnitaryGate` object, which is added to the circuit.\n",
+    "\n",
+    "If the operator is not unitary, an exception will be raised. This can be checked using the `Operator.is_unitary()` function, which will return `True` if the operator is unitary and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAgI0lEQVR4nO3deVxU9f4/8NcwCyCLjKAiIrIIBihCLlfAVBTMBcUyvTct7ZvXbovftLxgD29fy+/v/jSX7F6tTMu+LZpfS6zrlqlpuOSueA1RERBlGZUgcdhn+f0RzM+BQWEYZvgMr+c/cD7nnM95j8KLz/mcM2cker1eDyIiEpKDrQsgIiLzMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKByWxdALWOXq+HprLa1mXYLZmzIyQSidWPq9frodVqrX7c1pBKpTb5t+roGOKC01RWY3PQM7Yuw27NyN4EeScnqx9Xq9UiNTXV6sdtjSlTpkAmY6RYG6dTiIgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yogygrK8OtW7egUqlQWloKvV7fov337duH4uLiNquPzMMHHRDZqeLiYhw5cgRZWVnIzc1FaWmp0fpOnTohICAAgYGBiI2Nhb+/f5N9ffvtt9i6dSt27dqFxYsXw8vLywqvgJqDIU5kZzIzM7Fnzx6cOXPmgaPtiooKZGRkICMjAzt37kRwcDDGjRuH6Ohoo6cR1gc4ANy+fRvp6emIj4+3ymuhh7P76ZTi4mKkpKSgT58+cHJyQq9evTBv3jyUl5dj9uzZkEgkeP/9921dJlGrVVZW4pNPPsGSJUtw+vRpowB3cXFBeHg4YmJiEBsbi6ioKHTp0sVo/6ysLKxZswZLly7FnTt3gAYBDgDTp09ngLczdj0ST09Px7hx46BSqeDi4oKwsDAUFhZizZo1yM7ORklJCQAgMjLS1qW2LYkEYXMmoO+zCXD17YqqX8uQu/NnpK/YymeR24mcnBysXr3aaM5aqVRi9OjRiI2Nhbe3t8lnfZeWluLMmTPYv38/bty4AQC4ePEikpOTERUVhePHjxu2nT59OiZNmmSlV0TNZbchXlxcjIkTJ0KlUmHBggV466234ObmBgBYsWIFFi5cCJlMBolEgoiICFuX26aG/PdzCPvzBOTtOYlfPtoJj+CeCJs9Hp79AvDDtP8GWniBi9qXK1eu4J133kFlZSUAwNHREdOnT8fo0aMf+nxvpVKJhIQExMfHIz09HR9//DFKSkpQVVXFABeE3U6nvPrqq8jPz8fcuXOxatUqQ4ADQEpKCgYMGACNRgN/f3+4u7vbtNa25BHii9Dnx+H67hM4NHslsjYfwOm3P8eptz9Hj2H9ETA51tYlUivk5eUZBXhwcDBWrlyJxx9/vEUf0CCRSBAVFYVVq1ahd+/eRutiY2MZ4O2YXYZ4ZmYmtm7dCi8vLyxbtszkNgMHDgQADBgwwKg9NzcXkyZNgpubG5RKJWbOnIlff/3VKnW3hYAnhkHi4IBLH+82as/afAC1FVUImjLcZrVR69TW1mLt2rWGAI+IiMCbb76Jbt26md3nDz/8gLy8PKO2c+fO8dbCdswuQ3zLli3Q6XSYMWMGXF1dTW7j7OwMNAjxe/fuIS4uDvn5+diyZQs2bNiAI0eOIDExETqdzmr1W5JXZB/otFoUn88yatdW16Lkl+vwigyyWW3UOqmpqcjPzwcA+Pv74/XXX4ejo6PZ/TW8iFl/y2FlZSXWr1/f4vvKyTrsMsQPHjwIAIiLi2tym/of/vtDfMOGDSgoKMB3332HxMRETJ06FV999RVOnDiBHTt2WKFyy+vUXYnqknvQ1WgaratQlcDJszMc5HZ7acRuFRUVGX4mpVIpXn75ZTg5mf9ZoKbuQlm8eLHhDpaLFy/ixIkTFqicLM0uf3vrTwcbzu3V02g0OHbsGNAgxHft2oVhw4bBz8/P0BYdHY3AwEDs3LkTkydPNqueQYMGQaVSmbXvw8j1DngLQ5pcL3V2hLam1uQ6bfXv7TJnBWpqG4c8ASHBIaiVWP8sTKFQNDkVCAD79+83nB1OnjzZ6Ge2pUwFeP0c+J///GesWLECALB3715ER0c32U9ISAhqamrMrqOj8/b2xpkzZ1q8n12GeHl5OVB3GmjK1q1bUVxcDDc3NwQEBBjaL126hKlTpzbaPjw8HJcuXTK7HpVKhYKCArP3fxCFRAp0b3q9trIacpfOJtdJHeUAAE0lf/GaUlhUiBq91urHfdC0SHV1NdLS0gAAcrkcY8eONfs4DwpwAIiKioKvry/y8/Nx5coV5OXlNTk4KiwsRHU1b1m1NrsMcW9vb5SWluLcuXONRg5FRUVITk4G6i4E3X/vbGlpKTw8PBr116VLF1y5cqVV9bQVud4BeMBAseJWKTqH+MJBIWs0pdLJuwuqfr0LHUfhTfLp4WOzkXhTLly4YBioxMTEGN151RIPC3DU3bUyZswYfPrppwCAY8eONRniPj4+HIm3grk5YZchHh8fj8zMTCxfvhwJCQkICQkBAJw+fRrPPvus4Uq7td7kY84pUnPVVlRhc9AzTa4vTr+GniMj4RUVjNsnMw3tUkc5uvTzx60TmU3uS8DVrKuQdzJ/rtlcGo0GqampJtdlZ2cbvh80aJBZ/TcnwO8/Rn2I5+TkNNnn1atXW3RbI1mGXV7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CjAxO2FSqUSv/32W6P+SkpKGr1FWRS5//oZep0OYXMmGLUHz4iHvJMTcrYftlltZJ7c3FzD94GBgS3evyUBjrrfi/oz1NzcXN6l0s7YZYj7+vriyJEjmDBhApycnHD9+nV06dIF69evx+7du3H16lXARIiHhoaanPu+dOkSQkNDrVa/Jf12+QYu/89e+E8YiriNyQiePhqD3pqJIW/PgurnDORsP2rrEqmFCgsLAQCurq4tHly0NMBRN6VSP4VSXl6Ou3fvmlU3tQ27PfcJDQ3Frl27GrWr1Wpcv34dDg4O6Nevn9G6xMRELFq0CPn5+fD19QUAnDx5EtnZ2Vi5cqXVare0U4s/g/rmHYQ8Ew/f0Y+iqqQMmZ9+j/MrtvIt9wLq3LkzdDodPDw8TD4PpSk7duxocYDX8/T0hFKphEKhgFZr/Qu91DSJvoOdG508eRJDhw5F3759cfnyZaN1ZWVl6N+/P7y8vLBkyRJUVVUhJSUFXbt2xfHjx+Hg0P5OXB42J06tMyN7U7ubEzdXeno63n33XdTW1rbJs1CmTJnCOXEb6HD/4hcvXgRMTKUAgLu7Ow4ePIh58+bhT3/6E2QyGRITE/Hee++1ywAnaonIyEgsWLAA+fn5SExMtHU5ZCEM8QaCgoJMTsMQ2YPIyEj7f/RyB9PhhpcPC3EiIpF0uJF4/XNViIjsQYcbiRMR2ROGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQC63DPTiESgVQqxZQpUyzW38r1W3GvvBxuLi5I/ssfGy1bglQqtUg/1DIMcaJ2SCKRWPQDFvQAdPrfv8pkskbLJC5Op5BVDfvHK3iuaJutyyCyGwxxMtJn2kg8V7QNfaaNNLne1bcrnivahmH/eMVix/QbOxiRC6ZZrD+ijoQhTlZ17K8f4Uv/p43a/MYOQeRfGeJE5mCIk1XpNVpoq2utdjyJTAqpo9xqxyOyNl7RoFZx9e2Kp06vQ/qqr1F8IRuRC6ZC+Ygfqu+WIyf1MM4u3Qy9VmfYftg/XkGfP8bhsx5PAQDGpi6Bd0w4ABjNlR+d9z6uff0TOvfxQejs8egeHQ7Xnl6QSB3wW1Y+rny+D1lf/WhUS+SCaYj86zR8N2I+gqePhv/EGDh398CBGUsx/INXcTe7CN8nvdnoNYS/NAmDF8/E90/8F26dyGzDfy0iy2OIk0X0HB2Fvs89jitf7EPWloPwGzsY/V5OQvXdclxcs73J/S78MxVwkMB7aBgOz/2nof326SsAAO+Yfug+NAz5+89CffM2ZM6O8J8Yjdh3X4KTpzsurv22UZ/DP5gHTVUNMtbvBPR6qPPv4NrXaej30iS4B/mgLLvQaPvgp0fh7rUCBjgJiSFOFuHRtxf+NeI1qPPvAACufLEPSYdWI/T5cQ8M8aLD/0bQk48BQ8OQk3qk0frsb9Jw5Yt9Rm0ZG3Zh7La30X/uZPyybgf0Gq3R+pqyCvwwbYnRGcDVTfvR76VJCH56FM7+fZOhvdvgvvAI9sWZ//Nlq14/ka1wTpws4sbe04YAr6c69gs6dVdC1snJ7H41ldWG76WOcjgqXeGodEVB2gUo3F3QuU/PRvtc+niXUYADQFlOEVQ/Z6DP1BGQSP//j33w06Ohq9Xg2tc/mV0jkS1xJE5m0ev1RsvqvFuNtqkuVQMAHLu4QlNRZdZxZJ2cEPnXafCfFA3Xnl0brXf0cGnUdjenyGRfVzbtx4gP56NXwkDc2HsaMhcn+E+Kxs0DZ1FVfNes+ohsjSFORjRVNQAAqbOjyfWyTr+3a+u2q9dw5Hs/CSRm1zP8w3nolTAQVzcdgOrEJVSX3oNeq4Pv6EcR/peJkEgan0xqK6pN9pW3+wSqSsoQ/PRo3Nh7GgFJsZC7OCNr848mtycSAUOcjKhv3AYAeAQ3nqYAgM7BvgCAe3XbWULDUX09hXsn9EoYiOxth3F84QajdT6PRbT4OLoaDbK/SUPo7PFw7q5E8NOjUF74KwoOpZtdO5GtcU6cjPx6MQfqgjsImBwL5+5Ko3UOchlCnx8HvU6Hm/vOWOyYmvLfp1oUHq5G7br60b3EeCTv3M0DwTNGm3Wsq5sPwEEmxaA3n0G3QX1x7etD0OuaPosgau84Eicjeq0OJxZ+jLhPk5F08F1kfXUQ9/JUcOrqgYBJMVA+4ocL/0xtdJtea9w5l4XQ2UD0sjm4+eNZ6Gu1uHMuC+qbt1GYdgFBUx6DtqoaxenZcPXtipBnE6C+cRtOXdxbfKy7WQW4dTITQU+NgF6nQ9aWgxZ7HUS2wBCnRvJ/PIc9k95E/1cmo8+0EXBUukFTUY1ff8nFTy+8i+s7j1v0eDnfHkWXfgEISIpF74lD4SCV/v5mn5u3cXjuGgxcNAO9Egahz9SRKMstwrl3tkBfq8Gwf84163hXNu1H9z+EouhYhmH6iEhUEn1TE5IkhNqKKmwOesbWZQjFf2I0Rm5YgLSX3kPud8ceuO2M7E2Qt+IWyfZi6QebUaYuh7urCxa9MqPRMomLc+LU4TzyH2NR9etd5O05aetSiFqN0ynUITh5uqPHY/3R/Q+h8I4Ox9n/uwm6Go2tyyJqNYY4dQgeIb0wYt1rqP5Njcuf/4BfPtpp65LoIfR6PbRabTO2bB+kUikkEvPfE2Euhjh1CKrjGYYnJ5IYtFotUlNTbV1Gs02ZMsUmH3XHOXEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyJqBo1Gg9LSUluX0QifnUJEdqu6uho5OTnIyclBbm4uSktLodFoIJPJoFQqERgYiICAAAQFBUGhUDTZj0ajwXvvvYebN29i8eLF8PLysurreBCGOBHZncLCQuzfvx9paWmoqKhocrujR48CAFxcXDBy5EgkJCTA29vbaJv6AD979iwAYPny5Vi+fDkcHNrHREb7qKKNFRcXIyUlBX369IGTkxN69eqFefPmoby8HLNnz4ZEIsH7779v6zKJqJXUajU+/PBDvP766/j+++8fGOD3Ky8vx+7duzF//nysX7/esF/DAFcoFJg5c2a7CXB0hJF4eno6xo0bB5VKBRcXF4SFhaGwsBBr1qxBdnY2SkpKAACRkZG2LrXN9P/PJ+DZPxCeEYFw690d6pu3sW3Iy7Yui8iizp8/jw0bNhjNW8vlcgwdOhShoaEICAiAt7c35HI5amtrUVRUhJycHGRmZuLUqVOora0FABw6dAgXLlzAnDlzcODAAaMAT05ORv/+/W32Gk2x6xAvLi7GxIkToVKpsGDBArz11ltwc3MDAKxYsQILFy6ETCaDRCJBRESErcttMwMXzUBVyT2UXMyBwr2Trcshsrj9+/fj008/Rf1HBjs7O+PJJ59EXFwcXF1dG20vk8kQGBiIwMBAxMfHo6ysDIcOHcK3336LqqoqlJSUYPny5Ybt22uAw95D/NVXX0V+fj7mzp2LVatWGa1LSUnBV199hQsXLiAgIADu7u42q7OtbfvDy4ZPdU86tBpyF/E/+Jeo3o8//oiNGzcalgcMGIAXXngBnp6eze7D3d0dSUlJiImJwUcffYSMjAzDOplM1m4DHPY8J56ZmYmtW7fCy8sLy5YtM7nNwIEDgbr/9Hr1oT9kyBA4Ojra5OOWLK0+wInszZUrV/DJJ58YlidOnIg33nijRQF+P6VSCScn40GOVqtFp07t9wzWbkN8y5Yt0Ol0mDFjhsnTKdSdcqFBiF+7dg2pqanw9vbG4MGDrVYvEbVMdXU11q1bZ5hCmTBhAqZPn272wKvhRcz6i5d6vR7r1q0zzJm3N3Yb4gcPHgQAxMXFNblNfn4+0CDEhw8fjqKiIuzYsQPx8fFWqJSIzPHNN99ApVIBAIKDgzFjxgyLBbhCoUBKSgoCAgKAuqzYvn27Bau3HLudE8/LywMA9O7d2+R6jUaDY8eOAQ1CvC1uHRo0aJDhh83S5HoHvIUhbdI3ASHBIaiV6GxdRqs98R/z4eLqjiJVEXx9fRstt0cKhaLJqdDy8nLs27cPqLsD5cUXXzT7d9dUgNfPgSuVSixatAharRZ79+5FUlJSo+mWeiEhIaipqTGrBgDw9vbGmTNnWryf3YZ4eXk5AKCystLk+q1bt6K4uBhubm6Gv7ZtRaVSoaCgoE36VkikQPc26ZoAFBYVokavtXUZrabTag1fCwoKGi23R46Ojk2uS0tLMwRmXFwcevbsadYxHhTgqBsEDh8+HIcOHUJlZSWOHj3a5Bl6YWEhqqurzaqjNew2xL29vVFaWopz584hOjraaF1RURGSk5MBABEREW1+8bLhO8AsSa53AMQfKLZbPj187GIk7iCVGr727Nmz0XJ79KC3wddPlwLAmDFjzOr/YQF+f/+HDh0yHLepEPfx8Wn1SNwcdhvi8fHxyMzMxPLly5GQkICQkBAAwOnTp/Hss8+iuLgYsNKbfMw5RWqu2ooqbA56ps367+iuZl2FvJP4t2Qu/WAzytTl6OHdA/n5+Y2W2yONRoPU1NRG7Wq12lBzUFCQWdNBzQ1wAAgICICfnx9u3LiB3NxcVFVVmZxSuXr1KmQy60eq3V7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CigwXw4EbV/ubm5hu+Dg4NbvH9LArzhcfR6Pa5fv25W3W3Fbkfivr6+OHLkCJKTk5GWlobr168jLCwM69evx5w5cxAUFAR0kBAPfGo4XH27AgCcPN3hIJchYv4UAIA6/w5yth22cYVEzXd/iAYGBrZoX3MCHHWj8Xq5ubl45JFHWlx3W7HbEAeA0NBQ7Nq1q1G7Wq3G9evX4eDggH79+tmkNmsKeXo0vGPCjdoeXfg0AED1cwZDnISiVqsN37fkTT3mBnjD49TfNNFe2HWINyUjIwN6vR4hISEm34m1bds2AMClS5eMlv39/TFo0CArV9t6e6e8ZesSiCxm9OjRiIiIQE1NDfz8/Jq9X15eHv79738DZjwLJSgoCAsXLoRCoUC3bt3Mrr0tdMgQv3jxIvCAqZSpU6eaXJ41axY+++wzK1RIRE3p1q2bWUEaFBSEBQsWYO3atZg/f36LnoXi7u6OqKioFh/TGhjiJtS/jZeI7EtkZCTWrl3brp+F0lJ2e3fKgzwsxInIftlTgKOjjsTvf6MAEZHIOuRInIjIXjDEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhJYh3x2ij2ROTtiRvYmW5dht2TOTX/iOrUtqVSKKVOmWKSvleu34l55OdxcXJD8lz822dYa0roPn7Y2hrjgJBKJXXyQL1FDEonEYh88rAeg0//+tb5PU20i4nQKEZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiLcDK1euRHR0NJRKJTw8PDBs2DDs3bvX1mURPdCePXsQGRkJR0dH+Pv7Y/Xq1bYuyaoOHz6MpKQk9O7dGxKJBH//+99tUgdDvB04ePAgnn/+eRw6dAinTp1CTEwMEhMTcezYMVuXRmTSmTNnkJSUhHHjxiE9PR1vv/02Fi1ahI8++sjWpVmNWq1GWFgYVqxYAW9vb5vVIbPZkcng+++/N1pesWIF9u7di+3btyM2NtZmdRE1ZfXq1Rg8eDCWLVsGAAgNDUVGRgbeeecdvPjii7YuzyrGjx+P8ePHAwAWLlxoszoY4u2QTqdDWVkZXFxcbF0KCaa6phZ5BbcatWu0WsPXq7n5jZbv191Lic5uD/7ZO3bsGGbPnm3UNnbsWKxatQr5+fnw9fW1wKsxz42CW6iqqTVqM/V6m/o3cHZUoJdPN6vW3BoM8XZo6dKl+O233/DCCy/YuhQSjFwuw5FTF5B1vcDk+orKKnz69Z4mlz3cXTH/+aceepyioqJGUwj1y0VFRTYN8ZK79/C/Ow+aXNfw9Zpqe2ZyAnq1eZWWwznxdubDDz/E0qVLsW3bNpv+IpCYHCQSPDV+JJydHM3af+r4kXByVFi8LmuKDOuDiEcCzdr30X4h6Nc3wOI1tSWGeDuyatUqJCcnY8eOHYiPj7d1OSSozm4umJzQ8mspwwb3R1Bvn2Zt26NHD6hUKqO2W7duGdbZ2uQxw+Du2qlF+3i4u2JSfEyb1dRWGOLtxOLFi7FkyRLs2bOHAU6tNiCsDwaEBjV7++5eSjw+fHCzt4+NjcUPP/xg1LZ371707t27XZxBdnJ2wlPjRzZ7ewmAaRPEPAthiLcD8+fPx8qVK/Hll1+ib9++UKlUUKlUuHv3rq1LI4EljRkGd9eHXxyXOjhgWmIc5LLmXyJ77bXXcOrUKfztb3/D5cuX8fnnn2Pt2rV44403Wlm15YQE+CL60fBmbTtscAQC/Zp3FlJPrVYjPT0d6enpqKmpgUqlQnp6Oq5du2ZmxeaR6PV6vVWPSI1IJBKT7bNmzcJnn31m9XrIfmTl5mNjgwt5DT0+fDDioqNa3Pfu3buxaNEiXL58Gd7e3pg3bx5ef/31VlRreTW1Gqz9LBV3SpoeEHX3UmLurCda9EcMAH766SfExcU1ah8xYgR++ukns+o1B0NcMLk3i+Dr3RVyOW8soubZceAYfj6bYXJd757d8ZfpE+HgYL8n5TeLbmPdl/+CzkTUSR0c8MqsJ+DTzdMmtVmC/f7P2aF76gps/HoPVmz4X9wtU9u6HBLE2BF/QNcuHo3aFXIZpk2Is+sAB4BePbphVMyjJtclPDZI6AAHQ1wsaScvQKPRQunuBveHvBmDqJ5CLsMfE+Pg4GA8bZc4OgaeSneb1WVNcdFR6NWjq1Gbv683hg+JsFlNlsIQv49Wq8WXX36JMWPGoGvXrnB0dISfnx/Gjh2LTz75BNq6d3jZwj11BU6kXwIAxA8b2OQ8OpEpvj26YnTMQMNyaB8/DI7oa9OarEkqrb94KwUAKBRyTJ0w0i7OQsR/BRZSVlaGhIQEzJw5E/v374dCocCAAQOg0+mwb98+zJkzB/fu3bNZffWjcD+f7gj272mzOkhcI6Mj0atHN7g4O+HJscM73ECgaxcPjI8bCgCYOCoanh72cRbCC5t1pk6daniX5BdffGF01fnWrVvYuHEj5s2bZ9bzTNZ+vh331JVm16bX63GvvAKou/9VJpWa3Rd1bFqdDjqdrsV3YtgLvV6PmloNFHJZu/sj5ubqjP+c9WSL92OIAzh79iwGDRoEmUyG8+fPo1+/fhbtf+kHm1GmLrdon0RkX9xdXbDolRkt3q9j/jlu4LvvvgMATJgwweIBjrq/sObiKJyoYzA3JxjiAC5d+v2CYXR0dJv0b84pUr1dPx7H0TMX4efTHS89M6ndnQISkW0xxOsuagJA586d26R/c+fE7x+FF5fexbIPv2qD6oioPTB3TpwhDsDd/fer1G31rJJ76spWz4lXVFZZrB4ish8McQDh4eHYvn07jh8/3ib9mzPXxblwoo7F3Dlx3p0C4Pz583j00Uchl8uRnp6OsLAwW5fEuXAiaha+2QdAVFQUpk2bhtraWowbNw5paWlG62/duoVly5ahvNw6twny3ZlE1FwcidcpKytDUlKS4RGSPXv2hI+PD4qKilBQUAC9Xo/S0lJ4eDR+kJClcRRORM3FkXgdd3d3HDhwABs3bsTIkSNRUVGBCxcuwMHBAY8//jg2btwINzc3q9Ti6uIMJ0cFR+FE9FAcibdTVdU1cFTIGeJE9EAMcSIigXE6hYhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiAT2/wDLQqXVZ9+F9gAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 454.517x284.278 with 1 Axes>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create an operator\n",
+    "XX = Operator(Pauli(\"XX\"))\n",
+    "\n",
+    "# Add to a circuit\n",
+    "circ = QuantumCircuit(2, 2)\n",
+    "circ.append(XX, [0, 1])\n",
+    "circ.measure([0, 1], [0, 1])\n",
+    "circ.draw(\"mpl\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in the above example we initialize the operator from a `Pauli` object. However, the `Pauli` object may also be directly inserted into the circuit itself and will be converted into a sequence of single-qubit Pauli gates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'11': 1024}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
+    "\n",
+    "backend = Aer.get_backend(\"qasm_simulator\")\n",
+    "circ = generate_preset_pass_manager(optimization_level=1, backend=backend).run(circ)\n",
+    "job = backend.run(circ)\n",
+    "job.result().get_counts(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌────────────┐┌─┐   \n",
+       "q_0: ┤0           ├┤M├───\n",
+       "     │  Pauli(XX) │└╥┘┌─┐\n",
+       "q_1: ┤1           ├─╫─┤M├\n",
+       "     └────────────┘ ║ └╥┘\n",
+       "c: 2/═══════════════╩══╩═\n",
+       "                    0  1 </pre>"
+      ],
+      "text/plain": [
+       "     ┌────────────┐┌─┐   \n",
+       "q_0: ┤0           ├┤M├───\n",
+       "     │  Pauli(XX) │└╥┘┌─┐\n",
+       "q_1: ┤1           ├─╫─┤M├\n",
+       "     └────────────┘ ║ └╥┘\n",
+       "c: 2/═══════════════╩══╩═\n",
+       "                    0  1 "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Add to a circuit\n",
+    "circ2 = QuantumCircuit(2, 2)\n",
+    "circ2.append(Pauli(\"XX\"), [0, 1])\n",
+    "circ2.measure([0, 1], [0, 1])\n",
+    "circ2.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combining Operators\n",
+    "\n",
+    "Operators may be combined using several methods.\n",
+    "\n",
+    "### Tensor Product\n",
+    "\n",
+    "Two operators $A$ and $B$ may be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both $A$ and $B$ are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix $B$  on subsystem 0, and matrix $A$ on subsystem 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],\n",
+      "          [ 0.+0.j, -0.+0.j,  0.+0.j, -1.+0.j],\n",
+      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],\n",
+      "          [ 0.+0.j, -1.+0.j,  0.+0.j, -0.+0.j]],\n",
+      "         input_dims=(2, 2), output_dims=(2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
+    "A.tensor(B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tensor Expansion\n",
+    "\n",
+    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ we have `A.expand(B)` = $B\\otimes A$ where the subsystems indexed as matrix $A$ on subsystem 0, and matrix $B$ on subsystem 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j],\n",
+      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j, -0.+0.j, -1.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j, -1.+0.j, -0.+0.j]],\n",
+      "         input_dims=(2, 2), output_dims=(2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
+    "A.expand(B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Composition\n",
+    "\n",
+    "We can also compose two operators $A$ and $B$ to implement matrix multiplication using the `Operator.compose` method. We have that `A.compose(B)` returns the operator with matrix $B.A$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.+0.j,  1.+0.j],\n",
+      "          [-1.+0.j,  0.+0.j]],\n",
+      "         input_dims=(2,), output_dims=(2,))\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
+    "A.compose(B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also compose in the reverse order by applying $B$ in front of $A$ using the `front` kwarg of `compose`:  `A.compose(B, front=True)` = $A.B$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.+0.j, -1.+0.j],\n",
+      "          [ 1.+0.j,  0.+0.j]],\n",
+      "         input_dims=(2,), output_dims=(2,))\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
+    "A.compose(B, front=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsystem Composition\n",
+    "\n",
+    "Note that the previous compose requires that the total output dimension of the first operator $A$ is equal to total input dimension of the composed operator $B$ (and similarly, the output dimension of $B$ must be equal to the input dimension of $A$ when composing with `front=True`).\n",
+    "\n",
+    "We can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of* `compose` *method.*\n",
+    "\n",
+    "For example, to compose a two-qubit gate with a three-qubit Operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j,  0.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  1.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
+      "           -1.+0.j],\n",
+      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
+      "            0.+0.j],\n",
+      "          [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
+      "            0.+0.j]],\n",
+      "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compose XZ with a 3-qubit identity operator\n",
+    "op = Operator(np.eye(2**3))\n",
+    "XZ = Operator(Pauli(\"XZ\"))\n",
+    "op.compose(XZ, qargs=[0, 2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
+      "          [0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],\n",
+      "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compose YX in front of the previous operator\n",
+    "op = Operator(np.eye(2**3))\n",
+    "YX = Operator(Pauli(\"YX\"))\n",
+    "op.compose(YX, qargs=[0, 2], front=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linear combinations\n",
+    "\n",
+    "Operators may also be combined using standard linear operators for addition, subtraction and scalar multiplication by complex numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[-1.5+0.j,  0. +0.j,  0. +0.j,  0. +0.j],\n",
+      "          [ 0. +0.j,  1.5+0.j,  1. +0.j,  0. +0.j],\n",
+      "          [ 0. +0.j,  1. +0.j,  1.5+0.j,  0. +0.j],\n",
+      "          [ 0. +0.j,  0. +0.j,  0. +0.j, -1.5+0.j]],\n",
+      "         input_dims=(2, 2), output_dims=(2, 2))\n"
+     ]
+    }
+   ],
+   "source": [
+    "XX = Operator(Pauli(\"XX\"))\n",
+    "YY = Operator(Pauli(\"YY\"))\n",
+    "ZZ = Operator(Pauli(\"ZZ\"))\n",
+    "\n",
+    "op = 0.5 * (XX + YY - 3 * ZZ)\n",
+    "op"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An important point is that while `tensor`, `expand` and `compose` will preserve the unitarity of unitary operators, linear combinations will not; hence, adding two unitary operators will, in general, result in a non-unitary operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op.is_unitary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Implicit Conversion to Operators\n",
+    "\n",
+    "Note that for all the following methods, if the second object is not already an `Operator` object, it will be implicitly converted into one by the method. This means that matrices can be passed in directly without being explicitly converted to an `Operator` first. If the conversion is not possible, an exception will be raised."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator([[0.+0.j, 1.+0.j],\n",
+      "          [1.+0.j, 0.+0.j]],\n",
+      "         input_dims=(2,), output_dims=(2,))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compose with a matrix passed as a list\n",
+    "Operator(np.eye(2)).compose([[0, 1], [1, 0]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison of Operators\n",
+    "\n",
+    "Operators implement an equality method that can be used to check if two operators are approximately equal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Operator(Pauli(\"X\")) == Operator(XGate())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this checks that each matrix element of the operators is approximately equal; two unitaries that differ by a global phase will not be considered equal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Operator(XGate()) == np.exp(1j * 0.5) * Operator(XGate())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Process Fidelity\n",
+    "\n",
+    "We may also compare operators using the `process_fidelity` function from the *Quantum Information* module. This is an information theoretic quantity for how close two quantum channels are to each other, and in the case of unitary operators it does not depend on global phase."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Process fidelity = 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Two operators which differ only by phase\n",
+    "op_a = Operator(XGate())\n",
+    "op_b = np.exp(1j * 0.5) * Operator(XGate())\n",
+    "\n",
+    "# Compute process fidelity\n",
+    "F = process_fidelity(op_a, op_b)\n",
+    "print(\"Process fidelity =\", F)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that process fidelity is generally only a valid measure of closeness if the input operators are unitary (or CP in the case of quantum channels), and an exception will be raised if the inputs are not CP."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "<Admonition type=\"tip\" title=\"Recommendations\">\n",
+    "  - Explore the [Operator API](/api/qiskit/qiskit.quantum_info.Operator#operator) reference.\n",
+    "</Admonition>"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "celltoolbar": "Tags",
+  "description": "In-depth explanation of using the Operator class in Qiskit.",
+  "kernelspec": {
+   "display_name": "documentation",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "title": "The Operator class",
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/build/operator-class.ipynb
+++ b/docs/build/operator-class.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "b88d9242-a6f2-47b6-8e0a-daf60d0c4374",
    "metadata": {},
    "source": [
     "# The Operator class\n",
@@ -12,6 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "549bc166-9c0e-4e89-b7e2-8adafd7110c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,9 +26,9 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8292bbef-0a61-44db-a096-cee8c9b23827",
    "metadata": {},
    "source": [
-    "\n",
     "## Converting classes to Operators\n",
     "\n",
     "Several other classes in Qiskit can be directly converted to an `Operator` object using the operator initialization method. For example:\n",
@@ -41,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "cb6e9d7a-8dc9-4b32-81f0-278d2e7e64b5",
    "metadata": {},
    "outputs": [
     {
@@ -65,6 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "ffdda3ff-75ca-486c-8e52-be80244b969f",
    "metadata": {},
    "outputs": [
     {
@@ -87,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "b8cbc1d9-4957-4b2d-b59c-32c1efbfbeed",
    "metadata": {},
    "outputs": [
     {
@@ -107,6 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "e60c3079-84bf-40cd-ace7-bae419118c99",
    "metadata": {},
    "outputs": [
     {
@@ -143,6 +149,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "693e4885-bd79-4a2f-8e2b-8e4d81892c05",
    "metadata": {},
    "source": [
     "## Using Operators in circuits\n",
@@ -155,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "223c07c9-1b1d-4a33-a397-091cac2ec9e3",
    "metadata": {},
    "outputs": [
     {
@@ -182,6 +190,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "04a90485-7b03-4ae3-a37d-0ae87feee6a4",
    "metadata": {},
    "source": [
     "Note that in the above example we initialize the operator from a `Pauli` object. However, the `Pauli` object may also be directly inserted into the circuit itself and will be converted into a sequence of single-qubit Pauli gates:"
@@ -190,6 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "f486bc1e-62a7-4338-924a-5511ad7ca3eb",
    "metadata": {},
    "outputs": [
     {
@@ -215,6 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "85f37f4a-078e-401f-b222-ec230da6ae78",
    "metadata": {},
    "outputs": [
     {
@@ -253,6 +264,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59bf4972-731f-40c4-9d26-ca0110827cdc",
    "metadata": {},
    "source": [
     "## Combining Operators\n",
@@ -267,6 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "0fcf1f68-8af1-417f-b6c3-313846ec5b0d",
    "metadata": {},
    "outputs": [
     {
@@ -289,6 +302,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bca7c8a7-5f19-405c-9f27-3e75db53cb5e",
    "metadata": {},
    "source": [
     "### Tensor Expansion\n",
@@ -299,6 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "a38a8588-f0a5-4533-95dc-23ff383501d6",
    "metadata": {},
    "outputs": [
     {
@@ -321,6 +336,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6a33cf17-68f8-442d-b4e0-6b899d1d280a",
    "metadata": {},
    "source": [
     "### Composition\n",
@@ -331,6 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "a45e1ef6-09b4-4d70-a9e2-0eb5f1b59a83",
    "metadata": {},
    "outputs": [
     {
@@ -351,6 +368,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f54c6b4e-e8ac-4ae7-ac02-60300a46c88c",
    "metadata": {},
    "source": [
     "We can also compose in the reverse order by applying $B$ in front of $A$ using the `front` kwarg of `compose`:  `A.compose(B, front=True)` = $A.B$:"
@@ -359,6 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "30b6a60d-11fd-4b19-a673-790aab891554",
    "metadata": {},
    "outputs": [
     {
@@ -379,6 +398,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f08c91f5-88f0-408f-ae9e-03cec65de305",
    "metadata": {},
    "source": [
     "### Subsystem Composition\n",
@@ -393,6 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "e604f408-3ec3-49fa-830a-eaf960fdd40d",
    "metadata": {},
    "outputs": [
     {
@@ -429,6 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "d2024a14-891b-46e4-93e7-4dc73e33e928",
    "metadata": {},
    "outputs": [
     {
@@ -456,6 +478,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e362de3-866d-42b3-8d3c-a3905d9d4005",
    "metadata": {},
    "source": [
     "### Linear combinations\n",
@@ -466,6 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "79b9ccd5-a002-4499-9439-7c553177abb8",
    "metadata": {},
    "outputs": [
     {
@@ -491,6 +515,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "235d9549-a7f6-4c8c-8592-de57e5e45fc6",
    "metadata": {},
    "source": [
     "An important point is that while `tensor`, `expand` and `compose` will preserve the unitarity of unitary operators, linear combinations will not; hence, adding two unitary operators will, in general, result in a non-unitary operator:"
@@ -499,6 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "97615df2-f6dc-4367-8463-f5c0c1ef94eb",
    "metadata": {},
    "outputs": [
     {
@@ -518,6 +544,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1a2bf1cd-6f0f-446f-a993-ae9c2d22984e",
    "metadata": {},
    "source": [
     "### Implicit Conversion to Operators\n",
@@ -528,6 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "9d72e40f-8d72-4cd7-8350-1896e88528c0",
    "metadata": {},
    "outputs": [
     {
@@ -547,6 +575,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0ee93f02-c3ea-44b0-8b87-f79e3107749e",
    "metadata": {},
    "source": [
     "## Comparison of Operators\n",
@@ -557,6 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "ce9983d1-e20a-432d-af22-d6a1011f412c",
    "metadata": {},
    "outputs": [
     {
@@ -576,6 +606,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "36bbbbf9-3ed7-4aab-bc9e-f542325372f1",
    "metadata": {},
    "source": [
     "Note that this checks that each matrix element of the operators is approximately equal; two unitaries that differ by a global phase will not be considered equal:"
@@ -584,6 +615,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "a42ba8a1-5ab5-44d0-bd54-4147f4f28e53",
    "metadata": {},
    "outputs": [
     {
@@ -603,6 +635,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c06612c0-be6e-41b5-9ba5-92a9d7755c2f",
    "metadata": {},
    "source": [
     "### Process Fidelity\n",
@@ -613,6 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "id": "813d97d1-94d3-4c65-aca0-324b09cebc6a",
    "metadata": {},
    "outputs": [
     {
@@ -635,6 +669,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "993bab6d-7f37-4363-a17e-8b8e3b7de30a",
    "metadata": {},
    "source": [
     "Note that process fidelity is generally only a valid measure of closeness if the input operators are unitary (or CP in the case of quantum channels), and an exception will be raised if the inputs are not CP."
@@ -642,6 +677,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "52ef24af-888c-4c76-ab6f-4e1e8323cf2a",
    "metadata": {},
    "source": [
     "## Next steps\n",
@@ -657,7 +693,7 @@
   "celltoolbar": "Tags",
   "description": "In-depth explanation of using the Operator class in Qiskit.",
   "kernelspec": {
-   "display_name": "documentation",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -671,7 +707,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3"
   },
   "title": "The Operator class",
   "varInspector": {

--- a/docs/build/operator-class.ipynb
+++ b/docs/build/operator-class.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# The Operator class\n",
     "\n",
-    "This page shows how to use the [`Operator`](/api/qiskit/qiskit.quantum_info.Operator) class. For a high-level overview of the class, see [Overview of operator classes](/build/operators-overview#operator)."
+    "This page shows how to use the [`Operator`](/api/qiskit/qiskit.quantum_info.Operator) class. For a high-level overview of operator representations in Qiskit, including the `Operator` class and others, see [Overview of operator classes](/build/operators-overview)."
    ]
   },
   {

--- a/docs/build/operator-class.ipynb
+++ b/docs/build/operator-class.ipynb
@@ -20,8 +20,7 @@
     "import numpy as np\n",
     "from qiskit.circuit import QuantumCircuit\n",
     "from qiskit.circuit.library import CXGate, RXGate, XGate\n",
-    "from qiskit.quantum_info import Operator, Pauli, process_fidelity\n",
-    "from qiskit_aer import Aer"
+    "from qiskit.quantum_info import Operator, Pauli, process_fidelity"
    ]
   },
   {
@@ -199,32 +198,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f486bc1e-62a7-4338-924a-5511ad7ca3eb",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'11': 1024}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
-    "\n",
-    "backend = Aer.get_backend(\"qasm_simulator\")\n",
-    "circ = generate_preset_pass_manager(optimization_level=1, backend=backend).run(circ)\n",
-    "job = backend.run(circ)\n",
-    "job.result().get_counts(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
    "id": "85f37f4a-078e-401f-b222-ec230da6ae78",
    "metadata": {},
    "outputs": [
@@ -249,7 +222,7 @@
        "                    0  1 "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "0fcf1f68-8af1-417f-b6c3-313846ec5b0d",
    "metadata": {},
    "outputs": [
@@ -312,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "a38a8588-f0a5-4533-95dc-23ff383501d6",
    "metadata": {},
    "outputs": [
@@ -346,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "a45e1ef6-09b4-4d70-a9e2-0eb5f1b59a83",
    "metadata": {},
    "outputs": [
@@ -376,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "30b6a60d-11fd-4b19-a673-790aab891554",
    "metadata": {},
    "outputs": [
@@ -412,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "e604f408-3ec3-49fa-830a-eaf960fdd40d",
    "metadata": {},
    "outputs": [
@@ -449,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "d2024a14-891b-46e4-93e7-4dc73e33e928",
    "metadata": {},
    "outputs": [
@@ -488,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "79b9ccd5-a002-4499-9439-7c553177abb8",
    "metadata": {},
    "outputs": [
@@ -523,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "97615df2-f6dc-4367-8463-f5c0c1ef94eb",
    "metadata": {},
    "outputs": [
@@ -533,7 +506,7 @@
        "False"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -554,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "9d72e40f-8d72-4cd7-8350-1896e88528c0",
    "metadata": {},
    "outputs": [
@@ -585,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "ce9983d1-e20a-432d-af22-d6a1011f412c",
    "metadata": {},
    "outputs": [
@@ -595,7 +568,7 @@
        "True"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -614,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "a42ba8a1-5ab5-44d0-bd54-4147f4f28e53",
    "metadata": {},
    "outputs": [
@@ -624,7 +597,7 @@
        "False"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -645,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "813d97d1-94d3-4c65-aca0-324b09cebc6a",
    "metadata": {},
    "outputs": [

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -13,16 +13,16 @@
    "id": "8a16a455-4530-4f2e-be6c-8c0da255b1c5",
    "metadata": {},
    "source": [
-    "The `Operator` class is used in the Qiskit SDK to represent matrix operators acting on a quantum system. It has several methods to build composite operators using tensor products of smaller operators, and to compose operators.\n",
+    "The `Operator`, `Pauli`, and `SparsePauliOp` classes are used in the Qiskit SDK to represent matrix operators acting on a quantum system. They have several methods to build composite operators using tensor products of smaller operators, and to compose operators.\n",
     "\n",
-    "### Creating Operators\n",
+    "## Creating Operators\n",
     "\n",
-    "The easiest way to create an operator object is to initialize it with a matrix given as a list or a Numpy array. For example, to create a two-qubit Pauli-XX operator:"
+    "The easiest way to create an `Operator` object is to initialize it with a matrix given as a list or a Numpy array. For example, to create a two-qubit Pauli-XX operator:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 33,
    "id": "fc51e532-a85f-40bc-b333-e622f39bc6b3",
    "metadata": {
     "ExecuteTime": {
@@ -36,7 +36,7 @@
     "from qiskit_aer import Aer\n",
     "\n",
     "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
-    "from qiskit.quantum_info.operators import Operator, Pauli\n",
+    "from qiskit.quantum_info.operators import Operator, Pauli, SparsePauliOp\n",
     "from qiskit.quantum_info import process_fidelity\n",
     "\n",
     "from qiskit.circuit.library import RXGate, XGate, CXGate"
@@ -75,8 +75,6 @@
    "id": "6dbe8dec-e9a0-46aa-91a6-86e24a9ab945",
    "metadata": {},
    "source": [
-    "### Operator Properties\n",
-    "\n",
     "The operator object stores the underlying matrix, and the input and output dimension of subsystems.\n",
     "\n",
     "* `data`: To access the underlying Numpy array, we may use the `Operator.data` property.\n",
@@ -144,8 +142,6 @@
    "id": "b77139bc-a4f2-4894-86c4-6c71bc13bcce",
    "metadata": {},
    "source": [
-    "### Input and Output Dimensions\n",
-    "\n",
     "The operator class also keeps track of subsystem dimensions, which can be used for composing operators together. These can be accessed using the `input_dims` and `output_dims` functions.\n",
     "\n",
     "For $2^N$ by $2^M$ operators, the input and output dimension will be automatically assumed to be M-qubit and N-qubit:"
@@ -309,6 +305,125 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Paulis\n",
+    "\n",
+    "Instead of storing the full unitary matrix in an `Operator`, the `Pauli` class stores an abstract representation of an $N$-qubit Pauli operator. These objects are typically instantiated using a string of consisting of the characters: `['I', 'X', 'Y', 'Z']` and optionally a phase coefficient from the list: `['', '-i', '-', 'i']`.\n",
+    "\n",
+    "For example, we can generate the operator $X\\otimes X$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XX is of type <class 'qiskit.quantum_info.operators.symplectic.pauli.Pauli'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "op = Pauli('XX')\n",
+    "print(f'{op} is of type {type(op)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and examine some of its attributes as well as obtain its matrix representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimension of XX: (4, 4)\n",
+      "Phase of XX: 0\n",
+      "Matrix representation of XX: \n",
+      " [[0.+0.j 0.+0.j 0.+0.j 1.+0.j]\n",
+      " [0.+0.j 0.+0.j 1.+0.j 0.+0.j]\n",
+      " [0.+0.j 1.+0.j 0.+0.j 0.+0.j]\n",
+      " [1.+0.j 0.+0.j 0.+0.j 0.+0.j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Dimension of {op}: {op.dim}')\n",
+    "print(f'Phase of {op}: {op.phase}')\n",
+    "print(f'Matrix representation of {op}: \\n {op.to_matrix()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, if it (anti)commutes with another `Pauli`, and compute the dot product with another `Pauli`. Refer to the [api documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating SparsePauliOps\n",
+    "\n",
+    "The `SparsePauliOp` object is used as an abstract representation of a linear combination of $N$-qubit Pauli operators and can be instantiated using a string of characters in the same way as a `Pauli`. A linear combination of Pauli operators can also be created using the [`from_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_sparse_list) or [`from_sparse_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_list) methods shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operator created from sparse list:\n",
+      " SparsePauliOp(['XIIZI', 'IYIIY'],\n",
+      "              coeffs=[1.+0.j, 2.+0.j]) \n",
+      "\n",
+      "Operator created from list:\n",
+      " SparsePauliOp(['XIIZI', 'IYIIY'],\n",
+      "              coeffs=[1.+0.j, 2.+0.j]) \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# via tuples and local Paulis with indices\n",
+    "op = SparsePauliOp.from_sparse_list([(\"ZX\", [1, 4], 1), (\"YY\", [0, 3], 2)], num_qubits=5)\n",
+    "print(f'Operator created from sparse list:\\n {op} \\n')\n",
+    "\n",
+    "# equals the following construction from \"dense\" Paulis\n",
+    "op = SparsePauliOp.from_list([(\"XIIZI\", 1), (\"IYIIY\", 2)])\n",
+    "print(f'Operator created from list:\\n {op} \\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SparsePauliOp` objects are also overloaded with typical arithmetic operations. This allows one to add, subtract, compose, or compute dot products on two `SparsePauliOps`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "83647e0f-6edf-4a13-9540-78acb578d17c",
    "metadata": {},
    "source": [
@@ -325,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c84c7f7d-292a-4507-a3de-b1b4156d8ee9",
    "metadata": {
     "ExecuteTime": {
@@ -355,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "08265ba9-db26-4573-9a36-2687f6d58f2c",
    "metadata": {
     "ExecuteTime": {
@@ -383,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "7b51c2df-14b2-430e-8319-5162420ebc4c",
    "metadata": {
     "ExecuteTime": {
@@ -409,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "4d090045-7eef-4709-8ad3-272001de56f7",
    "metadata": {
     "ExecuteTime": {
@@ -464,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "ab1bebc7-5af1-4bae-bac5-a12558b8bd6f",
    "metadata": {
     "ExecuteTime": {
@@ -478,14 +593,12 @@
    "outputs": [
     {
      "data": {
-      "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"266.38pt\" height=\"172pt\" version=\"1.1\" viewBox=\"0 0 266.38 172\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 172h266.38v-172h-266.38z\" fill=\"#ffffff\"/><path d=\"m64.497 44.283h190.05\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 90.637h190.05\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m73.768 141.63 4.6354-9.2708\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.497 135.48h190.05\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 138.5h190.05\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m176.21 126.45h12.052l-6.026 8.6914z\" clip-path=\"url(#c720cd26066)\" fill=\"#778899\"/><path d=\"m222.56 126.45h12.052l-6.026 8.6914z\" clip-path=\"url(#c720cd26066)\" fill=\"#778899\"/><path d=\"m59.862 21.106h-1158.8v185.42h1158.8z\" clip-path=\"url(#c720cd26066)\" fill=\"#ffffff\" stroke=\"#ffffff\" stroke-width=\"1.5\"/><path d=\"m183.74 44.283v82.162\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m180.73 44.283v82.162\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m230.1 90.637v35.808\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m227.08 90.637v35.808\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m82.344 105.7h60.724v-76.484h-60.724z\" clip-path=\"url(#c720cd26066)\" fill=\"#9f1853\" stroke=\"#9f1853\" stroke-width=\"1.5\"/><path d=\"m167.17 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#c720cd26066)\" fill=\"#a8a8a8\" stroke=\"#a8a8a8\" stroke-width=\"1.5\"/><path d=\"m192.78 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-width=\"2\"/><path d=\"m182.24 48.803 10.546-10.546\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m213.53 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#c720cd26066)\" fill=\"#a8a8a8\" stroke=\"#a8a8a8\" stroke-width=\"1.5\"/><path d=\"m239.14 95.157c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-width=\"2\"/><path d=\"m228.59 95.157 10.546-10.546\" clip-path=\"url(#c720cd26066)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(37.189 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(37.189 95.088) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(69.133 130.19) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(46.291 141.48) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(85.588 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><use xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(85.588 94.224) scale(.13 -.13)\" fill=\"#ffffff\"><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(94.071 71.047) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-55\" transform=\"scale(.015625)\" d=\"m556 4666h635v-2835q0-750 271-1080 272-329 882-329 606 0 878 329 272 330 272 1080v2835h634v-2913q0-912-452-1378-451-466-1332-466-885 0-1337 466-451 466-451 1378v2913z\"/><path id=\"DejaVuSans-6e\" transform=\"scale(.015625)\" d=\"m3513 2113v-2113h-575v2094q0 497-194 743-194 247-581 247-466 0-735-297-269-296-269-809v-1978h-578v3500h578v-544q207 316 486 472 280 156 646 156 603 0 912-373 310-373 310-1098z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-79\" transform=\"scale(.015625)\" d=\"m2059-325q-243-625-475-815-231-191-618-191h-460v481h338q237 0 368 113 132 112 291 531l103 262-1415 3444h609l1094-2737 1094 2737h609l-1538-3825z\"/></defs><use xlink:href=\"#DejaVuSans-55\"/><use x=\"73.193359\" xlink:href=\"#DejaVuSans-6e\"/><use x=\"136.572266\" xlink:href=\"#DejaVuSans-69\"/><use x=\"164.355469\" xlink:href=\"#DejaVuSans-74\"/><use x=\"203.564453\" xlink:href=\"#DejaVuSans-61\"/><use x=\"264.84375\" xlink:href=\"#DejaVuSans-72\"/><use x=\"305.957031\" xlink:href=\"#DejaVuSans-79\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(193.82 130.19) scale(.104 -.104)\"><use xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#c720cd26066)\"><g transform=\"translate(240.18 130.19) scale(.104 -.104)\"><use xlink:href=\"#DejaVuSans-31\"/></g></g><defs><clipPath id=\"c720cd26066\"><rect x=\"7.2\" y=\"7.2\" width=\"251.98\" height=\"157.6\"/></clipPath></defs></svg>"
-      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAgI0lEQVR4nO3deVxU9f4/8NcwCyCLjKAiIrIIBihCLlfAVBTMBcUyvTct7ZvXbovftLxgD29fy+/v/jSX7F6tTMu+LZpfS6zrlqlpuOSueA1RERBlGZUgcdhn+f0RzM+BQWEYZvgMr+c/cD7nnM95j8KLz/mcM2cker1eDyIiEpKDrQsgIiLzMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKByWxdALWOXq+HprLa1mXYLZmzIyQSidWPq9frodVqrX7c1pBKpTb5t+roGOKC01RWY3PQM7Yuw27NyN4EeScnqx9Xq9UiNTXV6sdtjSlTpkAmY6RYG6dTiIgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yogygrK8OtW7egUqlQWloKvV7fov337duH4uLiNquPzMMHHRDZqeLiYhw5cgRZWVnIzc1FaWmp0fpOnTohICAAgYGBiI2Nhb+/f5N9ffvtt9i6dSt27dqFxYsXw8vLywqvgJqDIU5kZzIzM7Fnzx6cOXPmgaPtiooKZGRkICMjAzt37kRwcDDGjRuH6Ohoo6cR1gc4ANy+fRvp6emIj4+3ymuhh7P76ZTi4mKkpKSgT58+cHJyQq9evTBv3jyUl5dj9uzZkEgkeP/9921dJlGrVVZW4pNPPsGSJUtw+vRpowB3cXFBeHg4YmJiEBsbi6ioKHTp0sVo/6ysLKxZswZLly7FnTt3gAYBDgDTp09ngLczdj0ST09Px7hx46BSqeDi4oKwsDAUFhZizZo1yM7ORklJCQAgMjLS1qW2LYkEYXMmoO+zCXD17YqqX8uQu/NnpK/YymeR24mcnBysXr3aaM5aqVRi9OjRiI2Nhbe3t8lnfZeWluLMmTPYv38/bty4AQC4ePEikpOTERUVhePHjxu2nT59OiZNmmSlV0TNZbchXlxcjIkTJ0KlUmHBggV466234ObmBgBYsWIFFi5cCJlMBolEgoiICFuX26aG/PdzCPvzBOTtOYlfPtoJj+CeCJs9Hp79AvDDtP8GWniBi9qXK1eu4J133kFlZSUAwNHREdOnT8fo0aMf+nxvpVKJhIQExMfHIz09HR9//DFKSkpQVVXFABeE3U6nvPrqq8jPz8fcuXOxatUqQ4ADQEpKCgYMGACNRgN/f3+4u7vbtNa25BHii9Dnx+H67hM4NHslsjYfwOm3P8eptz9Hj2H9ETA51tYlUivk5eUZBXhwcDBWrlyJxx9/vEUf0CCRSBAVFYVVq1ahd+/eRutiY2MZ4O2YXYZ4ZmYmtm7dCi8vLyxbtszkNgMHDgQADBgwwKg9NzcXkyZNgpubG5RKJWbOnIlff/3VKnW3hYAnhkHi4IBLH+82as/afAC1FVUImjLcZrVR69TW1mLt2rWGAI+IiMCbb76Jbt26md3nDz/8gLy8PKO2c+fO8dbCdswuQ3zLli3Q6XSYMWMGXF1dTW7j7OwMNAjxe/fuIS4uDvn5+diyZQs2bNiAI0eOIDExETqdzmr1W5JXZB/otFoUn88yatdW16Lkl+vwigyyWW3UOqmpqcjPzwcA+Pv74/XXX4ejo6PZ/TW8iFl/y2FlZSXWr1/f4vvKyTrsMsQPHjwIAIiLi2tym/of/vtDfMOGDSgoKMB3332HxMRETJ06FV999RVOnDiBHTt2WKFyy+vUXYnqknvQ1WgaratQlcDJszMc5HZ7acRuFRUVGX4mpVIpXn75ZTg5mf9ZoKbuQlm8eLHhDpaLFy/ixIkTFqicLM0uf3vrTwcbzu3V02g0OHbsGNAgxHft2oVhw4bBz8/P0BYdHY3AwEDs3LkTkydPNqueQYMGQaVSmbXvw8j1DngLQ5pcL3V2hLam1uQ6bfXv7TJnBWpqG4c8ASHBIaiVWP8sTKFQNDkVCAD79+83nB1OnjzZ6Ge2pUwFeP0c+J///GesWLECALB3715ER0c32U9ISAhqamrMrqOj8/b2xpkzZ1q8n12GeHl5OVB3GmjK1q1bUVxcDDc3NwQEBBjaL126hKlTpzbaPjw8HJcuXTK7HpVKhYKCArP3fxCFRAp0b3q9trIacpfOJtdJHeUAAE0lf/GaUlhUiBq91urHfdC0SHV1NdLS0gAAcrkcY8eONfs4DwpwAIiKioKvry/y8/Nx5coV5OXlNTk4KiwsRHU1b1m1NrsMcW9vb5SWluLcuXONRg5FRUVITk4G6i4E3X/vbGlpKTw8PBr116VLF1y5cqVV9bQVud4BeMBAseJWKTqH+MJBIWs0pdLJuwuqfr0LHUfhTfLp4WOzkXhTLly4YBioxMTEGN151RIPC3DU3bUyZswYfPrppwCAY8eONRniPj4+HIm3grk5YZchHh8fj8zMTCxfvhwJCQkICQkBAJw+fRrPPvus4Uq7td7kY84pUnPVVlRhc9AzTa4vTr+GniMj4RUVjNsnMw3tUkc5uvTzx60TmU3uS8DVrKuQdzJ/rtlcGo0GqampJtdlZ2cbvh80aJBZ/TcnwO8/Rn2I5+TkNNnn1atXW3RbI1mGXV7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CjAxO2FSqUSv/32W6P+SkpKGr1FWRS5//oZep0OYXMmGLUHz4iHvJMTcrYftlltZJ7c3FzD94GBgS3evyUBjrrfi/oz1NzcXN6l0s7YZYj7+vriyJEjmDBhApycnHD9+nV06dIF69evx+7du3H16lXARIiHhoaanPu+dOkSQkNDrVa/Jf12+QYu/89e+E8YiriNyQiePhqD3pqJIW/PgurnDORsP2rrEqmFCgsLAQCurq4tHly0NMBRN6VSP4VSXl6Ou3fvmlU3tQ27PfcJDQ3Frl27GrWr1Wpcv34dDg4O6Nevn9G6xMRELFq0CPn5+fD19QUAnDx5EtnZ2Vi5cqXVare0U4s/g/rmHYQ8Ew/f0Y+iqqQMmZ9+j/MrtvIt9wLq3LkzdDodPDw8TD4PpSk7duxocYDX8/T0hFKphEKhgFZr/Qu91DSJvoOdG508eRJDhw5F3759cfnyZaN1ZWVl6N+/P7y8vLBkyRJUVVUhJSUFXbt2xfHjx+Hg0P5OXB42J06tMyN7U7ubEzdXeno63n33XdTW1rbJs1CmTJnCOXEb6HD/4hcvXgRMTKUAgLu7Ow4ePIh58+bhT3/6E2QyGRITE/Hee++1ywAnaonIyEgsWLAA+fn5SExMtHU5ZCEM8QaCgoJMTsMQ2YPIyEj7f/RyB9PhhpcPC3EiIpF0uJF4/XNViIjsQYcbiRMR2ROGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQC63DPTiESgVQqxZQpUyzW38r1W3GvvBxuLi5I/ssfGy1bglQqtUg/1DIMcaJ2SCKRWPQDFvQAdPrfv8pkskbLJC5Op5BVDfvHK3iuaJutyyCyGwxxMtJn2kg8V7QNfaaNNLne1bcrnivahmH/eMVix/QbOxiRC6ZZrD+ijoQhTlZ17K8f4Uv/p43a/MYOQeRfGeJE5mCIk1XpNVpoq2utdjyJTAqpo9xqxyOyNl7RoFZx9e2Kp06vQ/qqr1F8IRuRC6ZC+Ygfqu+WIyf1MM4u3Qy9VmfYftg/XkGfP8bhsx5PAQDGpi6Bd0w4ABjNlR+d9z6uff0TOvfxQejs8egeHQ7Xnl6QSB3wW1Y+rny+D1lf/WhUS+SCaYj86zR8N2I+gqePhv/EGDh398CBGUsx/INXcTe7CN8nvdnoNYS/NAmDF8/E90/8F26dyGzDfy0iy2OIk0X0HB2Fvs89jitf7EPWloPwGzsY/V5OQvXdclxcs73J/S78MxVwkMB7aBgOz/2nof326SsAAO+Yfug+NAz5+89CffM2ZM6O8J8Yjdh3X4KTpzsurv22UZ/DP5gHTVUNMtbvBPR6qPPv4NrXaej30iS4B/mgLLvQaPvgp0fh7rUCBjgJiSFOFuHRtxf+NeI1qPPvAACufLEPSYdWI/T5cQ8M8aLD/0bQk48BQ8OQk3qk0frsb9Jw5Yt9Rm0ZG3Zh7La30X/uZPyybgf0Gq3R+pqyCvwwbYnRGcDVTfvR76VJCH56FM7+fZOhvdvgvvAI9sWZ//Nlq14/ka1wTpws4sbe04YAr6c69gs6dVdC1snJ7H41ldWG76WOcjgqXeGodEVB2gUo3F3QuU/PRvtc+niXUYADQFlOEVQ/Z6DP1BGQSP//j33w06Ohq9Xg2tc/mV0jkS1xJE5m0ev1RsvqvFuNtqkuVQMAHLu4QlNRZdZxZJ2cEPnXafCfFA3Xnl0brXf0cGnUdjenyGRfVzbtx4gP56NXwkDc2HsaMhcn+E+Kxs0DZ1FVfNes+ohsjSFORjRVNQAAqbOjyfWyTr+3a+u2q9dw5Hs/CSRm1zP8w3nolTAQVzcdgOrEJVSX3oNeq4Pv6EcR/peJkEgan0xqK6pN9pW3+wSqSsoQ/PRo3Nh7GgFJsZC7OCNr848mtycSAUOcjKhv3AYAeAQ3nqYAgM7BvgCAe3XbWULDUX09hXsn9EoYiOxth3F84QajdT6PRbT4OLoaDbK/SUPo7PFw7q5E8NOjUF74KwoOpZtdO5GtcU6cjPx6MQfqgjsImBwL5+5Ko3UOchlCnx8HvU6Hm/vOWOyYmvLfp1oUHq5G7br60b3EeCTv3M0DwTNGm3Wsq5sPwEEmxaA3n0G3QX1x7etD0OuaPosgau84Eicjeq0OJxZ+jLhPk5F08F1kfXUQ9/JUcOrqgYBJMVA+4ocL/0xtdJtea9w5l4XQ2UD0sjm4+eNZ6Gu1uHMuC+qbt1GYdgFBUx6DtqoaxenZcPXtipBnE6C+cRtOXdxbfKy7WQW4dTITQU+NgF6nQ9aWgxZ7HUS2wBCnRvJ/PIc9k95E/1cmo8+0EXBUukFTUY1ff8nFTy+8i+s7j1v0eDnfHkWXfgEISIpF74lD4SCV/v5mn5u3cXjuGgxcNAO9Egahz9SRKMstwrl3tkBfq8Gwf84163hXNu1H9z+EouhYhmH6iEhUEn1TE5IkhNqKKmwOesbWZQjFf2I0Rm5YgLSX3kPud8ceuO2M7E2Qt+IWyfZi6QebUaYuh7urCxa9MqPRMomLc+LU4TzyH2NR9etd5O05aetSiFqN0ynUITh5uqPHY/3R/Q+h8I4Ox9n/uwm6Go2tyyJqNYY4dQgeIb0wYt1rqP5Njcuf/4BfPtpp65LoIfR6PbRabTO2bB+kUikkEvPfE2Euhjh1CKrjGYYnJ5IYtFotUlNTbV1Gs02ZMsUmH3XHOXEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyJqBo1Gg9LSUluX0QifnUJEdqu6uho5OTnIyclBbm4uSktLodFoIJPJoFQqERgYiICAAAQFBUGhUDTZj0ajwXvvvYebN29i8eLF8PLysurreBCGOBHZncLCQuzfvx9paWmoqKhocrujR48CAFxcXDBy5EgkJCTA29vbaJv6AD979iwAYPny5Vi+fDkcHNrHREb7qKKNFRcXIyUlBX369IGTkxN69eqFefPmoby8HLNnz4ZEIsH7779v6zKJqJXUajU+/PBDvP766/j+++8fGOD3Ky8vx+7duzF//nysX7/esF/DAFcoFJg5c2a7CXB0hJF4eno6xo0bB5VKBRcXF4SFhaGwsBBr1qxBdnY2SkpKAACRkZG2LrXN9P/PJ+DZPxCeEYFw690d6pu3sW3Iy7Yui8iizp8/jw0bNhjNW8vlcgwdOhShoaEICAiAt7c35HI5amtrUVRUhJycHGRmZuLUqVOora0FABw6dAgXLlzAnDlzcODAAaMAT05ORv/+/W32Gk2x6xAvLi7GxIkToVKpsGDBArz11ltwc3MDAKxYsQILFy6ETCaDRCJBRESErcttMwMXzUBVyT2UXMyBwr2Trcshsrj9+/fj008/Rf1HBjs7O+PJJ59EXFwcXF1dG20vk8kQGBiIwMBAxMfHo6ysDIcOHcK3336LqqoqlJSUYPny5Ybt22uAw95D/NVXX0V+fj7mzp2LVatWGa1LSUnBV199hQsXLiAgIADu7u42q7OtbfvDy4ZPdU86tBpyF/E/+Jeo3o8//oiNGzcalgcMGIAXXngBnp6eze7D3d0dSUlJiImJwUcffYSMjAzDOplM1m4DHPY8J56ZmYmtW7fCy8sLy5YtM7nNwIEDgbr/9Hr1oT9kyBA4Ojra5OOWLK0+wInszZUrV/DJJ58YlidOnIg33nijRQF+P6VSCScn40GOVqtFp07t9wzWbkN8y5Yt0Ol0mDFjhsnTKdSdcqFBiF+7dg2pqanw9vbG4MGDrVYvEbVMdXU11q1bZ5hCmTBhAqZPn272wKvhRcz6i5d6vR7r1q0zzJm3N3Yb4gcPHgQAxMXFNblNfn4+0CDEhw8fjqKiIuzYsQPx8fFWqJSIzPHNN99ApVIBAIKDgzFjxgyLBbhCoUBKSgoCAgKAuqzYvn27Bau3HLudE8/LywMA9O7d2+R6jUaDY8eOAQ1CvC1uHRo0aJDhh83S5HoHvIUhbdI3ASHBIaiV6GxdRqs98R/z4eLqjiJVEXx9fRstt0cKhaLJqdDy8nLs27cPqLsD5cUXXzT7d9dUgNfPgSuVSixatAharRZ79+5FUlJSo+mWeiEhIaipqTGrBgDw9vbGmTNnWryf3YZ4eXk5AKCystLk+q1bt6K4uBhubm6Gv7ZtRaVSoaCgoE36VkikQPc26ZoAFBYVokavtXUZrabTag1fCwoKGi23R46Ojk2uS0tLMwRmXFwcevbsadYxHhTgqBsEDh8+HIcOHUJlZSWOHj3a5Bl6YWEhqqurzaqjNew2xL29vVFaWopz584hOjraaF1RURGSk5MBABEREW1+8bLhO8AsSa53AMQfKLZbPj187GIk7iCVGr727Nmz0XJ79KC3wddPlwLAmDFjzOr/YQF+f/+HDh0yHLepEPfx8Wn1SNwcdhvi8fHxyMzMxPLly5GQkICQkBAAwOnTp/Hss8+iuLgYsNKbfMw5RWqu2ooqbA56ps367+iuZl2FvJP4t2Qu/WAzytTl6OHdA/n5+Y2W2yONRoPU1NRG7Wq12lBzUFCQWdNBzQ1wAAgICICfnx9u3LiB3NxcVFVVmZxSuXr1KmQy60eq3V7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CigwXw4EbV/ubm5hu+Dg4NbvH9LArzhcfR6Pa5fv25W3W3Fbkfivr6+OHLkCJKTk5GWlobr168jLCwM69evx5w5cxAUFAR0kBAPfGo4XH27AgCcPN3hIJchYv4UAIA6/w5yth22cYVEzXd/iAYGBrZoX3MCHHWj8Xq5ubl45JFHWlx3W7HbEAeA0NBQ7Nq1q1G7Wq3G9evX4eDggH79+tmkNmsKeXo0vGPCjdoeXfg0AED1cwZDnISiVqsN37fkTT3mBnjD49TfNNFe2HWINyUjIwN6vR4hISEm34m1bds2AMClS5eMlv39/TFo0CArV9t6e6e8ZesSiCxm9OjRiIiIQE1NDfz8/Jq9X15eHv79738DZjwLJSgoCAsXLoRCoUC3bt3Mrr0tdMgQv3jxIvCAqZSpU6eaXJ41axY+++wzK1RIRE3p1q2bWUEaFBSEBQsWYO3atZg/f36LnoXi7u6OqKioFh/TGhjiJtS/jZeI7EtkZCTWrl3brp+F0lJ2e3fKgzwsxInIftlTgKOjjsTvf6MAEZHIOuRInIjIXjDEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhJYh3x2ij2ROTtiRvYmW5dht2TOTX/iOrUtqVSKKVOmWKSvleu34l55OdxcXJD8lz822dYa0roPn7Y2hrjgJBKJXXyQL1FDEonEYh88rAeg0//+tb5PU20i4nQKEZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiLcDK1euRHR0NJRKJTw8PDBs2DDs3bvX1mURPdCePXsQGRkJR0dH+Pv7Y/Xq1bYuyaoOHz6MpKQk9O7dGxKJBH//+99tUgdDvB04ePAgnn/+eRw6dAinTp1CTEwMEhMTcezYMVuXRmTSmTNnkJSUhHHjxiE9PR1vv/02Fi1ahI8++sjWpVmNWq1GWFgYVqxYAW9vb5vVIbPZkcng+++/N1pesWIF9u7di+3btyM2NtZmdRE1ZfXq1Rg8eDCWLVsGAAgNDUVGRgbeeecdvPjii7YuzyrGjx+P8ePHAwAWLlxoszoY4u2QTqdDWVkZXFxcbF0KCaa6phZ5BbcatWu0WsPXq7n5jZbv191Lic5uD/7ZO3bsGGbPnm3UNnbsWKxatQr5+fnw9fW1wKsxz42CW6iqqTVqM/V6m/o3cHZUoJdPN6vW3BoM8XZo6dKl+O233/DCCy/YuhQSjFwuw5FTF5B1vcDk+orKKnz69Z4mlz3cXTH/+aceepyioqJGUwj1y0VFRTYN8ZK79/C/Ow+aXNfw9Zpqe2ZyAnq1eZWWwznxdubDDz/E0qVLsW3bNpv+IpCYHCQSPDV+JJydHM3af+r4kXByVFi8LmuKDOuDiEcCzdr30X4h6Nc3wOI1tSWGeDuyatUqJCcnY8eOHYiPj7d1OSSozm4umJzQ8mspwwb3R1Bvn2Zt26NHD6hUKqO2W7duGdbZ2uQxw+Du2qlF+3i4u2JSfEyb1dRWGOLtxOLFi7FkyRLs2bOHAU6tNiCsDwaEBjV7++5eSjw+fHCzt4+NjcUPP/xg1LZ371707t27XZxBdnJ2wlPjRzZ7ewmAaRPEPAthiLcD8+fPx8qVK/Hll1+ib9++UKlUUKlUuHv3rq1LI4EljRkGd9eHXxyXOjhgWmIc5LLmXyJ77bXXcOrUKfztb3/D5cuX8fnnn2Pt2rV44403Wlm15YQE+CL60fBmbTtscAQC/Zp3FlJPrVYjPT0d6enpqKmpgUqlQnp6Oq5du2ZmxeaR6PV6vVWPSI1IJBKT7bNmzcJnn31m9XrIfmTl5mNjgwt5DT0+fDDioqNa3Pfu3buxaNEiXL58Gd7e3pg3bx5ef/31VlRreTW1Gqz9LBV3SpoeEHX3UmLurCda9EcMAH766SfExcU1ah8xYgR++ukns+o1B0NcMLk3i+Dr3RVyOW8soubZceAYfj6bYXJd757d8ZfpE+HgYL8n5TeLbmPdl/+CzkTUSR0c8MqsJ+DTzdMmtVmC/f7P2aF76gps/HoPVmz4X9wtU9u6HBLE2BF/QNcuHo3aFXIZpk2Is+sAB4BePbphVMyjJtclPDZI6AAHQ1wsaScvQKPRQunuBveHvBmDqJ5CLsMfE+Pg4GA8bZc4OgaeSneb1WVNcdFR6NWjq1Gbv683hg+JsFlNlsIQv49Wq8WXX36JMWPGoGvXrnB0dISfnx/Gjh2LTz75BNq6d3jZwj11BU6kXwIAxA8b2OQ8OpEpvj26YnTMQMNyaB8/DI7oa9OarEkqrb94KwUAKBRyTJ0w0i7OQsR/BRZSVlaGhIQEzJw5E/v374dCocCAAQOg0+mwb98+zJkzB/fu3bNZffWjcD+f7gj272mzOkhcI6Mj0atHN7g4O+HJscM73ECgaxcPjI8bCgCYOCoanh72cRbCC5t1pk6daniX5BdffGF01fnWrVvYuHEj5s2bZ9bzTNZ+vh331JVm16bX63GvvAKou/9VJpWa3Rd1bFqdDjqdrsV3YtgLvV6PmloNFHJZu/sj5ubqjP+c9WSL92OIAzh79iwGDRoEmUyG8+fPo1+/fhbtf+kHm1GmLrdon0RkX9xdXbDolRkt3q9j/jlu4LvvvgMATJgwweIBjrq/sObiKJyoYzA3JxjiAC5d+v2CYXR0dJv0b84pUr1dPx7H0TMX4efTHS89M6ndnQISkW0xxOsuagJA586d26R/c+fE7x+FF5fexbIPv2qD6oioPTB3TpwhDsDd/fer1G31rJJ76spWz4lXVFZZrB4ish8McQDh4eHYvn07jh8/3ib9mzPXxblwoo7F3Dlx3p0C4Pz583j00Uchl8uRnp6OsLAwW5fEuXAiaha+2QdAVFQUpk2bhtraWowbNw5paWlG62/duoVly5ahvNw6twny3ZlE1FwcidcpKytDUlKS4RGSPXv2hI+PD4qKilBQUAC9Xo/S0lJ4eDR+kJClcRRORM3FkXgdd3d3HDhwABs3bsTIkSNRUVGBCxcuwMHBAY8//jg2btwINzc3q9Ti6uIMJ0cFR+FE9FAcibdTVdU1cFTIGeJE9EAMcSIigXE6hYhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiAT2/wDLQqXVZ9+F9gAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 454.517x284.278 with 1 Axes>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,7 +624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "5fd28c29-3047-416d-bfad-af38f003433f",
    "metadata": {},
    "outputs": [
@@ -521,7 +634,7 @@
        "{'11': 1024}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -536,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "b697f771-d0e1-4b8f-b98c-82a19d8d3cfe",
    "metadata": {
     "ExecuteTime": {
@@ -566,7 +679,7 @@
        "                    0  1 "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -595,7 +708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "fc397a0b-52a9-41da-85c2-e465749be4a5",
    "metadata": {
     "ExecuteTime": {
@@ -634,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "64ca5769-56ad-49d5-a95a-eb0054739dab",
    "metadata": {
     "ExecuteTime": {
@@ -673,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "bcf18f94-fe96-44f0-b455-bb42e2962a1f",
    "metadata": {
     "ExecuteTime": {
@@ -687,7 +800,7 @@
      "output_type": "stream",
      "text": [
       "Operator([[ 0.+0.j,  1.+0.j],\n",
-      "          [-1.+0.j,  0.+0.j]],\n",
+      "          [-1.+0.j, -0.+0.j]],\n",
       "         input_dims=(2,), output_dims=(2,))\n"
      ]
     }
@@ -708,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "ccdf52a6-0cd9-4a50-af3d-0350e7db7425",
    "metadata": {
     "ExecuteTime": {
@@ -722,7 +835,7 @@
      "output_type": "stream",
      "text": [
       "Operator([[ 0.+0.j, -1.+0.j],\n",
-      "          [ 1.+0.j,  0.+0.j]],\n",
+      "          [ 1.+0.j, -0.+0.j]],\n",
       "         input_dims=(2,), output_dims=(2,))\n"
      ]
     }
@@ -749,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "1fa1ebb3-c56d-49cf-9f16-6baf1a81bc56",
    "metadata": {
     "ExecuteTime": {
@@ -791,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "1fef1d8c-b331-4d32-8bf3-6834da726cf4",
    "metadata": {
     "ExecuteTime": {
@@ -835,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "c32d348b-02d7-4c84-91e7-021e8fe5a54e",
    "metadata": {
     "ExecuteTime": {
@@ -875,7 +988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "e407a9bf-0429-4528-8ade-c37fac1371fc",
    "metadata": {
     "ExecuteTime": {
@@ -890,7 +1003,7 @@
        "False"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -911,7 +1024,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "db28f1c8-899c-48c2-8db3-02c7cd41a2c4",
    "metadata": {
     "ExecuteTime": {
@@ -947,7 +1060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "7da2a904-fa1d-4c06-9a6a-0e3c2595827c",
    "metadata": {
     "ExecuteTime": {
@@ -962,7 +1075,7 @@
        "True"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -981,7 +1094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "4161780a-64ab-4f86-9526-62303a681839",
    "metadata": {
     "ExecuteTime": {
@@ -996,7 +1109,7 @@
        "False"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1017,7 +1130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "b75e9c20-5596-4697-bb0d-25874cf6ffb0",
    "metadata": {
     "ExecuteTime": {
@@ -1085,7 +1198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3"
+   "version": "3.11.7"
   },
   "title": "Operators module overview",
   "varInspector": {

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -1,29 +1,19 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "77fe28b1-cfb3-4984-80f2-ab3a05d718c2",
    "metadata": {},
    "source": [
-    "# Operators module overview"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a16a455-4530-4f2e-be6c-8c0da255b1c5",
-   "metadata": {},
-   "source": [
-    "The `Operator`, `Pauli`, and `SparsePauliOp` classes are used in the Qiskit SDK to represent matrix operators acting on a quantum system. They have several methods to build composite operators using tensor products of smaller operators, and to compose operators.\n",
+    "# Overview of operator classes\n",
     "\n",
-    "## Creating Operators\n",
     "\n",
-    "The easiest way to create an `Operator` object is to initialize it with a matrix given as a list or a Numpy array. For example, to create a two-qubit Pauli-XX operator:"
+    "In Qiskit, quantum operators are represented using classes from the [`quantum_info`](/api/qiskit/quantum_info) module. The most important operator class is [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp), which represents a general quantum operator as a linear combination of Pauli strings. `SparsePauliOp` is the class most commonly used to represent quantum observables. The rest of this page explains how to use `SparsePauliOp` and other operator classes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "fc51e532-a85f-40bc-b333-e622f39bc6b3",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.554914Z",
@@ -33,17 +23,181 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit import QuantumCircuit\n",
-    "from qiskit.circuit.library import CXGate, RXGate, XGate\n",
-    "from qiskit.quantum_info import process_fidelity\n",
-    "from qiskit.quantum_info.operators import Operator, Pauli, SparsePauliOp\n",
-    "from qiskit_aer import Aer"
+    "from qiskit.quantum_info.operators import Operator, Pauli, SparsePauliOp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SparsePauliOp\n",
+    "\n",
+    "The [`SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp) class represents a linear combination of Pauli strings. There are several ways to initialize a `SparsePauliOp`, but the most flexible way is to use the [`from_sparse_list`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_sparse_list) method, as demonstrated in the following code cell. The `from_sparse_list` accepts a list of `(pauli_string, qubit_indices, coefficient)` triplets."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "250dfa1d-e3b5-4308-9ddb-488a2af828d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SparsePauliOp(['XIIZI', 'IYIIY'],\n",
+       "              coeffs=[ 1.+0.j, -1.+1.j])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op1 = SparsePauliOp.from_sparse_list(\n",
+    "    [(\"ZX\", [1, 4], 1.0), (\"YY\", [0, 3], -1 + 1j)], num_qubits=5\n",
+    ")\n",
+    "op1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SparsePauliOp` supports arithmetic operations, as demonstrated in the following code cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "op1 + op2:\n",
+      "SparsePauliOp(['XIIZI', 'IYIIY', 'ZIIXX', 'IIZZI'],\n",
+      "              coeffs=[ 1.+0.j, -1.+1.j,  1.+2.j, -1.+1.j])\n",
+      "\n",
+      "2 * op1:\n",
+      "SparsePauliOp(['XIIZI', 'IYIIY'],\n",
+      "              coeffs=[ 2.+0.j, -2.+2.j])\n",
+      "\n",
+      "op1 @ op2:\n",
+      "SparsePauliOp(['YIIYX', 'XIZII', 'ZYIXZ', 'IYZZY'],\n",
+      "              coeffs=[ 1.+2.j, -1.+1.j, -1.+3.j,  0.-2.j])\n",
+      "\n",
+      "op1.tensor(op2):\n",
+      "SparsePauliOp(['XIIZIZIIXX', 'XIIZIIIZZI', 'IYIIYZIIXX', 'IYIIYIIZZI'],\n",
+      "              coeffs=[ 1.+2.j, -1.+1.j, -3.-1.j,  0.-2.j])\n"
+     ]
+    }
+   ],
+   "source": [
+    "op2 = SparsePauliOp.from_sparse_list(\n",
+    "    [(\"XXZ\", [0, 1, 4], 1 + 2j), (\"ZZ\", [1, 2], -1 + 1j)], num_qubits=5\n",
+    ")\n",
+    "\n",
+    "# Addition\n",
+    "print(\"op1 + op2:\")\n",
+    "print(op1 + op2)\n",
+    "print()\n",
+    "# Multiplication by a scalar\n",
+    "print(\"2 * op1:\")\n",
+    "print(2 * op1)\n",
+    "print()\n",
+    "# Operator multiplication (composition)\n",
+    "print(\"op1 @ op2:\")\n",
+    "print(op1 @ op2)\n",
+    "print()\n",
+    "# Tensor product\n",
+    "print(\"op1.tensor(op2):\")\n",
+    "print(op1.tensor(op2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pauli\n",
+    "\n",
+    "The [`Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) class represents a single Pauli string with an optional phase coefficient from the set $\\set{+1, i, -1, -i}$. A `Pauli` can be initialized by passing a string of characters from the set `{\"I\", \"X\", \"Y\", \"Z\"}`, optionally prefixed by one of `{\"\", \"i\", \"-\", \"-i\"}` to represent the phase coefficient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Pauli('iXX')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op1 = Pauli(\"iXX\")\n",
+    "op1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code cell demonstrates the use of some attributes and methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimension of iXX: (4, 4)\n",
+      "Phase of iXX: 3\n",
+      "Matrix representation of iXX: \n",
+      " [[0.+0.j 0.+0.j 0.+0.j 0.+1.j]\n",
+      " [0.+0.j 0.+0.j 0.+1.j 0.+0.j]\n",
+      " [0.+0.j 0.+1.j 0.+0.j 0.+0.j]\n",
+      " [0.+1.j 0.+0.j 0.+0.j 0.+0.j]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Dimension of {op1}: {op1.dim}\")\n",
+    "print(f\"Phase of {op1}: {op1.phase}\")\n",
+    "print(f\"Matrix representation of {op1}: \\n {op1.to_matrix()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, if it (anti)commutes with another `Pauli`, and compute the dot product with another `Pauli`. Refer to the [api documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Operator\n",
+    "\n",
+    "The [`Operator`](/api/qiskit/qiskit.quantum_info.Operator) class represents a general linear operator. Unlike `SparsePauliOp`, `Operator` stores the linear operator as a dense matrix. Because the memory required to store a dense matrix scales exponentially with the number of qubits, the `Operator` class is only suitable for use with a small number of qubits.\n",
+    "\n",
+    "You can initialize an `Operator` by directly passing a Numpy array storing the matrix of the operator. For example, the following code cell creates a two-qubit Pauli XX operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.572857Z",
@@ -64,13 +218,21 @@
     }
    ],
    "source": [
-    "XX = Operator([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])\n",
+    "XX = Operator(\n",
+    "    np.array(\n",
+    "        [\n",
+    "            [0, 0, 0, 1],\n",
+    "            [0, 0, 1, 0],\n",
+    "            [0, 1, 0, 0],\n",
+    "            [1, 0, 0, 0],\n",
+    "        ]\n",
+    "    )\n",
+    ")\n",
     "XX"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6dbe8dec-e9a0-46aa-91a6-86e24a9ab945",
    "metadata": {},
    "source": [
     "The operator object stores the underlying matrix, and the input and output dimension of subsystems.\n",
@@ -81,8 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "548bb147-213e-43f1-b4a6-e1ae3c09f755",
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.589962Z",
@@ -99,7 +260,7 @@
        "       [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -110,8 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "d7e3b756-6a77-4c77-b7c3-4dacda1a3807",
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.615497Z",
@@ -125,7 +285,7 @@
        "(4, 4)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +297,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b77139bc-a4f2-4894-86c4-6c71bc13bcce",
    "metadata": {},
    "source": [
     "The operator class also keeps track of subsystem dimensions, which can be used for composing operators together. These can be accessed using the `input_dims` and `output_dims` functions.\n",
@@ -147,8 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "214a4159-4913-49c4-aad9-05bbbd08e806",
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.804167Z",
@@ -173,7 +331,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6ed7631-2f8a-488a-9b3e-73ca54f9c5c3",
    "metadata": {},
    "source": [
     "If the input matrix is not divisible into qubit subsystems, then it will be stored as a single-qubit operator. For example, if we have a $6\\times6$ matrix:"
@@ -181,8 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "30fcfeb4-898a-43c5-9cc8-fd1944aac6c6",
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:57.764881Z",
@@ -207,7 +363,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0644ba22-890a-49b5-a39e-1a6af9a6851a",
    "metadata": {},
    "source": [
     "The input and output dimension can also be manually specified when initializing a new operator:"
@@ -215,8 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "93210e11-7671-4c6e-a736-54419242e3b5",
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.292849Z",
@@ -242,8 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "a615f9dd-76ca-43f4-baae-644291b15ae5",
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.779572Z",
@@ -269,7 +422,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1a8f582-0735-4d3a-875d-aff0aa24747b",
    "metadata": {},
    "source": [
     "We can also extract just the input or output dimensions of a subset of subsystems using the `input_dims` and `output_dims` functions:"
@@ -277,8 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "8824780d-881f-4203-b4a5-38d383ce2f99",
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:02.187313Z",
@@ -304,877 +455,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating Paulis\n",
-    "\n",
-    "Instead of storing the full unitary matrix in an `Operator`, the `Pauli` class stores an abstract representation of an $N$-qubit Pauli operator. These objects are typically instantiated using a string of consisting of the characters: `['I', 'X', 'Y', 'Z']` and optionally a phase coefficient from the list: `['', '-i', '-', 'i']`.\n",
-    "\n",
-    "For example, we can generate the operator $X\\otimes X$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "XX is of type <class 'qiskit.quantum_info.operators.symplectic.pauli.Pauli'>\n"
-     ]
-    }
-   ],
-   "source": [
-    "op = Pauli(\"XX\")\n",
-    "print(f\"{op} is of type {type(op)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and examine some of its attributes as well as obtain its matrix representation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dimension of XX: (4, 4)\n",
-      "Phase of XX: 0\n",
-      "Matrix representation of XX: \n",
-      " [[0.+0.j 0.+0.j 0.+0.j 1.+0.j]\n",
-      " [0.+0.j 0.+0.j 1.+0.j 0.+0.j]\n",
-      " [0.+0.j 1.+0.j 0.+0.j 0.+0.j]\n",
-      " [1.+0.j 0.+0.j 0.+0.j 0.+0.j]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"Dimension of {op}: {op.dim}\")\n",
-    "print(f\"Phase of {op}: {op.phase}\")\n",
-    "print(f\"Matrix representation of {op}: \\n {op.to_matrix()}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, if it (anti)commutes with another `Pauli`, and compute the dot product with another `Pauli`. Refer to the [api documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Creating SparsePauliOps\n",
-    "\n",
-    "The `SparsePauliOp` object is used as an abstract representation of a linear combination of $N$-qubit Pauli operators and can be instantiated using a string of characters in the same way as a `Pauli`. A linear combination of Pauli operators can also be created using the [`from_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_sparse_list) or [`from_sparse_list()`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#from_list) methods shown below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator created from sparse list:\n",
-      " SparsePauliOp(['XIIZI', 'IYIIY'],\n",
-      "              coeffs=[1.+0.j, 2.+0.j]) \n",
-      "\n",
-      "Operator created from list:\n",
-      " SparsePauliOp(['XIIZI', 'IYIIY'],\n",
-      "              coeffs=[1.+0.j, 2.+0.j]) \n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# via tuples and local Paulis with indices\n",
-    "op = SparsePauliOp.from_sparse_list(\n",
-    "    [(\"ZX\", [1, 4], 1), (\"YY\", [0, 3], 2)], num_qubits=5\n",
-    ")\n",
-    "print(f\"Operator created from sparse list:\\n {op} \\n\")\n",
-    "\n",
-    "# equals the following construction from \"dense\" Paulis\n",
-    "op = SparsePauliOp.from_list([(\"XIIZI\", 1), (\"IYIIY\", 2)])\n",
-    "print(f\"Operator created from list:\\n {op} \\n\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`SparsePauliOp` objects are also overloaded with typical arithmetic operations. This allows one to add, subtract, compose, or compute dot products on two `SparsePauliOps`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "83647e0f-6edf-4a13-9540-78acb578d17c",
-   "metadata": {},
-   "source": [
-    "## Converting classes to Operators\n",
-    "\n",
-    "Several other classes in Qiskit can be directly converted to an `Operator` object using the operator initialization method. For example:\n",
-    "\n",
-    "* `Pauli` objects\n",
-    "* `Gate` and `Instruction` objects\n",
-    "* `QuantumCircuit` objects\n",
-    "\n",
-    "Note that the last point means we can use the `Operator` class as a unitary simulator to compute the final unitary matrix for a quantum circuit, without having to call a simulator backend. If the circuit contains any unsupported operations, an exception will be raised. Unsupported operations are: measure, reset, conditional operations, or a gate that does not have a matrix definition or decomposition in terms of gate with matrix definitions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "c84c7f7d-292a-4507-a3de-b1b4156d8ee9",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:03:02.854419Z",
-     "start_time": "2019-08-21T09:03:02.842387Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],\n",
-      "         input_dims=(2, 2), output_dims=(2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create an Operator from a Pauli object\n",
-    "\n",
-    "pauliXX = Pauli(\"XX\")\n",
-    "Operator(pauliXX)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "08265ba9-db26-4573-9a36-2687f6d58f2c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:03:03.064145Z",
-     "start_time": "2019-08-21T09:03:03.058953Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j]],\n",
-      "         input_dims=(2, 2), output_dims=(2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create an Operator for a Gate object\n",
-    "Operator(CXGate())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "7b51c2df-14b2-430e-8319-5162420ebc4c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:03:03.353613Z",
-     "start_time": "2019-08-21T09:03:03.345462Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[0.70710678+0.j        , 0.        -0.70710678j],\n",
-      "          [0.        -0.70710678j, 0.70710678+0.j        ]],\n",
-      "         input_dims=(2,), output_dims=(2,))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create an operator from a parameterized Gate object\n",
-    "Operator(RXGate(np.pi / 2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "4d090045-7eef-4709-8ad3-272001de56f7",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:03:47.550069Z",
-     "start_time": "2019-08-21T09:03:47.408126Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.70710678+0.j,  0.70710678+0.j,  0.        +0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
-      "          [ 0.        +0.j,  0.        +0.j,  0.70710678+0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
-      "          [ 0.        +0.j,  0.        +0.j,  0.        +0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
-      "          ...,\n",
-      "          [ 0.        +0.j,  0.        +0.j,  0.        +0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
-      "          [ 0.        +0.j,  0.        +0.j,  0.70710678+0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j],\n",
-      "          [ 0.70710678+0.j, -0.70710678+0.j,  0.        +0.j, ...,\n",
-      "            0.        +0.j,  0.        +0.j,  0.        +0.j]],\n",
-      "         input_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), output_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create an operator from a QuantumCircuit object\n",
-    "circ = QuantumCircuit(10)\n",
-    "circ.h(0)\n",
-    "for j in range(1, 10):\n",
-    "    circ.cx(j - 1, j)\n",
-    "\n",
-    "# Convert circuit to an operator by implicit unitary simulation\n",
-    "Operator(circ)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5eb2fcf7-0a83-4fef-b08b-9d6e01c4226e",
-   "metadata": {},
-   "source": [
-    "## Using Operators in circuits\n",
-    "\n",
-    "Unitary `Operators` can be directly inserted into a `QuantumCircuit` using the `QuantumCircuit.append` method. This converts the `Operator` into a `UnitaryGate` object, which is added to the circuit.\n",
-    "\n",
-    "If the operator is not unitary, an exception will be raised. This can be checked using the `Operator.is_unitary()` function, which will return `True` if the operator is unitary and `False` otherwise."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "ab1bebc7-5af1-4bae-bac5-a12558b8bd6f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:03:49.196556Z",
-     "start_time": "2019-08-21T09:03:49.161398Z"
-    },
-    "tags": [
-     "nbsphinx-thumbnail"
-    ]
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAgI0lEQVR4nO3deVxU9f4/8NcwCyCLjKAiIrIIBihCLlfAVBTMBcUyvTct7ZvXbovftLxgD29fy+/v/jSX7F6tTMu+LZpfS6zrlqlpuOSueA1RERBlGZUgcdhn+f0RzM+BQWEYZvgMr+c/cD7nnM95j8KLz/mcM2cker1eDyIiEpKDrQsgIiLzMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKByWxdALWOXq+HprLa1mXYLZmzIyQSidWPq9frodVqrX7c1pBKpTb5t+roGOKC01RWY3PQM7Yuw27NyN4EeScnqx9Xq9UiNTXV6sdtjSlTpkAmY6RYG6dTiIgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yogygrK8OtW7egUqlQWloKvV7fov337duH4uLiNquPzMMHHRDZqeLiYhw5cgRZWVnIzc1FaWmp0fpOnTohICAAgYGBiI2Nhb+/f5N9ffvtt9i6dSt27dqFxYsXw8vLywqvgJqDIU5kZzIzM7Fnzx6cOXPmgaPtiooKZGRkICMjAzt37kRwcDDGjRuH6Ohoo6cR1gc4ANy+fRvp6emIj4+3ymuhh7P76ZTi4mKkpKSgT58+cHJyQq9evTBv3jyUl5dj9uzZkEgkeP/9921dJlGrVVZW4pNPPsGSJUtw+vRpowB3cXFBeHg4YmJiEBsbi6ioKHTp0sVo/6ysLKxZswZLly7FnTt3gAYBDgDTp09ngLczdj0ST09Px7hx46BSqeDi4oKwsDAUFhZizZo1yM7ORklJCQAgMjLS1qW2LYkEYXMmoO+zCXD17YqqX8uQu/NnpK/YymeR24mcnBysXr3aaM5aqVRi9OjRiI2Nhbe3t8lnfZeWluLMmTPYv38/bty4AQC4ePEikpOTERUVhePHjxu2nT59OiZNmmSlV0TNZbchXlxcjIkTJ0KlUmHBggV466234ObmBgBYsWIFFi5cCJlMBolEgoiICFuX26aG/PdzCPvzBOTtOYlfPtoJj+CeCJs9Hp79AvDDtP8GWniBi9qXK1eu4J133kFlZSUAwNHREdOnT8fo0aMf+nxvpVKJhIQExMfHIz09HR9//DFKSkpQVVXFABeE3U6nvPrqq8jPz8fcuXOxatUqQ4ADQEpKCgYMGACNRgN/f3+4u7vbtNa25BHii9Dnx+H67hM4NHslsjYfwOm3P8eptz9Hj2H9ETA51tYlUivk5eUZBXhwcDBWrlyJxx9/vEUf0CCRSBAVFYVVq1ahd+/eRutiY2MZ4O2YXYZ4ZmYmtm7dCi8vLyxbtszkNgMHDgQADBgwwKg9NzcXkyZNgpubG5RKJWbOnIlff/3VKnW3hYAnhkHi4IBLH+82as/afAC1FVUImjLcZrVR69TW1mLt2rWGAI+IiMCbb76Jbt26md3nDz/8gLy8PKO2c+fO8dbCdswuQ3zLli3Q6XSYMWMGXF1dTW7j7OwMNAjxe/fuIS4uDvn5+diyZQs2bNiAI0eOIDExETqdzmr1W5JXZB/otFoUn88yatdW16Lkl+vwigyyWW3UOqmpqcjPzwcA+Pv74/XXX4ejo6PZ/TW8iFl/y2FlZSXWr1/f4vvKyTrsMsQPHjwIAIiLi2tym/of/vtDfMOGDSgoKMB3332HxMRETJ06FV999RVOnDiBHTt2WKFyy+vUXYnqknvQ1WgaratQlcDJszMc5HZ7acRuFRUVGX4mpVIpXn75ZTg5mf9ZoKbuQlm8eLHhDpaLFy/ixIkTFqicLM0uf3vrTwcbzu3V02g0OHbsGNAgxHft2oVhw4bBz8/P0BYdHY3AwEDs3LkTkydPNqueQYMGQaVSmbXvw8j1DngLQ5pcL3V2hLam1uQ6bfXv7TJnBWpqG4c8ASHBIaiVWP8sTKFQNDkVCAD79+83nB1OnjzZ6Ge2pUwFeP0c+J///GesWLECALB3715ER0c32U9ISAhqamrMrqOj8/b2xpkzZ1q8n12GeHl5OVB3GmjK1q1bUVxcDDc3NwQEBBjaL126hKlTpzbaPjw8HJcuXTK7HpVKhYKCArP3fxCFRAp0b3q9trIacpfOJtdJHeUAAE0lf/GaUlhUiBq91urHfdC0SHV1NdLS0gAAcrkcY8eONfs4DwpwAIiKioKvry/y8/Nx5coV5OXlNTk4KiwsRHU1b1m1NrsMcW9vb5SWluLcuXONRg5FRUVITk4G6i4E3X/vbGlpKTw8PBr116VLF1y5cqVV9bQVud4BeMBAseJWKTqH+MJBIWs0pdLJuwuqfr0LHUfhTfLp4WOzkXhTLly4YBioxMTEGN151RIPC3DU3bUyZswYfPrppwCAY8eONRniPj4+HIm3grk5YZchHh8fj8zMTCxfvhwJCQkICQkBAJw+fRrPPvus4Uq7td7kY84pUnPVVlRhc9AzTa4vTr+GniMj4RUVjNsnMw3tUkc5uvTzx60TmU3uS8DVrKuQdzJ/rtlcGo0GqampJtdlZ2cbvh80aJBZ/TcnwO8/Rn2I5+TkNNnn1atXW3RbI1mGXV7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CjAxO2FSqUSv/32W6P+SkpKGr1FWRS5//oZep0OYXMmGLUHz4iHvJMTcrYftlltZJ7c3FzD94GBgS3evyUBjrrfi/oz1NzcXN6l0s7YZYj7+vriyJEjmDBhApycnHD9+nV06dIF69evx+7du3H16lXARIiHhoaanPu+dOkSQkNDrVa/Jf12+QYu/89e+E8YiriNyQiePhqD3pqJIW/PgurnDORsP2rrEqmFCgsLAQCurq4tHly0NMBRN6VSP4VSXl6Ou3fvmlU3tQ27PfcJDQ3Frl27GrWr1Wpcv34dDg4O6Nevn9G6xMRELFq0CPn5+fD19QUAnDx5EtnZ2Vi5cqXVare0U4s/g/rmHYQ8Ew/f0Y+iqqQMmZ9+j/MrtvIt9wLq3LkzdDodPDw8TD4PpSk7duxocYDX8/T0hFKphEKhgFZr/Qu91DSJvoOdG508eRJDhw5F3759cfnyZaN1ZWVl6N+/P7y8vLBkyRJUVVUhJSUFXbt2xfHjx+Hg0P5OXB42J06tMyN7U7ubEzdXeno63n33XdTW1rbJs1CmTJnCOXEb6HD/4hcvXgRMTKUAgLu7Ow4ePIh58+bhT3/6E2QyGRITE/Hee++1ywAnaonIyEgsWLAA+fn5SExMtHU5ZCEM8QaCgoJMTsMQ2YPIyEj7f/RyB9PhhpcPC3EiIpF0uJF4/XNViIjsQYcbiRMR2ROGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQCY4gTEQmMIU5EJDCGOBGRwBjiREQC63DPTiESgVQqxZQpUyzW38r1W3GvvBxuLi5I/ssfGy1bglQqtUg/1DIMcaJ2SCKRWPQDFvQAdPrfv8pkskbLJC5Op5BVDfvHK3iuaJutyyCyGwxxMtJn2kg8V7QNfaaNNLne1bcrnivahmH/eMVix/QbOxiRC6ZZrD+ijoQhTlZ17K8f4Uv/p43a/MYOQeRfGeJE5mCIk1XpNVpoq2utdjyJTAqpo9xqxyOyNl7RoFZx9e2Kp06vQ/qqr1F8IRuRC6ZC+Ygfqu+WIyf1MM4u3Qy9VmfYftg/XkGfP8bhsx5PAQDGpi6Bd0w4ABjNlR+d9z6uff0TOvfxQejs8egeHQ7Xnl6QSB3wW1Y+rny+D1lf/WhUS+SCaYj86zR8N2I+gqePhv/EGDh398CBGUsx/INXcTe7CN8nvdnoNYS/NAmDF8/E90/8F26dyGzDfy0iy2OIk0X0HB2Fvs89jitf7EPWloPwGzsY/V5OQvXdclxcs73J/S78MxVwkMB7aBgOz/2nof326SsAAO+Yfug+NAz5+89CffM2ZM6O8J8Yjdh3X4KTpzsurv22UZ/DP5gHTVUNMtbvBPR6qPPv4NrXaej30iS4B/mgLLvQaPvgp0fh7rUCBjgJiSFOFuHRtxf+NeI1qPPvAACufLEPSYdWI/T5cQ8M8aLD/0bQk48BQ8OQk3qk0frsb9Jw5Yt9Rm0ZG3Zh7La30X/uZPyybgf0Gq3R+pqyCvwwbYnRGcDVTfvR76VJCH56FM7+fZOhvdvgvvAI9sWZ//Nlq14/ka1wTpws4sbe04YAr6c69gs6dVdC1snJ7H41ldWG76WOcjgqXeGodEVB2gUo3F3QuU/PRvtc+niXUYADQFlOEVQ/Z6DP1BGQSP//j33w06Ohq9Xg2tc/mV0jkS1xJE5m0ev1RsvqvFuNtqkuVQMAHLu4QlNRZdZxZJ2cEPnXafCfFA3Xnl0brXf0cGnUdjenyGRfVzbtx4gP56NXwkDc2HsaMhcn+E+Kxs0DZ1FVfNes+ohsjSFORjRVNQAAqbOjyfWyTr+3a+u2q9dw5Hs/CSRm1zP8w3nolTAQVzcdgOrEJVSX3oNeq4Pv6EcR/peJkEgan0xqK6pN9pW3+wSqSsoQ/PRo3Nh7GgFJsZC7OCNr848mtycSAUOcjKhv3AYAeAQ3nqYAgM7BvgCAe3XbWULDUX09hXsn9EoYiOxth3F84QajdT6PRbT4OLoaDbK/SUPo7PFw7q5E8NOjUF74KwoOpZtdO5GtcU6cjPx6MQfqgjsImBwL5+5Ko3UOchlCnx8HvU6Hm/vOWOyYmvLfp1oUHq5G7br60b3EeCTv3M0DwTNGm3Wsq5sPwEEmxaA3n0G3QX1x7etD0OuaPosgau84Eicjeq0OJxZ+jLhPk5F08F1kfXUQ9/JUcOrqgYBJMVA+4ocL/0xtdJtea9w5l4XQ2UD0sjm4+eNZ6Gu1uHMuC+qbt1GYdgFBUx6DtqoaxenZcPXtipBnE6C+cRtOXdxbfKy7WQW4dTITQU+NgF6nQ9aWgxZ7HUS2wBCnRvJ/PIc9k95E/1cmo8+0EXBUukFTUY1ff8nFTy+8i+s7j1v0eDnfHkWXfgEISIpF74lD4SCV/v5mn5u3cXjuGgxcNAO9Egahz9SRKMstwrl3tkBfq8Gwf84163hXNu1H9z+EouhYhmH6iEhUEn1TE5IkhNqKKmwOesbWZQjFf2I0Rm5YgLSX3kPud8ceuO2M7E2Qt+IWyfZi6QebUaYuh7urCxa9MqPRMomLc+LU4TzyH2NR9etd5O05aetSiFqN0ynUITh5uqPHY/3R/Q+h8I4Ox9n/uwm6Go2tyyJqNYY4dQgeIb0wYt1rqP5Njcuf/4BfPtpp65LoIfR6PbRabTO2bB+kUikkEvPfE2Euhjh1CKrjGYYnJ5IYtFotUlNTbV1Gs02ZMsUmH3XHOXEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyISGEOciEhgDHEiIoExxImIBMYQJyJqBo1Gg9LSUluX0QifnUJEdqu6uho5OTnIyclBbm4uSktLodFoIJPJoFQqERgYiICAAAQFBUGhUDTZj0ajwXvvvYebN29i8eLF8PLysurreBCGOBHZncLCQuzfvx9paWmoqKhocrujR48CAFxcXDBy5EgkJCTA29vbaJv6AD979iwAYPny5Vi+fDkcHNrHREb7qKKNFRcXIyUlBX369IGTkxN69eqFefPmoby8HLNnz4ZEIsH7779v6zKJqJXUajU+/PBDvP766/j+++8fGOD3Ky8vx+7duzF//nysX7/esF/DAFcoFJg5c2a7CXB0hJF4eno6xo0bB5VKBRcXF4SFhaGwsBBr1qxBdnY2SkpKAACRkZG2LrXN9P/PJ+DZPxCeEYFw690d6pu3sW3Iy7Yui8iizp8/jw0bNhjNW8vlcgwdOhShoaEICAiAt7c35HI5amtrUVRUhJycHGRmZuLUqVOora0FABw6dAgXLlzAnDlzcODAAaMAT05ORv/+/W32Gk2x6xAvLi7GxIkToVKpsGDBArz11ltwc3MDAKxYsQILFy6ETCaDRCJBRESErcttMwMXzUBVyT2UXMyBwr2Trcshsrj9+/fj008/Rf1HBjs7O+PJJ59EXFwcXF1dG20vk8kQGBiIwMBAxMfHo6ysDIcOHcK3336LqqoqlJSUYPny5Ybt22uAw95D/NVXX0V+fj7mzp2LVatWGa1LSUnBV199hQsXLiAgIADu7u42q7OtbfvDy4ZPdU86tBpyF/E/+Jeo3o8//oiNGzcalgcMGIAXXngBnp6eze7D3d0dSUlJiImJwUcffYSMjAzDOplM1m4DHPY8J56ZmYmtW7fCy8sLy5YtM7nNwIEDgbr/9Hr1oT9kyBA4Ojra5OOWLK0+wInszZUrV/DJJ58YlidOnIg33nijRQF+P6VSCScn40GOVqtFp07t9wzWbkN8y5Yt0Ol0mDFjhsnTKdSdcqFBiF+7dg2pqanw9vbG4MGDrVYvEbVMdXU11q1bZ5hCmTBhAqZPn272wKvhRcz6i5d6vR7r1q0zzJm3N3Yb4gcPHgQAxMXFNblNfn4+0CDEhw8fjqKiIuzYsQPx8fFWqJSIzPHNN99ApVIBAIKDgzFjxgyLBbhCoUBKSgoCAgKAuqzYvn27Bau3HLudE8/LywMA9O7d2+R6jUaDY8eOAQ1CvC1uHRo0aJDhh83S5HoHvIUhbdI3ASHBIaiV6GxdRqs98R/z4eLqjiJVEXx9fRstt0cKhaLJqdDy8nLs27cPqLsD5cUXXzT7d9dUgNfPgSuVSixatAharRZ79+5FUlJSo+mWeiEhIaipqTGrBgDw9vbGmTNnWryf3YZ4eXk5AKCystLk+q1bt6K4uBhubm6Gv7ZtRaVSoaCgoE36VkikQPc26ZoAFBYVokavtXUZrabTag1fCwoKGi23R46Ojk2uS0tLMwRmXFwcevbsadYxHhTgqBsEDh8+HIcOHUJlZSWOHj3a5Bl6YWEhqqurzaqjNew2xL29vVFaWopz584hOjraaF1RURGSk5MBABEREW1+8bLhO8AsSa53AMQfKLZbPj187GIk7iCVGr727Nmz0XJ79KC3wddPlwLAmDFjzOr/YQF+f/+HDh0yHLepEPfx8Wn1SNwcdhvi8fHxyMzMxPLly5GQkICQkBAAwOnTp/Hss8+iuLgYsNKbfMw5RWqu2ooqbA56ps367+iuZl2FvJP4t2Qu/WAzytTl6OHdA/n5+Y2W2yONRoPU1NRG7Wq12lBzUFCQWdNBzQ1wAAgICICfnx9u3LiB3NxcVFVVmZxSuXr1KmQy60eq3V7YTElJgaenJ27evInw8HD0798fwcHBGDJkCAIDAzFq1CigwXw4EbV/ubm5hu+Dg4NbvH9LArzhcfR6Pa5fv25W3W3Fbkfivr6+OHLkCJKTk5GWlobr168jLCwM69evx5w5cxAUFAR0kBAPfGo4XH27AgCcPN3hIJchYv4UAIA6/w5yth22cYVEzXd/iAYGBrZoX3MCHHWj8Xq5ubl45JFHWlx3W7HbEAeA0NBQ7Nq1q1G7Wq3G9evX4eDggH79+tmkNmsKeXo0vGPCjdoeXfg0AED1cwZDnISiVqsN37fkTT3mBnjD49TfNNFe2HWINyUjIwN6vR4hISEm34m1bds2AMClS5eMlv39/TFo0CArV9t6e6e8ZesSiCxm9OjRiIiIQE1NDfz8/Jq9X15eHv79738DZjwLJSgoCAsXLoRCoUC3bt3Mrr0tdMgQv3jxIvCAqZSpU6eaXJ41axY+++wzK1RIRE3p1q2bWUEaFBSEBQsWYO3atZg/f36LnoXi7u6OqKioFh/TGhjiJtS/jZeI7EtkZCTWrl3brp+F0lJ2e3fKgzwsxInIftlTgKOjjsTvf6MAEZHIOuRInIjIXjDEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhIYQ5yISGAMcSIigTHEiYgExhAnIhJYh3x2ij2ROTtiRvYmW5dht2TOTX/iOrUtqVSKKVOmWKSvleu34l55OdxcXJD8lz822dYa0roPn7Y2hrjgJBKJXXyQL1FDEonEYh88rAeg0//+tb5PU20i4nQKEZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiBMRCYwhTkQkMIY4EZHAGOJERAJjiLcDK1euRHR0NJRKJTw8PDBs2DDs3bvX1mURPdCePXsQGRkJR0dH+Pv7Y/Xq1bYuyaoOHz6MpKQk9O7dGxKJBH//+99tUgdDvB04ePAgnn/+eRw6dAinTp1CTEwMEhMTcezYMVuXRmTSmTNnkJSUhHHjxiE9PR1vv/02Fi1ahI8++sjWpVmNWq1GWFgYVqxYAW9vb5vVIbPZkcng+++/N1pesWIF9u7di+3btyM2NtZmdRE1ZfXq1Rg8eDCWLVsGAAgNDUVGRgbeeecdvPjii7YuzyrGjx+P8ePHAwAWLlxoszoY4u2QTqdDWVkZXFxcbF0KCaa6phZ5BbcatWu0WsPXq7n5jZbv191Lic5uD/7ZO3bsGGbPnm3UNnbsWKxatQr5+fnw9fW1wKsxz42CW6iqqTVqM/V6m/o3cHZUoJdPN6vW3BoM8XZo6dKl+O233/DCCy/YuhQSjFwuw5FTF5B1vcDk+orKKnz69Z4mlz3cXTH/+aceepyioqJGUwj1y0VFRTYN8ZK79/C/Ow+aXNfw9Zpqe2ZyAnq1eZWWwznxdubDDz/E0qVLsW3bNpv+IpCYHCQSPDV+JJydHM3af+r4kXByVFi8LmuKDOuDiEcCzdr30X4h6Nc3wOI1tSWGeDuyatUqJCcnY8eOHYiPj7d1OSSozm4umJzQ8mspwwb3R1Bvn2Zt26NHD6hUKqO2W7duGdbZ2uQxw+Du2qlF+3i4u2JSfEyb1dRWGOLtxOLFi7FkyRLs2bOHAU6tNiCsDwaEBjV7++5eSjw+fHCzt4+NjcUPP/xg1LZ371707t27XZxBdnJ2wlPjRzZ7ewmAaRPEPAthiLcD8+fPx8qVK/Hll1+ib9++UKlUUKlUuHv3rq1LI4EljRkGd9eHXxyXOjhgWmIc5LLmXyJ77bXXcOrUKfztb3/D5cuX8fnnn2Pt2rV44403Wlm15YQE+CL60fBmbTtscAQC/Zp3FlJPrVYjPT0d6enpqKmpgUqlQnp6Oq5du2ZmxeaR6PV6vVWPSI1IJBKT7bNmzcJnn31m9XrIfmTl5mNjgwt5DT0+fDDioqNa3Pfu3buxaNEiXL58Gd7e3pg3bx5ef/31VlRreTW1Gqz9LBV3SpoeEHX3UmLurCda9EcMAH766SfExcU1ah8xYgR++ukns+o1B0NcMLk3i+Dr3RVyOW8soubZceAYfj6bYXJd757d8ZfpE+HgYL8n5TeLbmPdl/+CzkTUSR0c8MqsJ+DTzdMmtVmC/f7P2aF76gps/HoPVmz4X9wtU9u6HBLE2BF/QNcuHo3aFXIZpk2Is+sAB4BePbphVMyjJtclPDZI6AAHQ1wsaScvQKPRQunuBveHvBmDqJ5CLsMfE+Pg4GA8bZc4OgaeSneb1WVNcdFR6NWjq1Gbv683hg+JsFlNlsIQv49Wq8WXX36JMWPGoGvXrnB0dISfnx/Gjh2LTz75BNq6d3jZwj11BU6kXwIAxA8b2OQ8OpEpvj26YnTMQMNyaB8/DI7oa9OarEkqrb94KwUAKBRyTJ0w0i7OQsR/BRZSVlaGhIQEzJw5E/v374dCocCAAQOg0+mwb98+zJkzB/fu3bNZffWjcD+f7gj272mzOkhcI6Mj0atHN7g4O+HJscM73ECgaxcPjI8bCgCYOCoanh72cRbCC5t1pk6daniX5BdffGF01fnWrVvYuHEj5s2bZ9bzTNZ+vh331JVm16bX63GvvAKou/9VJpWa3Rd1bFqdDjqdrsV3YtgLvV6PmloNFHJZu/sj5ubqjP+c9WSL92OIAzh79iwGDRoEmUyG8+fPo1+/fhbtf+kHm1GmLrdon0RkX9xdXbDolRkt3q9j/jlu4LvvvgMATJgwweIBjrq/sObiKJyoYzA3JxjiAC5d+v2CYXR0dJv0b84pUr1dPx7H0TMX4efTHS89M6ndnQISkW0xxOsuagJA586d26R/c+fE7x+FF5fexbIPv2qD6oioPTB3TpwhDsDd/fer1G31rJJ76spWz4lXVFZZrB4ish8McQDh4eHYvn07jh8/3ib9mzPXxblwoo7F3Dlx3p0C4Pz583j00Uchl8uRnp6OsLAwW5fEuXAiaha+2QdAVFQUpk2bhtraWowbNw5paWlG62/duoVly5ahvNw6twny3ZlE1FwcidcpKytDUlKS4RGSPXv2hI+PD4qKilBQUAC9Xo/S0lJ4eDR+kJClcRRORM3FkXgdd3d3HDhwABs3bsTIkSNRUVGBCxcuwMHBAY8//jg2btwINzc3q9Ti6uIMJ0cFR+FE9FAcibdTVdU1cFTIGeJE9EAMcSIigXE6hYhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiATGECciEhhDnIhIYAxxIiKBMcSJiAT2/wDLQqXVZ9+F9gAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 454.517x284.278 with 1 Axes>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Create an operator\n",
-    "XX = Operator(Pauli(\"XX\"))\n",
-    "\n",
-    "# Add to a circuit\n",
-    "circ = QuantumCircuit(2, 2)\n",
-    "circ.append(XX, [0, 1])\n",
-    "circ.measure([0, 1], [0, 1])\n",
-    "circ.draw(\"mpl\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "de0ad8c9-74c6-4a3c-b59c-a9c96c902aa2",
-   "metadata": {},
-   "source": [
-    "Note that in the above example we initialize the operator from a `Pauli` object. However, the `Pauli` object may also be directly inserted into the circuit itself and will be converted into a sequence of single-qubit Pauli gates:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "5fd28c29-3047-416d-bfad-af38f003433f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'11': 1024}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
-    "\n",
-    "backend = Aer.get_backend(\"qasm_simulator\")\n",
-    "circ = generate_preset_pass_manager(optimization_level=1, backend=backend).run(circ)\n",
-    "job = backend.run(circ)\n",
-    "job.result().get_counts(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "b697f771-d0e1-4b8f-b98c-82a19d8d3cfe",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:12.017240Z",
-     "start_time": "2019-08-21T09:04:11.989825Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌────────────┐┌─┐   \n",
-       "q_0: ┤0           ├┤M├───\n",
-       "     │  Pauli(XX) │└╥┘┌─┐\n",
-       "q_1: ┤1           ├─╫─┤M├\n",
-       "     └────────────┘ ║ └╥┘\n",
-       "c: 2/═══════════════╩══╩═\n",
-       "                    0  1 </pre>"
-      ],
-      "text/plain": [
-       "     ┌────────────┐┌─┐   \n",
-       "q_0: ┤0           ├┤M├───\n",
-       "     │  Pauli(XX) │└╥┘┌─┐\n",
-       "q_1: ┤1           ├─╫─┤M├\n",
-       "     └────────────┘ ║ └╥┘\n",
-       "c: 2/═══════════════╩══╩═\n",
-       "                    0  1 "
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Add to a circuit\n",
-    "circ2 = QuantumCircuit(2, 2)\n",
-    "circ2.append(Pauli(\"XX\"), [0, 1])\n",
-    "circ2.measure([0, 1], [0, 1])\n",
-    "circ2.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "682526da-17a3-40c1-8c02-cb1deb083198",
-   "metadata": {},
-   "source": [
-    "## Combining Operators\n",
-    "\n",
-    "Operators may be combined using several methods.\n",
-    "\n",
-    "### Tensor Product\n",
-    "\n",
-    "Two operators $A$ and $B$ may be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both $A$ and $B$ are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix $B$  on subsystem 0, and matrix $A$ on subsystem 1."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "fc397a0b-52a9-41da-85c2-e465749be4a5",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:14.208734Z",
-     "start_time": "2019-08-21T09:04:14.201058Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],\n",
-      "          [ 0.+0.j, -0.+0.j,  0.+0.j, -1.+0.j],\n",
-      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],\n",
-      "          [ 0.+0.j, -1.+0.j,  0.+0.j, -0.+0.j]],\n",
-      "         input_dims=(2, 2), output_dims=(2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "A = Operator(Pauli(\"X\"))\n",
-    "B = Operator(Pauli(\"Z\"))\n",
-    "A.tensor(B)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "97285327-6adc-43c3-b858-d2baae6fe258",
-   "metadata": {},
-   "source": [
-    "### Tensor Expansion\n",
-    "\n",
-    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ we have `A.expand(B)` = $B\\otimes A$ where the subsystems indexed as matrix $A$ on subsystem 0, and matrix $B$ on subsystem 1."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "64ca5769-56ad-49d5-a95a-eb0054739dab",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:14.899024Z",
-     "start_time": "2019-08-21T09:04:14.891072Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j],\n",
-      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j, -0.+0.j, -1.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j, -1.+0.j, -0.+0.j]],\n",
-      "         input_dims=(2, 2), output_dims=(2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "A = Operator(Pauli(\"X\"))\n",
-    "B = Operator(Pauli(\"Z\"))\n",
-    "A.expand(B)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98bd95da-6e31-4805-8ece-dd87b0d60020",
-   "metadata": {},
-   "source": [
-    "### Composition\n",
-    "\n",
-    "We can also compose two operators $A$ and $B$ to implement matrix multiplication using the `Operator.compose` method. We have that `A.compose(B)` returns the operator with matrix $B.A$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "bcf18f94-fe96-44f0-b455-bb42e2962a1f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:15.655155Z",
-     "start_time": "2019-08-21T09:04:15.648295Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.+0.j,  1.+0.j],\n",
-      "          [-1.+0.j, -0.+0.j]],\n",
-      "         input_dims=(2,), output_dims=(2,))\n"
-     ]
-    }
-   ],
-   "source": [
-    "A = Operator(Pauli(\"X\"))\n",
-    "B = Operator(Pauli(\"Z\"))\n",
-    "A.compose(B)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f16ace4-045a-47f5-bb1e-6ae45833fffc",
-   "metadata": {},
-   "source": [
-    "We can also compose in the reverse order by applying $B$ in front of $A$ using the `front` kwarg of `compose`:  `A.compose(B, front=True)` = $A.B$:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "ccdf52a6-0cd9-4a50-af3d-0350e7db7425",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:16.460560Z",
-     "start_time": "2019-08-21T09:04:16.452319Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.+0.j, -1.+0.j],\n",
-      "          [ 1.+0.j, -0.+0.j]],\n",
-      "         input_dims=(2,), output_dims=(2,))\n"
-     ]
-    }
-   ],
-   "source": [
-    "A = Operator(Pauli(\"X\"))\n",
-    "B = Operator(Pauli(\"Z\"))\n",
-    "A.compose(B, front=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "48ba1e74-6ccc-4981-a2aa-58cf1ee50840",
-   "metadata": {},
-   "source": [
-    "### Subsystem Composition\n",
-    "\n",
-    "Note that the previous compose requires that the total output dimension of the first operator $A$ is equal to total input dimension of the composed operator $B$ (and similarly, the output dimension of $B$ must be equal to the input dimension of $A$ when composing with `front=True`).\n",
-    "\n",
-    "We can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of* `compose` *method.*\n",
-    "\n",
-    "For example, to compose a two-qubit gate with a three-qubit Operator:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "1fa1ebb3-c56d-49cf-9f16-6baf1a81bc56",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:17.113510Z",
-     "start_time": "2019-08-21T09:04:17.105398Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j,  0.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  1.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
-      "           -1.+0.j],\n",
-      "          [ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
-      "            0.+0.j],\n",
-      "          [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,\n",
-      "            0.+0.j]],\n",
-      "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Compose XZ with a 3-qubit identity operator\n",
-    "op = Operator(np.eye(2**3))\n",
-    "XZ = Operator(Pauli(\"XZ\"))\n",
-    "op.compose(XZ, qargs=[0, 2])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "1fef1d8c-b331-4d32-8bf3-6834da726cf4",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:17.324353Z",
-     "start_time": "2019-08-21T09:04:17.315952Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],\n",
-      "          [0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],\n",
-      "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Compose YX in front of the previous operator\n",
-    "op = Operator(np.eye(2**3))\n",
-    "YX = Operator(Pauli(\"YX\"))\n",
-    "op.compose(YX, qargs=[0, 2], front=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "64cd39c4-1927-4d7f-acb9-4155afc22cfb",
-   "metadata": {},
-   "source": [
-    "### Linear combinations\n",
-    "\n",
-    "Operators may also be combined using standard linear operators for addition, subtraction and scalar multiplication by complex numbers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "c32d348b-02d7-4c84-91e7-021e8fe5a54e",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:18.829988Z",
-     "start_time": "2019-08-21T09:04:18.812834Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[-1.5+0.j,  0. +0.j,  0. +0.j,  0. +0.j],\n",
-      "          [ 0. +0.j,  1.5+0.j,  1. +0.j,  0. +0.j],\n",
-      "          [ 0. +0.j,  1. +0.j,  1.5+0.j,  0. +0.j],\n",
-      "          [ 0. +0.j,  0. +0.j,  0. +0.j, -1.5+0.j]],\n",
-      "         input_dims=(2, 2), output_dims=(2, 2))\n"
-     ]
-    }
-   ],
-   "source": [
-    "XX = Operator(Pauli(\"XX\"))\n",
-    "YY = Operator(Pauli(\"YY\"))\n",
-    "ZZ = Operator(Pauli(\"ZZ\"))\n",
-    "\n",
-    "op = 0.5 * (XX + YY - 3 * ZZ)\n",
-    "op"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e9089a49-a346-420e-a2dc-37024498c8b4",
-   "metadata": {},
-   "source": [
-    "An important point is that while `tensor`, `expand` and `compose` will preserve the unitarity of unitary operators, linear combinations will not; hence, adding two unitary operators will, in general, result in a non-unitary operator:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "e407a9bf-0429-4528-8ade-c37fac1371fc",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:19.151814Z",
-     "start_time": "2019-08-21T09:04:19.147497Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "op.is_unitary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "85d84c97-c596-4696-9563-209ef3524654",
-   "metadata": {},
-   "source": [
-    "### Implicit Conversion to Operators\n",
-    "\n",
-    "Note that for all the following methods, if the second object is not already an `Operator` object, it will be implicitly converted into one by the method. This means that matrices can be passed in directly without being explicitly converted to an `Operator` first. If the conversion is not possible, an exception will be raised."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "db28f1c8-899c-48c2-8db3-02c7cd41a2c4",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:20.045005Z",
-     "start_time": "2019-08-21T09:04:20.039841Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operator([[0.+0.j, 1.+0.j],\n",
-      "          [1.+0.j, 0.+0.j]],\n",
-      "         input_dims=(2,), output_dims=(2,))\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Compose with a matrix passed as a list\n",
-    "Operator(np.eye(2)).compose([[0, 1], [1, 0]])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70e3d5ef-d23b-4c22-b8aa-c910216085e0",
-   "metadata": {},
-   "source": [
-    "## Comparison of Operators\n",
-    "\n",
-    "Operators implement an equality method that can be used to check if two operators are approximately equal."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "7da2a904-fa1d-4c06-9a6a-0e3c2595827c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:20.821642Z",
-     "start_time": "2019-08-21T09:04:20.815611Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Operator(Pauli(\"X\")) == Operator(XGate())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60d461e1-40eb-4043-9035-33f303b714f5",
-   "metadata": {},
-   "source": [
-    "Note that this checks that each matrix element of the operators is approximately equal; two unitaries that differ by a global phase will not be considered equal:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "id": "4161780a-64ab-4f86-9526-62303a681839",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:21.146256Z",
-     "start_time": "2019-08-21T09:04:21.141242Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Operator(XGate()) == np.exp(1j * 0.5) * Operator(XGate())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0eb8a6cf-492d-43d1-908f-379980bb64e4",
-   "metadata": {},
-   "source": [
-    "### Process Fidelity\n",
-    "\n",
-    "We may also compare operators using the `process_fidelity` function from the *Quantum Information* module. This is an information theoretic quantity for how close two quantum channels are to each other, and in the case of unitary operators it does not depend on global phase."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "id": "b75e9c20-5596-4697-bb0d-25874cf6ffb0",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-21T09:04:22.171481Z",
-     "start_time": "2019-08-21T09:04:22.147477Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Process fidelity = 1.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Two operators which differ only by phase\n",
-    "op_a = Operator(XGate())\n",
-    "op_b = np.exp(1j * 0.5) * Operator(XGate())\n",
-    "\n",
-    "# Compute process fidelity\n",
-    "F = process_fidelity(op_a, op_b)\n",
-    "print(\"Process fidelity =\", F)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4452e087-eb5b-4630-8732-76cba1fec582",
-   "metadata": {},
-   "source": [
-    "Note that process fidelity is generally only a valid measure of closeness if the input operators are unitary (or CP in the case of quantum channels), and an exception will be raised if the inputs are not CP."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "58ba5dc7-05d5-49a2-a5a9-6d6102c75bd9",
-   "metadata": {},
-   "source": [
     "## Next steps\n",
     "\n",
     "<Admonition type=\"tip\" title=\"Recommendations\">\n",
-    "  -  See an example of using operators in the [Grover's Algorithm](https://learning.quantum.ibm.com/tutorial/grovers-algorithm) tutorial.\n",
-    "  -  Explore the [Operator API](/api/qiskit/qiskit.quantum_info.Operator#operator) reference.\n",
+    "  - Learn how to [specify observables in the Pauli basis](/build/specify-observables-pauli)\n",
+    "  - See an example of using operators in the [Combine error mitigation options with the estimator primitive](https://learning.quantum.ibm.com/tutorial/combine-error-mitigation-options-with-the-estimator-primitive) tutorial.\n",
+    "  - Read more [in-depth coverage of the Operator class](/build/operator-class)\n",
+    "  - Explore the [Operator API](/api/qiskit/qiskit.quantum_info.Operator#operator) reference.\n",
     "</Admonition>"
    ]
   }
@@ -1184,7 +471,7 @@
   "celltoolbar": "Tags",
   "description": "Use the Qiskit quantum information module to construct and manipulate operators",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "documentation",
    "language": "python",
    "name": "python3"
   },
@@ -1198,7 +485,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   },
   "title": "Operators module overview",
   "varInspector": {

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -33,13 +33,11 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit_aer import Aer\n",
-    "\n",
-    "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
-    "from qiskit.quantum_info.operators import Operator, Pauli, SparsePauliOp\n",
+    "from qiskit import QuantumCircuit\n",
+    "from qiskit.circuit.library import CXGate, RXGate, XGate\n",
     "from qiskit.quantum_info import process_fidelity\n",
-    "\n",
-    "from qiskit.circuit.library import RXGate, XGate, CXGate"
+    "from qiskit.quantum_info.operators import Operator, Pauli, SparsePauliOp\n",
+    "from qiskit_aer import Aer"
    ]
   },
   {
@@ -168,9 +166,9 @@
     }
    ],
    "source": [
-    "op = Operator(np.random.rand(2 ** 1, 2 ** 2))\n",
-    "print('Input dimensions:', op.input_dims())\n",
-    "print('Output dimensions:', op.output_dims())"
+    "op = Operator(np.random.rand(2**1, 2**2))\n",
+    "print(\"Input dimensions:\", op.input_dims())\n",
+    "print(\"Output dimensions:\", op.output_dims())"
    ]
   },
   {
@@ -203,8 +201,8 @@
    ],
    "source": [
     "op = Operator(np.random.rand(6, 6))\n",
-    "print('Input dimensions:', op.input_dims())\n",
-    "print('Output dimensions:', op.output_dims())"
+    "print(\"Input dimensions:\", op.input_dims())\n",
+    "print(\"Output dimensions:\", op.output_dims())"
    ]
   },
   {
@@ -237,9 +235,9 @@
    ],
    "source": [
     "# Force input dimension to be (4,) rather than (2, 2)\n",
-    "op = Operator(np.random.rand(2 ** 1, 2 ** 2), input_dims=[4])\n",
-    "print('Input dimensions:', op.input_dims())\n",
-    "print('Output dimensions:', op.output_dims())"
+    "op = Operator(np.random.rand(2**1, 2**2), input_dims=[4])\n",
+    "print(\"Input dimensions:\", op.input_dims())\n",
+    "print(\"Output dimensions:\", op.output_dims())"
    ]
   },
   {
@@ -264,10 +262,9 @@
    ],
    "source": [
     "# Specify system is a qubit and qutrit\n",
-    "op = Operator(np.random.rand(6, 6),\n",
-    "              input_dims=[2, 3], output_dims=[2, 3])\n",
-    "print('Input dimensions:', op.input_dims())\n",
-    "print('Output dimensions:', op.output_dims())"
+    "op = Operator(np.random.rand(6, 6), input_dims=[2, 3], output_dims=[2, 3])\n",
+    "print(\"Input dimensions:\", op.input_dims())\n",
+    "print(\"Output dimensions:\", op.output_dims())"
    ]
   },
   {
@@ -299,8 +296,8 @@
     }
    ],
    "source": [
-    "print('Dimension of input system 0:', op.input_dims([0]))\n",
-    "print('Dimension of input system 1:', op.input_dims([1]))"
+    "print(\"Dimension of input system 0:\", op.input_dims([0]))\n",
+    "print(\"Dimension of input system 1:\", op.input_dims([1]))"
    ]
   },
   {
@@ -328,8 +325,8 @@
     }
    ],
    "source": [
-    "op = Pauli('XX')\n",
-    "print(f'{op} is of type {type(op)}')"
+    "op = Pauli(\"XX\")\n",
+    "print(f\"{op} is of type {type(op)}\")"
    ]
   },
   {
@@ -359,9 +356,9 @@
     }
    ],
    "source": [
-    "print(f'Dimension of {op}: {op.dim}')\n",
-    "print(f'Phase of {op}: {op.phase}')\n",
-    "print(f'Matrix representation of {op}: \\n {op.to_matrix()}')"
+    "print(f\"Dimension of {op}: {op.dim}\")\n",
+    "print(f\"Phase of {op}: {op.phase}\")\n",
+    "print(f\"Matrix representation of {op}: \\n {op.to_matrix()}\")"
    ]
   },
   {
@@ -402,12 +399,14 @@
    ],
    "source": [
     "# via tuples and local Paulis with indices\n",
-    "op = SparsePauliOp.from_sparse_list([(\"ZX\", [1, 4], 1), (\"YY\", [0, 3], 2)], num_qubits=5)\n",
-    "print(f'Operator created from sparse list:\\n {op} \\n')\n",
+    "op = SparsePauliOp.from_sparse_list(\n",
+    "    [(\"ZX\", [1, 4], 1), (\"YY\", [0, 3], 2)], num_qubits=5\n",
+    ")\n",
+    "print(f\"Operator created from sparse list:\\n {op} \\n\")\n",
     "\n",
     "# equals the following construction from \"dense\" Paulis\n",
     "op = SparsePauliOp.from_list([(\"XIIZI\", 1), (\"IYIIY\", 2)])\n",
-    "print(f'Operator created from list:\\n {op} \\n')"
+    "print(f\"Operator created from list:\\n {op} \\n\")"
    ]
   },
   {
@@ -464,7 +463,7 @@
    "source": [
     "# Create an Operator from a Pauli object\n",
     "\n",
-    "pauliXX = Pauli('XX')\n",
+    "pauliXX = Pauli(\"XX\")\n",
     "Operator(pauliXX)"
    ]
   },
@@ -559,7 +558,7 @@
     "circ = QuantumCircuit(10)\n",
     "circ.h(0)\n",
     "for j in range(1, 10):\n",
-    "    circ.cx(j-1, j)\n",
+    "    circ.cx(j - 1, j)\n",
     "\n",
     "# Convert circuit to an operator by implicit unitary simulation\n",
     "Operator(circ)"
@@ -605,13 +604,13 @@
    ],
    "source": [
     "# Create an operator\n",
-    "XX = Operator(Pauli('XX'))\n",
+    "XX = Operator(Pauli(\"XX\"))\n",
     "\n",
     "# Add to a circuit\n",
     "circ = QuantumCircuit(2, 2)\n",
     "circ.append(XX, [0, 1])\n",
-    "circ.measure([0,1], [0,1])\n",
-    "circ.draw('mpl')"
+    "circ.measure([0, 1], [0, 1])\n",
+    "circ.draw(\"mpl\")"
    ]
   },
   {
@@ -641,7 +640,8 @@
    ],
    "source": [
     "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
-    "backend = Aer.get_backend('qasm_simulator')\n",
+    "\n",
+    "backend = Aer.get_backend(\"qasm_simulator\")\n",
     "circ = generate_preset_pass_manager(optimization_level=1, backend=backend).run(circ)\n",
     "job = backend.run(circ)\n",
     "job.result().get_counts(0)"
@@ -687,8 +687,8 @@
    "source": [
     "# Add to a circuit\n",
     "circ2 = QuantumCircuit(2, 2)\n",
-    "circ2.append(Pauli('XX'), [0, 1])\n",
-    "circ2.measure([0,1], [0,1])\n",
+    "circ2.append(Pauli(\"XX\"), [0, 1])\n",
+    "circ2.measure([0, 1], [0, 1])\n",
     "circ2.draw()"
    ]
   },
@@ -730,8 +730,8 @@
     }
    ],
    "source": [
-    "A = Operator(Pauli('X'))\n",
-    "B = Operator(Pauli('Z'))\n",
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
     "A.tensor(B)"
    ]
   },
@@ -769,8 +769,8 @@
     }
    ],
    "source": [
-    "A = Operator(Pauli('X'))\n",
-    "B = Operator(Pauli('Z'))\n",
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
     "A.expand(B)"
    ]
   },
@@ -806,8 +806,8 @@
     }
    ],
    "source": [
-    "A = Operator(Pauli('X'))\n",
-    "B = Operator(Pauli('Z'))\n",
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
     "A.compose(B)"
    ]
   },
@@ -841,8 +841,8 @@
     }
    ],
    "source": [
-    "A = Operator(Pauli('X'))\n",
-    "B = Operator(Pauli('Z'))\n",
+    "A = Operator(Pauli(\"X\"))\n",
+    "B = Operator(Pauli(\"Z\"))\n",
     "A.compose(B, front=True)"
    ]
   },
@@ -897,8 +897,8 @@
    ],
    "source": [
     "# Compose XZ with a 3-qubit identity operator\n",
-    "op = Operator(np.eye(2 ** 3))\n",
-    "XZ = Operator(Pauli('XZ'))\n",
+    "op = Operator(np.eye(2**3))\n",
+    "XZ = Operator(Pauli(\"XZ\"))\n",
     "op.compose(XZ, qargs=[0, 2])"
    ]
   },
@@ -931,8 +931,8 @@
    ],
    "source": [
     "# Compose YX in front of the previous operator\n",
-    "op = Operator(np.eye(2 ** 3))\n",
-    "YX = Operator(Pauli('YX'))\n",
+    "op = Operator(np.eye(2**3))\n",
+    "YX = Operator(Pauli(\"YX\"))\n",
     "op.compose(YX, qargs=[0, 2], front=True)"
    ]
   },
@@ -970,9 +970,9 @@
     }
    ],
    "source": [
-    "XX = Operator(Pauli('XX'))\n",
-    "YY = Operator(Pauli('YY'))\n",
-    "ZZ = Operator(Pauli('ZZ'))\n",
+    "XX = Operator(Pauli(\"XX\"))\n",
+    "YY = Operator(Pauli(\"YY\"))\n",
+    "ZZ = Operator(Pauli(\"ZZ\"))\n",
     "\n",
     "op = 0.5 * (XX + YY - 3 * ZZ)\n",
     "op"
@@ -1081,7 +1081,7 @@
     }
    ],
    "source": [
-    "Operator(Pauli('X')) == Operator(XGate())"
+    "Operator(Pauli(\"X\")) == Operator(XGate())"
    ]
   },
   {
@@ -1154,7 +1154,7 @@
     "\n",
     "# Compute process fidelity\n",
     "F = process_fidelity(op_a, op_b)\n",
-    "print('Process fidelity =', F)"
+    "print(\"Process fidelity =\", F)"
    ]
   },
   {

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -3,6 +3,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
+   "id": "434beca8-b15d-4f42-a887-4636fb692789",
    "metadata": {},
    "source": [
     "# Overview of operator classes\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "6fc6f151-f2ca-44f6-811b-d15c71ee1fa6",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.554914Z",
@@ -28,6 +30,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "23a940b3-fce0-4f84-8461-5a72c0ce9aa7",
    "metadata": {},
    "source": [
     "## SparsePauliOp\n",
@@ -38,6 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "90053827-6a1f-4fb4-8188-808afe3ddd4f",
    "metadata": {},
    "outputs": [
     {
@@ -61,6 +65,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fc7ffabb-5245-4687-b84b-25176a64dc07",
    "metadata": {},
    "source": [
     "`SparsePauliOp` supports arithmetic operations, as demonstrated in the following code cell."
@@ -69,6 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "2e21467f-b6fe-4ac5-9654-66dec83a97fb",
    "metadata": {},
    "outputs": [
     {
@@ -117,6 +123,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "85fb16f2-5296-4c4d-9836-249358fd7e12",
    "metadata": {},
    "source": [
     "## Pauli\n",
@@ -127,6 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "edc33fe7-989e-489b-92f6-81975b20bd05",
    "metadata": {},
    "outputs": [
     {
@@ -147,6 +155,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82c19270-98d0-4543-bad5-5bfaacee406f",
    "metadata": {},
    "source": [
     "The following code cell demonstrates the use of some attributes and methods."
@@ -155,6 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "69b105cd-e978-45be-a3e9-bab344d9111f",
    "metadata": {},
    "outputs": [
     {
@@ -179,6 +189,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4c4b1efe-4025-4b88-bbce-d0b3060e0ab1",
    "metadata": {},
    "source": [
     "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, if it (anti)commutes with another `Pauli`, and compute the dot product with another `Pauli`. Refer to the [api documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
@@ -186,6 +197,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f02f8da-fab6-4ba6-b4ec-80d577cf8914",
    "metadata": {},
    "source": [
     "## Operator\n",
@@ -198,6 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "f8d9d183-586c-44ac-aa93-317a2adb40ad",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.572857Z",
@@ -233,6 +246,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4ded9878-c239-4e79-a60e-fff048c15784",
    "metadata": {},
    "source": [
     "The operator object stores the underlying matrix, and the input and output dimension of subsystems.\n",
@@ -244,6 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "d9a6fe93-00a1-498f-9110-67b022db0a4f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.589962Z",
@@ -272,6 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "784a657a-1731-4ecd-9bc0-aa0b96bc27e8",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.615497Z",
@@ -297,6 +313,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f84bf31-ce41-454a-9e2c-11c0ec4a04dc",
    "metadata": {},
    "source": [
     "The operator class also keeps track of subsystem dimensions, which can be used for composing operators together. These can be accessed using the `input_dims` and `output_dims` functions.\n",
@@ -307,6 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "b4576985-9ae2-46f0-a29d-9ca3bea53bf0",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.804167Z",
@@ -331,6 +349,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9bae9b8c-b7f5-4e1e-ad8b-4482f19af531",
    "metadata": {},
    "source": [
     "If the input matrix is not divisible into qubit subsystems, then it will be stored as a single-qubit operator. For example, if we have a $6\\times6$ matrix:"
@@ -339,6 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "186c1ac5-0bf2-4a86-84d8-bffa3f1763a1",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:57.764881Z",
@@ -363,6 +383,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e813709d-4ac3-4abc-863f-9d5d262ba753",
    "metadata": {},
    "source": [
     "The input and output dimension can also be manually specified when initializing a new operator:"
@@ -371,6 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "e14faef6-3b05-4447-9960-3b140ddff1a1",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.292849Z",
@@ -397,6 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "41845475-f6e9-4057-b21e-89cf1a62f672",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.779572Z",
@@ -422,6 +445,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ed55128-5b97-4733-ac0f-6b762e48691b",
    "metadata": {},
    "source": [
     "We can also extract just the input or output dimensions of a subset of subsystems using the `input_dims` and `output_dims` functions:"
@@ -430,6 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "c9fe7460-8e93-47aa-acc1-425bfe797c17",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:02.187313Z",
@@ -453,6 +478,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3e8538f5-77d4-4683-838f-abff122cd3f7",
    "metadata": {},
    "source": [
     "## Next steps\n",
@@ -471,7 +497,7 @@
   "celltoolbar": "Tags",
   "description": "Use the Qiskit quantum information module to construct and manipulate operators",
   "kernelspec": {
-   "display_name": "documentation",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -485,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3"
   },
   "title": "Operators module overview",
   "varInspector": {

--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -55,6 +55,8 @@ notifications:
     - "@Cryoris"
   "docs/build/operators_overview":
     - "`@mtreinish`"
+  "docs/build/operator-class":
+    - "`@mtreinish`"
   "docs/build/pulse":
     - "`@nkanazawa1989`"
     - "@abbycross"

--- a/scripts/nb-tester/notebooks.toml
+++ b/scripts/nb-tester/notebooks.toml
@@ -4,6 +4,7 @@ notebooks_normal_test = [
     "docs/build/circuit-library.ipynb",
     "docs/build/circuit-visualization.ipynb",
     "docs/build/classical-feedforward-and-control-flow.ipynb",
+    "docs/build/operator-class.ipynb",
     "docs/build/operators-overview.ipynb",
     "docs/build/pulse.ipynb",
     "docs/build/save-circuits.ipynb",


### PR DESCRIPTION
Closes #1440 

@kevinsung, here's what I have so far in terms of content to include. I think it might be worth mentioning the overloaded operators for the `SparsePauliOp` class and demonstrate some of the algebra that can be done.