### PR TITLE
Drop paul as serverless reviewer

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -187,7 +187,6 @@ notifications:
     - "@beckykd"
   "docs/run/quantum-serverless":
     - "@jenglick"
-    - "@psschwei"
     - "@pandasa123"
   "docs/run/processor-types":
     - "`@lerongil`"


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

there's other folks better suited to reviewing the docs for serverless these days