### PR TITLE
Add "Latest updates" link to patterns reorg

### DIFF
--- a/scripts/patterns-reorg/entries.py
+++ b/scripts/patterns-reorg/entries.py
@@ -99,6 +99,7 @@ GET_STARTED_CHILDREN = [
             ),
         ),
     ),
+    Entry("Latest updates", external_url="/announcements/product-updates"),
 ]
 
 CIRCUIT_CONSTRUCTION = (


### PR DESCRIPTION
After a meeting about #1301, we decided the most appropriate action was to link out to the existing "Product updates" page.