### PR TITLE
Revert "Add "Latest updates" link to patterns reorg (#1536)"

### DIFF
--- a/scripts/patterns-reorg/entries.py
+++ b/scripts/patterns-reorg/entries.py
@@ -99,7 +99,6 @@ GET_STARTED_CHILDREN = [
             ),
         ),
     ),
-    Entry("Latest updates", external_url="/announcements/product-updates"),
 ]
 
 CIRCUIT_CONSTRUCTION = (


### PR DESCRIPTION
Turns out we don't want to do this any more.
