### PR TITLE
Have cron job create PR to update notebook outputs

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -40,6 +40,26 @@ jobs:
           git diff --name-only >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Make pull request with notebook outputs
+        if: "!cancelled()"
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git switch -c actions/cron-${{ github.run_id }}
+          git commit -am "Re-run notebooks"
+          git push origin actions/cron-${{ github.run_id }}
+          gh pr create \
+           -B main \
+           -H actions/cron-${{ github.run_id }} \
+           --title "Update notebook outputs" \
+           --body "An action recently executed the notebooks in this repo. \
+            This PR updates all notebooks that ran successfully with the new cell outputs.
+            > [!NOTE]
+            > This pull request was created by a GitHub action." \
+           --reviewer frankharkins
+
       - name: Upload executed notebooks
         if: "!cancelled()"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Make pull request with notebook outputs
         if: "!cancelled()"
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Each time the fortnightly cron job runs, I usually make a PR updating the notebooks in this repo with the output of the cron job. This PR automates that process. As well as saving some manual work, this also means I can review those PRs too.

See https://github.com/frankharkins/documentation/pull/10 for an example of this working.