### PR TITLE
rename issue templates to be clearer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,10 +1,9 @@
-name: 🪲 Content bug or inaccuracy
+name: 🪲 Content bug or inaccuracy with Platform docs (_not_ API reference docs)
 description: Report typos, bugs, out-of-date content, broken links, etc.
 labels: ["bug 🐛", "content 📄"]
 assignees:
   - abbycross
   - beckykd
-  - javabster
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: Overall impressions and feedback
     url: https://ibmxm.iad1.qualtrics.com/jfe/form/SV_7Uq9FCMjZPyTsFM?Q_PopulateResponse={%22QID20%22:%223%22}
     about: Let us know what you think! Provide feedback to help us improve your documentation experience.
-  - name: Qiskit API feedback
+  - name: Content bug or inaccuracy with docs.quantum.ibm.com/api/qiskit
     url: https://github.com/Qiskit/qiskit/issues/new/choose
     about: Open an issue in the Qiskit repository for the docs found at https://docs.quantum.ibm.com/api/qiskit.
-  - name: Qiskit Runtime Client API feedback
+  - name: Content bug or inaccuracy with docs.quantum.ibm.com/api/qiskit-runtime
     url: https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose
     about: Open an issue in the qiskit-ibm-runtime repository for the docs found at https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/runtime_service.


### PR DESCRIPTION
Closes #1554 

Removing Abby M as an automatic assignee from bug reports too.

After the docs reorg, can reword the title of the bug issue for Platform docs by indicating it's for anything in the /guides/ directory. 