### PR TITLE
Edits to operators pages

### DIFF
--- a/docs/build/operator-class.ipynb
+++ b/docs/build/operator-class.ipynb
@@ -28,7 +28,7 @@
    "id": "8292bbef-0a61-44db-a096-cee8c9b23827",
    "metadata": {},
    "source": [
-    "## Converting classes to Operators\n",
+    "## Convert classes to Operators\n",
     "\n",
     "Several other classes in Qiskit can be directly converted to an `Operator` object using the operator initialization method. For example:\n",
     "\n",
@@ -36,7 +36,7 @@
     "* `Gate` and `Instruction` objects\n",
     "* `QuantumCircuit` objects\n",
     "\n",
-    "Note that the last point means we can use the `Operator` class as a unitary simulator to compute the final unitary matrix for a quantum circuit, without having to call a simulator backend. If the circuit contains any unsupported operations, an exception will be raised. Unsupported operations are: measure, reset, conditional operations, or a gate that does not have a matrix definition or decomposition in terms of gate with matrix definitions."
+    "Note that the last point means you can use the `Operator` class as a unitary simulator to compute the final unitary matrix for a quantum circuit, without having to call a simulator backend. If the circuit contains any unsupported operations, an exception is raised. Unsupported operations are: measure, reset, conditional operations, or a gate that does not have a matrix definition or decomposition in terms of gate with matrix definitions."
    ]
   },
   {
@@ -151,11 +151,11 @@
    "id": "693e4885-bd79-4a2f-8e2b-8e4d81892c05",
    "metadata": {},
    "source": [
-    "## Using Operators in circuits\n",
+    "## Use Operators in circuits\n",
     "\n",
     "Unitary `Operators` can be directly inserted into a `QuantumCircuit` using the `QuantumCircuit.append` method. This converts the `Operator` into a `UnitaryGate` object, which is added to the circuit.\n",
     "\n",
-    "If the operator is not unitary, an exception will be raised. This can be checked using the `Operator.is_unitary()` function, which will return `True` if the operator is unitary and `False` otherwise."
+    "If the operator is not unitary, an exception is raised. This can be checked using the `Operator.is_unitary()` function, which returns `True` if the operator is unitary and `False` otherwise."
    ]
   },
   {
@@ -192,7 +192,7 @@
    "id": "04a90485-7b03-4ae3-a37d-0ae87feee6a4",
    "metadata": {},
    "source": [
-    "Note that in the above example we initialize the operator from a `Pauli` object. However, the `Pauli` object may also be directly inserted into the circuit itself and will be converted into a sequence of single-qubit Pauli gates:"
+    "Note that in the above example the operator is initialized from a `Pauli` object. However, the `Pauli` object may also be directly inserted into the circuit itself and will be converted into a sequence of single-qubit Pauli gates:"
    ]
   },
   {
@@ -240,13 +240,13 @@
    "id": "59bf4972-731f-40c4-9d26-ca0110827cdc",
    "metadata": {},
    "source": [
-    "## Combining Operators\n",
+    "## Combine Operators\n",
     "\n",
     "Operators may be combined using several methods.\n",
     "\n",
-    "### Tensor Product\n",
+    "### Tensor product\n",
     "\n",
-    "Two operators $A$ and $B$ may be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both $A$ and $B$ are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix $B$  on subsystem 0, and matrix $A$ on subsystem 1."
+    "Two operators $A$ and $B$ can be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both $A$ and $B$ are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix $B$  on subsystem 0, and matrix $A$ on subsystem 1."
    ]
   },
   {
@@ -278,9 +278,9 @@
    "id": "bca7c8a7-5f19-405c-9f27-3e75db53cb5e",
    "metadata": {},
    "source": [
-    "### Tensor Expansion\n",
+    "### Tensor expansion\n",
     "\n",
-    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ we have `A.expand(B)` = $B\\otimes A$ where the subsystems indexed as matrix $A$ on subsystem 0, and matrix $B$ on subsystem 1."
+    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ you have `A.expand(B)` = $B\\otimes A$ where the subsystems are indexed as matrix $A$ on subsystem 0, and matrix $B$ on subsystem 1."
    ]
   },
   {
@@ -314,7 +314,7 @@
    "source": [
     "### Composition\n",
     "\n",
-    "We can also compose two operators $A$ and $B$ to implement matrix multiplication using the `Operator.compose` method. We have that `A.compose(B)` returns the operator with matrix $B.A$:"
+    "You can also compose two operators $A$ and $B$ to implement matrix multiplication using the `Operator.compose` method. `A.compose(B)` returns the operator with matrix $B.A$:"
    ]
   },
   {
@@ -344,7 +344,7 @@
    "id": "f54c6b4e-e8ac-4ae7-ac02-60300a46c88c",
    "metadata": {},
    "source": [
-    "We can also compose in the reverse order by applying $B$ in front of $A$ using the `front` kwarg of `compose`:  `A.compose(B, front=True)` = $A.B$:"
+    "You can also compose in the reverse order by applying $B$ in front of $A$ using the `front` kwarg of `compose`:  `A.compose(B, front=True)` = $A.B$:"
    ]
   },
   {
@@ -374,13 +374,13 @@
    "id": "f08c91f5-88f0-408f-ae9e-03cec65de305",
    "metadata": {},
    "source": [
-    "### Subsystem Composition\n",
+    "### Subsystem composition\n",
     "\n",
-    "Note that the previous compose requires that the total output dimension of the first operator $A$ is equal to total input dimension of the composed operator $B$ (and similarly, the output dimension of $B$ must be equal to the input dimension of $A$ when composing with `front=True`).\n",
+    "Note that the previous compose requires that the total output dimension of the first operator $A$ is equal to the total input dimension of the composed operator $B$ (and similarly, the output dimension of $B$ must be equal to the input dimension of $A$ when composing with `front=True`).\n",
     "\n",
-    "We can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of* `compose` *method.*\n",
+    "You can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of the* `compose` *method.*\n",
     "\n",
-    "For example, to compose a two-qubit gate with a three-qubit Operator:"
+    "For example, to compose a two-qubit gate with a three-qubit operator:"
    ]
   },
   {
@@ -456,7 +456,7 @@
    "source": [
     "### Linear combinations\n",
     "\n",
-    "Operators may also be combined using standard linear operators for addition, subtraction and scalar multiplication by complex numbers."
+    "Operators may also be combined using standard linear operators for addition, subtraction, and scalar multiplication by complex numbers."
    ]
   },
   {
@@ -491,7 +491,7 @@
    "id": "235d9549-a7f6-4c8c-8592-de57e5e45fc6",
    "metadata": {},
    "source": [
-    "An important point is that while `tensor`, `expand` and `compose` will preserve the unitarity of unitary operators, linear combinations will not; hence, adding two unitary operators will, in general, result in a non-unitary operator:"
+    "An important point is that while `tensor`, `expand`, and `compose` preserves the unitarity of unitary operators, linear combinations do not; hence, adding two unitary operators will, in general, result in a non-unitary operator:"
    ]
   },
   {
@@ -520,9 +520,9 @@
    "id": "1a2bf1cd-6f0f-446f-a993-ae9c2d22984e",
    "metadata": {},
    "source": [
-    "### Implicit Conversion to Operators\n",
+    "### Implicit conversion to Operators\n",
     "\n",
-    "Note that for all the following methods, if the second object is not already an `Operator` object, it will be implicitly converted into one by the method. This means that matrices can be passed in directly without being explicitly converted to an `Operator` first. If the conversion is not possible, an exception will be raised."
+    "Note that for all the following methods, if the second object is not already an `Operator` object, it is implicitly converted into one by the method. This means that matrices can be passed in directly without being explicitly converted to an `Operator` first. If the conversion is not possible, an exception is raised."
    ]
   },
   {
@@ -551,7 +551,7 @@
    "id": "0ee93f02-c3ea-44b0-8b87-f79e3107749e",
    "metadata": {},
    "source": [
-    "## Comparison of Operators\n",
+    "## Compare Operators\n",
     "\n",
     "Operators implement an equality method that can be used to check if two operators are approximately equal."
    ]
@@ -582,7 +582,7 @@
    "id": "36bbbbf9-3ed7-4aab-bc9e-f542325372f1",
    "metadata": {},
    "source": [
-    "Note that this checks that each matrix element of the operators is approximately equal; two unitaries that differ by a global phase will not be considered equal:"
+    "Note that this checks that each matrix element of the operators is approximately equal; two unitaries that differ by a global phase are not considered equal:"
    ]
   },
   {
@@ -611,9 +611,9 @@
    "id": "c06612c0-be6e-41b5-9ba5-92a9d7755c2f",
    "metadata": {},
    "source": [
-    "### Process Fidelity\n",
+    "### Process fidelity\n",
     "\n",
-    "We may also compare operators using the `process_fidelity` function from the *Quantum Information* module. This is an information theoretic quantity for how close two quantum channels are to each other, and in the case of unitary operators it does not depend on global phase."
+    "You can also compare operators using the `process_fidelity` function from the *Quantum Information* module. This is an information-theoretic quantity for how close two quantum channels are to each other, and in the case of unitary operators it does not depend on global phase."
    ]
   },
   {
@@ -645,7 +645,7 @@
    "id": "993bab6d-7f37-4363-a17e-8b8e3b7de30a",
    "metadata": {},
    "source": [
-    "Note that process fidelity is generally only a valid measure of closeness if the input operators are unitary (or CP in the case of quantum channels), and an exception will be raised if the inputs are not CP."
+    "Note that process fidelity is generally only a valid measure of closeness if the input operators are unitary (or CP in the case of quantum channels), and an exception is raised if the inputs are not CP."
    ]
   },
   {

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -192,7 +192,7 @@
    "id": "4c4b1efe-4025-4b88-bbce-d0b3060e0ab1",
    "metadata": {},
    "source": [
-    "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, if it (anti)commutes with another `Pauli`, and compute the dot product with another `Pauli`. Refer to the [api documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
+    "`Pauli` objects possess a number of other methods to manipulate the operators such as determining its adjoint, whether it (anti)commutes with another `Pauli`, and computing the dot product with another `Pauli`. Refer to the [API documentation](/api/qiskit/qiskit.quantum_info.Pauli) for more info."
    ]
   },
   {
@@ -251,8 +251,8 @@
    "source": [
     "The operator object stores the underlying matrix, and the input and output dimension of subsystems.\n",
     "\n",
-    "* `data`: To access the underlying Numpy array, we may use the `Operator.data` property.\n",
-    "* `dims`: To return the total input and output dimension of the operator, we may use the `Operator.dim` property. *Note: the output is returned as a tuple* `(input_dim, output_dim)`, *which is the reverse of the shape of the underlying matrix.*"
+    "* `data`: To access the underlying Numpy array, you can use the `Operator.data` property.\n",
+    "* `dims`: To return the total input and output dimension of the operator, you can use the `Operator.dim` property. *Note: the output is returned as a tuple* `(input_dim, output_dim)`, *which is the reverse of the shape of the underlying matrix.*"
    ]
   },
   {
@@ -352,7 +352,7 @@
    "id": "9bae9b8c-b7f5-4e1e-ad8b-4482f19af531",
    "metadata": {},
    "source": [
-    "If the input matrix is not divisible into qubit subsystems, then it will be stored as a single-qubit operator. For example, if we have a $6\\times6$ matrix:"
+    "If the input matrix is not divisible into qubit subsystems, then it will be stored as a single-qubit operator. For example, for a $6\\times6$ matrix:"
    ]
   },
   {
@@ -448,7 +448,7 @@
    "id": "1ed55128-5b97-4733-ac0f-6b762e48691b",
    "metadata": {},
    "source": [
-    "We can also extract just the input or output dimensions of a subset of subsystems using the `input_dims` and `output_dims` functions:"
+    "You can also extract just the input or output dimensions of a subset of subsystems using the `input_dims` and `output_dims` functions:"
    ]
   },
   {
@@ -484,9 +484,9 @@
     "## Next steps\n",
     "\n",
     "<Admonition type=\"tip\" title=\"Recommendations\">\n",
-    "  - Learn how to [specify observables in the Pauli basis](/build/specify-observables-pauli)\n",
+    "  - Learn how to [specify observables in the Pauli basis](/build/specify-observables-pauli).\n",
     "  - See an example of using operators in the [Combine error mitigation options with the estimator primitive](https://learning.quantum.ibm.com/tutorial/combine-error-mitigation-options-with-the-estimator-primitive) tutorial.\n",
-    "  - Read more [in-depth coverage of the Operator class](/build/operator-class)\n",
+    "  - Read more [in-depth coverage of the Operator class](/build/operator-class).\n",
     "  - Explore the [Operator API](/api/qiskit/qiskit.quantum_info.Operator#operator) reference.\n",
     "</Admonition>"
    ]

--- a/docs/build/operators-overview.ipynb
+++ b/docs/build/operators-overview.ipynb
@@ -318,7 +318,7 @@
    "source": [
     "The operator class also keeps track of subsystem dimensions, which can be used for composing operators together. These can be accessed using the `input_dims` and `output_dims` functions.\n",
     "\n",
-    "For $2^N$ by $2^M$ operators, the input and output dimension will be automatically assumed to be M-qubit and N-qubit:"
+    "For $2^N$ by $2^M$ operators, the input and output dimensions are automatically assumed to be M-qubit and N-qubit:"
    ]
   },
   {


### PR DESCRIPTION
Noticed a few edits to make in a [recent closed PR](https://github.com/Qiskit/documentation/pull/1517). 

- Changed "we" to "you"
- avoided "will" when appropriate
- replaced "may" with either "can" or "might" depending on context
- general typo/punctuation/capitalization cleanup