### PR TITLE
Make code example in "save-jobs" more robust

### DIFF
--- a/docs/run/save-jobs.ipynb
+++ b/docs/run/save-jobs.ipynb
@@ -79,7 +79,8 @@
    "source": [
     "# Get ID of most recent successful job for demonstration.\n",
     "# This will not work if you've never successfully run a job.\n",
-    "job_id = service.jobs(pending=False)[0].job_id()\n",
+    "successful_job = next(j for j in service.jobs() if j.status().name == \"DONE\")\n",
+    "job_id = successful_job.job_id()\n",
     "print(job_id)"
    ]
   },


### PR DESCRIPTION
This code example fails in our tests if the most recent job is cancelled. This PR filters by job status to avoid that.
