### PR TITLE
Fix circuit in sampler in migration guide

### DIFF
--- a/docs/api/migration-guides/local-simulators.mdx
+++ b/docs/api/migration-guides/local-simulators.mdx
@@ -185,7 +185,7 @@ params = rng.choice(
 aer_sim = AerSimulator(method="stabilizer")
 
 pm = generate_preset_pass_manager(backend=aer_sim, optimization_level=1)
-isa_qc = pm.run(qc)
+isa_circuit = pm.run(circuit)
 sampler = Sampler(backend=aer_sim)
-result = sampler.run([isa_qc]).result()
+result = sampler.run([(isa_circuit, params)]).result()
 ```


### PR DESCRIPTION
## Purpose

Fix circuit in sampler in migration guide

## Details

In the migration guide **Migrate from cloud simulators to local simulators**, the section on Clifford simulation creates a `circuit` but does not use it in the pass manager and sampler. This is fixed here.