### PR TITLE
Extracting Qubit Indices

### DIFF
--- a/docs/build/circuit-construction.ipynb
+++ b/docs/build/circuit-construction.ipynb
@@ -535,7 +535,7 @@
     "</Admonition>"
    ]
   }
- ],
+],
  "metadata": {
   "description": "How to construct and visualize quantum circuits in Qiskit.",
   "kernelspec": {

--- a/docs/build/circuit-construction.ipynb
+++ b/docs/build/circuit-construction.ipynb
@@ -351,6 +351,67 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bc54d7bc-b2d8-4b30-9b0b-05689e07a463",
+   "metadata": {},
+   "source": [
+    "# Extract Quantum Register Information from Qiskit Quantum Circuit Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
+   "metadata": {},
+   "source": [
+    "To extract the quantum register index from Qubit objects in a quantum circuit using the Qiskit SDK, you can use two methods: find_bit and qubits.index,The find_bit method of the QuantumCircuit class can be used to find the index of a qubit in the circuit. This method returns a tuple where the first element is the index of the qubit and the second element is the register,The qubits attribute of the QuantumCircuit class is a list of all qubits in the circuit. You can directly use the index method of this list to find the index of a specific qubit.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b410d397-b67d-4f31-90cf-9c1c34c157c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Name of gate: Instruction(name='u', num_qubits=1, num_clbits=0, params=[0, 0, 3.141592653589793])\n",
+      "qargs indices (find_bit): [1]\n",
+      "qargs indices (index): [1]\n",
+      "\n",
+      "Name of gate: Instruction(name='cx', num_qubits=2, num_clbits=0, params=[])\n",
+      "qargs indices (find_bit): [2, 0]\n",
+      "qargs indices (index): [2, 0]\n",
+      "\n"
+     ]
+    {
+   ],
+   "source": [
+    "import qiskit\n",
+    "from qiskit.circuit.random import random_circuit\n",
+    "\n",
+    "# Parameters\n",
+    "num_qubits = 3\n",
+    "depth = 1\n",
+    "max_operands = 2\n",
+    "\n",
+    "# Create a random circuit\n",
+    "qc = random_circuit(num_qubits, depth, max_operands=max_operands, seed=1)\n",
+    "qc = qc.decompose(reps=3)\n",
+    "\n",
+    "# Iterate over each gate in the circuit\n",
+    "for name_of_gate, qargs, cargs in qc.data:\n",
+    "    print(\"Name of gate:\", name_of_gate)\n",
+    "    \n",
+    "    #  Using find_bit to get the index\n",
+    "    qarg_indices_find_bit = [qc.find_bit(qarg)[0] for qarg in qargs]\n",
+    "    print(\"qargs indices (find_bit):\", qarg_indices_find_bit)\n",
+    "    \n",
+   ]
+  }
+ ],
+  {
+   "cell_type": "markdown",
    "id": "649fc3fd-caf1-45f1-ad8e-3b5d26ca859b",
    "metadata": {},
    "source": [
@@ -499,3 +560,4 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
+

--- a/docs/build/decompose.ipynb
+++ b/docs/build/decompose.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc54d7bc-b2d8-4b30-9b0b-05689e07a463",
+   "metadata": {},
+   "source": [
+    "# Extract Quantum Register Information from Qiskit Quantum Circuit Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
+   "metadata": {},
+   "source": [
+    "To extract the quantum register index from Qubit objects in a quantum circuit using the Qiskit SDK, you can use two methods: find_bit and qubits.index,The find_bit method of the QuantumCircuit class can be used to find the index of a qubit in the circuit. This method returns a tuple where the first element is the index of the qubit and the second element is the register,The qubits attribute of the QuantumCircuit class is a list of all qubits in the circuit. You can directly use the index method of this list to find the index of a specific qubit.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b410d397-b67d-4f31-90cf-9c1c34c157c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Name of gate: Instruction(name='u', num_qubits=1, num_clbits=0, params=[0, 0, 3.141592653589793])\n",
+      "qargs indices (find_bit): [1]\n",
+      "qargs indices (index): [1]\n",
+      "\n",
+      "Name of gate: Instruction(name='cx', num_qubits=2, num_clbits=0, params=[])\n",
+      "qargs indices (find_bit): [2, 0]\n",
+      "qargs indices (index): [2, 0]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import qiskit\n",
+    "from qiskit.circuit.random import random_circuit\n",
+    "\n",
+    "# Parameters\n",
+    "num_qubits = 3\n",
+    "depth = 1\n",
+    "max_operands = 2\n",
+    "\n",
+    "# Create a random circuit\n",
+    "qc = random_circuit(num_qubits, depth, max_operands=max_operands, seed=1)\n",
+    "qc = qc.decompose(reps=3)\n",
+    "\n",
+    "# Iterate over each gate in the circuit\n",
+    "for name_of_gate, qargs, cargs in qc.data:\n",
+    "    print(\"Name of gate:\", name_of_gate)\n",
+    "    \n",
+    "    # Method 1: Using find_bit to get the index\n",
+    "    qarg_indices_find_bit = [qc.find_bit(qarg)[0] for qarg in qargs]\n",
+    "    print(\"qargs indices (find_bit):\", qarg_indices_find_bit)\n",
+    "    \n",
+    "    # Method 2: Using qubits.index to get the index\n",
+    "    qarg_indices_index = [qc.qubits.index(qarg) for qarg in qargs]\n",
+    "    print(\"qargs indices (index):\", qarg_indices_index)\n",
+    "    print(\"\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
 the issue brought up by the users on Slack regarding how to retrieve the index of a qubit within a QuantumCircuit object. The original documentation lacked clarity on this point, which led to confusion among users. The updated version explains how to extract the index of a qubit from a Qubit object using both QuantumCircuit.find_bit() and QuantumCircuit.qubits.index(), ensuring that users can easily understand how to manage qubits and registers in their circuits.
fixes #1469 