### PR TITLE
Use new Docker image for previews

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,28 +13,19 @@
 # This Dockerfile is used to preview the docs in pull requests via GitHub Actions.
 #
 # Keep it aligned with ./start. This Dockerfile is similar,
-# but it uses a private Docker image from IBM Cloud Registry rather
-# than a public image from Dockerhub. It also sets the CLI args
-# directly in the Dockerfile because the GitHub Action expects that.
+# but it sets the CLI args directly in the Dockerfile
+# because the GitHub Action expects that.
 #
-# To test it out locally, you will first need an IBM ID that has permissions to the quantum group. This is currently restricted to IBM maintainers. Then, set up IBM Cloud:
-#
-#   1. Install IBM CLI, https://cloud.ibm.com/docs/cli?topic=cli-getting-started
-#   2. ❯ ibmcloud plugin install cr
-#   3. ❯ ibmcloud login --sso
-#   4. ❯ ibmcloud cr region-set global
-#   5. ❯ ibmcloud cr login
-#
-#   Once logged in to IBM Cloud:
+# To test it out locally:
 #
 #   1. ❯ docker build -t qiskit-docs-preview .
 #   2. ❯ docker run --rm -p 3000:3000 -t qiskit-docs-preview
 #   3. Open up http://localhost:3000
 
-FROM icr.io/quantum-computing/iqp-channel-docs-dev:open-source
+FROM qiskit/documentation:latest
 
 COPY docs/ /home/node/app/docs
 COPY translations/ /home/node/app/docs
 COPY public/ /home/node/app/packages/preview/public/
 
-EXPOSE 3000 5001
+EXPOSE 3000

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,6 +6,7 @@ in_page_toc_max_heading_level: 2
 
 ---
 
+
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 

--- a/docs/start/index.mdx
+++ b/docs/start/index.mdx
@@ -6,7 +6,6 @@ in_page_toc_max_heading_level: 2
 
 ---
 
-
 # Introduction
 
 The quantum community has explored quantum computing on the cloud since 2016.  Now the community has a new challenge: *demonstrate useful quantum computation*. 

--- a/start
+++ b/start
@@ -49,8 +49,6 @@ def main() -> None:
         f"{PWD}/public:/home/node/app/packages/preview/public",
         "-p",
         "3000:3000",
-        "-p",
-        "5001:5001",
         # Needed for ctrl-c to shut down the container.
         "--init",
         "qiskit/documentation",


### PR DESCRIPTION
We removed the remote refresh mechanism from the previews, so port 5001 is no longer relevant. 

We also can now use the Dockerhub image for both `./start` and IBM Code Engine PR previews, so we can be consistent and stop using the IBM Container Registry version. That simplifies our infra.