### PR TITLE
update the latest updates page

### DIFF
--- a/docs/run/error-mitigation-explanation.ipynb
+++ b/docs/run/error-mitigation-explanation.ipynb
@@ -261,7 +261,7 @@
   }
  ],
  "metadata": {
-  "description": "Explanation of error mitigation techniques available through Qiskit Runtime",
+  "description": "Explanation of error mitigation and suppression techniques available through Qiskit Runtime",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -279,7 +279,7 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
-  "title": "Error mitigation techniques"
+  "title": "Error mitigation and suppression techniques"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/start/latest-updates.mdx
+++ b/docs/start/latest-updates.mdx
@@ -8,7 +8,7 @@ description: The latest updates from Qiskit and IBM Quantum, including the lates
 *Last updated 26 June 2024*
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
-Keep up with the latest and greatest from Qiskit and IBM Quantum! Gathered here are the the most recent Qiskit package release summaries, documentation updates, blogs, community events, and more.
+Keep up with the latest and greatest from Qiskit and IBM Quantum&trade;! Gathered here are the the most recent Qiskit package release summaries, documentation updates, blogs, community events, and more.
 
 ## Latest release summaries
 
@@ -18,7 +18,7 @@ Keep up with the latest and greatest from Qiskit and IBM Quantum! Gathered here 
 
 *To see the release notes for all versions, visit the [Qiskit SDK release notes](/api/qiskit/release-notes).*
 
-Qiskit SDK v1.1.0 has arrived, marking the first minor version release of the Qiskit SDK’s first major version. On the IBM Quantum&trade; blog, we review some of the key highlights — including top new features and improvements, as well as some important deprecations. Read the blog [here](https://www.ibm.com/quantum/blog/qiskit-1-1-release-summary).
+Qiskit SDK v1.1.0 has arrived, marking the first minor version release of the Qiskit SDK’s first major version. On the IBM Quantum blog, we review some of the key highlights — including top new features and improvements, as well as some important deprecations. Read the blog [here](https://www.ibm.com/quantum/blog/qiskit-1-1-release-summary).
 
 The updates and improvements include the following:
 
@@ -91,19 +91,19 @@ Probabilistic error amplification (PEA) error mitigation method is now available
 The `optimization_level` option is deprecated for Estimator V2 and will be removed no sooner than 30 September 2024.
 
 
-## Qiskit blog: How execution modes enable efficient, utility-scale workloads 
+## IBM Quantum blog: Defining — and citing — the Qiskit SDK
+
+*Browse all blogs at the [IBM Quantum blog page](https://www.ibm.com/quantum/blog).*
 
 {/* Bring over the Quantum news (blog) announcement post */}
 
-*Browse all blogs at the [Quantum Research blog page](https://www.ibm.com/quantum/blog).*
+Since its original launch in 2017, researchers have used the Qiskit SDK to write thousands of papers in quantum information science and engineering. However, those researchers have also lacked a definitive, authoritative academic citation that explains what the Qiskit SDK and how it enables their experiments—at least, not until now.
 
-In a recent post on the IBM Quantum&trade; blog, we introduce three new and improved execution modes that make running utility-scale workloads more reliable, more predictable, and more efficient than ever before.
+[“Quantum computing with Qiskit,”](https://arxiv.org/abs/2405.08810) a paper published recently on arXiv, fills this gap by providing the research community with a succinct overview of the SDK’s architecture and core components. It also offers fascinating insight into the design philosophy that has informed the Qiskit SDK’s development since its earliest days, and delivers a detailed, end-to-end example of a workflow that uses Qiskit to solve a challenging problem in condensed matter physics.
 
-Execution modes are the rules and procedures that govern how a user’s quantum circuits run on classical and quantum resources. When IBM put the first quantum computer in the cloud in 2016, users could only execute circuits as individual jobs. Since then, we’ve been working to see how execution modes can optimize the user experience even further.
+The authors of “Quantum computing with Qiskit” include developers who helped build the very first version of Qiskit back in 2017, and who have seen firsthand how it has grown into the sophisticated, versatile tool it is today. Their hope is that the paper will serve as a convenient, citable source that helps researchers better understand what Qiskit is and how it is used for quantum information science.
 
-After previewing them at the IBM Quantum Summit, we're thrilled to share more details on three execution modes that give users more flexibility in choosing how their circuits should be grouped together or divided up for optimal execution. These include **job mode** for running standalone jobs, **batch mode** for running non-iterative multi-job workloads, and **session mode** for running iterative workloads as a single experiment.
-
-For more details on the new and improved execution modes, including example code that demonstrates batch mode and session mode, see [the full blog post](https://www.ibm.com/quantum/blog/execution-modes).
+For more details on the new paper, including key takeaways and example citations, be sure to read [our recent post on the IBM Quantum blog](https://www.ibm.com/quantum/blog/defining-and-citing-the-qiskit-sdk), or read [the full paper on arXiv](https://arxiv.org/abs/2405.08810).
 
 ## What's new in the documentation
 

--- a/docs/start/latest-updates.mdx
+++ b/docs/start/latest-updates.mdx
@@ -97,7 +97,7 @@ The `optimization_level` option is deprecated for Estimator V2 and will be remov
 
 {/* Bring over the Quantum news (blog) announcement post */}
 
-Since its original launch in 2017, researchers have used the Qiskit SDK to write thousands of papers in quantum information science and engineering. However, those researchers have also lacked a definitive, authoritative academic citation that explains what the Qiskit SDK and how it enables their experiments—at least, not until now.
+Since its original launch in 2017, researchers have used the Qiskit SDK to write thousands of papers in quantum information science and engineering. However, those researchers have also lacked a definitive, authoritative academic citation that explains what the Qiskit SDK and how it enables their experiments — at least, not until now.
 
 [“Quantum computing with Qiskit,”](https://arxiv.org/abs/2405.08810) a paper published recently on arXiv, fills this gap by providing the research community with a succinct overview of the SDK’s architecture and core components. It also offers fascinating insight into the design philosophy that has informed the Qiskit SDK’s development since its earliest days, and delivers a detailed, end-to-end example of a workflow that uses Qiskit to solve a challenging problem in condensed matter physics.
 
@@ -108,7 +108,6 @@ For more details on the new paper, including key takeaways and example citations
 ## What's new in the documentation
 
 {/* Copy over the latest "What's new in the docs" announcement */}
-
 
 IBM Quantum documentation recently added a number of user-facing improvements, including content updates and new features. Many of these changes are a result of specific user requests! Check out the highlights below.
 

--- a/docs/start/latest-updates.mdx
+++ b/docs/start/latest-updates.mdx
@@ -78,18 +78,17 @@ On the IBM Quantum blog, we take a deep dive into the new beta release with a sp
 
 This summary of the latest changes to the Qiskit Runtime service applies to anyone using Qiskit Runtime, regardless of how you communicate with the service (using qiskit-ibm-runtime or otherwise), or which version of the client SDK you use. 
 
-### 28 March 2024
+### 18 June 2024
 
-Qiskit Runtime primitives now support OpenQASM 3 as the input format for circuits and standard JSON output format. See [Qiskit IBM Runtime REST API](/api/runtime) for examples.
+The `optimization_level` option is deprecated for Estimator V2 and will be removed no sooner than 30 September 2024.
 
 ### 3 June 2024
 
 Probabilistic error amplification (PEA) error mitigation method is now available as an experimental option for Estimator V2. See the [`EstimatorOptions` API reference](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EstimatorOptions) for more details.
 
-### 18 June 2024
+### 28 March 2024
 
-The `optimization_level` option is deprecated for Estimator V2 and will be removed no sooner than 30 September 2024.
-
+Qiskit Runtime primitives now support OpenQASM 3 as the input format for circuits and standard JSON output format. See [Qiskit IBM Runtime REST API](/api/runtime) for examples.
 
 ## IBM Quantum blog: Defining — and citing — the Qiskit SDK
 

--- a/docs/start/latest-updates.mdx
+++ b/docs/start/latest-updates.mdx
@@ -5,7 +5,7 @@ description: The latest updates from Qiskit and IBM Quantum, including the lates
 
 # Latest updates
 
-*Last updated 24 June 2024*
+*Last updated 26 June 2024*
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
 Keep up with the latest and greatest from Qiskit and IBM Quantum! Gathered here are the the most recent Qiskit package release summaries, documentation updates, blogs, community events, and more.
@@ -112,22 +112,17 @@ For more details on the new and improved execution modes, including example code
 
 IBM Quantum documentation recently added a number of user-facing improvements, including content updates and new features. Many of these changes are a result of specific user requests! Check out the highlights below.
 
-### Updated content
+**New pages**
 
-- A new guide to [Execution mode changes](/api/migration-guides/sessions), as well as updated information across the platform on the new and improved [execution modes](/run/execution-modes)
-- [Hello world](/start/hello-world) and [Install](/start/install) pages have been updated with brand new content from the [Coding with Qiskit](https://www.youtube.com/playlist?list=PLOFEBzvs-VvrgHZt3exM_NNiNKtZlHvZi) YouTube series
-- All content and examples have been updated to use V2 primitives and Qiskit SDK v1.0
-- Information on [Hardware considerations](/verify#hardware-considerations) for simulating in local testing mode have been added
-- The [Fixed and dynamic repetition rate execution](/run/circuit-execution) page has been updated with a new example for [specifying `rep_delay` for a primitive job](/run/circuit-execution#specify-rep_delay-for-a-primitive-job)
+- [Error mitigation techniques](/run/error-mitigation-explanation)
+- [Error mitigation and suppression techniques](/run/error-mitigation-explanation)
+- [The Operator class](/build/operator-class)
+- [Transpile against custom backends](/transpile/custom-backend)
 
-### User experience improvements
+**New API reference docs**
 
-- Two new ways to submit feedback! Click the "Report a bug or request content on [GitHub](https://github.com/Qiskit/documentation/issues/new/choose)" link on every page - or use the new anonymous [feedback form](https://ibmxm.iad1.qualtrics.com/jfe/form/SV_7Uq9FCMjZPyTsFM?Q_PopulateResponse={%22QID20%22:%223%22}) to share your ideas, experiences, and suggestions
-
-Improvements to API reference documentation readability:
-- Module pages make better use of headers to express the information hierarchy 
-- The Qiskit SDK table of contents was reorganized into logical groups
-- API docs now more clearly display modifiers like `class`, `static`, and `abstract` in front of code objects
+- [Qiskit Transpiler Service Client](/api/qiskit-transpiler-service)
+- [Qiskit Transpiler Service REST API](/api/qiskit-transpiler-service-rest)
 
 *A huge thank you goes out to everyone in the open-source community who contributed and gave feedback!* Please [open an issue](https://github.com/Qiskit/documentation/issues/new/choose) if you find a bug, have a suggestion, or want to share your experience.
 

--- a/docs/start/latest-updates.mdx
+++ b/docs/start/latest-updates.mdx
@@ -5,7 +5,7 @@ description: The latest updates from Qiskit and IBM Quantum, including the lates
 
 # Latest updates
 
-*Last updated 26 June 2024*
+*Last updated 27 June 2024*
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
 Keep up with the latest and greatest from Qiskit and IBM Quantum&trade;! Gathered here are the the most recent Qiskit package release summaries, documentation updates, blogs, community events, and more.
@@ -97,11 +97,11 @@ The `optimization_level` option is deprecated for Estimator V2 and will be remov
 
 {/* Bring over the Quantum news (blog) announcement post */}
 
-Since its original launch in 2017, researchers have used the Qiskit SDK to write thousands of papers in quantum information science and engineering. However, those researchers have also lacked a definitive, authoritative academic citation that explains what the Qiskit SDK and how it enables their experiments — at least, not until now.
+Since its launch in 2017, researchers have used the Qiskit SDK to write thousands of papers in the fields of quantum information science and engineering. However, those researchers have also lacked a definitive, authoritative academic citation that explains what the Qiskit SDK and how it enables their experiments —  until now.
 
 [“Quantum computing with Qiskit,”](https://arxiv.org/abs/2405.08810) a paper published recently on arXiv, fills this gap by providing the research community with a succinct overview of the SDK’s architecture and core components. It also offers fascinating insight into the design philosophy that has informed the Qiskit SDK’s development since its earliest days, and delivers a detailed, end-to-end example of a workflow that uses Qiskit to solve a challenging problem in condensed matter physics.
 
-The authors of “Quantum computing with Qiskit” include developers who helped build the very first version of Qiskit back in 2017, and who have seen firsthand how it has grown into the sophisticated, versatile tool it is today. Their hope is that the paper will serve as a convenient, citable source that helps researchers better understand what Qiskit is and how it is used for quantum information science.
+The authors of “Quantum computing with Qiskit” include developers who helped build the very first version of Qiskit in 2017, and who have seen firsthand how it has grown into the sophisticated, versatile tool it is today. Their hope is that the paper will serve as a convenient, citable source that helps researchers better understand what Qiskit is and how it is used for quantum information science.
 
 For more details on the new paper, including key takeaways and example citations, be sure to read [our recent post on the IBM Quantum blog](https://www.ibm.com/quantum/blog/defining-and-citing-the-qiskit-sdk), or read [the full paper on arXiv](https://arxiv.org/abs/2405.08810).
 


### PR DESCRIPTION
bring in the latest blog and the newest docs updates. 
Also closes https://github.com/Qiskit/documentation/issues/1597 to use reverse chronological order for the Runtime service updates.