### PR TITLE
Fix `update_internal_links` script

### DIFF
--- a/scripts/patterns-reorg/update_internal_links.py
+++ b/scripts/patterns-reorg/update_internal_links.py
@@ -52,10 +52,11 @@ def update_link(markdown: str, folder: str, link: str, prefix: str) -> str:
         else:
             search_key = f"{folder}/{link_split[-1]}"
 
+    search_key = f"/{search_key.removeprefix('/')}"
     if search_key not in REDIRECTS:
         return markdown
 
-    new_link = REDIRECTS[search_key]
+    new_link = REDIRECTS[search_key].removeprefix("/guides/")
     if new_link == "":
         new_link = "/guides"
 


### PR DESCRIPTION
This PR fixes the `update_internal_links.py` script that was broken because we changed the `redirects.json` file to have a different style.