### PR TITLE
Remove the right ToC from the patterns Intro page

### DIFF
--- a/scripts/patterns-reorg/page_content.py
+++ b/scripts/patterns-reorg/page_content.py
@@ -211,6 +211,7 @@ def index_page_content() -> str:
 ---
 title: Introduction to Qiskit
 description: What is Qiskit? This document provides an introduction to the Qiskit stack.
+in_page_toc_show: false
 ---
 
 # Introduction to Qiskit


### PR DESCRIPTION
This PR sets `in_page_toc_show` to `false` to the front matter of the patterns Intro page in order to remove the right ToC.