### PR TITLE
Fix custom-transpiler-pass notebook

### DIFF
--- a/docs/transpile/custom-transpiler-pass.ipynb
+++ b/docs/transpile/custom-transpiler-pass.ipynb
@@ -295,7 +295,7 @@
     }
    ],
    "source": [
-    "np.alltrue([Operator(twirled_qc).equiv(qc) for twirled_qc in twirled_qcs])"
+    "np.all([Operator(twirled_qc).equiv(qc) for twirled_qc in twirled_qcs])"
    ]
   },
   {


### PR DESCRIPTION
The `custom-transpiler-pass.ipynb` notebook was using a [deprecated](https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations) numpy function called `alltrue`. This PR changes the notebook to use instead the function `all`.

In this [CI](https://github.com/Qiskit/documentation/actions/runs/9762810433/job/26947134720?pr=1631) run you can find the notebook failing because of the deprecation.