### PR TITLE
Add r2 to Heron entry in processor-types file

### DIFF
--- a/docs/guides/processor-types.mdx
+++ b/docs/guides/processor-types.mdx
@@ -30,7 +30,7 @@ At 156 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that
 
   `r1` (December 2023)
 
-  The first version of Heron with 133 qubits and no TLS mitigation control.
+  The first version of Heron with 133 qubits.
 
 </Admonition>
 

--- a/docs/guides/processor-types.mdx
+++ b/docs/guides/processor-types.mdx
@@ -23,6 +23,13 @@ At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that
 
 * [Native gates and operations](native-gates): `cz, id, delay, measure, reset, rz, sx, x, if_else, for_loop, switch_case`
 
+<Admonition type="info" title="Revisions">
+  `r2` (July 2024) 
+
+  This is a revision of our original Heron processor. The chip has been redesigned to now include 156 qubits in a heavy-hexagonal lattice. While continuing to make use of the innovations of the original Heron systems, it also introduces a new TLS mitigation feature that controls the TLS environment of the chip, thereby improving coherence and stability across the whole chip.
+
+</Admonition>
+
 ## Osprey
 
 ![Osprey processor icon](/images/guides/processor-types/osprey.svg)

--- a/docs/guides/processor-types.mdx
+++ b/docs/guides/processor-types.mdx
@@ -17,7 +17,7 @@ Processor types are named for the general technology qualities that go into buil
 
 Quantum volume: 512
 
-At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that pulls in substantial innovations in signal delivery that were previously deployed in [Osprey](#osprey). The signals required to enable the fast, high-fidelity two-qubit and single-qubit control are delivered with high-density flex cabling.
+At 156 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that pulls in substantial innovations in signal delivery that were previously deployed in [Osprey](#osprey). The signals required to enable the fast, high-fidelity two-qubit and single-qubit control are delivered with high-density flex cabling.
 
 *   [View available Heron systems](https://quantum.ibm.com/services/resources?tab=systems&type=Heron)
 

--- a/docs/guides/processor-types.mdx
+++ b/docs/guides/processor-types.mdx
@@ -26,7 +26,7 @@ At 133 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that
 <Admonition type="info" title="Revisions">
   `r2` (July 2024) 
 
-  This is a revision of our original Heron processor. The chip has been redesigned to now include 156 qubits in a heavy-hexagonal lattice. While continuing to make use of the innovations of the original Heron systems, it also introduces a new TLS mitigation feature that controls the TLS environment of the chip, thereby improving coherence and stability across the whole chip.
+  This is a revision of the original Heron processor. The chip has been redesigned to include 156 qubits in a heavy-hexagonal lattice. While continuing to make use of the innovations of the original Heron systems, it also introduces a new TLS mitigation feature that controls the TLS environment of the chip, thereby improving coherence and stability across the whole chip.
 
 </Admonition>
 

--- a/docs/guides/processor-types.mdx
+++ b/docs/guides/processor-types.mdx
@@ -28,6 +28,10 @@ At 156 qubits, Heron is an [Eagle](#eagle)-sized upgrade to [Egret](#egret) that
 
   This is a revision of the original Heron processor. The chip has been redesigned to include 156 qubits in a heavy-hexagonal lattice. While continuing to make use of the innovations of the original Heron systems, it also introduces a new TLS mitigation feature that controls the TLS environment of the chip, thereby improving coherence and stability across the whole chip.
 
+  `r1` (December 2023)
+
+  The first version of Heron with 133 qubits and no TLS mitigation control.
+
 </Admonition>
 
 ## Osprey


### PR DESCRIPTION
Text from the hardware team:



    HeronR2:

    This is a revision of our original Heron processor. The chip has been redesigned to now include 156 qubits in a heavy-hexagonal lattice. While continuing to make use of the innovations of the original Heron systems, it also introduces a new TLS mitigation feature that controls the TLS environment of the chip, thereby improving coherence and stability across the whole chip.
