### PR TITLE
Fix markdown link extraction

### DIFF
--- a/scripts/lib/links/extractLinks.test.ts
+++ b/scripts/lib/links/extractLinks.test.ts
@@ -45,7 +45,7 @@ test("markdownFromNotebook()", () => {
         "metadata": {}
     }
   `);
-  expect(result).toBe("Line 1.\nLine 2.\nLine 3.");
+  expect(result).toBe("Line 1.\nLine 2.\n\nLine 3.");
 });
 
 test("parseAnchors()", () => {

--- a/scripts/lib/links/extractLinks.ts
+++ b/scripts/lib/links/extractLinks.ts
@@ -44,7 +44,7 @@ export function markdownFromNotebook(rawContent: string): string {
   return cells
     .filter((cell) => cell.cell_type === "markdown")
     .map((cell) => cell.source.join(""))
-    .join("\n");
+    .join("\n\n");
 }
 
 export function parseAnchors(markdown: string): Set<string> {


### PR DESCRIPTION
In Jupyter notebooks, we weren't correctly detecting headers if the markdown section right above it ended in `</Admonition`. This broke CI in https://github.com/Qiskit/documentation/pull/1673.