### PR TITLE
Add PR preview GitHub infrastructure

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pr-preview:
-    name: PR preview cleanup
+    name: PR preview
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     env:
@@ -42,6 +42,8 @@ jobs:
           ref: gh-pages
       - name: Deploy to GitHub Pages
         run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
           git add .
           git commit -m "Deploy PR preview for PR ${{ github.event.pull_request.number }}"
           git push

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,47 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+name: PR preview
+on: 
+  pull_request:
+    # paths:
+    #   - "docs/**/*"
+    #   - "public/images/**/*"
+
+jobs:
+  pr-preview:
+    name: PR preview cleanup
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PR_PREVIEW_PATH: pr-${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+  
+      - name: Build static site
+        run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_PATH }} --proof-of-concept
+
+      - name: Switch to gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Deploy to GitHub Pages
+        run: |
+          git add .
+          git commit -m "Deploy PR preview for PR ${{ github.event.pull_request.number }}"
+          git push

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 name: PR preview
-on: 
+on:
   pull_request:
     # paths:
     #   - "docs/**/*"
@@ -32,18 +32,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-  
+
       - name: Build static site
         run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_PATH }} --proof-of-concept
 
-      - name: Switch to gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
       - name: Deploy to GitHub Pages
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
+          git fetch origin gh-pages
+          git switch gh-pages
           git add .
           git commit -m "Deploy PR preview for PR ${{ github.event.pull_request.number }}"
           git push

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,9 +13,9 @@
 name: PR preview
 on:
   pull_request:
-    # paths:
-    #   - "docs/**/*"
-    #   - "public/images/**/*"
+    paths:
+      - "docs/**/*"
+      - "public/images/**/*"
 
 jobs:
   pr-preview:
@@ -63,3 +63,4 @@ jobs:
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ env.PR_PREVIEW_URL }}
+          override: false

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       PR_PREVIEW_PATH: pr-${{ github.event.pull_request.number }}
-      PR_PREVIEW_URL: https://qiskit.github.io/documentation/pr-${{ github.event.pull_request.number }}
+      PR_PREVIEW_URL: https://qiskit.github.io/documentation/pr-${{ github.event.pull_request.number }}/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -41,22 +41,16 @@ jobs:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: pr_preview
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Build static site
         run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_PATH }} --proof-of-concept
 
       - name: Deploy to GitHub Pages
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git fetch origin gh-pages
-          git switch gh-pages
-          git add .
-          git commit -m "Deploy PR preview for PR ${{ github.event.pull_request.number }}"
-          git push
+        run: scripts/pr_previews/deploy.py ${{ env.PR_PREVIEW_PATH }}
 
       - name: Determine deployment result
-        run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_URL }}
+        run: scripts/pr_previews/poll_deployment.py ${{ env.PR_PREVIEW_URL }}
       - name: Report deployment status
         uses: bobheadxi/deployments@v1
         if: always()

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Deploy to GitHub Pages
         run: scripts/pr_previews/deploy.py ${{ env.PR_PREVIEW_PATH }}
+      - name: Switch back to original branch
+        uses: actions/checkout@v4
 
       - name: Determine deployment result
         run: scripts/pr_previews/poll_deployment.py ${{ env.PR_PREVIEW_URL }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       PR_PREVIEW_PATH: pr-${{ github.event.pull_request.number }}
+      PR_PREVIEW_URL: https://qiskit.github.io/documentation/${{ env.PR_PREVIEW_PATH }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -32,6 +33,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Set up deployment status
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: pr_preview
 
       - name: Build static site
         run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_PATH }} --proof-of-concept
@@ -45,3 +54,16 @@ jobs:
           git add .
           git commit -m "Deploy PR preview for PR ${{ github.event.pull_request.number }}"
           git push
+
+      - name: Determine deployment result
+        run: scripts/pr_previews/builder.py ${{ env.PR_PREVIEW_URL }}
+      - name: Report deployment status
+        uses: bobheadxi/deployments@v1
+        if: always()
+        with:
+          step: finish
+          token: ${{ github.token }}
+          env: ${{ steps.deployment.outputs.env }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ env.PR_PREVIEW_URL }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       PR_PREVIEW_PATH: pr-${{ github.event.pull_request.number }}
-      PR_PREVIEW_URL: https://qiskit.github.io/documentation/${{ env.PR_PREVIEW_PATH }}
+      PR_PREVIEW_URL: https://qiskit.github.io/documentation/pr-${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/scripts/pr_previews/builder.py
+++ b/scripts/pr_previews/builder.py
@@ -37,14 +37,43 @@ logging.basicConfig(
 def create_parser() -> ArgumentParser:
     parser = ArgumentParser()
     parser.add_argument("dest", help="The output folder", type=Path)
+    parser.add_argument(
+        "--proof-of-concept",
+        help="Build a simple index.html, rather than actual docs app.",
+        action="store_true",
+    )
     return parser
 
 
 def main() -> None:
     args = create_parser().parse_args()
+    if args.proof_of_concept:
+        write_proof_of_concept(args.dest)
+        return
+
     with setup_dir() as dir:
         yarn_build(dir)
         save_output(dir, args.dest)
+
+
+def write_proof_of_concept(dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "index.html").write_text(
+        """\
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Proof of Concept</title>
+        </head>
+        <body>
+            <h1>Proof of concept</h1>
+        </body>
+        </html>
+        """
+    )
+    logger.info(f"Wrote proof-of-concept index.html to {dest}")
 
 
 def yarn_build(root_dir: Path) -> None:

--- a/scripts/pr_previews/builder.py
+++ b/scripts/pr_previews/builder.py
@@ -60,7 +60,7 @@ def write_proof_of_concept(dest: Path) -> None:
         <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Proof of Concept</title>
+            <title>Proof of Concept: {dest.name}</title>
         </head>
         <body>
             <h1>Proof of concept: {dest.name}</h1>

--- a/scripts/pr_previews/builder.py
+++ b/scripts/pr_previews/builder.py
@@ -59,7 +59,7 @@ def main() -> None:
 def write_proof_of_concept(dest: Path) -> None:
     dest.mkdir(parents=True, exist_ok=True)
     (dest / "index.html").write_text(
-        """\
+        f"""\
         <!DOCTYPE html>
         <html lang="en">
         <head>
@@ -68,7 +68,7 @@ def write_proof_of_concept(dest: Path) -> None:
             <title>Proof of Concept</title>
         </head>
         <body>
-            <h1>Proof of concept</h1>
+            <h1>Proof of concept: {dest.name}</h1>
         </body>
         </html>
         """

--- a/scripts/pr_previews/deploy.py
+++ b/scripts/pr_previews/deploy.py
@@ -37,10 +37,6 @@ def main() -> None:
             f"Expected {folder} to have been created with the new content"
         )
 
-    starting_branch = run_subprocess(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-    ).stdout.strip()
-
     run_subprocess(["git", "config", "user.name", "github-actions[bot]"])
     run_subprocess(
         ["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"]
@@ -60,8 +56,13 @@ def main() -> None:
         run_subprocess(["git", "add", "."])
         run_subprocess(["git", "commit", "-m", f"Deploy PR preview for {folder}"])
         run_subprocess(["git", "push"])
+        logger.info("Pushed updates to gh-pages branch")
+    else:
+        logger.info("No changed files detected, so no push made to gh-pages")
 
-    run_subprocess(["git", "switch", starting_branch])
+    logger.warning(
+        "The branch is set to gh-pages. You probably want to `git switch` back to your original branch"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/pr_previews/deploy.py
+++ b/scripts/pr_previews/deploy.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import logging
+import shutil
+from argparse import ArgumentParser
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+from utils import configure_logging, run_subprocess
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "folder", help="the folder to deploy to GitHub Pages", type=Path
+    )
+    return parser
+
+
+def main() -> None:
+    folder: Path = create_parser().parse_args().folder
+    if not folder.exists():
+        raise AssertionError(f"Expected {folder} to have been created with the new content")
+
+    run_subprocess(["git", "config", "user.name", "github-actions[bot]"])
+    run_subprocess(
+        ["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"]
+    )
+
+    run_subprocess(["git", "fetch", "origin", "gh-pages"])
+
+    # Handle if the content folder already exists on gh-pages branch.
+    run_subprocess(["git", "stash", "--include-untracked"])
+    run_subprocess(["git", "switch", "gh-pages"])
+    if folder.exists():
+        shutil.rmtree(folder)
+    run_subprocess(["git", "stash", "pop"])
+
+    run_subprocess(["git", "add", "."])
+    run_subprocess(["git", "commit", "-m", f"Deploy PR preview for {folder}"])
+    run_subprocess(["git", "push"])
+
+
+if __name__ == "__main__":
+    configure_logging()
+    main()

--- a/scripts/pr_previews/deploy.py
+++ b/scripts/pr_previews/deploy.py
@@ -33,7 +33,13 @@ def create_parser() -> ArgumentParser:
 def main() -> None:
     folder: Path = create_parser().parse_args().folder
     if not folder.exists():
-        raise AssertionError(f"Expected {folder} to have been created with the new content")
+        raise AssertionError(
+            f"Expected {folder} to have been created with the new content"
+        )
+
+    starting_branch = run_subprocess(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+    ).stdout.strip()
 
     run_subprocess(["git", "config", "user.name", "github-actions[bot]"])
     run_subprocess(
@@ -52,6 +58,8 @@ def main() -> None:
     run_subprocess(["git", "add", "."])
     run_subprocess(["git", "commit", "-m", f"Deploy PR preview for {folder}"])
     run_subprocess(["git", "push"])
+
+    run_subprocess(["git", "switch", starting_branch])
 
 
 if __name__ == "__main__":

--- a/scripts/pr_previews/deploy.py
+++ b/scripts/pr_previews/deploy.py
@@ -55,9 +55,11 @@ def main() -> None:
         shutil.rmtree(folder)
     run_subprocess(["git", "stash", "pop"])
 
-    run_subprocess(["git", "add", "."])
-    run_subprocess(["git", "commit", "-m", f"Deploy PR preview for {folder}"])
-    run_subprocess(["git", "push"])
+    changed_files = run_subprocess(["git", "status", "--porcelain"]).stdout.strip()
+    if changed_files:
+        run_subprocess(["git", "add", "."])
+        run_subprocess(["git", "commit", "-m", f"Deploy PR preview for {folder}"])
+        run_subprocess(["git", "push"])
 
     run_subprocess(["git", "switch", starting_branch])
 

--- a/scripts/pr_previews/poll_deployment.py
+++ b/scripts/pr_previews/poll_deployment.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import logging
+import http.client
+import time
+from argparse import ArgumentParser
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+INITIAL_DELAY_S = 20
+TIMEOUT_S = 60
+RETRY_INTERVAL_S = 5
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument("url", help="The URL to check")
+    return parser
+
+
+def main() -> None:
+    url = create_parser().parse_args().url
+
+    logger.info(f"Waiting {INITIAL_DELAY_S} seconds before initial ping to {url}")
+    time.sleep(INITIAL_DELAY_S)
+
+    end_time = time.time() + TIMEOUT_S - INITIAL_DELAY_S
+    while time.time() < end_time:
+        status = get_status(url)
+        if status == 200:
+            logger.info(f"Success: 200")
+            return
+
+        logger.warning(f"Response: {status}. Retrying in {RETRY_INTERVAL_S} seconds...")
+        time.sleep(RETRY_INTERVAL_S)
+
+    logger.error(f"Timeout: did not respond with 200 within {TIMEOUT_S} seconds")
+    raise SystemExit(1)
+
+
+def get_status(url: str) -> int:
+    parsed_url = urlparse(url)
+    conn = http.client.HTTPSConnection(parsed_url.netloc, timeout=5)
+    try:
+        conn.request("HEAD", parsed_url.path)
+        return conn.getresponse().status
+    except Exception as e:
+        logger.error(f"Error checking server: {e}")
+        return -1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pr_previews/poll_deployment.py
+++ b/scripts/pr_previews/poll_deployment.py
@@ -18,12 +18,10 @@ import time
 from argparse import ArgumentParser
 from urllib.parse import urlparse
 
+from utils import configure_logging
+
+
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    datefmt="%H:%M:%S",
-)
 
 INITIAL_DELAY_S = 20
 TIMEOUT_S = 60
@@ -70,4 +68,5 @@ def get_status(url: str) -> int:
 
 
 if __name__ == "__main__":
+    configure_logging()
     main()

--- a/scripts/pr_previews/utils.py
+++ b/scripts/pr_previews/utils.py
@@ -1,0 +1,53 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def run_subprocess(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    stream_output: bool = False,
+) -> subprocess.CompletedProcess:
+    output_dest = None if stream_output else subprocess.PIPE
+    if stream_output:
+        logger.info(f"Starting subprocess: {', '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=output_dest,
+        stderr=output_dest,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result
+    logger.error(f"Subprocess failed with code {result.returncode}: {cmd}")
+    if not stream_output:
+        logger.error(f"stdout: {result.stdout}")
+        logger.error(f"stderr: {result.stderr}")
+    raise SystemExit()


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/1043.

This deploys a new folder at https://qiskit.github.io/documentation/pr-{x}. For now, it's a contrived `index.html` only to get the technique working. We will switch to the full built preview app once the Docker image is accessible.

The GitHub workflow follows this logic:

1. Build the static site
2. Deploy by pushing the files to the `gh-pages` branch under the folder `pr-{x}`
3. Check if the deploy has worked by polling https://qiskit.github.io/documentation/pr-{x}, with a one minute timeout.

A follow up will add the cleanup mechanism.