### PR TITLE
Improve index page for GitHub pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,79 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PR previews</title>
-</head>
-<body>
-    <h1>PR previews</h1>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Documentation PR previews</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        line-height: 1.6;
+        color: #333;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: #f5f5f5;
+      }
+
+      h1,
+      h2 {
+        color: #2c3e50;
+      }
+
+      h1 {
+        border-bottom: 2px solid #3498db;
+        padding-bottom: 10px;
+      }
+
+      a {
+        color: #3498db;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+
+      ul {
+        padding-left: 20px;
+      }
+
+      code {
+        background-color: #f0f0f0;
+        border: 1px solid #ddd;
+        border-radius: 3px;
+        padding: 2px 5px;
+        font-family: "Courier New", Courier, monospace;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Documentation PR previews</h1>
+    <p>
+      This site allows us to have previews of what the content in your pull
+      request looks like.
+    </p>
+
+    <h2>How to access your preview</h2>
+    <p>Use either of these approaches:</p>
+    <ul>
+      <li>
+        Go directly to the link
+        <a href="https://qiskit.github.io/documentation/pr-"
+          >https://qiskit.github.io/documentation/pr-[number]</a
+        >, e.g.
+        <a href="https://qiskit.github.io/documentation/pr-84"
+          >https://qiskit.github.io/documentation/pr-84</a
+        >
+      </li>
+      <li>In your pull request, look for the button "View deployment"</li>
+    </ul>
+    <p>You can also load a local preview by running <code>./start</code>.</p>
+
+    <h2>No API docs</h2>
+    <p>
+      API docs are not included in PR previews to speed up the build process.
+      You must use local previews with <code>./start</code> for these.
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
While the deployment action links directly to the subfolder, people might still stumble on the index page.

<img width="869" alt="Screenshot 2024-07-11 at 1 09 44 PM" src="https://github.com/Qiskit/documentation/assets/14852634/5b4089f4-aa9e-4a8a-b791-5059e48d285a">
