### PR TITLE
Fix typo in Runtime save_account code

### DIFF
--- a/docs/api/migration-guides/qiskit-runtime-from-ibm-provider.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-from-ibm-provider.mdx
@@ -24,7 +24,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 
 # IBM Quantum channel; set to default
 
-QiskitRuntimeService.save_account(channel="ibm_quantum", token="<IQP_TOKEN>", overwrite=True, default=true)
+QiskitRuntimeService.save_account(channel="ibm_quantum", token="<IQP_TOKEN>", overwrite=True, set_as_default=True)
 ```
 
 Additionally, you can now name your saved credentials and load the credentials by name.

--- a/docs/api/migration-guides/qiskit-runtime-from-ibmq-provider.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-from-ibmq-provider.mdx
@@ -66,7 +66,7 @@ information on retrieving account credentials, see [Select and set up an IBM Qua
 ``` python
 # IBM Quantum channel; set to default 
 
-QiskitRuntimeService.save_account(channel="ibm_quantum", token="<IQP_TOKEN>", overwrite=True, default=true)
+QiskitRuntimeService.save_account(channel="ibm_quantum", token="<IQP_TOKEN>", overwrite=True, set_as_default=True)
 ```
 
 Additionally, you can now name your saved credentials and load the credentials by name.


### PR DESCRIPTION
Closes #1667. Update broken code to 

`QiskitRuntimeService.save_account(channel="ibm_quantum", token="<IQP_TOKEN>", overwrite=True, set_as_default=True)`

Affects two migration guides.