### PR TITLE
Group API scripts together

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "fmt": "prettier --write .",
     "test": "jest",
     "typecheck": "tsc",
-    "regen-apis": "node -r esbuild-register scripts/commands/regenerateApiDocs.ts",
-    "gen-api": "node -r esbuild-register scripts/commands/updateApiDocs.ts",
-    "make-historical": "node -r esbuild-register scripts/commands/convertApiDocsToHistorical.ts"
+    "regen-apis": "node -r esbuild-register scripts/commands/api/regenerateApiDocs.ts",
+    "gen-api": "node -r esbuild-register scripts/commands/api/updateApiDocs.ts",
+    "make-historical": "node -r esbuild-register scripts/commands/api/convertApiDocsToHistorical.ts"
   },
   "devDependencies": {
     "@swc/jest": "^0.2.29",

--- a/scripts/commands/api/convertApiDocsToHistorical.ts
+++ b/scripts/commands/api/convertApiDocsToHistorical.ts
@@ -18,9 +18,9 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import transformLinks from "transform-markdown-links";
 
-import { pathExists, getRoot } from "../lib/fs";
-import { zxMain } from "../lib/zx";
-import { Pkg } from "../lib/api/Pkg";
+import { pathExists, getRoot } from "../../lib/fs";
+import { zxMain } from "../../lib/zx";
+import { Pkg } from "../../lib/api/Pkg";
 
 interface Arguments {
   [x: string]: unknown;

--- a/scripts/commands/api/regenerateApiDocs.ts
+++ b/scripts/commands/api/regenerateApiDocs.ts
@@ -16,9 +16,9 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { $ } from "zx";
 
-import { Pkg } from "../lib/api/Pkg";
-import { zxMain } from "../lib/zx";
-import { pathExists } from "../lib/fs";
+import { Pkg } from "../../lib/api/Pkg";
+import { zxMain } from "../../lib/zx";
+import { pathExists } from "../../lib/fs";
 
 interface Arguments {
   [x: string]: unknown;

--- a/scripts/commands/api/updateApiDocs.ts
+++ b/scripts/commands/api/updateApiDocs.ts
@@ -13,11 +13,11 @@
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
-import { Pkg } from "../lib/api/Pkg";
-import { zxMain } from "../lib/zx";
-import { pathExists, rmFilesInFolder } from "../lib/fs";
-import { downloadSphinxArtifact } from "../lib/api/sphinxArtifacts";
-import { runConversionPipeline } from "../lib/api/conversionPipeline";
+import { Pkg } from "../../lib/api/Pkg";
+import { zxMain } from "../../lib/zx";
+import { pathExists, rmFilesInFolder } from "../../lib/fs";
+import { downloadSphinxArtifact } from "../../lib/api/sphinxArtifacts";
+import { runConversionPipeline } from "../../lib/api/conversionPipeline";
 
 interface Arguments {
   [x: string]: unknown;


### PR DESCRIPTION
I was spending some time in `scripts/commands` and realized it's gotten quite big. The 3 API scripts are all very focused on one single workflow, so we can make things better organized with a folder.