### PR TITLE
[needs discussion] Move 'Workflow' into 'Getting started'

### DIFF
--- a/docs/guides/_toc.json
+++ b/docs/guides/_toc.json
@@ -19,6 +19,19 @@
             {
               "title": "Set up an IBM Quantum channel",
               "url": "/guides/setup-channel"
+            },
+            {
+              "title": "Advanced setup",
+              "children": [
+                {
+                  "title": "Install the Qiskit SDK from source",
+                  "url": "/guides/install-qiskit-source"
+                },
+                {
+                  "title": "Configure the Qiskit SDK locally",
+                  "url": "/guides/configure-qiskit-local"
+                }
+              ]
             }
           ]
         },
@@ -31,43 +44,29 @@
           "url": "/guides/latest-updates"
         },
         {
-          "title": "Advanced setup",
+          "title": "Workflow",
           "children": [
             {
-              "title": "Install the Qiskit SDK from source",
-              "url": "/guides/install-qiskit-source"
+              "title": "Introduction to Qiskit patterns",
+              "url": "/guides/intro-to-patterns"
             },
             {
-              "title": "Configure the Qiskit SDK locally",
-              "url": "/guides/configure-qiskit-local"
+              "title": "Map problem to circuits",
+              "url": "/guides/map-problem-to-circuits"
+            },
+            {
+              "title": "Optimize for hardware",
+              "url": "/guides/optimize-for-hardware"
+            },
+            {
+              "title": "Execute on hardware",
+              "url": "/guides/execute-on-hardware"
+            },
+            {
+              "title": "Post-process results",
+              "url": "/guides/post-process-results"
             }
           ]
-        }
-      ],
-      "collapsible": false
-    },
-    {
-      "title": "Workflow",
-      "children": [
-        {
-          "title": "Introduction to Qiskit patterns",
-          "url": "/guides/intro-to-patterns"
-        },
-        {
-          "title": "Map problem to circuits",
-          "url": "/guides/map-problem-to-circuits"
-        },
-        {
-          "title": "Optimize for hardware",
-          "url": "/guides/optimize-for-hardware"
-        },
-        {
-          "title": "Execute on hardware",
-          "url": "/guides/execute-on-hardware"
-        },
-        {
-          "title": "Post-process results",
-          "url": "/guides/post-process-results"
         }
       ],
       "collapsible": false


### PR DESCRIPTION
This moves the Workflow pages to be a folder under "Getting started", and also moves "Advanced setup" to live under "Install".

Motivations:

- Free up left ToC real estate in preparation for Qiskit Functions
- Analytics show that people are using the Workflow pages less than we'd expect and they focus more on 'Getting started' and 'Tools'.

<details><summary>Unexpanded</summary>

<img width="262" alt="Screenshot 2024-07-17 at 2 26 22 PM" src="https://github.com/user-attachments/assets/6c7a4c70-8f67-49e3-8f89-2fce982aaa7c">
</details>

<details><summary>Expanded 'Advanced setup'</summary>

<img width="258" alt="Screenshot 2024-07-17 at 2 26 42 PM" src="https://github.com/user-attachments/assets/def90e6e-8735-4d92-a1f0-5deb3c6b65bc">
</details>

<details><summary>Expanded 'Workflow'</summary>

<img width="261" alt="Screenshot 2024-07-17 at 2 27 41 PM" src="https://github.com/user-attachments/assets/580abbc1-4407-4253-ae74-1af1d37437e3">
</details>