### PR TITLE
Avoid race condition with PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -17,6 +17,10 @@ on:
       - "docs/**/*"
       - "public/images/**/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-preview:
     name: PR preview


### PR DESCRIPTION
A PR preview failed to deploy today because a prior workflow was already pushing the deploy, which messed up the Git state. We should only ever attempt to deploy one PR preview at a time - pushing a new commit should cancel the prior deploy attempt if still in progress.

To cancel, this uses the technique from https://www.meziantou.net/how-to-cancel-github-workflows-when-pushing-new-commits-on-a-branch.htm.