### PR TITLE
Point Code of Conduct to the docs site

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 # Code of Conduct
 
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [docs.quantum.ibm.com/open-source/code-of-conduct](https://docs.quantum.ibm.com/open-source/code-of-conduct)
 
 ---
 


### PR DESCRIPTION
The code of conduct was migrated to https://docs.quantum.ibm.com/open-source/code-of-conduct from qiskit/qiskit repo because it is more discoverable.