### PR TITLE
Refactor tests to prepare for Playwright

### DIFF
--- a/scripts/js/lib/api/dedupeHtmlIds.test.ts
+++ b/scripts/js/lib/api/dedupeHtmlIds.test.ts
@@ -22,10 +22,5 @@ test("dedupeHtmlIds()", async () => {
   # foo
   <span id="foo" />
   `),
-  ).toMatchInlineSnapshot(`
-    "<span id="bar" />
-
-    # foo
-    "
-  `);
+  ).toEqual(`<span id="bar" />\n\n# foo\n`);
 });

--- a/scripts/js/lib/api/generateApiComponents.test.ts
+++ b/scripts/js/lib/api/generateApiComponents.test.ts
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { expect, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 
 import {
   ComponentProps,

--- a/scripts/js/lib/api/generateToc.test.ts
+++ b/scripts/js/lib/api/generateToc.test.ts
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { describe, expect, test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 
 import { generateToc } from "./generateToc";
 import { Pkg, ReleaseNotesConfig } from "./Pkg";
@@ -22,33 +22,251 @@ const DEFAULT_ARGS = {
   isReleaseNotes: false,
 };
 
-describe("generateToc", () => {
-  test("generate a basic toc", () => {
-    const toc = generateToc(Pkg.mock({}), [
+test("generate a basic toc", () => {
+  const toc = generateToc(Pkg.mock({}), [
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project",
+      },
+      url: "/api/my-quantum-project",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.options",
+      },
+      url: "/api/my-quantum-project/options",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.options.submodule",
+      },
+      url: "/api/my-quantum-project/my_quantum_project.options.submodule",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: { apiType: "class", apiName: "Sampler" },
+      url: "/api/my-quantum-project/my_quantum_project.Sampler",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: { apiType: "method", apiName: "Sampler.run" },
+      url: "/api/my-quantum-project/my_quantum_project.Sampler.run",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: { apiType: "class", apiName: "Estimator" },
+      url: "/api/my-quantum-project/my_quantum_project.Estimator",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: { apiType: "class" },
+      url: "/api/my-quantum-project/my_quantum_project.NoName",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: { apiType: "class", apiName: "Options" },
+      url: "docs/my-quantum-project/my_quantum_project.options.Options",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "function",
+        apiName: "runSomething",
+      },
+      url: "docs/my-quantum-project/my_quantum_project.runSomething",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.single",
+      },
+      url: "/api/my-quantum-project/single",
+      ...DEFAULT_ARGS,
+    },
+  ]);
+
+  expect(toc).toEqual({
+    children: [
       {
+        title: "my_quantum_project",
+        url: "/api/my-quantum-project",
+      },
+      {
+        title: "my_quantum_project.options",
+        url: "/api/my-quantum-project/options",
+      },
+      {
+        title: "my_quantum_project.options.submodule",
+        url: "/api/my-quantum-project/my_quantum_project.options.submodule",
+      },
+      {
+        title: "my_quantum_project.single",
+        url: "/api/my-quantum-project/single",
+      },
+      {
+        title: "Release notes",
+        url: "/api/my-quantum-project/release-notes",
+      },
+    ],
+    collapsed: true,
+    title: "My Quantum Project",
+  });
+});
+
+test("TOC with grouped modules", () => {
+  // This ordering is intentional.
+  const topLevelEntries: TocGroupingEntry[] = [
+    {
+      moduleId: "my_quantum_project",
+      title: "API index (custom)",
+      kind: "module",
+    },
+    { name: "Group 2", kind: "section" },
+    { name: "Group 1", kind: "section" },
+    {
+      moduleId: "my_quantum_project.another",
+      title: "dedicated module",
+      kind: "module",
+    },
+    // Ensure we can handle unused entries.
+    { moduleId: "unused_module", title: "unused", kind: "module" },
+    { name: "Unused section", kind: "section" },
+  ];
+  const tocGrouping = {
+    entries: topLevelEntries,
+    moduleToSection: (module: string) =>
+      module == "my_quantum_project.module" ? "Group 1" : "Group 2",
+  };
+
+  const toc = generateToc(Pkg.mock({ tocGrouping }), [
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project",
+      },
+      url: "/api/my-quantum-project",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.module",
+      },
+      url: "/api/my-quantum-project/my_quantum_project.module",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.module.submodule",
+      },
+      url: "/api/my-quantum-project/my_quantum_project.module.submodule",
+      ...DEFAULT_ARGS,
+    },
+    {
+      meta: {
+        apiType: "module",
+        apiName: "my_quantum_project.another",
+      },
+      url: "/api/my-quantum-project/my_quantum_project.another",
+      ...DEFAULT_ARGS,
+    },
+  ]);
+  expect(toc).toEqual({
+    collapsed: true,
+    title: "My Quantum Project",
+    children: [
+      {
+        title: "API index (custom)",
+        url: "/api/my-quantum-project",
+      },
+      {
+        title: "Group 2",
+        children: [
+          {
+            title: "my_quantum_project.module.submodule",
+            url: "/api/my-quantum-project/my_quantum_project.module.submodule",
+          },
+        ],
+      },
+      {
+        title: "Group 1",
+        children: [
+          {
+            title: "my_quantum_project.module",
+            url: "/api/my-quantum-project/my_quantum_project.module",
+          },
+        ],
+      },
+      {
+        title: "dedicated module",
+        url: "/api/my-quantum-project/my_quantum_project.another",
+      },
+      {
+        title: "Release notes",
+        url: "/api/my-quantum-project/release-notes",
+      },
+    ],
+  });
+});
+
+test("TOC with separate release note files", () => {
+  const toc = generateToc(
+    Pkg.mock({
+      releaseNotesConfig: new ReleaseNotesConfig({
+        separatePagesVersions: ["0.39", "0.38"],
+      }),
+    }),
+    [
+      {
+        ...DEFAULT_ARGS,
         meta: {
           apiType: "module",
           apiName: "my_quantum_project",
         },
         url: "/api/my-quantum-project",
-        ...DEFAULT_ARGS,
+        isReleaseNotes: true,
+      },
+    ],
+  );
+
+  expect(toc).toEqual({
+    children: [
+      {
+        title: "my_quantum_project",
+        url: "/api/my-quantum-project",
       },
       {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.options",
-        },
-        url: "/api/my-quantum-project/options",
-        ...DEFAULT_ARGS,
+        children: [
+          {
+            title: "0.39",
+            url: "/api/my-quantum-project/release-notes/0.39",
+          },
+          {
+            title: "0.38",
+            url: "/api/my-quantum-project/release-notes/0.38",
+          },
+        ],
+        title: "Release notes",
       },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.options.submodule",
-        },
-        url: "/api/my-quantum-project/my_quantum_project.options.submodule",
-        ...DEFAULT_ARGS,
-      },
+    ],
+    collapsed: true,
+    title: "My Quantum Project",
+  });
+});
+
+test("generate a toc without modules and releaes notes", () => {
+  const toc = generateToc(
+    Pkg.mock({
+      releaseNotesConfig: new ReleaseNotesConfig({ enabled: false }),
+    }),
+    [
       {
         meta: { apiType: "class", apiName: "Sampler" },
         url: "/api/my-quantum-project/my_quantum_project.Sampler",
@@ -71,7 +289,7 @@ describe("generateToc", () => {
       },
       {
         meta: { apiType: "class", apiName: "Options" },
-        url: "docs/my-quantum-project/my_quantum_project.options.Options",
+        url: "docs/my_quantum_project.options.Options",
         ...DEFAULT_ARGS,
       },
       {
@@ -79,240 +297,20 @@ describe("generateToc", () => {
           apiType: "function",
           apiName: "runSomething",
         },
-        url: "docs/my-quantum-project/my_quantum_project.runSomething",
+        url: "docs/my_quantum_project.runSomething",
         ...DEFAULT_ARGS,
       },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.single",
-        },
-        url: "/api/my-quantum-project/single",
-        ...DEFAULT_ARGS,
-      },
-    ]);
+    ],
+  );
 
-    expect(toc).toEqual({
-      children: [
-        {
-          title: "my_quantum_project",
-          url: "/api/my-quantum-project",
-        },
-        {
-          title: "my_quantum_project.options",
-          url: "/api/my-quantum-project/options",
-        },
-        {
-          title: "my_quantum_project.options.submodule",
-          url: "/api/my-quantum-project/my_quantum_project.options.submodule",
-        },
-        {
-          title: "my_quantum_project.single",
-          url: "/api/my-quantum-project/single",
-        },
-        {
-          title: "Release notes",
-          url: "/api/my-quantum-project/release-notes",
-        },
-      ],
-      collapsed: true,
-      title: "My Quantum Project",
-    });
-  });
-
-  test("TOC with grouped modules", () => {
-    // This ordering is intentional.
-    const topLevelEntries: TocGroupingEntry[] = [
+  expect(toc).toEqual({
+    children: [
       {
-        moduleId: "my_quantum_project",
-        title: "API index (custom)",
-        kind: "module",
-      },
-      { name: "Group 2", kind: "section" },
-      { name: "Group 1", kind: "section" },
-      {
-        moduleId: "my_quantum_project.another",
-        title: "dedicated module",
-        kind: "module",
-      },
-      // Ensure we can handle unused entries.
-      { moduleId: "unused_module", title: "unused", kind: "module" },
-      { name: "Unused section", kind: "section" },
-    ];
-    const tocGrouping = {
-      entries: topLevelEntries,
-      moduleToSection: (module: string) =>
-        module == "my_quantum_project.module" ? "Group 1" : "Group 2",
-    };
-
-    const toc = generateToc(Pkg.mock({ tocGrouping }), [
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project",
-        },
+        title: "API index",
         url: "/api/my-quantum-project",
-        ...DEFAULT_ARGS,
       },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.module",
-        },
-        url: "/api/my-quantum-project/my_quantum_project.module",
-        ...DEFAULT_ARGS,
-      },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.module.submodule",
-        },
-        url: "/api/my-quantum-project/my_quantum_project.module.submodule",
-        ...DEFAULT_ARGS,
-      },
-      {
-        meta: {
-          apiType: "module",
-          apiName: "my_quantum_project.another",
-        },
-        url: "/api/my-quantum-project/my_quantum_project.another",
-        ...DEFAULT_ARGS,
-      },
-    ]);
-    expect(toc).toEqual({
-      collapsed: true,
-      title: "My Quantum Project",
-      children: [
-        {
-          title: "API index (custom)",
-          url: "/api/my-quantum-project",
-        },
-        {
-          title: "Group 2",
-          children: [
-            {
-              title: "my_quantum_project.module.submodule",
-              url: "/api/my-quantum-project/my_quantum_project.module.submodule",
-            },
-          ],
-        },
-        {
-          title: "Group 1",
-          children: [
-            {
-              title: "my_quantum_project.module",
-              url: "/api/my-quantum-project/my_quantum_project.module",
-            },
-          ],
-        },
-        {
-          title: "dedicated module",
-          url: "/api/my-quantum-project/my_quantum_project.another",
-        },
-        {
-          title: "Release notes",
-          url: "/api/my-quantum-project/release-notes",
-        },
-      ],
-    });
-  });
-
-  test("TOC with separate release note files", () => {
-    const toc = generateToc(
-      Pkg.mock({
-        releaseNotesConfig: new ReleaseNotesConfig({
-          separatePagesVersions: ["0.39", "0.38"],
-        }),
-      }),
-      [
-        {
-          ...DEFAULT_ARGS,
-          meta: {
-            apiType: "module",
-            apiName: "my_quantum_project",
-          },
-          url: "/api/my-quantum-project",
-          isReleaseNotes: true,
-        },
-      ],
-    );
-
-    expect(toc).toEqual({
-      children: [
-        {
-          title: "my_quantum_project",
-          url: "/api/my-quantum-project",
-        },
-        {
-          children: [
-            {
-              title: "0.39",
-              url: "/api/my-quantum-project/release-notes/0.39",
-            },
-            {
-              title: "0.38",
-              url: "/api/my-quantum-project/release-notes/0.38",
-            },
-          ],
-          title: "Release notes",
-        },
-      ],
-      collapsed: true,
-      title: "My Quantum Project",
-    });
-  });
-
-  test("generate a toc without modules and releaes notes", () => {
-    const toc = generateToc(
-      Pkg.mock({
-        releaseNotesConfig: new ReleaseNotesConfig({ enabled: false }),
-      }),
-      [
-        {
-          meta: { apiType: "class", apiName: "Sampler" },
-          url: "/api/my-quantum-project/my_quantum_project.Sampler",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: { apiType: "method", apiName: "Sampler.run" },
-          url: "/api/my-quantum-project/my_quantum_project.Sampler.run",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: { apiType: "class", apiName: "Estimator" },
-          url: "/api/my-quantum-project/my_quantum_project.Estimator",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: { apiType: "class" },
-          url: "/api/my-quantum-project/my_quantum_project.NoName",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: { apiType: "class", apiName: "Options" },
-          url: "docs/my_quantum_project.options.Options",
-          ...DEFAULT_ARGS,
-        },
-        {
-          meta: {
-            apiType: "function",
-            apiName: "runSomething",
-          },
-          url: "docs/my_quantum_project.runSomething",
-          ...DEFAULT_ARGS,
-        },
-      ],
-    );
-
-    expect(toc).toEqual({
-      children: [
-        {
-          title: "API index",
-          url: "/api/my-quantum-project",
-        },
-      ],
-      collapsed: true,
-      title: "My Quantum Project",
-    });
+    ],
+    collapsed: true,
+    title: "My Quantum Project",
   });
 });

--- a/scripts/js/lib/api/htmlToMd.test.ts
+++ b/scripts/js/lib/api/htmlToMd.test.ts
@@ -65,12 +65,10 @@ test("handle tabs", async () => {
       </details>
     </div>
 `),
-  ).toMatchInlineSnapshot(`
-              "### Account initialization
+  ).toEqual(`### Account initialization
 
-              You need to initialize your account before you can start using the Qiskit Runtime service. This is done by initializing a [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance with your account credentials.
-              "
-          `);
+You need to initialize your account before you can start using the Qiskit Runtime service. This is done by initializing a [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance with your account credentials.
+`);
 });
 
 // ------------------------------------------------------------------
@@ -90,12 +88,11 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 (2) a single float f, interpreted as {pi: f, pi/2: f/2, pi/3: f/3}.</p>
     </div>
     `),
-  ).toMatchInlineSnapshot(`
-      "For the full list of backend attributes, see the IBMBackend class documentation \\<[https://qiskit.org/documentation/apidoc/providers\\_models.html](https://qiskit.org/documentation/apidoc/providers_models.html)>
+  )
+    .toEqual(`For the full list of backend attributes, see the IBMBackend class documentation \\<[https://qiskit.org/documentation/apidoc/providers\\_models.html](https://qiskit.org/documentation/apidoc/providers_models.html)>
 
-      **basis\\_fidelity** (*dict | float*) – available strengths and fidelity of each. Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or (2) a single float f, interpreted as \\{pi: f, pi/2: f/2, pi/3: f/3}.
-      "
-    `);
+**basis\\_fidelity** (*dict | float*) – available strengths and fidelity of each. Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or (2) a single float f, interpreted as \\{pi: f, pi/2: f/2, pi/3: f/3}.
+`);
 });
 
 // ------------------------------------------------------------------
@@ -113,15 +110,13 @@ test("translate codeblocks to code fences with lang python", async () => {
 </pre>
     </div>
     `),
-  ).toMatchInlineSnapshot(`
-              "\`\`\`python
-              QiskitRuntimeService.backends(
-                  filters=lambda b: b.max_shots > 50000)
-              QiskitRuntimeService.backends(
-                  filters=lambda x: ("rz" in x.basis_gates )
-              \`\`\`
-              "
-          `);
+  ).toEqual(`\`\`\`python
+QiskitRuntimeService.backends(
+    filters=lambda b: b.max_shots > 50000)
+QiskitRuntimeService.backends(
+    filters=lambda x: ("rz" in x.basis_gates )
+\`\`\`
+`);
 });
 
 // ------------------------------------------------------------------
@@ -169,43 +164,41 @@ test("handle inlined methods and attributes", async () => {
 </dd></dl>
  </div>
       `),
-  ).toMatchInlineSnapshot(`
-      "# DAGCircuit
+  ).toEqual(`# DAGCircuit
 
-      <Class id="qiskit.dagcircuit.DAGCircuit" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py" signature="qiskit.dagcircuit.DAGCircuit" modifiers="class">
-        Bases: \`object\`
+<Class id="qiskit.dagcircuit.DAGCircuit" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py" signature="qiskit.dagcircuit.DAGCircuit" modifiers="class">
+  Bases: \`object\`
 
-        Quantum circuit as a directed acyclic graph.
+  Quantum circuit as a directed acyclic graph.
 
-        ## Attributes
+  ## Attributes
 
-        ### ancillas
+  ### ancillas
 
-        <Attribute id="qiskit.circuit.QuantumCircuit.ancillas">
-          Returns a list of ancilla bits in the order that the registers were added.
-        </Attribute>
+  <Attribute id="qiskit.circuit.QuantumCircuit.ancillas">
+    Returns a list of ancilla bits in the order that the registers were added.
+  </Attribute>
 
-        ## Methods
+  ## Methods
 
-        ### add\\_calibration
+  ### add\\_calibration
 
-        <Function id="qiskit.dagcircuit.DAGCircuit.add_calibration" signature="add_calibration(gate, qubits, schedule, params=None)">
-          Register a low-level, custom pulse definition for the given gate.
+  <Function id="qiskit.dagcircuit.DAGCircuit.add_calibration" signature="add_calibration(gate, qubits, schedule, params=None)">
+    Register a low-level, custom pulse definition for the given gate.
 
-          **Parameters**
+    **Parameters**
 
-          *   **gate** (*Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]*) – Gate information.
-          *   **qubits** (*Union\\[int, Tuple\\[int]]*) – List of qubits to be measured.
-          *   **schedule** ([*Schedule*](qiskit.pulse.Schedule#qiskit.pulse.Schedule "qiskit.pulse.Schedule")) – Schedule information.
-          *   **params** (*Optional\\[List\\[Union\\[float,* [*Parameter*](qiskit.circuit.Parameter#qiskit.circuit.Parameter "qiskit.circuit.Parameter")*]]]*) – A list of parameters.
+    *   **gate** (*Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]*) – Gate information.
+    *   **qubits** (*Union\\[int, Tuple\\[int]]*) – List of qubits to be measured.
+    *   **schedule** ([*Schedule*](qiskit.pulse.Schedule#qiskit.pulse.Schedule "qiskit.pulse.Schedule")) – Schedule information.
+    *   **params** (*Optional\\[List\\[Union\\[float,* [*Parameter*](qiskit.circuit.Parameter#qiskit.circuit.Parameter "qiskit.circuit.Parameter")*]]]*) – A list of parameters.
 
-          **Raises**
+    **Raises**
 
-          **Exception** – if the gate is of type string and params is None.
-        </Function>
-      </Class>
-      "
-    `);
+    **Exception** – if the gate is of type string and params is None.
+  </Function>
+</Class>
+`);
 });
 
 // ------------------------------------------------------------------
@@ -257,13 +250,12 @@ test("transform tables", async () => {
       </table>
     </div>
     `),
-  ).toMatchInlineSnapshot(`
-              "|                                                                                                                                                                                            |                                                                        |
-              | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-              | [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\\[channel, auth, token, ...]) | Class for interacting with the Qiskit Runtime service.                 |
-              | [\`Estimator\`](../stubs/qiskit_ibm_runtime.Estimator#qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\\[circuits, observables, ...])                                            | Class for interacting with Qiskit Runtime Estimator primitive service. |
-              "
-          `);
+  )
+    .toEqual(`|                                                                                                                                                                                            |                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\\[channel, auth, token, ...]) | Class for interacting with the Qiskit Runtime service.                 |
+| [\`Estimator\`](../stubs/qiskit_ibm_runtime.Estimator#qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\\[circuits, observables, ...])                                            | Class for interacting with Qiskit Runtime Estimator primitive service. |
+`);
 });
 
 test("preserve <span> with ids", async () => {
@@ -279,14 +271,12 @@ test("preserve <span> with ids", async () => {
     </article>
   </div>
     `),
-  ).toMatchInlineSnapshot(`
-      "<span id="qiskit-assembler" />
+  ).toEqual(`<span id="qiskit-assembler" />
 
-      <span id="circuit-and-schedule-assembler-qiskit-assembler" />
+<span id="circuit-and-schedule-assembler-qiskit-assembler" />
 
-      # Circuit Assembler
-      "
-    `);
+# Circuit Assembler
+`);
 });
 
 test("merge contiguous <em> removing spaces", async () => {
@@ -296,10 +286,9 @@ test("merge contiguous <em> removing spaces", async () => {
         <li><p><strong>gate</strong> (<em> Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]   </em>) – Gate information.</p></li>
       </div>
     `),
-  ).toMatchInlineSnapshot(`
-      "*   **gate** ( *Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]* ) – Gate information.
-      "
-    `);
+  ).toEqual(
+    `*   **gate** ( *Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]* ) – Gate information.\n`,
+  );
 });
 
 test("remove <br/>", async () => {
@@ -313,12 +302,11 @@ for execution on present day noisy quantum systems.</p>
 </p>
 </div>
     `),
-  ).toMatchInlineSnapshot(`
-      "Transpilation is the process of rewriting a given input circuit to match the topology of a specific quantum device, and/or to optimize the circuit for execution on present day noisy quantum systems.
+  )
+    .toEqual(`Transpilation is the process of rewriting a given input circuit to match the topology of a specific quantum device, and/or to optimize the circuit for execution on present day noisy quantum systems.
 
-      Qiskit has four pre-built transpilation pipelines available here:
-      "
-    `);
+Qiskit has four pre-built transpilation pipelines available here:
+`);
 });
 
 test("transform <dl>, <dd>, <dt> elements", async () => {
@@ -339,16 +327,14 @@ test("transform <dl>, <dd>, <dt> elements", async () => {
   </dl>
 </div>
 `),
-  ).toMatchInlineSnapshot(`
-        "## Return type
+  ).toEqual(`## Return type
 
-        [RuntimeJob](qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")
+[RuntimeJob](qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")
 
-        ## Returns
+## Returns
 
-        Submitted job. The result of the job is an instance of \`qiskit.primitives.EstimatorResult\`.
-        "
-      `);
+Submitted job. The result of the job is an instance of \`qiskit.primitives.EstimatorResult\`.
+`);
 });
 
 // For more information: https://github.com/Qiskit/documentation/issues/485
@@ -381,26 +367,25 @@ test("transform <dt> sig-object tags without id", async () => {
       </dd></dl>
       </div>
   `),
-  ).toMatchInlineSnapshot(`
-    "In addition to the public abstract methods, subclasses should also implement the following private methods:
+  )
+    .toEqual(`In addition to the public abstract methods, subclasses should also implement the following private methods:
 
-    <Function signature="_default_options()" modifiers="classmethod">
-      Return the default options
+<Function signature="_default_options()" modifiers="classmethod">
+  Return the default options
 
-      This method will return a [\`qiskit.providers.Options\`](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options") subclass object that will be used for the default options. These should be the default parameters to use for the options of the backend.
+  This method will return a [\`qiskit.providers.Options\`](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options") subclass object that will be used for the default options. These should be the default parameters to use for the options of the backend.
 
-      **Returns**
+  **Returns**
 
-      **A options object with**
+  **A options object with**
 
-      default values set
+  default values set
 
-      **Return type**
+  **Return type**
 
-      [qiskit.providers.Options](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options")
-    </Function>
-    "
-    `);
+  [qiskit.providers.Options](qiskit.providers.Options#qiskit.providers.Options "qiskit.providers.Options")
+</Function>
+`);
 });
 
 // ------------------------------------------------------------------
@@ -427,20 +412,18 @@ test("transform admonitions", async () => {
   </div>
 </div>
         `),
-  ).toMatchInlineSnapshot(`
-        "<Admonition title="Note" type="note">
-          To use these tools locally, you’ll need to install the additional dependencies for the visualization functions:
-        </Admonition>
+  ).toEqual(`<Admonition title="Note" type="note">
+  To use these tools locally, you’ll need to install the additional dependencies for the visualization functions:
+</Admonition>
 
-        <Admonition title="Warning" type="caution">
-          This is a warning
-        </Admonition>
+<Admonition title="Warning" type="caution">
+  This is a warning
+</Admonition>
 
-        <Admonition title="Important" type="danger">
-          The global phase gate ($e^{i\\theta}$).
-        </Admonition>
-        "
-      `);
+<Admonition title="Important" type="danger">
+  The global phase gate ($e^{i\\theta}$).
+</Admonition>
+`);
 });
 
 test("parse deprecations warnings", async () => {
@@ -452,12 +435,10 @@ test("parse deprecations warnings", async () => {
 </div>
       </div>
       `),
-  ).toMatchInlineSnapshot(`
-        "<Admonition title="Deprecated since version 0.23.0" type="danger">
-          The method \`qiskit.circuit.quantumregister.QuantumRegister.qasm()\` is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.
-        </Admonition>
-        "
-      `);
+  ).toEqual(`<Admonition title="Deprecated since version 0.23.0" type="danger">
+  The method \`qiskit.circuit.quantumregister.QuantumRegister.qasm()\` is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.
+</Admonition>
+`);
 });
 
 // ------------------------------------------------------------------
@@ -477,12 +458,11 @@ test("transform inline math", async () => {
 </table>
 </div>
         `),
-  ).toMatchInlineSnapshot(`
-        "|                                                                                                                                                                       |                                        |
-        | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-        | [\`GlobalPhaseGate\`](../stubs/qiskit.circuit.library.GlobalPhaseGate#qiskit.circuit.library.GlobalPhaseGate "qiskit.circuit.library.GlobalPhaseGate")(phase\\[, label]) | The global phase gate ($e^{i\\theta}$). |
-        "
-      `);
+  )
+    .toEqual(`|                                                                                                                                                                       |                                        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| [\`GlobalPhaseGate\`](../stubs/qiskit.circuit.library.GlobalPhaseGate#qiskit.circuit.library.GlobalPhaseGate "qiskit.circuit.library.GlobalPhaseGate")(phase\\[, label]) | The global phase gate ($e^{i\\theta}$). |
+`);
 });
 
 test("transform block math", async () => {
@@ -507,27 +487,25 @@ test("transform block math", async () => {
 \\[x = \\sum_{i=0}^{n-1} 2^i q_i,\\]</div>
 </div>
         `),
-  ).toMatchInlineSnapshot(`
-        "$$
-        \\begin{split}CCX q_0, q_1, q_2 =
-            I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
-           \\begin{pmatrix}
-                1 & 0 & 0 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 1 & 0 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 0 & 1 & 0 & 0 & 0 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 0 & 0 & 1\\\\
-                0 & 0 & 0 & 0 & 1 & 0 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 1 & 0 & 0\\\\
-                0 & 0 & 0 & 0 & 0 & 0 & 1 & 0\\\\
-                0 & 0 & 0 & 1 & 0 & 0 & 0 & 0
-            \\end{pmatrix}\\end{split}
-        $$
+  ).toEqual(`$$
+\\begin{split}CCX q_0, q_1, q_2 =
+    I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
+   \\begin{pmatrix}
+        1 & 0 & 0 & 0 & 0 & 0 & 0 & 0\\\\
+        0 & 1 & 0 & 0 & 0 & 0 & 0 & 0\\\\
+        0 & 0 & 1 & 0 & 0 & 0 & 0 & 0\\\\
+        0 & 0 & 0 & 0 & 0 & 0 & 0 & 1\\\\
+        0 & 0 & 0 & 0 & 1 & 0 & 0 & 0\\\\
+        0 & 0 & 0 & 0 & 0 & 1 & 0 & 0\\\\
+        0 & 0 & 0 & 0 & 0 & 0 & 1 & 0\\\\
+        0 & 0 & 0 & 1 & 0 & 0 & 0 & 0
+    \\end{pmatrix}\\end{split}
+$$
 
-        $$
-        x = \\sum_{i=0}^{n-1} 2^i q_i,
-        $$
-        "
-      `);
+$$
+x = \\sum_{i=0}^{n-1} 2^i q_i,
+$$
+`);
 });
 
 // ------------------------------------------------------------------
@@ -567,14 +545,12 @@ test("remove .html extension from relative links", async () => {
     </section>
   </article>
 </div>`),
-  ).toMatchInlineSnapshot(`
-      "<span id="qiskit-ibm-runtime-api-reference" />
+  ).toEqual(`<span id="qiskit-ibm-runtime-api-reference" />
 
-      # qiskit-ibm-runtime API reference
+# qiskit-ibm-runtime API reference
 
-      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
-      "
-    `);
+*   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
+`);
 });
 
 test("remove permalink", async () => {
@@ -590,15 +566,13 @@ test("remove permalink", async () => {
          </div>
        </section>
     </article>`),
-  ).toMatchInlineSnapshot(`
-      "<span id="qiskit-ibm-runtime-api-reference" />
+  ).toEqual(`<span id="qiskit-ibm-runtime-api-reference" />
 
-      # qiskit-ibm-runtime API reference
+# qiskit-ibm-runtime API reference
 
-      *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
-      *   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
-      "
-    `);
+*   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
+*   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
+`);
 });
 
 test("remove download links", async () => {
@@ -612,7 +586,7 @@ test("remove download links", async () => {
   <p>(<a class="reference download internal" download="" href="../_downloads/366189d70d6a05b2c91f442d20ba6114/qiskit-circuit-QuantumCircuit-1.py"><code class="xref download docutils literal notranslate"><span class="pre">Source</span> <span class="pre">code</span></code></a>)</p>
 </div>
 `),
-  ).toMatchInlineSnapshot(`""`);
+  ).toEqual("");
 });
 
 test("convert source links", async () => {
@@ -620,10 +594,9 @@ test("convert source links", async () => {
     await toMd(`<div role='main'>
 <span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
 </div>`),
-  ).toMatchInlineSnapshot(`
-              "IBMBackend.control\\_channel(*qubits*)[\\[source\\]](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py)
-              "
-          `);
+  ).toEqual(
+    `IBMBackend.control\\_channel(*qubits*)[\\[source\\]](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py)\n`,
+  );
 });
 
 // ------------------------------------------------------------------
@@ -672,24 +645,21 @@ test("convert class signature headings", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "# Estimator
-    
-    ### Sampler
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `# Estimator
 
-    <Class id="qiskit_ibm_runtime.Sampler" github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/sampler.py" signature="SamplerExample(circuits=None, parameters=None)" modifiers="class">
-      Class for interacting with Qiskit Runtime Sampler primitive service.
-    </Class>
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_runtime.Sampler",
-        "apiType": "class",
-      },
-    }
-  `);
+### Sampler
+
+<Class id="qiskit_ibm_runtime.Sampler" github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/sampler.py" signature="SamplerExample(circuits=None, parameters=None)" modifiers="class">
+  Class for interacting with Qiskit Runtime Sampler primitive service.
+</Class>\n`,
+    meta: {
+      apiName: "qiskit_ibm_runtime.Sampler",
+      apiType: "class",
+    },
+  });
 });
 
 test("convert class property headings", async () => {
@@ -726,22 +696,19 @@ test("convert class property headings", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "# circuits
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `# circuits
 
-    <Attribute id="qiskit_ibm_runtime.Estimator.circuits" attributeTypeHint="tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]" isDedicatedPage={true}>
-      Quantum circuits that represents quantum states.
-    </Attribute>
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_runtime.Estimator.circuits",
-        "apiType": "property",
-      },
-    }
-  `);
+<Attribute id="qiskit_ibm_runtime.Estimator.circuits" attributeTypeHint="tuple[qiskit.circuit.quantumcircuit.QuantumCircuit, ...]" isDedicatedPage={true}>
+  Quantum circuits that represents quantum states.
+</Attribute>\n`,
+    meta: {
+      apiName: "qiskit_ibm_runtime.Estimator.circuits",
+      apiType: "property",
+    },
+  });
 });
 
 test("convert class method headings", async () => {
@@ -757,22 +724,19 @@ test("convert class method headings", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "# run
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `# run
 
-    <Function id="qiskit_ibm_runtime.Estimator.run" isDedicatedPage={true} signature="Estimator.run(circuits, observables, parameter_values=None, **kwargs)">
-      Submit a request to the estimator primitive program.
-    </Function>
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_runtime.Estimator.run",
-        "apiType": "method",
-      },
-    }
-  `);
+<Function id="qiskit_ibm_runtime.Estimator.run" isDedicatedPage={true} signature="Estimator.run(circuits, observables, parameter_values=None, **kwargs)">
+  Submit a request to the estimator primitive program.
+</Function>\n`,
+    meta: {
+      apiName: "qiskit_ibm_runtime.Estimator.run",
+      apiType: "method",
+    },
+  });
 });
 
 test("convert class attributes headings", async () => {
@@ -788,20 +752,17 @@ test("convert class attributes headings", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "# callback
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `# callback
 
-    <Attribute id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" attributeTypeHint="Optional[Callable]" attributeValue="None" isDedicatedPage={true} />
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_runtime.options.EnvironmentOptions.callback",
-        "apiType": "attribute",
-      },
-    }
-  `);
+<Attribute id="qiskit_ibm_runtime.options.EnvironmentOptions.callback" attributeTypeHint="Optional[Callable]" attributeValue="None" isDedicatedPage={true} />\n`,
+    meta: {
+      apiName: "qiskit_ibm_runtime.options.EnvironmentOptions.callback",
+      apiType: "attribute",
+    },
+  });
 });
 
 test("convert functions headings", async () => {
@@ -834,34 +795,31 @@ By default this is sys.stdout.</p></li>
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "<span id="job-monitor" />
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `<span id="job-monitor" />
 
-    # job\\_monitor
+# job\\_monitor
 
-    <Function id="qiskit_ibm_provider.job.job_monitor" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/job_monitor.py" signature="job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)">
-      Monitor the status of an \`IBMJob\` instance.
+<Function id="qiskit_ibm_provider.job.job_monitor" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/job_monitor.py" signature="job_monitor(job, interval=None, output=<_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)">
+  Monitor the status of an \`IBMJob\` instance.
 
-      **Parameters**
+  **Parameters**
 
-      *   **job** (\`IBMJob\`) – Job to monitor.
-      *   **interval** (\`Optional\`\\[\`float\`]) – Time interval between status queries.
-      *   **output** (\`TextIO\`) – The file like object to write status messages to. By default this is sys.stdout.
+  *   **job** (\`IBMJob\`) – Job to monitor.
+  *   **interval** (\`Optional\`\\[\`float\`]) – Time interval between status queries.
+  *   **output** (\`TextIO\`) – The file like object to write status messages to. By default this is sys.stdout.
 
-      **Return type**
+  **Return type**
 
-      \`None\`
-    </Function>
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_provider.job.job_monitor",
-        "apiType": "function",
-      },
-    }
-  `);
+  \`None\`
+</Function>\n`,
+    meta: {
+      apiName: "qiskit_ibm_provider.job.job_monitor",
+      apiType: "function",
+    },
+  });
 });
 
 test("convert exception headings", async () => {
@@ -883,26 +841,23 @@ test("convert exception headings", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "<span id="ibmjoberror" />
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `<span id="ibmjoberror" />
 
-    # IBMJobError
+# IBMJobError
 
-    <Class id="qiskit_ibm_provider.job.IBMJobError" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/exceptions.py" signature="IBMJobError(*message)" modifiers="exception">
-      Base class for errors raised by the job modules.
+<Class id="qiskit_ibm_provider.job.IBMJobError" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_provider/job/exceptions.py" signature="IBMJobError(*message)" modifiers="exception">
+  Base class for errors raised by the job modules.
 
-      Set the error message.
-    </Class>
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_provider.job.IBMJobError",
-        "apiType": "exception",
-      },
-    }
-  `);
+  Set the error message.
+</Class>\n`,
+    meta: {
+      apiName: "qiskit_ibm_provider.job.IBMJobError",
+      apiType: "exception",
+    },
+  });
 });
 
 test("convert module headings removing () around the title", async () => {
@@ -916,28 +871,25 @@ test("convert module headings removing () around the title", async () => {
 `,
       true,
     ),
-  ).toMatchInlineSnapshot(`
-    {
-      "images": [],
-      "isReleaseNotes": false,
-      "markdown": "<span id="module-qiskit_ibm_runtime" />
+  ).toEqual({
+    images: [],
+    isReleaseNotes: false,
+    markdown: `<span id="module-qiskit_ibm_runtime" />
 
-    <span id="qiskit-runtime-qiskit-ibm-runtime" />
+<span id="qiskit-runtime-qiskit-ibm-runtime" />
 
-    # Qiskit Runtime
+# Qiskit Runtime
 
-    <span id="module-qiskit_ibm_runtime" />
+<span id="module-qiskit_ibm_runtime" />
 
-    \`qiskit_ibm_runtime\`
+\`qiskit_ibm_runtime\`
 
-    Modules related to Qiskit Runtime IBM Client.
-    ",
-      "meta": {
-        "apiName": "qiskit_ibm_runtime",
-        "apiType": "module",
-      },
-    }
-    `);
+Modules related to Qiskit Runtime IBM Client.\n`,
+    meta: {
+      apiName: "qiskit_ibm_runtime",
+      apiType: "module",
+    },
+  });
 });
 
 // ------------------------------------------------------------------
@@ -963,29 +915,26 @@ test("identify release notes", async () => {
       fileName: "release_notes.html",
       ...DEFAULT_ARGS,
     }),
-  ).toMatchInlineSnapshot(`
-  {
-    "images": [],
-    "isReleaseNotes": true,
-    "markdown": "# My Quantum release notes
+  ).toEqual({
+    images: [],
+    isReleaseNotes: true,
+    markdown: `# My Quantum release notes
 
-  <span id="release-notes-0-14-0" />
+<span id="release-notes-0-14-0" />
 
-  <span id="id1" />
+<span id="id1" />
 
-  ## 0.14.0
+## 0.14.0
 
-  <span id="new-features" />
+<span id="new-features" />
 
-  <span id="release-notes-0-14-0-new-features" />
+<span id="release-notes-0-14-0-new-features" />
 
-  ### New Features
+### New Features
 
-  *   There is a new class, \`qiskit_ibm_runtime.Batch\` that currently works the same way as [\`qiskit_ibm_runtime.Session\`](stubs/qiskit_ibm_runtime.Session#qiskit_ibm_runtime.Session \"qiskit_ibm_runtime.Session\") but will later be updated to better support submitting multiple jobs at once.
-  ",
-    "meta": {},
-  }
-  `);
+*   There is a new class, \`qiskit_ibm_runtime.Batch\` that currently works the same way as [\`qiskit_ibm_runtime.Session\`](stubs/qiskit_ibm_runtime.Session#qiskit_ibm_runtime.Session \"qiskit_ibm_runtime.Session\") but will later be updated to better support submitting multiple jobs at once.\n`,
+    meta: {},
+  });
 });
 
 test("generate correct heading level", async () => {

--- a/scripts/js/lib/api/htmlToMd.test.ts
+++ b/scripts/js/lib/api/htmlToMd.test.ts
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { describe, test, expect } from "@jest/globals";
+import { test, expect } from "@jest/globals";
 
 import { sphinxHtmlToMarkdown } from "./htmlToMd";
 
@@ -30,14 +30,13 @@ async function toMd(html: string, withMetadata: boolean = false) {
   return withMetadata ? result : result.markdown;
 }
 
-describe("sphinxHtmlToMarkdown", () => {
-  // ------------------------------------------------------------------
-  // Transform tabs
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform tabs
+// ------------------------------------------------------------------
 
-  test("handle tabs", async () => {
-    expect(
-      await toMd(`<div role='main'>
+test("handle tabs", async () => {
+  expect(
+    await toMd(`<div role='main'>
       <details
         class='sd-sphinx-override sd-dropdown sd-card sd-mb-3 sd-fade-in-slide-down'
       >
@@ -66,21 +65,21 @@ describe("sphinxHtmlToMarkdown", () => {
       </details>
     </div>
 `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
               "### Account initialization
 
               You need to initialize your account before you can start using the Qiskit Runtime service. This is done by initializing a [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService") instance with your account credentials.
               "
           `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform special characters
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform special characters
+// ------------------------------------------------------------------
 
-  test("handle special characters: `<` and `{`", async () => {
-    expect(
-      await toMd(`
+test("handle special characters: `<` and `{`", async () => {
+  expect(
+    await toMd(`
     <div role='main'>
     <p>For the full list of backend attributes, see the <cite>IBMBackend</cite> class documentation
 &lt;<a class='reference external' href='https://qiskit.org/documentation/apidoc/providers_models.html'>https://qiskit.org/documentation/apidoc/providers_models.html</a>&gt;</p>
@@ -91,21 +90,21 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 (2) a single float f, interpreted as {pi: f, pi/2: f/2, pi/3: f/3}.</p>
     </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "For the full list of backend attributes, see the IBMBackend class documentation \\<[https://qiskit.org/documentation/apidoc/providers\\_models.html](https://qiskit.org/documentation/apidoc/providers_models.html)>
 
       **basis\\_fidelity** (*dict | float*) – available strengths and fidelity of each. Can be either (1) a dictionary mapping XX angle values to fidelity at that angle; or (2) a single float f, interpreted as \\{pi: f, pi/2: f/2, pi/3: f/3}.
       "
     `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform code blocks
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform code blocks
+// ------------------------------------------------------------------
 
-  test("translate codeblocks to code fences with lang python", async () => {
-    expect(
-      await toMd(`
+test("translate codeblocks to code fences with lang python", async () => {
+  expect(
+    await toMd(`
     <div role='main'>
 <pre><span></span><span class='n'>QiskitRuntimeService</span><span class='o'>.</span><span class='n'>backends</span><span class='p'>(</span>
     <span class='n'>filters</span><span class='o'>=</span><span class='k'>lambda</span> <span class='n'>b</span><span class='p'>:</span> <span class='n'>b</span><span class='o'>.</span><span class='n'>max_shots</span> <span class='o'>&gt;</span> <span class='mi'>50000</span><span class='p'>)</span>
@@ -114,7 +113,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 </pre>
     </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
               "\`\`\`python
               QiskitRuntimeService.backends(
                   filters=lambda b: b.max_shots > 50000)
@@ -123,15 +122,15 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
               \`\`\`
               "
           `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform methods and attributes
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform methods and attributes
+// ------------------------------------------------------------------
 
-  test("handle inlined methods and attributes", async () => {
-    expect(
-      await toMd(`
+test("handle inlined methods and attributes", async () => {
+  expect(
+    await toMd(`
       <div role="main">
 
 <h1>DAGCircuit<a class="headerlink" href="#dagcircuit" title="Permalink to this heading">#</a></h1>
@@ -170,7 +169,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
 </dd></dl>
  </div>
       `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "# DAGCircuit
 
       <Class id="qiskit.dagcircuit.DAGCircuit" isDedicatedPage={true} github="https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit/dagcircuit/dagcircuit.py" signature="qiskit.dagcircuit.DAGCircuit" modifiers="class">
@@ -207,15 +206,15 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
       </Class>
       "
     `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform HTML tags
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform HTML tags
+// ------------------------------------------------------------------
 
-  test("transform tables", async () => {
-    expect(
-      await toMd(`
+test("transform tables", async () => {
+  expect(
+    await toMd(`
       <div role='main'>
       <table class='autosummary longtable docutils align-default'>
         <tbody>
@@ -258,18 +257,18 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
       </table>
     </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
               "|                                                                                                                                                                                            |                                                                        |
               | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
               | [\`QiskitRuntimeService\`](../stubs/qiskit_ibm_runtime.QiskitRuntimeService#qiskit_ibm_runtime.QiskitRuntimeService "qiskit_ibm_runtime.QiskitRuntimeService")(\\[channel, auth, token, ...]) | Class for interacting with the Qiskit Runtime service.                 |
               | [\`Estimator\`](../stubs/qiskit_ibm_runtime.Estimator#qiskit_ibm_runtime.Estimator "qiskit_ibm_runtime.Estimator")(\\[circuits, observables, ...])                                            | Class for interacting with Qiskit Runtime Estimator primitive service. |
               "
           `);
-  });
+});
 
-  test("preserve <span> with ids", async () => {
-    expect(
-      await toMd(`
+test("preserve <span> with ids", async () => {
+  expect(
+    await toMd(`
   <div role='main' class='main-content' itemscope='itemscope' itemtype='http://schema.org/Article'>
     <article itemprop='articleBody' id='pytorch-article' class='pytorch-article'>
       <span id='qiskit-assembler'></span>
@@ -280,7 +279,7 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
     </article>
   </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "<span id="qiskit-assembler" />
 
       <span id="circuit-and-schedule-assembler-qiskit-assembler" />
@@ -288,24 +287,24 @@ Can be either (1) a dictionary mapping XX angle values to fidelity at that angle
       # Circuit Assembler
       "
     `);
-  });
+});
 
-  test("merge contiguous <em> removing spaces", async () => {
-    expect(
-      await toMd(`
+test("merge contiguous <em> removing spaces", async () => {
+  expect(
+    await toMd(`
       <div role="main">
         <li><p><strong>gate</strong> (<em> Union</em><em>[</em><a class="reference internal" href="qiskit.circuit.Gate.html#qiskit.circuit.Gate" title="qiskit.circuit.Gate"><em>Gate</em></a><em>, </em><em>str</em><em>]   </em>) – Gate information.</p></li>
       </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "*   **gate** ( *Union\\[*[*Gate*](qiskit.circuit.Gate#qiskit.circuit.Gate "qiskit.circuit.Gate")*, str]* ) – Gate information.
       "
     `);
-  });
+});
 
-  test("remove <br/>", async () => {
-    expect(
-      await toMd(`
+test("remove <br/>", async () => {
+  expect(
+    await toMd(`
     <div role="main">
     <p>Transpilation is the process of rewriting a given input circuit to match
 the topology of a specific quantum device, and/or to optimize the circuit
@@ -314,17 +313,17 @@ for execution on present day noisy quantum systems.</p>
 </p>
 </div>
     `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "Transpilation is the process of rewriting a given input circuit to match the topology of a specific quantum device, and/or to optimize the circuit for execution on present day noisy quantum systems.
 
       Qiskit has four pre-built transpilation pipelines available here:
       "
     `);
-  });
+});
 
-  test("transform <dl>, <dd>, <dt> elements", async () => {
-    expect(
-      await toMd(`<div role='main'>
+test("transform <dl>, <dd>, <dt> elements", async () => {
+  expect(
+    await toMd(`<div role='main'>
   <dl>
     <dt class='field-even'>Return type<span class='colon'>:</span></dt>
     <dd class='field-even'><p><a class='reference internal'
@@ -340,7 +339,7 @@ for execution on present day noisy quantum systems.</p>
   </dl>
 </div>
 `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
         "## Return type
 
         [RuntimeJob](qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob "qiskit_ibm_runtime.RuntimeJob")
@@ -350,12 +349,12 @@ for execution on present day noisy quantum systems.</p>
         Submitted job. The result of the job is an instance of \`qiskit.primitives.EstimatorResult\`.
         "
       `);
-  });
+});
 
-  // For more information: https://github.com/Qiskit/documentation/issues/485
-  test("transform <dt> sig-object tags without id", async () => {
-    expect(
-      await toMd(`
+// For more information: https://github.com/Qiskit/documentation/issues/485
+test("transform <dt> sig-object tags without id", async () => {
+  expect(
+    await toMd(`
       <div role="main">
       <p>In addition to the public abstract methods, subclasses should also implement the following
       private methods:</p>
@@ -382,7 +381,7 @@ for execution on present day noisy quantum systems.</p>
       </dd></dl>
       </div>
   `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "In addition to the public abstract methods, subclasses should also implement the following private methods:
 
     <Function signature="_default_options()" modifiers="classmethod">
@@ -402,15 +401,15 @@ for execution on present day noisy quantum systems.</p>
     </Function>
     "
     `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform admonitions
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform admonitions
+// ------------------------------------------------------------------
 
-  test("transform admonitions", async () => {
-    expect(
-      await toMd(`<div role='main'>
+test("transform admonitions", async () => {
+  expect(
+    await toMd(`<div role='main'>
   <div class='admonition note'>
     <p class='admonition-title'>Note</p>
     <p>To use these tools locally, you’ll need to install the
@@ -428,7 +427,7 @@ for execution on present day noisy quantum systems.</p>
   </div>
 </div>
         `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
         "<Admonition title="Note" type="note">
           To use these tools locally, you’ll need to install the additional dependencies for the visualization functions:
         </Admonition>
@@ -442,32 +441,32 @@ for execution on present day noisy quantum systems.</p>
         </Admonition>
         "
       `);
-  });
+});
 
-  test("parse deprecations warnings", async () => {
-    expect(
-      await toMd(`
+test("parse deprecations warnings", async () => {
+  expect(
+    await toMd(`
       <div role="main">
       <div class="deprecated">
 <p><span class="versionmodified deprecated">Deprecated since version 0.23.0: </span>The method <code class="docutils literal notranslate"><span class="pre">qiskit.circuit.quantumregister.QuantumRegister.qasm()</span></code> is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.</p>
 </div>
       </div>
       `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
         "<Admonition title="Deprecated since version 0.23.0" type="danger">
           The method \`qiskit.circuit.quantumregister.QuantumRegister.qasm()\` is deprecated as of qiskit-terra 0.23.0. It will be removed no earlier than 3 months after the release date. Correct exporting to OpenQASM 2 is the responsibility of a larger exporter; it cannot safely be done on an object-by-object basis without context. No replacement will be provided, because the premise is wrong.
         </Admonition>
         "
       `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Handle math expressions
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Handle math expressions
+// ------------------------------------------------------------------
 
-  test("transform inline math", async () => {
-    expect(
-      await toMd(`
+test("transform inline math", async () => {
+  expect(
+    await toMd(`
 <div role='main'>
 <table>
 <tbody>
@@ -478,17 +477,17 @@ for execution on present day noisy quantum systems.</p>
 </table>
 </div>
         `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
         "|                                                                                                                                                                       |                                        |
         | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
         | [\`GlobalPhaseGate\`](../stubs/qiskit.circuit.library.GlobalPhaseGate#qiskit.circuit.library.GlobalPhaseGate "qiskit.circuit.library.GlobalPhaseGate")(phase\\[, label]) | The global phase gate ($e^{i\\theta}$). |
         "
       `);
-  });
+});
 
-  test("transform block math", async () => {
-    expect(
-      await toMd(`
+test("transform block math", async () => {
+  expect(
+    await toMd(`
 <div role='main'>
 <div class="math notranslate nohighlight">
 \\[\\begin{split}CCX q_0, q_1, q_2 =
@@ -508,7 +507,7 @@ for execution on present day noisy quantum systems.</p>
 \\[x = \\sum_{i=0}^{n-1} 2^i q_i,\\]</div>
 </div>
         `),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
         "$$
         \\begin{split}CCX q_0, q_1, q_2 =
             I \\otimes I \\otimes |0 \\rangle \\langle 0| + CX \\otimes |1 \\rangle \\langle 1| =
@@ -529,15 +528,15 @@ for execution on present day noisy quantum systems.</p>
         $$
         "
       `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Transform links
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Transform links
+// ------------------------------------------------------------------
 
-  test("remove .html extension from relative links", async () => {
-    expect(
-      await toMd(`<div
+test("remove .html extension from relative links", async () => {
+  expect(
+    await toMd(`<div
   role='main'
   class='main-content'
   itemscope='itemscope'
@@ -568,7 +567,7 @@ for execution on present day noisy quantum systems.</p>
     </section>
   </article>
 </div>`),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "<span id="qiskit-ibm-runtime-api-reference" />
 
       # qiskit-ibm-runtime API reference
@@ -576,11 +575,11 @@ for execution on present day noisy quantum systems.</p>
       *   [Qiskit Runtime (\`qiskit_ibm_runtime\`)](runtime_service)
       "
     `);
-  });
+});
 
-  test("remove permalink", async () => {
-    expect(
-      await toMd(`<article role="main">
+test("remove permalink", async () => {
+  expect(
+    await toMd(`<article role="main">
         <section id="qiskit-ibm-runtime-api-reference">
           <h1>qiskit-ibm-runtime API reference<a class="headerlink" href="#qiskit-ibm-runtime-api-reference" title="Link to this heading">#</a></h1>
          <div class="toctree-wrapper compound">
@@ -591,7 +590,7 @@ for execution on present day noisy quantum systems.</p>
          </div>
        </section>
     </article>`),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
       "<span id="qiskit-ibm-runtime-api-reference" />
 
       # qiskit-ibm-runtime API reference
@@ -600,11 +599,11 @@ for execution on present day noisy quantum systems.</p>
       *   [Primitive options (\`qiskit_ibm_runtime.options\`)](options)
       "
     `);
-  });
+});
 
-  test("remove download links", async () => {
-    expect(
-      await toMd(`<div
+test("remove download links", async () => {
+  expect(
+    await toMd(`<div
   role='main'
   class='main-content'
   itemscope='itemscope'
@@ -613,28 +612,28 @@ for execution on present day noisy quantum systems.</p>
   <p>(<a class="reference download internal" download="" href="../_downloads/366189d70d6a05b2c91f442d20ba6114/qiskit-circuit-QuantumCircuit-1.py"><code class="xref download docutils literal notranslate"><span class="pre">Source</span> <span class="pre">code</span></code></a>)</p>
 </div>
 `),
-    ).toMatchInlineSnapshot(`""`);
-  });
+  ).toMatchInlineSnapshot(`""`);
+});
 
-  test("convert source links", async () => {
-    expect(
-      await toMd(`<div role='main'>
+test("convert source links", async () => {
+  expect(
+    await toMd(`<div role='main'>
 <span class='sig-prename descclassname'><span class='pre'>IBMBackend.</span></span><span class='sig-name descname'><span class='pre'>control_channel</span></span><span class='sig-paren'>(</span><em class='sig-param'><span class='n'><span class='pre'>qubits</span></span></em><span class='sig-paren'>)</span><a class='reference internal' href='../_modules/qiskit_ibm_runtime/ibm_backend.html#IBMBackend.control_channel'><span class='viewcode-link'><span class='pre'>[source]</span></span></a><a class='headerlink' href='#qiskit_ibm_runtime.IBMBackend.control_channel' title='Permalink to this definition'>¶</a>
 </div>`),
-    ).toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
               "IBMBackend.control\\_channel(*qubits*)[\\[source\\]](https://github.com/Qiskit/qiskit-ibm-runtime/tree/0.9.2/qiskit_ibm_runtime/ibm_backend.py)
               "
           `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // apiType headings conversion
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// apiType headings conversion
+// ------------------------------------------------------------------
 
-  test("convert class signature headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert class signature headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
     <h1>Estimator<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
       <dl class='py class'>
         <dt class='sig sig-object py' id='qiskit_ibm_runtime.Sampler'>
@@ -671,9 +670,9 @@ for execution on present day noisy quantum systems.</p>
       </dl>
     </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -691,12 +690,12 @@ for execution on present day noisy quantum systems.</p>
       },
     }
   `);
-  });
+});
 
-  test("convert class property headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert class property headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
 <h1>Estimator.circuits<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
 <dl class='py property'>
   <dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.circuits'>
@@ -725,9 +724,9 @@ for execution on present day noisy quantum systems.</p>
 </dl>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -743,12 +742,12 @@ for execution on present day noisy quantum systems.</p>
       },
     }
   `);
-  });
+});
 
-  test("convert class method headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert class method headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
 <h1>Estimator.run<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
 <dl class='py method'>
 <dt class='sig sig-object py' id='qiskit_ibm_runtime.Estimator.run'>
@@ -756,9 +755,9 @@ for execution on present day noisy quantum systems.</p>
 <dd><p>Submit a request to the estimator primitive program.</p></dd></dl>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -774,12 +773,12 @@ for execution on present day noisy quantum systems.</p>
       },
     }
   `);
-  });
+});
 
-  test("convert class attributes headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert class attributes headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
 <h1>EnvironmentOptions.callback<a class='headerlink' href='#estimator' title='Permalink to this heading'>¶</a></h1>
 <dl class='py attribute'>
 <dt class='sig sig-object py' id='qiskit_ibm_runtime.options.EnvironmentOptions.callback'>
@@ -787,9 +786,9 @@ for execution on present day noisy quantum systems.</p>
 <dd></dd></dl>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -803,12 +802,12 @@ for execution on present day noisy quantum systems.</p>
       },
     }
   `);
-  });
+});
 
-  test("convert functions headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert functions headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
 <section id="job-monitor">
 <h1>job_monitor<a class="headerlink" href="#job-monitor" title="Permalink to this heading">¶</a></h1>
 <dl class="py function">
@@ -833,9 +832,9 @@ By default this is sys.stdout.</p></li>
 </section>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -863,12 +862,12 @@ By default this is sys.stdout.</p></li>
       },
     }
   `);
-  });
+});
 
-  test("convert exception headings", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert exception headings", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
 <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
 <section id="ibmjoberror">
 <h1>IBMJobError<a class="headerlink" href="#ibmjoberror" title="Permalink to this heading">¶</a></h1>
@@ -882,9 +881,9 @@ By default this is sys.stdout.</p></li>
 </article>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -904,20 +903,20 @@ By default this is sys.stdout.</p></li>
       },
     }
   `);
-  });
+});
 
-  test("convert module headings removing () around the title", async () => {
-    expect(
-      await toMd(
-        `<div role='main'>
+test("convert module headings removing () around the title", async () => {
+  expect(
+    await toMd(
+      `<div role='main'>
   <span class="target" id="module-qiskit_ibm_runtime"></span><section id="qiskit-runtime-qiskit-ibm-runtime">
 <h1>Qiskit Runtime (<a class="reference internal" href="#module-qiskit_ibm_runtime" title="qiskit_ibm_runtime"><code class="xref py py-mod docutils literal notranslate"><span class="pre">qiskit_ibm_runtime</span></code></a>)<a class="headerlink" href="#qiskit-runtime-qiskit-ibm-runtime" title="Permalink to this heading">¶</a></h1>
 <p>Modules related to Qiskit Runtime IBM Client.</p>
 </div>
 `,
-        true,
-      ),
-    ).toMatchInlineSnapshot(`
+      true,
+    ),
+  ).toMatchInlineSnapshot(`
     {
       "images": [],
       "isReleaseNotes": false,
@@ -939,16 +938,16 @@ By default this is sys.stdout.</p></li>
       },
     }
     `);
-  });
+});
 
-  // ------------------------------------------------------------------
-  // Release notes HTML to markdown
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Release notes HTML to markdown
+// ------------------------------------------------------------------
 
-  test("identify release notes", async () => {
-    expect(
-      await sphinxHtmlToMarkdown({
-        html: `
+test("identify release notes", async () => {
+  expect(
+    await sphinxHtmlToMarkdown({
+      html: `
             <div role="main">
             <h1>Release Notes<a class="headerlink" href="#release-notes" title="Link to this heading">#</a></h1>
             <section id="release-notes-0-14-0">
@@ -961,10 +960,10 @@ By default this is sys.stdout.</p></li>
             to better support submitting multiple jobs at once.</p></li>
             </ul>
             `,
-        fileName: "release_notes.html",
-        ...DEFAULT_ARGS,
-      }),
-    ).toMatchInlineSnapshot(`
+      fileName: "release_notes.html",
+      ...DEFAULT_ARGS,
+    }),
+  ).toMatchInlineSnapshot(`
   {
     "images": [],
     "isReleaseNotes": true,
@@ -987,7 +986,6 @@ By default this is sys.stdout.</p></li>
     "meta": {},
   }
   `);
-  });
 });
 
 test("generate correct heading level", async () => {

--- a/scripts/js/lib/api/mergeClassMembers.test.ts
+++ b/scripts/js/lib/api/mergeClassMembers.test.ts
@@ -10,16 +10,15 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { describe, expect, test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 
 import { mergeClassMembers } from "./mergeClassMembers";
 import { HtmlToMdResultWithUrl } from "./HtmlToMdResult";
 
-describe("mergeClassMembers", () => {
-  test("merge class members", async () => {
-    const results: HtmlToMdResultWithUrl[] = [
-      {
-        markdown: `<Class id='qiskit_ibm_runtime.RuntimeOptions'>
+test("merge class members", async () => {
+  const results: HtmlToMdResultWithUrl[] = [
+    {
+      markdown: `<Class id='qiskit_ibm_runtime.RuntimeOptions'>
   ## Attributes
 
   |                                                                                                                                                                                                         |                 |
@@ -32,41 +31,41 @@ describe("mergeClassMembers", () => {
   | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
   | [\`RuntimeOptions.validate\`](qiskit_ibm_runtime.RuntimeOptions.validate#qiskit_ibm_runtime.RuntimeOptions.validate "qiskit_ibm_runtime.RuntimeOptions.validate")(channel) | Validate options. |
 </Class>`,
-        meta: {
-          apiType: "class",
-          apiName: "RuntimeOptions",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions",
-        images: [],
-        isReleaseNotes: false,
+      meta: {
+        apiType: "class",
+        apiName: "RuntimeOptions",
       },
-      {
-        markdown: `# RuntimeOptions.backend
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions",
+      images: [],
+      isReleaseNotes: false,
+    },
+    {
+      markdown: `# RuntimeOptions.backend
 <Attribute id='qiskit_ibm_runtime.RuntimeOptions.backend' signature='Optional[str] = None' />
 `,
-        meta: {
-          apiType: "attribute",
-          apiName: "RuntimeOptions.backend",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.backend",
-        images: [],
-        isReleaseNotes: false,
+      meta: {
+        apiType: "attribute",
+        apiName: "RuntimeOptions.backend",
       },
-      {
-        markdown: `# RuntimeOptions.circuits
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.backend",
+      images: [],
+      isReleaseNotes: false,
+    },
+    {
+      markdown: `# RuntimeOptions.circuits
 
         <Attribute id='qiskit_ibm_runtime.RuntimeOptions.circuits' signature='Optional[str] = None' />
 `,
-        meta: {
-          apiType: "property",
-          apiName: "RuntimeOptions.circuits",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.circuits",
-        images: [],
-        isReleaseNotes: false,
+      meta: {
+        apiType: "property",
+        apiName: "RuntimeOptions.circuits",
       },
-      {
-        markdown: `
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.circuits",
+      images: [],
+      isReleaseNotes: false,
+    },
+    {
+      markdown: `
 # RuntimeOptions.validate
 
 <Function id='qiskit_ibm_runtime.RuntimeOptions.validate' signature='RuntimeOptions.validate(channel)'>
@@ -85,18 +84,18 @@ describe("mergeClassMembers", () => {
       \`None\`
 </Function>
           `,
-        meta: {
-          apiType: "method",
-          apiName: "RuntimeOptions.backend",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.validate",
-        images: [],
-        isReleaseNotes: false,
+      meta: {
+        apiType: "method",
+        apiName: "RuntimeOptions.backend",
       },
-    ];
-    const merged = await mergeClassMembers(results);
-    expect(merged.find((item) => item.meta.apiType === "class")?.markdown)
-      .toMatchInlineSnapshot(`
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions.validate",
+      images: [],
+      isReleaseNotes: false,
+    },
+  ];
+  const merged = await mergeClassMembers(results);
+  expect(merged.find((item) => item.meta.apiType === "class")?.markdown)
+    .toMatchInlineSnapshot(`
         "<Class id="qiskit_ibm_runtime.RuntimeOptions">
           ## Attributes
 
@@ -130,13 +129,13 @@ describe("mergeClassMembers", () => {
         </Class>
         "
       `);
-    expect(merged.length).toEqual(1);
-  });
+  expect(merged.length).toEqual(1);
+});
 
-  test("merge class with methods already inlined", async () => {
-    const results: HtmlToMdResultWithUrl[] = [
-      {
-        markdown: `## Attributes
+test("merge class with methods already inlined", async () => {
+  const results: HtmlToMdResultWithUrl[] = [
+    {
+      markdown: `## Attributes
 
 |                                                                                                                                                                                                         |                 |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
@@ -156,18 +155,18 @@ Inlined attribute
 
 Inlined method
 `,
-        meta: {
-          apiType: "class",
-          apiName: "RuntimeOptions",
-        },
-        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions",
-        images: [],
-        isReleaseNotes: false,
+      meta: {
+        apiType: "class",
+        apiName: "RuntimeOptions",
       },
-    ];
-    const merged = await mergeClassMembers(results);
-    expect(merged.find((item) => item.meta.apiType === "class")?.markdown)
-      .toEqual(`## Attributes
+      url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeOptions",
+      images: [],
+      isReleaseNotes: false,
+    },
+  ];
+  const merged = await mergeClassMembers(results);
+  expect(merged.find((item) => item.meta.apiType === "class")?.markdown)
+    .toEqual(`## Attributes
 
 |                                                                                                                    |   |
 | ------------------------------------------------------------------------------------------------------------------ | - |
@@ -187,25 +186,24 @@ Inlined attribute
 
 Inlined method
 `);
-    expect(merged.length).toEqual(1);
-  });
+  expect(merged.length).toEqual(1);
+});
 
-  test("keep members without an owning class", async () => {
-    // Regression test for https://github.com/Qiskit/documentation/issues/814.
-    const results: HtmlToMdResultWithUrl[] = [
-      {
-        markdown:
-          '<span id="baseestimator" />\n\n# BaseEstimator\n\nalias of `BaseEstimatorV1`\n',
-        meta: {
-          apiType: "attribute",
-          apiName: "qiskit.primitives.BaseEstimator",
-        },
-        images: [],
-        isReleaseNotes: false,
-        url: "/docs/api/qiskit/qiskit.primitives.BaseEstimator",
+test("keep members without an owning class", async () => {
+  // Regression test for https://github.com/Qiskit/documentation/issues/814.
+  const results: HtmlToMdResultWithUrl[] = [
+    {
+      markdown:
+        '<span id="baseestimator" />\n\n# BaseEstimator\n\nalias of `BaseEstimatorV1`\n',
+      meta: {
+        apiType: "attribute",
+        apiName: "qiskit.primitives.BaseEstimator",
       },
-    ];
-    const merged = await mergeClassMembers(results);
-    expect(merged).toEqual(results);
-  });
+      images: [],
+      isReleaseNotes: false,
+      url: "/docs/api/qiskit/qiskit.primitives.BaseEstimator",
+    },
+  ];
+  const merged = await mergeClassMembers(results);
+  expect(merged).toEqual(results);
 });

--- a/scripts/js/lib/api/mergeClassMembers.test.ts
+++ b/scripts/js/lib/api/mergeClassMembers.test.ts
@@ -95,40 +95,38 @@ test("merge class members", async () => {
   ];
   const merged = await mergeClassMembers(results);
   expect(merged.find((item) => item.meta.apiType === "class")?.markdown)
-    .toMatchInlineSnapshot(`
-        "<Class id="qiskit_ibm_runtime.RuntimeOptions">
-          ## Attributes
+    .toEqual(`<Class id="qiskit_ibm_runtime.RuntimeOptions">
+  ## Attributes
 
-          ### RuntimeOptions.backend
+  ### RuntimeOptions.backend
 
-          <Attribute id="qiskit_ibm_runtime.RuntimeOptions.backend" signature="Optional[str] = None" />
+  <Attribute id="qiskit_ibm_runtime.RuntimeOptions.backend" signature="Optional[str] = None" />
 
-          ### RuntimeOptions.circuits
+  ### RuntimeOptions.circuits
 
-          <Attribute id="qiskit_ibm_runtime.RuntimeOptions.circuits" signature="Optional[str] = None" />
+  <Attribute id="qiskit_ibm_runtime.RuntimeOptions.circuits" signature="Optional[str] = None" />
 
-          ## Methods
+  ## Methods
 
-          ### RuntimeOptions.validate
+  ### RuntimeOptions.validate
 
-          <Function id="qiskit_ibm_runtime.RuntimeOptions.validate" signature="RuntimeOptions.validate(channel)">
-            Validate options.
+  <Function id="qiskit_ibm_runtime.RuntimeOptions.validate" signature="RuntimeOptions.validate(channel)">
+    Validate options.
 
-            *   Parameters:
+    *   Parameters:
 
-                **channel** (\`str\`) – channel type.
+        **channel** (\`str\`) – channel type.
 
-            *   Raises:
+    *   Raises:
 
-                **IBMInputValueError** – If one or more option is invalid.
+        **IBMInputValueError** – If one or more option is invalid.
 
-            *   Return type:
+    *   Return type:
 
-                \`None\`
-          </Function>
-        </Class>
-        "
-      `);
+        \`None\`
+  </Function>
+</Class>
+`);
   expect(merged.length).toEqual(1);
 });
 

--- a/scripts/js/lib/api/objectsInv.test.ts
+++ b/scripts/js/lib/api/objectsInv.test.ts
@@ -18,6 +18,12 @@ const TEST_FOLDER = "scripts/js/lib/api/testdata/";
 const TEMP_FOLDER = "scripts/js/lib/api/testdata/temp/";
 
 describe("objects.inv", () => {
+  afterAll(async () => {
+    if (await stat(TEMP_FOLDER + "objects.inv")) {
+      await unlink(TEMP_FOLDER + "objects.inv");
+    }
+  });
+
   test("read file and decompress", async () => {
     const objectsInv = await ObjectsInv.fromFile(TEST_FOLDER);
 
@@ -117,11 +123,5 @@ describe("objects.inv", () => {
       "legacy_release_notes#release-notes-agnas-0-5-0",
       "andex",
     ]);
-  });
-
-  afterAll(async () => {
-    if (await stat(TEMP_FOLDER + "objects.inv")) {
-      await unlink(TEMP_FOLDER + "objects.inv");
-    }
   });
 });

--- a/scripts/js/lib/api/objectsInv.test.ts
+++ b/scripts/js/lib/api/objectsInv.test.ts
@@ -27,7 +27,7 @@ describe("objects.inv", () => {
   test("read file and decompress", async () => {
     const objectsInv = await ObjectsInv.fromFile(TEST_FOLDER);
 
-    expect(objectsInv.preamble).toMatch(
+    expect(objectsInv.preamble).toEqual(
       "# Sphinx inventory version 2\n" +
         "# Project: Qiskit\n" +
         "# Version: 0.45\n" +
@@ -38,24 +38,18 @@ describe("objects.inv", () => {
     // This test fails when you include / exclude entries, which shifts some array indices.
     // Use the following code to find the new indices.
     // console.log(objectsInv.entries.findLastIndex( e => { return e.uri.includes("index") }))
-    expect(uriIndices.map((i) => objectsInv.entries[i].uri))
-      .toMatchInlineSnapshot(`
-      [
-        "stubs/qiskit.algorithms.AlgorithmJob.html#qiskit.algorithms.AlgorithmJob.job_id",
-        "stubs/qiskit.algorithms.FasterAmplitudeEstimation.html#qiskit.algorithms.FasterAmplitudeEstimation.sampler",
-        "stubs/qiskit.algorithms.Grover.html#qiskit.algorithms.Grover.quantum_instance",
-        "apidoc/assembler.html#qiskit.assembler.disassemble",
-        "index.html",
-      ]
-    `);
+    expect(uriIndices.map((i) => objectsInv.entries[i].uri)).toEqual([
+      "stubs/qiskit.algorithms.AlgorithmJob.html#qiskit.algorithms.AlgorithmJob.job_id",
+      "stubs/qiskit.algorithms.FasterAmplitudeEstimation.html#qiskit.algorithms.FasterAmplitudeEstimation.sampler",
+      "stubs/qiskit.algorithms.Grover.html#qiskit.algorithms.Grover.quantum_instance",
+      "apidoc/assembler.html#qiskit.assembler.disassemble",
+      "index.html",
+    ]);
     const nameIndices = [23575, 24146];
-    expect(nameIndices.map((i) => objectsInv.entries[i].dispname))
-      .toMatchInlineSnapshot(`
-    [
+    expect(nameIndices.map((i) => objectsInv.entries[i].dispname)).toEqual([
       "Qiskit 0.45 documentation",
       "FakeOslo",
-    ]
-    `);
+    ]);
   });
 
   test("write file and re-read matches original", async () => {
@@ -66,8 +60,8 @@ describe("objects.inv", () => {
     expect(originalObjectsInv.entries.length).toEqual(
       newObjectsInv.entries.length,
     );
-    expect(originalObjectsInv.preamble).toMatch(newObjectsInv.preamble);
-    expect(originalObjectsInv.entriesString()).toMatch(
+    expect(originalObjectsInv.preamble).toEqual(newObjectsInv.preamble);
+    expect(originalObjectsInv.entriesString()).toEqual(
       newObjectsInv.entriesString(),
     );
   });

--- a/scripts/js/lib/api/specialCaseResults.test.ts
+++ b/scripts/js/lib/api/specialCaseResults.test.ts
@@ -64,11 +64,9 @@ test("transformSpecialCaseUrl()", () => {
     "ibm-provider#qiskit-ibm-provider",
   ];
   const transformedUrls = urls.map((x) => transformSpecialCaseUrl(x));
-  expect(transformedUrls).toMatchInlineSnapshot(`
-    [
-      "release-notes",
-      "release-notes#release-notes-0-2-1-bug-fixes",
-      "index#qiskit-ibm-provider",
-    ]
-  `);
+  expect(transformedUrls).toEqual([
+    "release-notes",
+    "release-notes#release-notes-0-2-1-bug-fixes",
+    "index#qiskit-ibm-provider",
+  ]);
 });

--- a/scripts/js/lib/api/updateLinks.test.ts
+++ b/scripts/js/lib/api/updateLinks.test.ts
@@ -80,55 +80,50 @@ describe("updateLinks", () => {
     );
 
     await updateLinks(data, objectsInv);
-    expect(data).toMatchInlineSnapshot(`
-      [
-        {
-          "images": [],
-          "isReleaseNotes": false,
-          "markdown": "[link1](qiskit_ibm_runtime.RuntimeJob)
-      [link2](qiskit_ibm_runtime.RuntimeJob)
-      [link3](qiskit_ibm_runtime.RuntimeJob#job)
-      [link4](qiskit_ibm_runtime.RuntimeJob)
-      [link5](qiskit_ibm_runtime.RuntimeJob)
-      [link6](qiskit_ibm_runtime.RuntimeJob)
-      [link7](#qiskit_ibm_runtime.RuntimeJob.job)
-      [link8](/api/qiskit/algorithms)
-      [link9](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)
-      ",
-          "meta": {
-            "apiName": "qiskit_ibm_runtime.RuntimeJob",
-            "apiType": "class",
-          },
-          "url": "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+    expect(data).toEqual([
+      {
+        images: [],
+        isReleaseNotes: false,
+        markdown: `[link1](qiskit_ibm_runtime.RuntimeJob)
+[link2](qiskit_ibm_runtime.RuntimeJob)
+[link3](qiskit_ibm_runtime.RuntimeJob#job)
+[link4](qiskit_ibm_runtime.RuntimeJob)
+[link5](qiskit_ibm_runtime.RuntimeJob)
+[link6](qiskit_ibm_runtime.RuntimeJob)
+[link7](#qiskit_ibm_runtime.RuntimeJob.job)
+[link8](/api/qiskit/algorithms)
+[link9](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)\n`,
+        meta: {
+          apiName: "qiskit_ibm_runtime.RuntimeJob",
+          apiType: "class",
         },
-        {
-          "images": [],
-          "isReleaseNotes": false,
-          "markdown": "[run](qiskit_ibm_runtime.RuntimeJob#run)
-      ",
-          "meta": {
-            "apiName": "qiskit_ibm_runtime.Sampler",
-            "apiType": "class",
-          },
-          "url": "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+      },
+      {
+        images: [],
+        isReleaseNotes: false,
+        markdown: "[run](qiskit_ibm_runtime.RuntimeJob#run)\n",
+        meta: {
+          apiName: "qiskit_ibm_runtime.Sampler",
+          apiType: "class",
         },
-      ]
-    `);
-    expect(objectsInv.entries.map((e) => e.uri)).toMatchInlineSnapshot(`
-      [
-        "qiskit.algorithms.Eigensolver#qiskit.algorithms.Eigensolver",
-        "qiskit.algorithms.EstimationProblem#qiskit.algorithms.EstimationProblem.state_preparation",
-        "qiskit.algorithms.FasterAmplitudeEstimationResult#qiskit.algorithms.FasterAmplitudeEstimationResult.success_probability",
-        "qiskit_ibm_runtime.QiskitRuntimeService",
-        "qiskit_ibm_runtime.RuntimeJob#submit",
-        "qiskit_ibm_runtime.RuntimeEncoder#qiskit_ibm_runtime.RuntimeEncoder",
-        "qiskit_ibm_runtime.options.Options#options",
-        "tutorials/qaoa_with_primitives",
-        "tutorials/vqe_with_estimator#step-1:-map-classical-inputs-to-a-quantum-problem",
-        "qiskit.algorithms.gradients.LinCombEstimatorGradient#supported_gates",
-        "qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations#measure_patch_cycles",
-      ]
-    `);
+        url: "/docs/api/qiskit-ibm-runtime/stubs/qiskit_ibm_runtime.RuntimeJob",
+      },
+    ]);
+
+    expect(objectsInv.entries.map((e) => e.uri)).toEqual([
+      "qiskit.algorithms.Eigensolver#qiskit.algorithms.Eigensolver",
+      "qiskit.algorithms.EstimationProblem#qiskit.algorithms.EstimationProblem.state_preparation",
+      "qiskit.algorithms.FasterAmplitudeEstimationResult#qiskit.algorithms.FasterAmplitudeEstimationResult.success_probability",
+      "qiskit_ibm_runtime.QiskitRuntimeService",
+      "qiskit_ibm_runtime.RuntimeJob#submit",
+      "qiskit_ibm_runtime.RuntimeEncoder#qiskit_ibm_runtime.RuntimeEncoder",
+      "qiskit_ibm_runtime.options.Options#options",
+      "tutorials/qaoa_with_primitives",
+      "tutorials/vqe_with_estimator#step-1:-map-classical-inputs-to-a-quantum-problem",
+      "qiskit.algorithms.gradients.LinCombEstimatorGradient#supported_gates",
+      "qiskit_ibm_provider.transpiler.passes.scheduling.DynamicCircuitInstructionDurations#measure_patch_cycles",
+    ]);
   });
 });
 
@@ -171,19 +166,17 @@ test("normalizeUrl()", () => {
   const newUrls = urls.map((url) =>
     normalizeUrl(url, resultsByName, itemNames),
   );
-  expect(newUrls).toMatchInlineSnapshot(`
-      [
-        "qiskit_ibm_runtime.RuntimeJob",
-        "qiskit_ibm_runtime.RuntimeJob",
-        "qiskit_ibm_runtime.RuntimeJob#job",
-        "qiskit_ibm_runtime.RuntimeJob",
-        "qiskit_ibm_runtime.RuntimeJob",
-        "qiskit_ibm_runtime.RuntimeJob",
-        "#qiskit_ibm_runtime.RuntimeJob.job",
-        "qiskit_ibm_runtime.RuntimeJob#run",
-        "qiskit_ibm_runtime.RuntimeJob",
-      ]
-    `);
+  expect(newUrls).toEqual([
+    "qiskit_ibm_runtime.RuntimeJob",
+    "qiskit_ibm_runtime.RuntimeJob",
+    "qiskit_ibm_runtime.RuntimeJob#job",
+    "qiskit_ibm_runtime.RuntimeJob",
+    "qiskit_ibm_runtime.RuntimeJob",
+    "qiskit_ibm_runtime.RuntimeJob",
+    "#qiskit_ibm_runtime.RuntimeJob.job",
+    "qiskit_ibm_runtime.RuntimeJob#run",
+    "qiskit_ibm_runtime.RuntimeJob",
+  ]);
 });
 
 describe("relativizeLink()", () => {

--- a/scripts/js/lib/testUtils.ts
+++ b/scripts/js/lib/testUtils.ts
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+import { expect } from "@jest/globals";
 import { CheerioAPI, Cheerio, load as cheerioLoad } from "cheerio";
 
 export class CheerioDoc {


### PR DESCRIPTION
To unblock packaging our scripts for the Qiskit Functions repos, I plan to migrate us to Playwright. I was having issues with getting Jest to work with TypeScript and ES Modules (vs CommonJS modules), whereas Playwright works out-of-the-box.

Playwright does not have `toMatchInlineSnapshot`, and `toMatch` has different semantics; so, this switches to `toEqual`. It also removes unnecessary `describe()` blocks.