### PR TITLE
Remove `getRoot()` helper function

### DIFF
--- a/scripts/js/commands/api/convertApiDocsToHistorical.ts
+++ b/scripts/js/commands/api/convertApiDocsToHistorical.ts
@@ -18,7 +18,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import transformLinks from "transform-markdown-links";
 
-import { pathExists, getRoot } from "../../lib/fs";
+import { pathExists } from "../../lib/fs";
 import { zxMain } from "../../lib/zx";
 import { Pkg } from "../../lib/api/Pkg";
 
@@ -48,15 +48,14 @@ zxMain(async () => {
     throw new Error(`Unrecognized package: ${args.package}`);
   }
 
-  const packageFile = await readFile(
-    `${getRoot()}/docs/api/${pkgName}/_package.json`,
-    { encoding: "utf8" },
-  );
+  const packageFile = await readFile(`docs/api/${pkgName}/_package.json`, {
+    encoding: "utf8",
+  });
   const packageInfo = JSON.parse(packageFile);
   const versionMatch = packageInfo.version.match(/^(\d+\.\d+)/);
   const versionWithoutPatch = versionMatch[0];
 
-  const projectNewHistoricalFolder = `${getRoot()}/docs/api/${pkgName}/${versionWithoutPatch}`;
+  const projectNewHistoricalFolder = `docs/api/${pkgName}/${versionWithoutPatch}`;
   if (await pathExists(projectNewHistoricalFolder)) {
     console.error(
       `${pkgName} has already a historical version ${versionWithoutPatch}.`,
@@ -99,7 +98,7 @@ async function copyApiDocsAndUpdateLinks(
     );
   }
 
-  const releaseNotePath = `${getRoot()}/docs/api/${pkgName}/release-notes/${versionWithoutPatch}.mdx`;
+  const releaseNotePath = `docs/api/${pkgName}/release-notes/${versionWithoutPatch}.mdx`;
   if (await pathExists(releaseNotePath)) {
     updateLinksFile(
       pkgName,
@@ -124,7 +123,7 @@ async function generateJsonFiles(
   );
 
   console.log("Generating toc");
-  let tocFile = await readFile(`${getRoot()}/docs/api/${pkgName}/_toc.json`, {
+  let tocFile = await readFile(`docs/api/${pkgName}/_toc.json`, {
     encoding: "utf8",
   });
 
@@ -144,16 +143,16 @@ async function generateJsonFiles(
 
 async function copyImages(pkgName: string, versionWithoutPatch: string) {
   console.log("Copying images");
-  const imageDirSource = `${getRoot()}/public/images/api/${pkgName}/`;
-  const imageDirDest = `${getRoot()}/public/images/api/${pkgName}/${versionWithoutPatch}`;
+  const imageDirSource = `public/images/api/${pkgName}/`;
+  const imageDirDest = `public/images/api/${pkgName}/${versionWithoutPatch}`;
   await mkdirp(imageDirDest);
   await $`find ${imageDirSource}/* -maxdepth 0 -type f | grep -v "release_notes" | xargs -I {} cp -a {} ${imageDirDest}`;
 }
 
 async function copyObjectsInv(pkgName: string, versionWithoutPatch: string) {
   console.log("Copying objects.inv");
-  const sourceDir = `${getRoot()}/public/api/${pkgName}`;
-  const destDir = `${getRoot()}/public/api/${pkgName}/${versionWithoutPatch}`;
+  const sourceDir = `public/api/${pkgName}`;
+  const destDir = `public/api/${pkgName}/${versionWithoutPatch}`;
   await mkdirp(destDir);
   await $`cp -a ${sourceDir}/objects.inv ${destDir}`;
 }

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -13,7 +13,6 @@
 import { join } from "path/posix";
 
 import { findSeparateReleaseNotesVersions } from "./releaseNotes";
-import { getRoot } from "../fs";
 import { determineHistoricalQiskitGithubUrl } from "../qiskitMetapackage";
 import { TocGrouping, QISKIT_TOC_GROUPING } from "./TocGrouping";
 
@@ -161,9 +160,7 @@ export class Pkg {
   }
 
   sphinxArtifactFolder(): string {
-    return `${getRoot()}/.sphinx-artifacts/${this.name}/${
-      this.versionWithoutPatch
-    }`;
+    return `.sphinx-artifacts/${this.name}/${this.versionWithoutPatch}`;
   }
 
   isHistorical(): boolean {

--- a/scripts/js/lib/api/releaseNotes.ts
+++ b/scripts/js/lib/api/releaseNotes.ts
@@ -16,7 +16,7 @@ import { readFile, writeFile, readdir } from "fs/promises";
 import { $ } from "zx";
 import transformLinks from "transform-markdown-links";
 
-import { getRoot, pathExists } from "../fs";
+import { pathExists } from "../fs";
 import type { Pkg } from "./Pkg";
 import type { HtmlToMdResultWithUrl } from "./HtmlToMdResult";
 
@@ -88,9 +88,7 @@ export async function maybeUpdateReleaseNotesFolder(
 export const findSeparateReleaseNotesVersions = async (
   pkgName: string,
 ): Promise<string[]> => {
-  return (
-    await $`ls ${getRoot()}/docs/api/${pkgName}/release-notes`.quiet()
-  ).stdout
+  return (await $`ls docs/api/${pkgName}/release-notes`.quiet()).stdout
     .trim()
     .split("\n")
     .map((x) => parse(x).name)
@@ -148,12 +146,12 @@ async function updateHistoricalTocFiles(pkg: Pkg): Promise<void> {
   console.log("Updating _toc.json files for the historical versions");
 
   const historicalFolders = (
-    await readdir(`${getRoot()}/docs/api/${pkg.name}`, { withFileTypes: true })
+    await readdir(`docs/api/${pkg.name}`, { withFileTypes: true })
   ).filter((file) => file.isDirectory() && file.name.match(/[0-9].*/));
 
   for (let folder of historicalFolders) {
     let tocFile = await readFile(
-      `${getRoot()}/docs/api/${pkg.name}/${folder.name}/_toc.json`,
+      `docs/api/${pkg.name}/${folder.name}/_toc.json`,
       {
         encoding: "utf8",
       },
@@ -169,7 +167,7 @@ async function updateHistoricalTocFiles(pkg: Pkg): Promise<void> {
     }
 
     await writeFile(
-      `${getRoot()}/docs/api/${pkg.name}/${folder.name}/_toc.json`,
+      `docs/api/${pkg.name}/${folder.name}/_toc.json`,
       JSON.stringify(jsonData, null, 2) + "\n",
     );
   }
@@ -202,7 +200,7 @@ async function writeReleaseNoteForVersion(
     );
   }
 
-  const basePath = `${getRoot()}/docs/api/${pkg.name}/release-notes`;
+  const basePath = `docs/api/${pkg.name}/release-notes`;
   const versionPath = `${basePath}/${pkg.versionWithoutPatch}.mdx`;
 
   const versionsMarkdown = releaseNoteMarkdown

--- a/scripts/js/lib/api/sphinxArtifacts.ts
+++ b/scripts/js/lib/api/sphinxArtifacts.ts
@@ -16,7 +16,7 @@ import { finished } from "stream/promises";
 import { Readable } from "stream";
 import fs from "fs";
 
-import { pathExists, getRoot } from "../fs";
+import { pathExists } from "../fs";
 import { mkdirp } from "mkdirp";
 import { Pkg } from "./Pkg";
 
@@ -42,7 +42,7 @@ export async function downloadSphinxArtifact(pkg: Pkg, artifactFolder: string) {
   }
 
   const artifactJson = JSON.parse(
-    fs.readFileSync(`${getRoot()}/scripts/api-html-artifacts.json`, "utf-8"),
+    fs.readFileSync(`scripts/api-html-artifacts.json`, "utf-8"),
   );
 
   const artifactName = pkg.isDev() ? "dev" : `${pkg.versionWithoutPatch}`;

--- a/scripts/js/lib/fs.test.ts
+++ b/scripts/js/lib/fs.test.ts
@@ -12,15 +12,15 @@
 
 import { expect, test } from "@jest/globals";
 
-import { getRoot, pathExists } from "./fs";
+import { pathExists } from "./fs";
 
-test("pathExists() with getRoot()", async () => {
-  const readme = await pathExists(`${getRoot()}/README.md`);
+test("pathExists()", async () => {
+  const readme = await pathExists(`README.md`);
   expect(readme).toBe(true);
 
-  const dir = await pathExists(`${getRoot()}/docs/`);
+  const dir = await pathExists(`docs/`);
   expect(dir).toBe(true);
 
-  const fake = await pathExists(`${getRoot()}/fake-file`);
+  const fake = await pathExists(`fake-file`);
   expect(fake).toBe(false);
 });

--- a/scripts/js/lib/fs.ts
+++ b/scripts/js/lib/fs.ts
@@ -11,13 +11,8 @@
 // that they have been altered from the originals.
 
 import fs from "fs/promises";
-import path from "path";
 
 import { $ } from "zx/core";
-
-export function getRoot() {
-  return path.normalize(`${__dirname}/../../../`);
-}
 
 export async function pathExists(path: string) {
   try {

--- a/scripts/js/lib/links/extractLinks.ts
+++ b/scripts/js/lib/links/extractLinks.ts
@@ -23,7 +23,6 @@ import remarkGfm from "remark-gfm";
 import { ObjectsInv } from "../api/objectsInv";
 import { readMarkdown } from "../markdownReader";
 import { removePrefix, removeSuffix } from "../stringUtils";
-import { getRoot } from "../fs";
 
 export type ParsedFile = {
   /** Anchors that the file defines. These can be linked to from other files. */
@@ -76,11 +75,9 @@ export async function parseLinks(
 }
 
 async function parseObjectsInv(filePath: string): Promise<Set<string>> {
-  const absoluteFilePath = path.join(
-    getRoot(),
+  const objinv = await ObjectsInv.fromFile(
     removeSuffix(filePath, "objects.inv"),
   );
-  const objinv = await ObjectsInv.fromFile(absoluteFilePath);
   // All URIs are relative to the objects.inv file
   const dirname = removePrefix(path.dirname(filePath), "public");
   return new Set(objinv.entries.map((entry) => path.join(dirname, entry.uri)));


### PR DESCRIPTION
`getRoot()` isn't going to work well when we package `scripts/js` for the Qiskit Functions repositories. One particular challenge is that in this repo, we run scripts from `scripts/js/commands/`—but the Functions repos will run from `node_modules/qiskit-documentation/dist/commands`—so the relative path we were using cannot work for both situations.

Another issue is that Playwright does not define `__dirname` because it runs with ES Modules rather than CommonJS.

Turns out, we don't even need to use `getRoot()`. The relative paths will be relative to the cwd, which should be the repo root anyways.