### PR TITLE
Allow skipping API docs in local previews

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
       - name: Start local Docker preview
         run: |
-          ./start &
+          ./start --apis &
           sleep 20
       - name: Check all pages render
         run: >

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can preview the docs locally by following these two steps:
 
 The preview application does not include the top nav bar. Instead, navigate to the folder you want with the links in the home page. You can return to the home page at any time by clicking "IBM Quantum Documentation Preview" in the top-left of the header.
 
-Warning: `./start` does not check if there is a new version of the docs application available. You can run `docker pull qiskit/documentation` to update to the latest version of the app.
+Warning: `./start` does not check if there is a new version of the docs application available. You can run `docker pull qiskit/documentation` to update to the latest version of the app. It will also ignore the API docs to speed things up, if you want to view them, run `./start --apis`.
 
 ### API docs authors: How to preview your changes
 

--- a/start
+++ b/start
@@ -35,7 +35,7 @@ def skip_apis() -> tuple[str]:
     """Mounts an empty directory to /docs/api/ to effectively exclude it"""
     if "--apis" in sys.argv:
         return ()
-    print("Skipping API docs for speed, use --apis to include them")
+    print("Skipping API docs for speed; use --apis to include them")
     return ("-v", "/home/node/app/docs/api")
 
 def main() -> None:

--- a/start
+++ b/start
@@ -31,6 +31,12 @@ def translation_volume_mounts() -> Iterator[str]:
             continue
         yield from ["-v", f"{path}:/home/node/app/docs/{path.name}"]
 
+def skip_apis() -> tuple[str]:
+    """Mounts an empty directory to /docs/api/ to effectively exclude it"""
+    if "--apis" in sys.argv:
+        return ()
+    print("Skipping API docs for speed, use --apis to include them")
+    return ("-v", "/home/node/app/docs/api")
 
 def main() -> None:
     print(
@@ -44,6 +50,7 @@ def main() -> None:
         "run",
         "-v",
         f"{PWD}/docs:/home/node/app/docs",
+        *skip_apis(),
         *translation_volume_mounts(),
         "-v",
         f"{PWD}/public:/home/node/app/packages/preview/public",

--- a/start
+++ b/start
@@ -19,18 +19,6 @@ from typing import Iterator
 PWD = Path(__file__).parent
 
 
-def translation_volume_mounts() -> Iterator[str]:
-    """Return the CLI args to mount each language in the translations/ folder.
-
-    Unlike the root `Dockerfile`, we cannot use `-v $PWD/translations:/home/node/app/docs` because
-    Docker complains that the volume is already mounted when we mount the `/docs` folder. So, instead
-    we need to be more specific to mount each language's folder.
-    """
-    for path in PWD.glob("translations/*"):
-        if not path.is_dir():
-            continue
-        yield from ["-v", f"{path}:/home/node/app/docs/{path.name}"]
-
 def skip_apis() -> tuple[str]:
     """Mounts an empty directory to /docs/api/ to effectively exclude it"""
     if "--apis" in sys.argv:
@@ -51,7 +39,6 @@ def main() -> None:
         "-v",
         f"{PWD}/docs:/home/node/app/docs",
         *skip_apis(),
-        *translation_volume_mounts(),
         "-v",
         f"{PWD}/public:/home/node/app/packages/preview/public",
         "-p",


### PR DESCRIPTION
The preview app is slow due because the it searches through the docs folder each time we load a page. Eric had the idea to improve the speed by removing API docs from the image. Since the API docs are so large, this roughly halves the time taken per page load. Writers can ask to include API docs using the `--apis` option.

Helps with https://github.com/Qiskit/documentation/issues/1720.
