### PR TITLE
Spellcheck Jupyter notebooks & allow running checker from other repos

### DIFF
--- a/docs/guides/create-transpiler-plugin.ipynb
+++ b/docs/guides/create-transpiler-plugin.ipynb
@@ -493,7 +493,7 @@
     "\n",
     "As before, if your project uses `setup.cfg` or `setup.py` instead of `pyproject.toml`, see the [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/entry_point.html) for how to adapt these lines for your situation.\n",
     "\n",
-    "To check that your plugin is successfully detected by Qiskit, install your plugin package and follow the instructions at [Transpiler plugins](transpiler-plugins#list-available-high-level-sythesis-plugins) for listing installed plugins, and ensure that your plugin appears in the list:"
+    "To check that your plugin is successfully detected by Qiskit, install your plugin package and follow the instructions at [Transpiler plugins](transpiler-plugins#list-available-high-level-synthesis-plugins) for listing installed plugins, and ensure that your plugin appears in the list:"
    ]
   },
   {

--- a/docs/guides/transpiler-plugins.ipynb
+++ b/docs/guides/transpiler-plugins.ipynb
@@ -122,7 +122,7 @@
    "id": "5497ad2a-92aa-4461-8182-89472848e214",
    "metadata": {},
    "source": [
-    "### List available high-level sythesis plugins\n",
+    "### List available high-level synthesis plugins\n",
     "\n",
     "Use the [high_level_synthesis_plugin_names](/api/qiskit/qiskit.transpiler.passes.synthesis.plugin.high_level_synthesis_plugin_names) function, passing the name of the type of \"high-level object\" to be synthesized. The name corresponds to the [`name`](/api/qiskit/qiskit.circuit.Operation#name) attribute of the [Operation](/api/qiskit/qiskit.circuit.Operation) class representing the type of object being synthesized."
    ]

--- a/docs/guides/transpiler-stages.ipynb
+++ b/docs/guides/transpiler-stages.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "source": [
     "## Layout stage\n",
-    "The next stage involves the layout or connectivity of the backend a circuit will be sent to.  In general, quantum circuits are abstract entities whose qubits are \"virtual\" or \"logical\" representations of actual qubits used in computations.  To execute a sequence of gates, a one-to-one mapping from the \"virtual\" qubits to the \"physical\" qubits in an actual quantum device is necesary.  This mapping is stored as a `Layout` object and is part of the constraints defined within a backend's [instruction set architecture (ISA)](./transpile#instruction-set-architecture).\n",
+    "The next stage involves the layout or connectivity of the backend a circuit will be sent to.  In general, quantum circuits are abstract entities whose qubits are \"virtual\" or \"logical\" representations of actual qubits used in computations.  To execute a sequence of gates, a one-to-one mapping from the \"virtual\" qubits to the \"physical\" qubits in an actual quantum device is necessary.  This mapping is stored as a `Layout` object and is part of the constraints defined within a backend's [instruction set architecture (ISA)](./transpile#instruction-set-architecture).\n",
     "\n",
     "\n",
     "![This image illustrates qubits being mapped from the wire representation to a diagram that represents how the qubits are connected on the system.](/images/guides/transpiler-stages/layout-mapping.png \"Qubit mapping\")\n",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc",
     "check": "npm run check:qiskit-bot && npm run check:patterns-index && npm run check:metadata && npm run check:spelling && npm run check:internal-links && npm run check:orphan-pages && npm run check:fmt",
     "check:metadata": "tsx scripts/js/commands/checkMetadata.ts",
-    "check:spelling": "cspell --no-progress docs/**/*.mdx docs/api/**/*.mdx --config scripts/config/cspell/cSpell.json",
+    "check:spelling": "tsx scripts/js/commands/checkSpelling.ts",
     "check:fmt": "prettier --check .",
     "check:internal-links": "tsx scripts/js/commands/checkInternalLinks.ts",
     "check:external-links": "tsx scripts/js/commands/checkExternalLinks.ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "scripts/config/cspell"
   ],
   "scripts": {
     "prepare": "tsc",

--- a/scripts/config/cspell/cSpell.json
+++ b/scripts/config/cspell/cSpell.json
@@ -48,7 +48,7 @@
     "^<span id=\\S+ />$",
     "^<span id=\\S+></span>$",
     // HTML elements
-    "<\/?thead>",
-    "<\/?iframe"
+    "</?thead>",
+    "</?iframe"
   ]
 }

--- a/scripts/config/cspell/cSpell.json
+++ b/scripts/config/cspell/cSpell.json
@@ -46,6 +46,9 @@
     "\\S+_\\S+(_\\S+)*",
     // separate line <span id="" /> tags
     "^<span id=\\S+ />$",
-    "^<span id=\\S+></span>$"
+    "^<span id=\\S+></span>$",
+    // HTML elements
+    "<\/?thead>",
+    "<\/?iframe"
   ]
 }

--- a/scripts/config/cspell/cSpell.json
+++ b/scripts/config/cspell/cSpell.json
@@ -47,12 +47,5 @@
     // separate line <span id="" /> tags
     "^<span id=\\S+ />$",
     "^<span id=\\S+></span>$"
-  ],
-  "ignorePaths": [
-    // We cannot easily control these API docs since they live in other repositories.
-    "../../../docs/api/qiskit/**/*.mdx",
-    "../../../docs/api/qiskit-ibm-runtime/**/*.mdx",
-    "../../../docs/api/qiskit-ibm-provider/**/*.mdx",
-    "../../../docs/api/qiskit-transpiler-service/**/*.mdx"
   ]
 }

--- a/scripts/config/cspell/dictionaries/qiskit.txt
+++ b/scripts/config/cspell/dictionaries/qiskit.txt
@@ -163,4 +163,6 @@ transpiling
 mthree
 Algorithmiq
 unphysical
-
+randomizations
+simulability
+unitarity

--- a/scripts/js/commands/checkSpelling.ts
+++ b/scripts/js/commands/checkSpelling.ts
@@ -1,0 +1,52 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2024.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { zxMain } from "../lib/zx";
+import { $ } from "zx";
+import yargs from "yargs/yargs";
+import { hideBin } from "yargs/helpers";
+
+import { Pkg } from "../lib/api/Pkg";
+
+interface Arguments {
+  [x: string]: unknown;
+  apis: boolean;
+  config: string;
+}
+
+function readArgs(): Arguments {
+  return yargs(hideBin(process.argv))
+    .version(false)
+    .option("apis", {
+      type: "boolean",
+      default: false,
+      description: "Check the API docs (currently failing)",
+    })
+    .option("config", {
+      type: "string",
+      default: "scripts/config/cspell/cSpell.json",
+      description: "Path to cSpell.json",
+    })
+    .parseSync();
+}
+
+zxMain(async () => {
+  const args = readArgs();
+  const cspellCmd = ["npx", "cspell", "--no-progress", "--config", args.config];
+
+  await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx docs/api/migration-guides/*.mdx`;
+
+  if (args.apis) {
+    const apiFolders = Pkg.VALID_NAMES.map((api) => `docs/api/${api}/**/*.mdx`);
+    await $`${cspellCmd} ${apiFolders}`;
+  }
+});

--- a/scripts/js/commands/checkSpelling.ts
+++ b/scripts/js/commands/checkSpelling.ts
@@ -66,7 +66,7 @@ async function checkAllNotebooks(configPath: string): Promise<void> {
       allGood = false;
       const deduplicated = new Set(errors);
       deduplicated.forEach((mistake) =>
-        console.error(`Spelling mistake in ${path}: ${mistake}`),
+        console.error(`❌ Unrecognized word in ${path}: ${mistake}`),
       );
     }
   });
@@ -84,14 +84,14 @@ async function checkForNotebookMistakes(
   configPath: string,
 ): Promise<string[]> {
   // We should only check the markdown blocks, not code blocks.
-  const text = await readMarkdown(fp);
+  const markdown = await readMarkdown(fp);
 
   const checkOptions = {
     configFile: configPath,
   };
   const doc = {
     uri: fp,
-    text,
+    text: markdown,
   };
   const result = await spellCheckDocument(doc, checkOptions, {});
 

--- a/scripts/js/lib/fs.ts
+++ b/scripts/js/lib/fs.ts
@@ -11,9 +11,6 @@
 // that they have been altered from the originals.
 
 import fs from "fs/promises";
-import path from "path";
-import os from "os";
-import { randomBytes } from "crypto";
 
 import { $ } from "zx/core";
 
@@ -34,30 +31,4 @@ export async function pathExists(path: string) {
  */
 export async function rmFilesInFolder(dir: string): Promise<void> {
   await $`find ${dir} -maxdepth 1 -type f -path "${dir}/*" | xargs rm -f {}`.quiet();
-}
-
-/**
- * Copies every file to the destDir.
- *
- * Will preserve the dirname of each file. For example, `dir/f.txt` will be copied
- * over to `{dest}/dir/f.txt`.
- */
-export async function copyFiles(
-  files: string[],
-  destDir: string,
-): Promise<void> {
-  await Promise.all(
-    files.map(async (fp) => {
-      const dest = path.join(destDir, fp);
-      await fs.mkdir(path.dirname(dest), { recursive: true });
-      await fs.copyFile(fp, dest);
-    }),
-  );
-}
-
-export async function createTmpdir(): Promise<string> {
-  const randomSuffix = randomBytes(3).toString("hex");
-  const temp = path.join(os.tmpdir(), `qiskit-docs-${randomSuffix}`);
-  await fs.mkdir(temp);
-  return temp;
 }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1741. We use the cspell library to check Jupyter notebooks:

```
❯ npm run check:spelling

> qiskit-documentation@0.1.0 check:spelling
> tsx scripts/js/commands/checkSpelling.ts

$ npx cspell --no-progress --config scripts/config/cspell/cSpell.json docs/**/*.mdx !docs/api/**/*.mdx docs/api/migration-guides/*.mdx
CSpell: Files checked: 53, Issues found: 0 in 0 files
❌ Unrecognized word in docs/guides/hello-world.ipynb: typoooooo
```

There is now an `--apis` flag, although there are currently failures.

--

Other repositories can also now run cspell with this `script`:

```
"check:spelling": "node node_modules/qiskit-documentation/dist/commands/checkSpelling.js --config node_modules/qiskit-documentation/scripts/config/cspell/cspell.json"
```