### PR TITLE
Fix pages render check in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Start local Docker preview
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |
-          ./start &
+          ./start --apis &
           sleep 20
       - name: Check that pages render
         if: steps.changed-docs-files.outputs.any_changed == 'true'


### PR DESCRIPTION
We need to volume mount API docs in the pages render check because `/api/migration-guides`. This fixes https://github.com/Qiskit/documentation/actions/runs/10079828374/job/27868447282?pr=1665#step:16:76

See https://github.com/Qiskit/documentation/pull/1750 for the source of the regression.