### PR TITLE
Use absolute internal links in migration guides

### DIFF
--- a/docs/api/migration-guides/index.mdx
+++ b/docs/api/migration-guides/index.mdx
@@ -9,10 +9,10 @@ description: Migrate to using the newest from Qiskit and Qiskit Runtime
 These migration guides help you more effectively use Qiskit and Qiskit Runtime:
 
 * Migrate to Qiskit 1.0
-   * [Qiskit 1.0 packaging changes](/api/migration-guides/qiskit-1.0-installation)
-   * [Qiskit 1.0 feature changes](/api/migration-guides/qiskit-1.0-features)
-* [Migrate to the Qiskit Runtime V2 primitives](/api/migration-guides/v2-primitives)
-* [Qiskit Runtime execution mode changes](/api/migration-guides/sessions)
+   * [Qiskit 1.0 packaging changes](./qiskit-1.0-installation)
+   * [Qiskit 1.0 feature changes](./qiskit-1.0-features)
+* [Migrate to the Qiskit Runtime V2 primitives](./v2-primitives)
+* [Qiskit Runtime execution mode changes](./sessions)
 * Migrate to Qiskit Runtime
    * [Overview](./qiskit-runtime)
    * [Migrate from `qiskit-ibmq-provider`](./qiskit-runtime-from-ibmq-provider)
@@ -20,7 +20,7 @@ These migration guides help you more effectively use Qiskit and Qiskit Runtime:
    * [Migrate options](./qiskit-runtime-options)
    * [Common use cases](./qiskit-runtime-use-case)
    * [Examples](./qiskit-runtime-examples)
-* [Migrate from cloud simulators to local simulators](/api/migration-guides/local-simulators)
+* [Migrate from cloud simulators to local simulators](./local-simulators)
 * Qiskit 0.44 changes
    * [`qiskit.algorithms` new interface](./qiskit-algorithms-module)
    * [`qiskit.opflow` deprecation](./qiskit-opflow-module)

--- a/docs/api/migration-guides/qiskit-algorithms-module.mdx
+++ b/docs/api/migration-guides/qiskit-algorithms-module.mdx
@@ -20,17 +20,17 @@ description: How to update your code to use the new interface for `qiskit.algori
 
 ## Background
 
-The [`qiskit.algorithms`](../qiskit/0.46/algorithms) module was originally built on top of the [`qiskit.opflow`](../qiskit/0.46/opflow) library and the
-[`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) utility. The development of the [`qiskit.primitives`](../qiskit/primitives)
-introduced a higher-level execution paradigm, with the `Estimator` for computing expectation values for observables, and `Sampler` for executing circuits and returning probability distributions. These tools allowed the [`qiskit.algorithms`](../qiskit/0.46/algorithms) module to be refactored, after which,
-[`qiskit.opflow`](../qiskit/0.46/opflow) and [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) were deprecated.
+The [`qiskit.algorithms`](/api/qiskit/0.46/algorithms) module was originally built on top of the [`qiskit.opflow`](/api/qiskit/0.46/opflow) library and the
+[`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) utility. The development of the [`qiskit.primitives`](/api/qiskit/primitives)
+introduced a higher-level execution paradigm, with the `Estimator` for computing expectation values for observables, and `Sampler` for executing circuits and returning probability distributions. These tools allowed the [`qiskit.algorithms`](/api/qiskit/0.46/algorithms) module to be refactored, after which,
+[`qiskit.opflow`](/api/qiskit/0.46/opflow) and [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) were deprecated.
 
 <Admonition type="caution">
-  The transition away from [`qiskit.opflow`](../qiskit/0.46/opflow) affects the classes that algorithms use as part of the problem
-  setup. Most [`qiskit.opflow`](../qiskit/0.46/opflow) dependencies have a direct [`qiskit.quantum_info`](../qiskit/quantum_info)
-  replacement. One common example is the class [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp), used to define Hamiltonians
-  (for example, to plug into VQE), which can be replaced by [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).
-  For information to migrate other [`qiskit.opflow`](../qiskit/0.46/opflow) objects, refer to the [Opflow migration guide](./qiskit-opflow-module).
+  The transition away from [`qiskit.opflow`](/api/qiskit/0.46/opflow) affects the classes that algorithms use as part of the problem
+  setup. Most [`qiskit.opflow`](/api/qiskit/0.46/opflow) dependencies have a direct [`qiskit.quantum_info`](/api/qiskit/quantum_info)
+  replacement. One common example is the class [`qiskit.opflow.primitive_ops.PauliSumOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp), used to define Hamiltonians
+  (for example, to plug into VQE), which can be replaced by [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp).
+  For information to migrate other [`qiskit.opflow`](/api/qiskit/0.46/opflow) objects, refer to the [Opflow migration guide](./qiskit-opflow-module).
 </Admonition>
 
 For further background and detailed migration steps, see these guides:
@@ -40,16 +40,16 @@ For further background and detailed migration steps, see these guides:
 
 ## What has changed
 
-The [`qiskit.algorithms`](../qiskit/0.46/algorithms) module has been fully refactored to use the [`qiskit.primitives`](../qiskit/primitives), for circuit execution, instead of the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), which is now deprecated.
+The [`qiskit.algorithms`](/api/qiskit/0.46/algorithms) module has been fully refactored to use the [`qiskit.primitives`](/api/qiskit/primitives), for circuit execution, instead of the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), which is now deprecated.
 
 There have been three types of refactoring:
 
-1. Algorithms that were refactored in a new location to support [`qiskit.primitives`](../qiskit/primitives). These algorithms have the same
-   class names as the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance)-based ones but are in a new subpackage.
+1. Algorithms that were refactored in a new location to support [`qiskit.primitives`](/api/qiskit/primitives). These algorithms have the same
+   class names as the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance)-based ones but are in a new subpackage.
 
  <Admonition type="caution">
    Be careful with import paths. The legacy algorithms can still be imported from
-   [`qiskit.algorithms`](../qiskit/0.46/algorithms). Until the legacy imports are removed, this convenience import is not available
+   [`qiskit.algorithms`](/api/qiskit/0.46/algorithms). Until the legacy imports are removed, this convenience import is not available
    for the refactored algorithms. Thus, to import the refactored algorithms you must specify the full import path.  For example, `from qiskit.algorithms.eigensolvers import VQD`.
  </Admonition>
 
@@ -57,45 +57,45 @@ There have been three types of refactoring:
  - [Eigensolvers](#eigensolvers)
  - [Time Evolvers](#time-evolvers)
 
-2. Algorithms that were refactored in-place (same namespace) to support both [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) and
-   [`qiskit.primitives`](../qiskit/primitives). In the future, [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) will be removed.
+2. Algorithms that were refactored in-place (same namespace) to support both [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) and
+   [`qiskit.primitives`](/api/qiskit/primitives). In the future, [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) will be removed.
 
  - [Amplitude Amplifiers](#amplitude-amplifiers)
  - [Amplitude Estimators](#amplitude-estimators)
  - [Phase Estimators](#phase-estimators)
 
-3. Algorithms that were deprecated and are now removed entirely from [`qiskit.algorithms`](../qiskit/0.46/algorithms). These are algorithms that do not serve
+3. Algorithms that were deprecated and are now removed entirely from [`qiskit.algorithms`](/api/qiskit/0.46/algorithms). These are algorithms that do not serve
    as building blocks for applications and are only valuable for education, as described in the following tutorials:
 
  - [Linear Solvers (HHL)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-applications/hhl_tutorial.ipynb) ,
  - [Factorizers (Shor)](https://github.com/Qiskit/textbook/blob/main/notebooks/ch-algorithms/shor.ipynb)
 
 This migration guide focuses on the algorithms with migration alternatives within
-[`qiskit.algorithms`](../qiskit/0.46/algorithms), that is, refactoring types 1 and 2.
+[`qiskit.algorithms`](/api/qiskit/0.46/algorithms), that is, refactoring types 1 and 2.
 
 ## How to choose a primitive configuration for your algorithm
 
 The classes in
-[`qiskit.algorithms`](../qiskit/0.46/algorithms) are initialized with any implementation of [`qiskit.primitives.BaseSampler`](../qiskit/0.46/qiskit.primitives.BaseSampler) or [`qiskit.primitives.BaseEstimator`](../qiskit/0.46/qiskit.primitives.BaseEstimator).
+[`qiskit.algorithms`](/api/qiskit/0.46/algorithms) are initialized with any implementation of [`qiskit.primitives.BaseSampler`](/api/qiskit/0.46/qiskit.primitives.BaseSampler) or [`qiskit.primitives.BaseEstimator`](/api/qiskit/0.46/qiskit.primitives.BaseEstimator).
 
 Once you know which primitive you want to use, choose the primitive implementation that meets your needs. For example:
 
-* For quick prototyping, use the reference implementations of primitives included in Qiskit: [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator).
+* For quick prototyping, use the reference implementations of primitives included in Qiskit: [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator).
 
 * For finer algorithm tuning, use a local simulator such as the primitive implementation in Aer: [`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html) and [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html).
 
 * For running on quantum hardware choose from these options:
 
-   - Access services with native primitive implementations, such as the Qiskit Runtime service by using [`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`.](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)
-   - Wrap any QPU (quantum processing unti) with `Backend` primitives ([`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator)). These wrappers implement a primitive interface on top of a backend that only supports `backend.run()`.
+   - Access services with native primitive implementations, such as the Qiskit Runtime service by using [`qiskit_ibm_runtime.Sampler`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`.](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)
+   - Wrap any QPU (quantum processing unti) with `Backend` primitives ([`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator)). These wrappers implement a primitive interface on top of a backend that only supports `backend.run()`.
 
 For detailed information and examples, particularly on the use of the `Backend` primitives, refer to
 the [QuantumInstance migration guide](./qiskit-quantum-instance).
 
 This guide describes these common configurations for algorithms that determine which primitive import to use:
 
-* Running an algorithm with a statevector simulator when you want the ideal outcome without shot noise.  For example, using the [`qiskit.opflow`](../qiskit/0.46/opflow) legacy
-   [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/0.46/qiskit.opflow.expectations.MatrixExpectation):
+* Running an algorithm with a statevector simulator when you want the ideal outcome without shot noise.  For example, using the [`qiskit.opflow`](/api/qiskit/0.46/opflow) legacy
+   [`qiskit.opflow.expectations.MatrixExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.MatrixExpectation):
 
  - Reference Primitives with default configuration.  See [QAOA](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/algorithms/05_qaoa.ipynb) for an example.
 
@@ -112,7 +112,7 @@ This guide describes these common configurations for algorithms that determine w
  estimator = Estimator(backend_options={"method": "statevector"})
  ```
 
-* Running an algorithm using a simulator or device with shot noise.  For example, using the [`qiskit.opflow`](../qiskit/0.46/opflow) legacy [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/0.46/qiskit.opflow.expectations.PauliExpectation):
+* Running an algorithm using a simulator or device with shot noise.  For example, using the [`qiskit.opflow`](/api/qiskit/0.46/opflow) legacy [`qiskit.opflow.expectations.PauliExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.PauliExpectation):
 
  - Reference primitives with shots.  See the [VQE](#vqe) examples.
 
@@ -142,8 +142,8 @@ This guide describes these common configurations for algorithms that determine w
  from qiskit_ibm_runtime import Sampler, Estimator
  ```
 
-* Running an algorithm on an Aer simulator using a custom instruction.  For example, using the [`qiskit.opflow`](../qiskit/0.46/opflow) legacy
-[`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation).
+* Running an algorithm on an Aer simulator using a custom instruction.  For example, using the [`qiskit.opflow`](/api/qiskit/0.46/opflow) legacy
+[`qiskit.opflow.expectations.AerPauliExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation).
 
 - Aer Primitives with default options.  See [TrotterQRTE](#trotterqrte) for examples.
 
@@ -158,12 +158,12 @@ estimator = Estimator()
 ## Minimum Eigensolvers
 
 The minimum eigensolver algorithms were refactored in a new location.
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers) are now initialized
-by using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, depending
+Instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), [`qiskit.algorithms.minimum_eigensolvers`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers) are now initialized
+by using an instance of the [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive, depending
 on the algorithm. The legacy classes can still be found in `qiskit.algorithms.minimum_eigen_solvers`.
 
 <Admonition type="caution">
-  For the [`qiskit.algorithms.minimum_eigensolvers`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers) classes, depending on the import path,
+  For the [`qiskit.algorithms.minimum_eigensolvers`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers) classes, depending on the import path,
   you will access either the primitive-based or the quantum-instance-based implementation. You have to be careful, because the class name does not change.
 
   - Old import (QuantumInstance-based): `from qiskit.algorithms import VQE, QAOA, NumPyMinimumEigensolver`
@@ -174,29 +174,29 @@ on the algorithm. The legacy classes can still be found in `qiskit.algorithms.mi
 
 The legacy `qiskit.algorithms.minimum_eigen_solvers.VQE` class has now been split according to the use case:
 
-- For general-purpose Hamiltonians, use the Estimator-based [`qiskit.algorithms.minimum_eigensolvers.VQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE)
+- For general-purpose Hamiltonians, use the Estimator-based [`qiskit.algorithms.minimum_eigensolvers.VQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE)
   class.
 - If you have a diagonal Hamiltonian and want the algorithm to return a sampling of the state, use
-  the new Sampler-based [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) algorithm. Previously, this was done by using the legacy `qiskit.algorithms.minimum_eigen_solvers.VQE` with
-  [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation).
+  the new Sampler-based [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) algorithm. Previously, this was done by using the legacy `qiskit.algorithms.minimum_eigen_solvers.VQE` with
+  [`qiskit.opflow.expectations.CVaRExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation).
 
 <Admonition type="note">
-  In addition to taking in an [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
-  the new [`qiskit.algorithms.minimum_eigensolvers.VQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE) signature has undergone the following changes:
+  In addition to taking in an [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
+  the new [`qiskit.algorithms.minimum_eigensolvers.VQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE) signature has undergone the following changes:
 
   * The `expectation` and `include_custom` parameters have been removed, as this functionality is now
      defined at the `Estimator` level.
   * The `gradient` parameter now takes in an instance of a primitive-based gradient class from
-     [`qiskit.algorithms.gradients`](../qiskit/0.46/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](../qiskit/0.46/qiskit.opflow.gradients.Gradient) class.
+     [`qiskit.algorithms.gradients`](/api/qiskit/0.46/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](/api/qiskit/0.46/qiskit.opflow.gradients.Gradient) class.
   * The `max_evals_grouped` parameter has been removed, as it can be set directly on the optimizer class.
   * The `estimator`, `ansatz` and `optimizer` are the only parameters that can be defined positionally
      (and in this order). All others have become keyword-only arguments.
 </Admonition>
 
 <Admonition type="note">
-  The new [`qiskit.algorithms.minimum_eigensolvers.VQEResult`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQEResult) class does not include the state, as
+  The new [`qiskit.algorithms.minimum_eigensolvers.VQEResult`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQEResult) class does not include the state, as
   this output was only useful in the case of diagonal operators. However, it is available as part of the new
-  [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) [`qiskit.algorithms.minimum_eigensolvers.SamplingVQEResult`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQEResult).
+  [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) [`qiskit.algorithms.minimum_eigensolvers.SamplingVQEResult`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQEResult).
 </Admonition>
 
 #### VQE examples
@@ -333,27 +333,27 @@ For complete code examples, see the following updated tutorials:
 ### QAOA
 
 The new QAOA only supports diagonal operators.  This is because the legacy `qiskit.algorithms.minimum_eigen_solvers.QAOA` class extended
-`qiskit.algorithms.minimum_eigen_solvers.VQE`, but now, [`qiskit.algorithms.minimum_eigensolvers.QAOA`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.QAOA)
-extends [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE).
+`qiskit.algorithms.minimum_eigen_solvers.VQE`, but now, [`qiskit.algorithms.minimum_eigensolvers.QAOA`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.QAOA)
+extends [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE).
 
 <Admonition type="note">
-  In addition to taking in a [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
-  the new [`qiskit.algorithms.minimum_eigensolvers.QAOA`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.QAOA) signature has undergone the following changes:
+  In addition to taking in a [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) instance instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
+  the new [`qiskit.algorithms.minimum_eigensolvers.QAOA`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.QAOA) signature has undergone the following changes:
 
   * The `expectation` and `include_custom` parameters have been removed and the `aggregation`
      parameter has been added.  This was previously defined through a custom `expectation` parameter.
   * The `gradient` parameter now takes in an instance of a primitive-based gradient class from
-     [`qiskit.algorithms.gradients`](../qiskit/0.46/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](../qiskit/0.46/qiskit.opflow.gradients.Gradient) class.
+     [`qiskit.algorithms.gradients`](/api/qiskit/0.46/qiskit.algorithms.gradients) instead of the legacy [`qiskit.opflow.gradients.Gradient`](/api/qiskit/0.46/qiskit.opflow.gradients.Gradient) class.
   * The `max_evals_grouped` parameter has been removed, as it can be set directly on the optimizer class.
   * The `sampler` and `optimizer` parameters are the only parameters that can be defined positionally
      (and in this order). All others have become keyword-only arguments.
 </Admonition>
 
 <Admonition type="note">
-  If you want to run QAOA on a non-diagonal operator, use the [`qiskit.circuit.library.QAOAAnsatz`](../qiskit/qiskit.circuit.library.QAOAAnsatz) with
-  [`qiskit.algorithms.minimum_eigensolvers.VQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE), but there will be no state result.
+  If you want to run QAOA on a non-diagonal operator, use the [`qiskit.circuit.library.QAOAAnsatz`](/api/qiskit/qiskit.circuit.library.QAOAAnsatz) with
+  [`qiskit.algorithms.minimum_eigensolvers.VQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE), but there will be no state result.
   If your application requires the final probability distribution, instantiate a `Sampler`
-  and run it with the optimal circuit after [`qiskit.algorithms.minimum_eigensolvers.VQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE).
+  and run it with the optimal circuit after [`qiskit.algorithms.minimum_eigensolvers.VQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.VQE).
 </Admonition>
 
 #### QAOA example
@@ -424,7 +424,7 @@ For complete code examples, see the updated [QAOA tutorial.](https://github.com/
 
 Because this is a classical solver, the workflow has not changed between the old and new implementation.
 However, the import has changed from `qiskit.algorithms.minimum_eigen_solvers.NumPyMinimumEigensolver`
-to [`qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver) to conform to the new interfaces
+to [`qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver) to conform to the new interfaces
 and result classes.
 
 #### NumPyMinimumEigensolver example
@@ -472,13 +472,13 @@ For complete code examples, see the updated [VQE, callback, gradients, initial p
 ## Eigensolvers
 
 The eigensolver algorithms were refactored in a new location.  Instead of using
-[`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), [`qiskit.algorithms.eigensolvers`](../qiskit/0.46/qiskit.algorithms.eigensolvers) are now initialized
-using an instance of the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive, or
+[`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), [`qiskit.algorithms.eigensolvers`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers) are now initialized
+using an instance of the [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive, or
 a primitive-based subroutine, depending on the algorithm. The legacy classes can still be found
 in `qiskit.algorithms.eigen_solvers`.
 
 <Admonition type="caution">
-  For the [`qiskit.algorithms.eigensolvers`](../qiskit/0.46/qiskit.algorithms.eigensolvers) classes, depending on the import path,
+  For the [`qiskit.algorithms.eigensolvers`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers) classes, depending on the import path,
   you will access either the primitive-based or the QuantumInstance-based
 implementation. You have to be careful, because the class name is the same.
 
@@ -488,19 +488,19 @@ implementation. You have to be careful, because the class name is the same.
 
 ### VQD
 
-The new [`qiskit.algorithms.eigensolvers.VQD`](../qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) class is initialized with an instance of the
-[`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance).
+The new [`qiskit.algorithms.eigensolvers.VQD`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) class is initialized with an instance of the
+[`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance).
 It also takes an instance of a state fidelity class from mod:`qiskit.algorithms.state_fidelities`,
-such as the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler)-based [`qiskit.algorithms.state_fidelities.ComputeUncompute`](../qiskit/0.46/qiskit.algorithms.state_fidelities.ComputeUncompute).
+such as the [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler)-based [`qiskit.algorithms.state_fidelities.ComputeUncompute`](/api/qiskit/0.46/qiskit.algorithms.state_fidelities.ComputeUncompute).
 
 <Admonition type="note">
-  In addition to taking in a [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
-  the new [`qiskit.algorithms.eigensolvers.VQD`](../qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) signature has undergone the following changes:
+  In addition to taking in a [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
+  the new [`qiskit.algorithms.eigensolvers.VQD`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) signature has undergone the following changes:
 
   * The `expectation` and `include_custom` parameters have been removed, as this functionality is now
      defined at the `Estimator` level.
   * The custom `fidelity` parameter has been added and the custom `gradient` parameter has
-     been removed because current classes in [`qiskit.algorithms.gradients`](../qiskit/0.46/qiskit.algorithms.gradients) cannot use state fidelity
+     been removed because current classes in [`qiskit.algorithms.gradients`](/api/qiskit/0.46/qiskit.algorithms.gradients) cannot use state fidelity
      gradients.
   * The `max_evals_grouped` parameter has been removed because it can be set directly on the `optimizer` class.
   * The `estimator`, `fidelity`, `ansatz` and `optimizer` parameters are the only parameters that can be defined positionally
@@ -508,10 +508,10 @@ such as the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler)-b
 </Admonition>
 
 <Admonition type="note">
-  Similar to VQE, the new [`qiskit.algorithms.eigensolvers.VQDResult`](../qiskit/0.46/qiskit.algorithms.eigensolvers.VQDResult) class does not include
+  Similar to VQE, the new [`qiskit.algorithms.eigensolvers.VQDResult`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.VQDResult) class does not include
   the state. If your application requires the final probability distribution, instantiate
   a `Sampler` and run it with the optimal circuit for the desired excited state
-  after running [`qiskit.algorithms.eigensolvers.VQD`](../qiskit/0.46/qiskit.algorithms.eigensolvers.VQD).
+  after running [`qiskit.algorithms.eigensolvers.VQD`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.VQD).
 </Admonition>
 
 #### VQD Example
@@ -584,7 +584,7 @@ For complete code examples, see the updated [VQD tutorial.](https://github.com/Q
 Similarly to its minimum eigensolver counterpart, because this is a classical solver, the workflow has not changed
 between the old and new implementation.
 However, the import has changed from `qiskit.algorithms.eigen_solvers.NumPyEigensolver`
-to [`qiskit.algorithms.eigensolvers.NumPyEigensolver`](../qiskit/0.46/qiskit.algorithms.eigensolvers.NumPyEigensolver) to conform to the new interfaces and result classes.
+to [`qiskit.algorithms.eigensolvers.NumPyEigensolver`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.NumPyEigensolver) to conform to the new interfaces and result classes.
 
 #### NumPyEigensolver Example
 
@@ -629,8 +629,8 @@ print(result.eigenvalues)
 ## Time Evolvers
 
 The time evolvers were refactored in a new location.
-Instead of using a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.time_evolvers` are now initialized
-using a [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive instance. The legacy classes can still be found
+Instead of using a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.time_evolvers` are now initialized
+using a [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive instance. The legacy classes can still be found
 in `qiskit.algorithms.evolvers`.
 
 In addition to the migration, the module has been substantially expanded to include Variational Quantum Time Evolution
@@ -648,8 +648,8 @@ In addition to the migration, the module has been substantially expanded to incl
 </Admonition>
 
 <Admonition type="note">
-  In addition to taking in a [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
-  the new [`qiskit.algorithms.eigensolvers.VQD`](../qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) signature has undergone the following changes:
+  In addition to taking in a [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) instance instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
+  the new [`qiskit.algorithms.eigensolvers.VQD`](/api/qiskit/0.46/qiskit.algorithms.eigensolvers.VQD) signature has undergone the following changes:
 
   * The `expectation` parameter has been removed, as this functionality is now
      defined at the `Estimator` level.
@@ -725,8 +725,8 @@ q:  ┤ exp(it X) ├┤ exp(it Z) ├
 ## Amplitude amplifiers
 
 The amplitude amplifier algorithms were refactored in-place.
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_amplifiers` are now initialized
-using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
+Instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_amplifiers` are now initialized
+using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
   The full `qiskit.algorithms.amplitude_amplifiers` module has been refactored in place. Therefore, you don't need to
@@ -764,8 +764,8 @@ For complete code examples, see the following updated tutorials:
 ## Amplitude estimators
 
 Similarly to the amplitude amplifiers, the amplitude estimators were refactored in-place.
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_estimators` are now initialized
-using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
+Instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.amplitude_estimators` are now initialized
+using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
   The full `qiskit.algorithms.amplitude_estimators` module has been refactored in place. You do not need to
@@ -807,8 +807,8 @@ For a complete code example, see the updated [Amplitude Estimation tutorial.](ht
 ## Phase estimators
 
 The phase estimators were refactored in-place.
-Instead of a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.phase_estimators` are now initialized by
-using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler).
+Instead of a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), `qiskit.algorithms.phase_estimators` are now initialized by
+using an instance of any `Sampler` primitive.  That is, [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler).
 
 <Admonition type="note">
   The full `qiskit.algorithms.phase_estimators` module has been refactored in place. Therefore, you do not need to change import paths.

--- a/docs/api/migration-guides/qiskit-opflow-module.mdx
+++ b/docs/api/migration-guides/qiskit-opflow-module.mdx
@@ -5,102 +5,102 @@ description: How to update your code to stop using the deprecated `qiskit.opflow
 
 # Opflow migration guide
 
-The new [`qiskit.primitives`](../qiskit/primitives), in combination with the [`qiskit.quantum_info`](../qiskit/quantum_info) module, have superseded
-functionality of [`qiskit.opflow`](../qiskit/0.46/opflow), which is being deprecated.
+The new [`qiskit.primitives`](/api/qiskit/primitives), in combination with the [`qiskit.quantum_info`](/api/qiskit/quantum_info) module, have superseded
+functionality of [`qiskit.opflow`](/api/qiskit/0.46/opflow), which is being deprecated.
 
 This migration guide contains instructions and code examples to migrate Qiskit code that uses
-the [`qiskit.opflow`](../qiskit/0.46/opflow) module to the [`qiskit.primitives`](../qiskit/primitives) and [`qiskit.quantum_info`](../qiskit/quantum_info) modules.
+the [`qiskit.opflow`](/api/qiskit/0.46/opflow) module to the [`qiskit.primitives`](/api/qiskit/primitives) and [`qiskit.quantum_info`](/api/qiskit/quantum_info) modules.
 
 <Admonition type="note">
-  The [`qiskit.opflow`](../qiskit/0.46/opflow) module was tightly coupled to the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) class, which
-  is also being deprecated. For information about migrating the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), see
+  The [`qiskit.opflow`](/api/qiskit/0.46/opflow) module was tightly coupled to the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class, which
+  is also being deprecated. For information about migrating the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), see
   the [Quantum instance migration guide.](./qiskit-quantum-instance)
 </Admonition>
 
 <span id="attention_primitives"></span>
 <Admonition type="note">
-  Most references to the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) in this guide
-  can be replaced with instances of any primitive implementation. For example Aer primitives ([`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html)/[`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)) or the Qiskit Runtime primitives ([`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler)/[`qiskit_ibm_runtime.Estimator`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)).
-  Specific QPUs (quantum processing units) can be wrapped with ([`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler), [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator)) to also present primitive-compatible interfaces.
+  Most references to the [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) in this guide
+  can be replaced with instances of any primitive implementation. For example Aer primitives ([`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html)/[`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)) or the Qiskit Runtime primitives ([`qiskit_ibm_runtime.Sampler`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler)/[`qiskit_ibm_runtime.Estimator`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator)).
+  Specific QPUs (quantum processing units) can be wrapped with ([`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler), [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator)) to also present primitive-compatible interfaces.
 
   Certain classes, such as the
-  [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation), can only be replaced by a specific primitive instance
+  [`qiskit.opflow.expectations.AerPauliExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation), can only be replaced by a specific primitive instance
   (in this case, [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html)), or require a specific option configuration.
   If this is the case, it will be explicitly indicated in the corresponding section.
 </Admonition>
 
 ## Background
 
-The [`qiskit.opflow`](../qiskit/0.46/opflow) module was originally introduced as a layer between circuits and algorithms, a series of building blocks
+The [`qiskit.opflow`](/api/qiskit/0.46/opflow) module was originally introduced as a layer between circuits and algorithms, a series of building blocks
 for quantum algorithm research and development.
 
-The release of the [`qiskit.primitives`](../qiskit/primitives) introduced a new paradigm for interacting with quantum computers. Instead of
-preparing a circuit to execute with a `backend.run()` type of method, algorithms can leverage the [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and
-[`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitives, send parametrized circuits and observables, and directly receive quasi-probability distributions or
+The release of the [`qiskit.primitives`](/api/qiskit/primitives) introduced a new paradigm for interacting with quantum computers. Instead of
+preparing a circuit to execute with a `backend.run()` type of method, algorithms can leverage the [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) and
+[`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitives, send parametrized circuits and observables, and directly receive quasi-probability distributions or
 expectation values (respectively). This workflow simplifies the pre-processing and post-processing steps
-that previously relied on this module; allowing us to move away from [`qiskit.opflow`](../qiskit/0.46/opflow)
-and find new paths for developing algorithms based on the [`qiskit.primitives`](../qiskit/primitives) interface and
-the [`qiskit.quantum_info`](../qiskit/quantum_info) module.
+that previously relied on this module; allowing us to move away from [`qiskit.opflow`](/api/qiskit/0.46/opflow)
+and find new paths for developing algorithms based on the [`qiskit.primitives`](/api/qiskit/primitives) interface and
+the [`qiskit.quantum_info`](/api/qiskit/quantum_info) module.
 
 This guide describes the opflow submodules and provides either a direct alternative
-(for example, using [`qiskit.quantum_info`](../qiskit/quantum_info)), or an explanation of how to replace their functionality in algorithms.
+(for example, using [`qiskit.quantum_info`](/api/qiskit/quantum_info)), or an explanation of how to replace their functionality in algorithms.
 
 The functional equivalency can be roughly summarized as follows:
 
 | Opflow Module | Alternative |
 | --- | --- |
-| Operators ([`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase), [`Operator Globals`](#operator-globals), [`qiskit.opflow.primitive_ops`](../qiskit/0.46/qiskit.opflow.primitive_ops), [`qiskit.opflow.list_ops`](../qiskit/0.46/qiskit.opflow.list_ops)) | `qiskit.quantum_info` [`Operators`](../qiskit/quantum_info#operators) |
-| [`qiskit.opflow.state_fns`](../qiskit/0.46/qiskit.opflow.state_fns) | `qiskit.quantum_info` [`States`](../qiskit/quantum_info#states) |
-| [`qiskit.opflow.converters`](../qiskit/0.46/qiskit.opflow.converters) | [`qiskit.primitives`](../qiskit/primitives) |
-| [`qiskit.opflow.evolutions`](../qiskit/0.46/qiskit.opflow.evolutions) | `qiskit.synthesis` [`Evolution`](../qiskit/synthesis#evolution-synthesis) |
-| [`qiskit.opflow.expectations`](../qiskit/0.46/qiskit.opflow.expectations) | [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) |
-| [`qiskit.opflow.gradients`](../qiskit/0.46/qiskit.opflow.gradients) | [`qiskit.algorithms.gradients`](../qiskit/0.46/qiskit.algorithms.gradients) |
+| Operators ([`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase), [`Operator Globals`](#operator-globals), [`qiskit.opflow.primitive_ops`](/api/qiskit/0.46/qiskit.opflow.primitive_ops), [`qiskit.opflow.list_ops`](/api/qiskit/0.46/qiskit.opflow.list_ops)) | `qiskit.quantum_info` [`Operators`](/api/qiskit/quantum_info#operators) |
+| [`qiskit.opflow.state_fns`](/api/qiskit/0.46/qiskit.opflow.state_fns) | `qiskit.quantum_info` [`States`](/api/qiskit/quantum_info#states) |
+| [`qiskit.opflow.converters`](/api/qiskit/0.46/qiskit.opflow.converters) | [`qiskit.primitives`](/api/qiskit/primitives) |
+| [`qiskit.opflow.evolutions`](/api/qiskit/0.46/qiskit.opflow.evolutions) | `qiskit.synthesis` [`Evolution`](/api/qiskit/synthesis#evolution-synthesis) |
+| [`qiskit.opflow.expectations`](/api/qiskit/0.46/qiskit.opflow.expectations) | [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) |
+| [`qiskit.opflow.gradients`](/api/qiskit/0.46/qiskit.opflow.gradients) | [`qiskit.algorithms.gradients`](/api/qiskit/0.46/qiskit.algorithms.gradients) |
 
 ## Operator base class
 
-The [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) abstract class can be replaced with `qiskit.quantum_info.BaseOperator`,
+The [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) abstract class can be replaced with `qiskit.quantum_info.BaseOperator`,
 keeping in mind that `qiskit.quantum_info.BaseOperator` is more generic than its opflow counterpart.
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) | `qiskit.quantum_info.BaseOperator` |
+| [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) | `qiskit.quantum_info.BaseOperator` |
 
 <Admonition type="note">
-  Despite the similar class names, [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) and
+  Despite the similar class names, [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) and
   `qiskit.quantum_info.BaseOperator` are not completely equivalent, and the transition
   should be handled with care. Namely:
 
-  * [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) implements a broader algebra mixin. Some operator overloads that were
-  commonly used in [`qiskit.opflow`](../qiskit/0.46/opflow) (for example `~` for `.adjoint()`) are not defined for
+  * [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) implements a broader algebra mixin. Some operator overloads that were
+  commonly used in [`qiskit.opflow`](/api/qiskit/0.46/opflow) (for example `~` for `.adjoint()`) are not defined for
   `qiskit.quantum_info.BaseOperator`. You might want to check the specific
-  [`qiskit.quantum_info`](../qiskit/quantum_info) subclass instead.
+  [`qiskit.quantum_info`](/api/qiskit/quantum_info) subclass instead.
 
-  * [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) also implements methods such as `.to_matrix()` or `.to_spmatrix()`,
+  * [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) also implements methods such as `.to_matrix()` or `.to_spmatrix()`,
   which are only found in some of the `qiskit.quantum_info.BaseOperator` subclasses.
 
-  See the [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) and [`qiskit.quantum_info.BaseOperator`](../qiskit/quantum_info#quantum-information) API references
+  See the [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) and [`qiskit.quantum_info.BaseOperator`](/api/qiskit/quantum_info#quantum-information) API references
   for more information.
 </Admonition>
 
 ## Operator globals
 
 Opflow provided shortcuts to define common single qubit states, operators, and non-parametrized gates in the
-[`operator_globals`](../qiskit/0.46/opflow#operator-globals) module.
+[`operator_globals`](/api/qiskit/0.46/opflow#operator-globals) module.
 
 These were mainly used for didactic purposes or quick prototyping and can easily be replaced by their corresponding
-[`qiskit.quantum_info`](../qiskit/quantum_info) class: [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli), [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) or
-[`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector).
+[`qiskit.quantum_info`](/api/qiskit/quantum_info) class: [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli), [`qiskit.quantum_info.Clifford`](/api/qiskit/qiskit.quantum_info.Clifford) or
+[`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector).
 
 ### Single-qubit Paulis
 
 The single-qubit Paulis were commonly used for algorithm testing, as they could be combined to create more complex operators
 (for example, `0.39 * (I ^ Z) + 0.5 * (X ^ X)`).
-These operations implicitly created operators of type  [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp), and can be replaced by
-directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp), as shown in the following examples.
+These operations implicitly created operators of type  [`qiskit.opflow.primitive_ops.PauliSumOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp), and can be replaced by
+directly creating a corresponding [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp), as shown in the following examples.
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I` | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) <Admonition type="note">For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/0.46/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).</Admonition> |
+| `qiskit.opflow.X`, `qiskit.opflow.Y`, `qiskit.opflow.Z`, `qiskit.opflow.I` | [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) <Admonition type="note">For direct compatibility with classes in [`qiskit.algorithms`](/api/qiskit/0.46/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp).</Admonition> |
 
 #### Example 1: Define the XX operator
 
@@ -185,7 +185,7 @@ SparsePauliOp(['IZI', 'IXX'],
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, `qiskit.opflow.CZ`, `qiskit.opflow.Swap` | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit). If necessary, a [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator) can be directly constructed from quantum circuits. Another alternative is to wrap the circuit in [`qiskit.quantum_info.Clifford`](../qiskit/qiskit.quantum_info.Clifford) and call `Clifford.to_operator()` <Admonition type="note">Constructing [`qiskit.quantum_info`](../qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and scales exponentially with the size of the circuit.</Admonition> |
+| `qiskit.opflow.CX`, `qiskit.opflow.S`, `qiskit.opflow.H`, `qiskit.opflow.T`, `qiskit.opflow.CZ`, `qiskit.opflow.Swap` | Append corresponding gate to [`qiskit.circuit.QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit). If necessary, a [`qiskit.quantum_info.Operator`](/api/qiskit/qiskit.quantum_info.Operator) can be directly constructed from quantum circuits. Another alternative is to wrap the circuit in [`qiskit.quantum_info.Clifford`](/api/qiskit/qiskit.quantum_info.Clifford) and call `Clifford.to_operator()` <Admonition type="note">Constructing [`qiskit.quantum_info`](/api/qiskit/quantum_info) operators from circuits is not efficient, as it is a dense operation and scales exponentially with the size of the circuit.</Admonition> |
 
 #### Example 1: Define the HH operator
 
@@ -249,7 +249,7 @@ Operator([[ 0.5+0.j,  0.5+0.j,  0.5+0.j,  0.5+0.j],
 
 | Opflow | Alternative |
 | --- | --- |
-| `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. <Admonition type="note">To efficiently simulate stabilizer states, [`qiskit.quantum_info`](../qiskit/quantum_info) includes a [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) class. See the [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState) API reference for more information.</Admonition> |
+| `qiskit.opflow.Zero`, `qiskit.opflow.One`, `qiskit.opflow.Plus`, `qiskit.opflow.Minus` | [`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector) or [`qiskit.circuit.QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit), depending on the use case. <Admonition type="note">To efficiently simulate stabilizer states, [`qiskit.quantum_info`](/api/qiskit/quantum_info) includes a [`qiskit.quantum_info.StabilizerState`](/api/qiskit/qiskit.quantum_info.StabilizerState) class. See the [`qiskit.quantum_info.StabilizerState`](/api/qiskit/qiskit.quantum_info.StabilizerState) API reference for more information.</Admonition> |
 
 #### Example 1: Stabilizer states
 
@@ -305,26 +305,26 @@ State 2:  StabilizerState(StabilizerTable: ['-IX', '+XI'])
 
 ## Primitive and List Ops
 
-Most of the workflows that previously relied on components from [`qiskit.opflow.primitive_ops`](../qiskit/0.46/qiskit.opflow.primitive_ops) and
-[`qiskit.opflow.list_ops`](../qiskit/0.46/qiskit.opflow.list_ops) can now leverage elements from [`qiskit.quantum_info`](../qiskit/quantum_info)
+Most of the workflows that previously relied on components from [`qiskit.opflow.primitive_ops`](/api/qiskit/0.46/qiskit.opflow.primitive_ops) and
+[`qiskit.opflow.list_ops`](/api/qiskit/0.46/qiskit.opflow.list_ops) can now leverage elements from [`qiskit.quantum_info`](/api/qiskit/quantum_info)
 operators instead.
 Some of these classes do not require a one-to-one replacement because they were created to interface with other
 opflow components.
 
 ### Primitive Ops
 
-[`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) is the [`qiskit.opflow.primitive_ops`](../qiskit/0.46/qiskit.opflow.primitive_ops) module's base class.
+[`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) is the [`qiskit.opflow.primitive_ops`](/api/qiskit/0.46/qiskit.opflow.primitive_ops) module's base class.
 It also acts as a factory to instantiate a corresponding sub-class, depending on the computational primitive used
 to initialize it.
 
 <Admonition type="tip">
-  Interpreting [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) as a factory class:
+  Interpreting [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) as a factory class:
 
-  | Class passed to [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) | Subclass returned |
+  | Class passed to [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) | Subclass returned |
   | --- | --- |
-  | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) | [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliOp) |
-  | [`qiskit.circuit.Instruction`](../qiskit/qiskit.circuit.Instruction), [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit) | [`qiskit.opflow.primitive_ops.CircuitOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.CircuitOp) |
-  | `list`, `np.ndarray`, `scipy.sparse.spmatrix`, [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator) | [`qiskit.opflow.primitive_ops.MatrixOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.MatrixOp) |
+  | [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) | [`qiskit.opflow.primitive_ops.PauliOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliOp) |
+  | [`qiskit.circuit.Instruction`](/api/qiskit/qiskit.circuit.Instruction), [`qiskit.circuit.QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) | [`qiskit.opflow.primitive_ops.CircuitOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.CircuitOp) |
+  | `list`, `np.ndarray`, `scipy.sparse.spmatrix`, [`qiskit.quantum_info.Operator`](/api/qiskit/qiskit.quantum_info.Operator) | [`qiskit.opflow.primitive_ops.MatrixOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.MatrixOp) |
 </Admonition>
 
 When migrating opflow code, it is important to look for alternatives to replace the specific subclasses that
@@ -332,13 +332,13 @@ are used within the original code:
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) | As mentioned previously, this class is used to generate an instance of one of the classes below, so there is no direct replacement. |
-| [`qiskit.opflow.primitive_ops.CircuitOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.CircuitOp) | [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit) |
-| [`qiskit.opflow.primitive_ops.MatrixOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.MatrixOp) | [`qiskit.quantum_info.Operator`](../qiskit/qiskit.quantum_info.Operator) |
-| [`qiskit.opflow.primitive_ops.PauliOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliOp) | [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](../qiskit/0.46/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
-| [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp) | [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). See example [below](#example-pauli-sum-op). |
-| [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.TaperedPauliSumOp) | This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object. This functionality is not currently used in any workflow, and has been deprecated without replacement. See [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries) example for updated workflow. |
-| [`qiskit.opflow.primitive_ops.Z2Symmetries`](../qiskit/0.46/qiskit.opflow.primitive_ops.Z2Symmetries) | [`qiskit.quantum_info.analysis.Z2Symmetries`](../qiskit/qiskit.quantum_info.Z2Symmetries). See example [below](#example-z2-sym). |
+| [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) | As mentioned previously, this class is used to generate an instance of one of the classes below, so there is no direct replacement. |
+| [`qiskit.opflow.primitive_ops.CircuitOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.CircuitOp) | [`qiskit.circuit.QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) |
+| [`qiskit.opflow.primitive_ops.MatrixOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.MatrixOp) | [`qiskit.quantum_info.Operator`](/api/qiskit/qiskit.quantum_info.Operator) |
+| [`qiskit.opflow.primitive_ops.PauliOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliOp) | [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli). For direct compatibility with classes in [`qiskit.algorithms`](/api/qiskit/0.46/algorithms), wrap in [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp). |
+| [`qiskit.opflow.primitive_ops.PauliSumOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp) | [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp). See example [below](#example-pauli-sum-op). |
+| [`qiskit.opflow.primitive_ops.TaperedPauliSumOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.TaperedPauliSumOp) | This class was used to combine a [`qiskit.opflow.primitive_ops.PauliSumOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PauliSumOp) with its identified symmetries in one object. This functionality is not currently used in any workflow, and has been deprecated without replacement. See [`qiskit.quantum_info.analysis.Z2Symmetries`](/api/qiskit/qiskit.quantum_info.Z2Symmetries) example for updated workflow. |
+| [`qiskit.opflow.primitive_ops.Z2Symmetries`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.Z2Symmetries) | [`qiskit.quantum_info.analysis.Z2Symmetries`](/api/qiskit/qiskit.quantum_info.Z2Symmetries). See example [below](#example-z2-sym). |
 
 <span id="example-pauli-sum-op"></span>
 
@@ -471,47 +471,47 @@ Tapered Op from Z2 symmetries:  [SparsePauliOp(['I', 'X'],
 
 ### ListOps
 
-The [`qiskit.opflow.list_ops`](../qiskit/0.46/qiskit.opflow.list_ops) module contained classes for manipulating lists of [`qiskit.opflow.primitive_ops`](../qiskit/0.46/qiskit.opflow.primitive_ops)
-or [`qiskit.opflow.state_fns`](../qiskit/0.46/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](../qiskit/quantum_info) alternatives for this functionality are
-[`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList) and [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp) (for sums of [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli)s).
+The [`qiskit.opflow.list_ops`](/api/qiskit/0.46/qiskit.opflow.list_ops) module contained classes for manipulating lists of [`qiskit.opflow.primitive_ops`](/api/qiskit/0.46/qiskit.opflow.primitive_ops)
+or [`qiskit.opflow.state_fns`](/api/qiskit/0.46/qiskit.opflow.state_fns). The [`qiskit.quantum_info`](/api/qiskit/quantum_info) alternatives for this functionality are
+[`qiskit.quantum_info.PauliList`](/api/qiskit/qiskit.quantum_info.PauliList) and [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp) (for sums of [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli)s).
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.list_ops.ListOp`](../qiskit/0.46/qiskit.opflow.list_ops.ListOp) | No direct replacement. This is the base class for operator lists. In general, these could be replaced with a Python `list`. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, there are a few alternatives, depending on the use case. One alternative is [`qiskit.quantum_info.PauliList`](../qiskit/qiskit.quantum_info.PauliList). |
-| [`qiskit.opflow.list_ops.ComposedOp`](../qiskit/0.46/qiskit.opflow.list_ops.ComposedOp) | No direct replacement. Current workflows do not require composing states and operators within one object (no lazy evaluation). |
-| [`qiskit.opflow.list_ops.SummedOp`](../qiskit/0.46/qiskit.opflow.list_ops.SummedOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
-| [`qiskit.opflow.list_ops.TensoredOp`](../qiskit/0.46/qiskit.opflow.list_ops.TensoredOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](../qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp). |
+| [`qiskit.opflow.list_ops.ListOp`](/api/qiskit/0.46/qiskit.opflow.list_ops.ListOp) | No direct replacement. This is the base class for operator lists. In general, these could be replaced with a Python `list`. For [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) operators, there are a few alternatives, depending on the use case. One alternative is [`qiskit.quantum_info.PauliList`](/api/qiskit/qiskit.quantum_info.PauliList). |
+| [`qiskit.opflow.list_ops.ComposedOp`](/api/qiskit/0.46/qiskit.opflow.list_ops.ComposedOp) | No direct replacement. Current workflows do not require composing states and operators within one object (no lazy evaluation). |
+| [`qiskit.opflow.list_ops.SummedOp`](/api/qiskit/0.46/qiskit.opflow.list_ops.SummedOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp). |
+| [`qiskit.opflow.list_ops.TensoredOp`](/api/qiskit/0.46/qiskit.opflow.list_ops.TensoredOp) | No direct replacement. For [`qiskit.quantum_info.Pauli`](/api/qiskit/qiskit.quantum_info.Pauli) operators, use [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp). |
 
 ## State functions
 
-The [`qiskit.opflow.state_fns`](../qiskit/0.46/qiskit.opflow.state_fns) module can generally be replaced by subclasses of the [`qiskit.quantum_info`](../qiskit/quantum_info)
+The [`qiskit.opflow.state_fns`](/api/qiskit/0.46/qiskit.opflow.state_fns) module can generally be replaced by subclasses of the [`qiskit.quantum_info`](/api/qiskit/quantum_info)
 `qiskit.quantum_info.states.quantum_state.QuantumState`.
 
-Similar to [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp), [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn)
+Similar to [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp), [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn)
 acts as a factory to create the corresponding subclass depending on the computational primitive used to initialize it.
 
 <Admonition type="tip">
-  Interpreting [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn) as a factory class:
+  Interpreting [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn) as a factory class:
 
-| Class passed to [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn) | Subclass returned |
+| Class passed to [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn) | Subclass returned |
 | --- | --- |
-| `str`, `dict`, [`qiskit.result.Result`](../qiskit/qiskit.result.Result) | [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) |
-| `list`, `np.ndarray`, [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) | [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) |
-| [`qiskit.circuit.QuantumCircuit`](../qiskit/qiskit.circuit.QuantumCircuit), [`qiskit.circuit.Instruction`](../qiskit/qiskit.circuit.Instruction) | [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn) |
-| [`qiskit.opflow.OperatorBase`](../qiskit/0.46/qiskit.opflow.OperatorBase) | [`qiskit.opflow.state_fns.OperatorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.OperatorStateFn) |
+| `str`, `dict`, [`qiskit.result.Result`](/api/qiskit/qiskit.result.Result) | [`qiskit.opflow.state_fns.DictStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) |
+| `list`, `np.ndarray`, [`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector) | [`qiskit.opflow.state_fns.VectorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) |
+| [`qiskit.circuit.QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit), [`qiskit.circuit.Instruction`](/api/qiskit/qiskit.circuit.Instruction) | [`qiskit.opflow.state_fns.CircuitStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn) |
+| [`qiskit.opflow.OperatorBase`](/api/qiskit/0.46/qiskit.opflow.OperatorBase) | [`qiskit.opflow.state_fns.OperatorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.OperatorStateFn) |
 </Admonition>
 
-Examine references to [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn) in opflow code to identify the subclass that is being used, then find an alternative.
+Examine references to [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn) in opflow code to identify the subclass that is being used, then find an alternative.
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn) | In most cases, [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector). However, remember that [`qiskit.opflow.state_fns.StateFn`](../qiskit/0.46/qiskit.opflow.state_fns.StateFn) is a factory class. |
-| [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn) | [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) |
-| [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) | This class was used to store efficient representations of sparse measurement results. The [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) now returns the measurements as an instance of [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution). See the example in [`Converters`](#converters). |
-| [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) | This class can be replaced with [`qiskit.quantum_info.Statevector`](../qiskit/qiskit.quantum_info.Statevector) or [`qiskit.quantum_info.StabilizerState`](../qiskit/qiskit.quantum_info.StabilizerState), for Clifford-based vectors.|
-| [`qiskit.opflow.state_fns.SparseVectorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.SparseVectorStateFn) | No direct replacement. This class was used for sparse statevector representations. |
-| [`qiskit.opflow.state_fns.OperatorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.OperatorStateFn) | No direct replacement. This class was used to represent measurements against operators. |
-| [`qiskit.opflow.state_fns.CVaRMeasurement`](../qiskit/0.46/qiskit.opflow.state_fns.CVaRMeasurement) | Used in [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation). This function is now covered by [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE). See the example in [`Expectations`](#expectations). |
+| [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn) | In most cases, [`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector). However, remember that [`qiskit.opflow.state_fns.StateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.StateFn) is a factory class. |
+| [`qiskit.opflow.state_fns.CircuitStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn) | [`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector) |
+| [`qiskit.opflow.state_fns.DictStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) | This class was used to store efficient representations of sparse measurement results. The [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) now returns the measurements as an instance of [`qiskit.result.QuasiDistribution`](/api/qiskit/qiskit.result.QuasiDistribution). See the example in [`Converters`](#converters). |
+| [`qiskit.opflow.state_fns.VectorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) | This class can be replaced with [`qiskit.quantum_info.Statevector`](/api/qiskit/qiskit.quantum_info.Statevector) or [`qiskit.quantum_info.StabilizerState`](/api/qiskit/qiskit.quantum_info.StabilizerState), for Clifford-based vectors.|
+| [`qiskit.opflow.state_fns.SparseVectorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.SparseVectorStateFn) | No direct replacement. This class was used for sparse statevector representations. |
+| [`qiskit.opflow.state_fns.OperatorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.OperatorStateFn) | No direct replacement. This class was used to represent measurements against operators. |
+| [`qiskit.opflow.state_fns.CVaRMeasurement`](/api/qiskit/0.46/qiskit.opflow.state_fns.CVaRMeasurement) | Used in [`qiskit.opflow.expectations.CVaRExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation). This function is now covered by [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE). See the example in [`Expectations`](#expectations). |
 
 ### Example 1: Apply an operator to a state
 
@@ -584,19 +584,19 @@ See more examples in [Expectations](#expectations)  and [Converters](#converters
 
 ## Converters
 
-The role of the [`qiskit.opflow.converters`](../qiskit/0.46/qiskit.opflow.converters) submodule was to convert the operators into other opflow operator classes:
-([`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/0.46/qiskit.opflow.converters.TwoQubitReduction), [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/0.46/qiskit.opflow.converters.PauliBasisChange), and so on).
-The [`qiskit.opflow.converters.CircuitSampler`](../qiskit/0.46/qiskit.opflow.converters.CircuitSampler) traversed an operator and outputted
+The role of the [`qiskit.opflow.converters`](/api/qiskit/0.46/qiskit.opflow.converters) submodule was to convert the operators into other opflow operator classes:
+([`qiskit.opflow.converters.TwoQubitReduction`](/api/qiskit/0.46/qiskit.opflow.converters.TwoQubitReduction), [`qiskit.opflow.converters.PauliBasisChange`](/api/qiskit/0.46/qiskit.opflow.converters.PauliBasisChange), and so on).
+The [`qiskit.opflow.converters.CircuitSampler`](/api/qiskit/0.46/qiskit.opflow.converters.CircuitSampler) traversed an operator and outputted
 approximations of its state functions using a quantum computer.
-This functionality has been replaced by the [`qiskit.primitives`](../qiskit/primitives).
+This functionality has been replaced by the [`qiskit.primitives`](/api/qiskit/primitives).
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.converters.CircuitSampler`](../qiskit/0.46/qiskit.opflow.converters.CircuitSampler) | [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) if used with [`qiskit.opflow.expectations`](../qiskit/0.46/qiskit.opflow.expectations). See examples [below]( #example-convert-state). |
-| [`qiskit.opflow.converters.AbelianGrouper`](../qiskit/0.46/qiskit.opflow.converters.AbelianGrouper) | This class allowed a sum a of Pauli operators to be grouped. Similar functionality can be achieved through the [`qiskit.quantum_info.SparsePauliOp.group_commuting`](../qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting) method of [`qiskit.quantum_info.SparsePauliOp`](../qiskit/qiskit.quantum_info.SparsePauliOp).  However, this is not a one-to-one replacement, as you can see in the example [below](#example-commuting). |
-| [`qiskit.opflow.converters.DictToCircuitSum`](../qiskit/0.46/qiskit.opflow.converters.DictToCircuitSum) | No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) or [`qiskit.opflow.state_fns.VectorStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) to an equivalent [`qiskit.opflow.state_fns.CircuitStateFn`](../qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn). |
-| [`qiskit.opflow.converters.PauliBasisChange`](../qiskit/0.46/qiskit.opflow.converters.PauliBasisChange) | No direct replacement. This class was used for changing Paulis into other bases. |
-| [`qiskit.opflow.converters.TwoQubitReduction`](../qiskit/0.46/qiskit.opflow.converters.TwoQubitReduction) | No direct replacement. This class implements a chemistry-specific reduction for the `ParityMapper` class in [Qiskit Nature](https://qiskit.org/ecosystem/nature/). The general symmetry logic this mapper depends on has been refactored to other classes in [`qiskit.quantum_info`](../qiskit/quantum_info), so this specific [`qiskit.opflow`](../qiskit/0.46/opflow) implementation is no longer necessary. |
+| [`qiskit.opflow.converters.CircuitSampler`](/api/qiskit/0.46/qiskit.opflow.converters.CircuitSampler) | [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) or [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) if used with [`qiskit.opflow.expectations`](/api/qiskit/0.46/qiskit.opflow.expectations). See examples [below]( #example-convert-state). |
+| [`qiskit.opflow.converters.AbelianGrouper`](/api/qiskit/0.46/qiskit.opflow.converters.AbelianGrouper) | This class allowed a sum a of Pauli operators to be grouped. Similar functionality can be achieved through the [`qiskit.quantum_info.SparsePauliOp.group_commuting`](/api/qiskit/qiskit.quantum_info.SparsePauliOp#group_commuting) method of [`qiskit.quantum_info.SparsePauliOp`](/api/qiskit/qiskit.quantum_info.SparsePauliOp).  However, this is not a one-to-one replacement, as you can see in the example [below](#example-commuting). |
+| [`qiskit.opflow.converters.DictToCircuitSum`](/api/qiskit/0.46/qiskit.opflow.converters.DictToCircuitSum) | No direct replacement. This class was used to convert from [`qiskit.opflow.state_fns.DictStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.DictStateFn) or [`qiskit.opflow.state_fns.VectorStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.VectorStateFn) to an equivalent [`qiskit.opflow.state_fns.CircuitStateFn`](/api/qiskit/0.46/qiskit.opflow.state_fns.CircuitStateFn). |
+| [`qiskit.opflow.converters.PauliBasisChange`](/api/qiskit/0.46/qiskit.opflow.converters.PauliBasisChange) | No direct replacement. This class was used for changing Paulis into other bases. |
+| [`qiskit.opflow.converters.TwoQubitReduction`](/api/qiskit/0.46/qiskit.opflow.converters.TwoQubitReduction) | No direct replacement. This class implements a chemistry-specific reduction for the `ParityMapper` class in [Qiskit Nature](https://qiskit.org/ecosystem/nature/). The general symmetry logic this mapper depends on has been refactored to other classes in [`qiskit.quantum_info`](/api/qiskit/quantum_info), so this specific [`qiskit.opflow`](/api/qiskit/0.46/opflow) implementation is no longer necessary. |
 
 <span id="example-convert-state"></span>
 
@@ -762,50 +762,50 @@ print(repr(grouped_sum))
 
 ## Evolutions
 
-The [`qiskit.opflow.evolutions`](../qiskit/0.46/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
+The [`qiskit.opflow.evolutions`](/api/qiskit/0.46/qiskit.opflow.evolutions) submodule was created to provide building blocks for Hamiltonian simulation algorithms,
 including methods for Trotterization. The original opflow workflow for Hamiltonian simulation did not allow for
 delayed synthesis of the gates or efficient transpilation of the circuits, so this functionality was migrated to the
-`qiskit.synthesis` [Evolution Synthesis](../qiskit/synthesis#evolution-synthesis) module.
+`qiskit.synthesis` [Evolution Synthesis](/api/qiskit/synthesis#evolution-synthesis) module.
 
 <Admonition type="note">
-  The [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) class computes evolutions for exponentiated
+  The [`qiskit.opflow.evolutions.PauliTrotterEvolution`](/api/qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) class computes evolutions for exponentiated
   sums of Paulis by converting to the Z basis, rotating with an RZ, changing back, and Trotterizing.
   When calling `.convert()`, the class follows a recursive strategy that involves creating
-  [`qiskit.opflow.evolutions.EvolvedOp`](../qiskit/0.46/qiskit.opflow.evolutions.EvolvedOp) placeholders for the operators,
-  constructing [`qiskit.circuit.library.PauliEvolutionGate`s](../qiskit/qiskit.circuit.library.PauliEvolutionGate) out of the operator primitives, and supplying one of
+  [`qiskit.opflow.evolutions.EvolvedOp`](/api/qiskit/0.46/qiskit.opflow.evolutions.EvolvedOp) placeholders for the operators,
+  constructing [`qiskit.circuit.library.PauliEvolutionGate`s](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate) out of the operator primitives, and supplying one of
   the desired synthesis methods to perform the Trotterization. The methods can be specified by using a
-  `string`, which is then inputted into a [`qiskit.opflow.evolutions.TrotterizationFactory`](../qiskit/0.46/qiskit.opflow.evolutions.TrotterizationFactory),
-  or by supplying a method instance of [`qiskit.opflow.evolutions.Trotter`](../qiskit/0.46/qiskit.opflow.evolutions.Trotter),
-  [`qiskit.opflow.evolutions.Suzuki`](../qiskit/0.46/qiskit.opflow.evolutions.Suzuki) or [`qiskit.opflow.evolutions.QDrift`](../qiskit/0.46/qiskit.opflow.evolutions.QDrift).
+  `string`, which is then inputted into a [`qiskit.opflow.evolutions.TrotterizationFactory`](/api/qiskit/0.46/qiskit.opflow.evolutions.TrotterizationFactory),
+  or by supplying a method instance of [`qiskit.opflow.evolutions.Trotter`](/api/qiskit/0.46/qiskit.opflow.evolutions.Trotter),
+  [`qiskit.opflow.evolutions.Suzuki`](/api/qiskit/0.46/qiskit.opflow.evolutions.Suzuki) or [`qiskit.opflow.evolutions.QDrift`](/api/qiskit/0.46/qiskit.opflow.evolutions.QDrift).
 
-  The Trotterization methods that extend [`qiskit.opflow.evolutions.TrotterizationBase`](../qiskit/0.46/qiskit.opflow.evolutions.TrotterizationBase) were migrated to
-  [`qiskit.synthesis`](../qiskit/synthesis)
-  and now extend the [`qiskit.synthesis.ProductFormula`](../qiskit/qiskit.synthesis.ProductFormula) base class. They no longer contain a `.convert()` method for
-  standalone use, but are designed to be plugged into the [`qiskit.circuit.library.PauliEvolutionGate`](../qiskit/qiskit.circuit.library.PauliEvolutionGate) and called by using `.synthesize()`.
-  In this context, the job of the [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) class can now be handled directly by the algorithms, for example, [`qiskit.algorithms.time_evolvers.trotterization.TrotterQRTE`](../qiskit/0.46/qiskit.algorithms.time_evolvers.trotterization.TrotterQRTE).
+  The Trotterization methods that extend [`qiskit.opflow.evolutions.TrotterizationBase`](/api/qiskit/0.46/qiskit.opflow.evolutions.TrotterizationBase) were migrated to
+  [`qiskit.synthesis`](/api/qiskit/synthesis)
+  and now extend the [`qiskit.synthesis.ProductFormula`](/api/qiskit/qiskit.synthesis.ProductFormula) base class. They no longer contain a `.convert()` method for
+  standalone use, but are designed to be plugged into the [`qiskit.circuit.library.PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate) and called by using `.synthesize()`.
+  In this context, the job of the [`qiskit.opflow.evolutions.PauliTrotterEvolution`](/api/qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) class can now be handled directly by the algorithms, for example, [`qiskit.algorithms.time_evolvers.trotterization.TrotterQRTE`](/api/qiskit/0.46/qiskit.algorithms.time_evolvers.trotterization.TrotterQRTE).
 
-  Similarly, the [`qiskit.opflow.evolutions.MatrixEvolution`](../qiskit/0.46/qiskit.opflow.evolutions.MatrixEvolution) class performs evolution by classical matrix exponentiation,
-  constructing a circuit with [`qiskit.extensions.UnitaryGate`s](../qiskit/0.44/qiskit.extensions.UnitaryGate) or [`qiskit.extensions.HamiltonianGate`s](../qiskit/0.44/qiskit.extensions.HamiltonianGate) that contain the exponentiation of the operator.
-  This class is no longer necessary, as the [`qiskit.extensions.HamiltonianGate`s](../qiskit/0.44/qiskit.extensions.HamiltonianGate) can be directly handled by the algorithms.
+  Similarly, the [`qiskit.opflow.evolutions.MatrixEvolution`](/api/qiskit/0.46/qiskit.opflow.evolutions.MatrixEvolution) class performs evolution by classical matrix exponentiation,
+  constructing a circuit with [`qiskit.extensions.UnitaryGate`s](/api/qiskit/0.44/qiskit.extensions.UnitaryGate) or [`qiskit.extensions.HamiltonianGate`s](/api/qiskit/0.44/qiskit.extensions.HamiltonianGate) that contain the exponentiation of the operator.
+  This class is no longer necessary, as the [`qiskit.extensions.HamiltonianGate`s](/api/qiskit/0.44/qiskit.extensions.HamiltonianGate) can be directly handled by the algorithms.
 </Admonition>
 
 ### Trotterizations
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.evolutions.TrotterizationFactory`](../qiskit/0.46/qiskit.opflow.evolutions.TrotterizationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
-| [`qiskit.opflow.evolutions.Trotter`](../qiskit/0.46/qiskit.opflow.evolutions.Trotter) | [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter) or [`qiskit.synthesis.LieTrotter`](../qiskit/qiskit.synthesis.LieTrotter) |
-| [`qiskit.opflow.evolutions.Suzuki`](../qiskit/0.46/qiskit.opflow.evolutions.Suzuki) | [`qiskit.synthesis.SuzukiTrotter`](../qiskit/qiskit.synthesis.SuzukiTrotter) |
-| [`qiskit.opflow.evolutions.QDrift`](../qiskit/0.46/qiskit.opflow.evolutions.QDrift) | [`qiskit.synthesis.QDrift`](../qiskit/qiskit.synthesis.QDrift) |
+| [`qiskit.opflow.evolutions.TrotterizationFactory`](/api/qiskit/0.46/qiskit.opflow.evolutions.TrotterizationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.evolutions.Trotter`](/api/qiskit/0.46/qiskit.opflow.evolutions.Trotter) | [`qiskit.synthesis.SuzukiTrotter`](/api/qiskit/qiskit.synthesis.SuzukiTrotter) or [`qiskit.synthesis.LieTrotter`](/api/qiskit/qiskit.synthesis.LieTrotter) |
+| [`qiskit.opflow.evolutions.Suzuki`](/api/qiskit/0.46/qiskit.opflow.evolutions.Suzuki) | [`qiskit.synthesis.SuzukiTrotter`](/api/qiskit/qiskit.synthesis.SuzukiTrotter) |
+| [`qiskit.opflow.evolutions.QDrift`](/api/qiskit/0.46/qiskit.opflow.evolutions.QDrift) | [`qiskit.synthesis.QDrift`](/api/qiskit/qiskit.synthesis.QDrift) |
 
 ### Other evolution classes
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.evolutions.EvolutionFactory`](../qiskit/0.46/qiskit.opflow.evolutions.EvolutionFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
-| [`qiskit.opflow.evolutions.EvolvedOp`](../qiskit/0.46/qiskit.opflow.evolutions.EvolvedOp) | No direct replacement. The workflow no longer requires a specific operator for evolutions. |
-| [`qiskit.opflow.evolutions.MatrixEvolution`](../qiskit/0.46/qiskit.opflow.evolutions.MatrixEvolution) | [`qiskit.extensions.HamiltonianGate`](../qiskit/0.44/qiskit.extensions.HamiltonianGate) |
-| [`qiskit.opflow.evolutions.PauliTrotterEvolution`](../qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) | [`qiskit.circuit.library.PauliEvolutionGate`](../qiskit/qiskit.circuit.library.PauliEvolutionGate) |
+| [`qiskit.opflow.evolutions.EvolutionFactory`](/api/qiskit/0.46/qiskit.opflow.evolutions.EvolutionFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.evolutions.EvolvedOp`](/api/qiskit/0.46/qiskit.opflow.evolutions.EvolvedOp) | No direct replacement. The workflow no longer requires a specific operator for evolutions. |
+| [`qiskit.opflow.evolutions.MatrixEvolution`](/api/qiskit/0.46/qiskit.opflow.evolutions.MatrixEvolution) | [`qiskit.extensions.HamiltonianGate`](/api/qiskit/0.44/qiskit.extensions.HamiltonianGate) |
+| [`qiskit.opflow.evolutions.PauliTrotterEvolution`](/api/qiskit/0.46/qiskit.opflow.evolutions.PauliTrotterEvolution) | [`qiskit.circuit.library.PauliEvolutionGate`](/api/qiskit/qiskit.circuit.library.PauliEvolutionGate) |
 
 #### Example 1: Trotter evolution
 
@@ -942,17 +942,17 @@ q: ┤ U3(2,-π/2,π/2) ├
 ## Expectations
 
 Expectations are converters that enable an observable's expectation value to be computed with respect to some state function.
-This function can now be found in the [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. Remember that there
+This function can now be found in the [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive. Remember that there
 are different `Estimator` implementations, as noted [previously.](#attention_primitives)
 
 ### Algorithm-Agnostic Expectations
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.expectations.ExpectationFactory`](../qiskit/0.46/qiskit.opflow.expectations.ExpectationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
-| [`qiskit.opflow.expectations.AerPauliExpectation`](../qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation) | Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html). See example below. |
-| [`qiskit.opflow.expectations.MatrixExpectation`](../qiskit/0.46/qiskit.opflow.expectations.MatrixExpectation) | Use [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) primitive. If no shots are set, it performs an exact Statevector calculation. See example below. |
-| [`qiskit.opflow.expectations.PauliExpectation`](../qiskit/0.46/qiskit.opflow.expectations.PauliExpectation) | Use any Estimator primitive. For [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator), set `shots!=None` for a shotbased simulation. For [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html), this is the default. |
+| [`qiskit.opflow.expectations.ExpectationFactory`](/api/qiskit/0.46/qiskit.opflow.expectations.ExpectationFactory) | No direct replacement. This class was used to create instances of one of the classes listed below. |
+| [`qiskit.opflow.expectations.AerPauliExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.AerPauliExpectation) | Use [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html). See example below. |
+| [`qiskit.opflow.expectations.MatrixExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.MatrixExpectation) | Use [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) primitive. If no shots are set, it performs an exact Statevector calculation. See example below. |
+| [`qiskit.opflow.expectations.PauliExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.PauliExpectation) | Use any Estimator primitive. For [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator), set `shots!=None` for a shotbased simulation. For [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html), this is the default. |
 
 #### Example 1: Aer Pauli expectation
 
@@ -1063,7 +1063,7 @@ print(values_plus)
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.expectations.CVaRExpectation`](../qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation) | Functionality migrated into new VQE algorithm: [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](../qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) |
+| [`qiskit.opflow.expectations.CVaRExpectation`](/api/qiskit/0.46/qiskit.opflow.expectations.CVaRExpectation) | Functionality migrated into new VQE algorithm: [`qiskit.algorithms.minimum_eigensolvers.SamplingVQE`](/api/qiskit/0.46/qiskit.algorithms.minimum_eigensolvers.SamplingVQE) |
 
 #### Example 1: VQE with CVaR
 
@@ -1119,9 +1119,9 @@ print(result.eigenvalue)
 
 ## Gradients
 
-The opflow [`qiskit.opflow.gradients`](../qiskit/0.46/qiskit.opflow.gradients) framework has been replaced by the [`qiskit.algorithms.gradients`](../qiskit/0.46/qiskit.algorithms.gradients)
+The opflow [`qiskit.opflow.gradients`](/api/qiskit/0.46/qiskit.opflow.gradients) framework has been replaced by the [`qiskit.algorithms.gradients`](/api/qiskit/0.46/qiskit.algorithms.gradients)
 module. The new gradients are **primitive-based subroutines** commonly used by algorithms and applications, which
-can also be run standalone. For this reason, they now reside under [`qiskit.algorithms`](../qiskit/0.46/algorithms).
+can also be run standalone. For this reason, they now reside under [`qiskit.algorithms`](/api/qiskit/0.46/algorithms).
 
 The former gradient framework contained base classes, converters, and derivatives. The "derivatives"
 followed a factory design pattern, where different methods could be provided by using string identifiers
@@ -1209,13 +1209,13 @@ list:
 
 | Opflow | Alternative |
 | --- | --- |
-| [`qiskit.opflow.gradients.DerivativeBase`](../qiskit/0.46/qiskit.opflow.gradients.DerivativeBase) | No replacement. This was the base class for the gradient, hessian, and QFI base classes. |
-| [`qiskit.opflow.gradients.GradientBase`](../qiskit/0.46/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](../qiskit/0.46/qiskit.opflow.gradients.Gradient) | [`qiskit.algorithms.gradients.BaseSamplerGradient`](../qiskit/0.46/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](../qiskit/0.46/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method, as explained above. |
-| [`qiskit.opflow.gradients.HessianBase`](../qiskit/0.46/qiskit.opflow.gradients.HessianBase) and [`qiskit.opflow.gradients.Hessian`](../qiskit/0.46/qiskit.opflow.gradients.Hessian) | No replacement. The new gradient framework does not work with hessians as independent objects. |
-| [`qiskit.opflow.gradients.QFIBase`](../qiskit/0.46/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](../qiskit/0.46/qiskit.opflow.gradients.QFI) | The new [`qiskit.algorithms.gradients.QFI`](../qiskit/0.46/qiskit.algorithms.gradients.QFI) class extends QGT, so the corresponding base class is [`qiskit.algorithms.gradients.BaseQGT`](../qiskit/0.46/qiskit.algorithms.gradients.BaseQGT) |
-| [`qiskit.opflow.gradients.CircuitGradient`](../qiskit/0.46/qiskit.opflow.gradients.CircuitGradient) | No replacement. This class was used to convert between circuit and gradient [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) and this functionality is no longer necessary. |
-| [`qiskit.opflow.gradients.CircuitQFI`](../qiskit/0.46/qiskit.opflow.gradients.CircuitQFI) | No replacement. This class was used to convert between circuit and QFI [`qiskit.opflow.primitive_ops.PrimitiveOp`](../qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) and this functionality is no longer necessary. |
-| [`qiskit.opflow.gradients.NaturalGradient`](../qiskit/0.46/qiskit.opflow.gradients.NaturalGradient) | No replacement. The same functionality can be achieved with the QFI module. |
+| [`qiskit.opflow.gradients.DerivativeBase`](/api/qiskit/0.46/qiskit.opflow.gradients.DerivativeBase) | No replacement. This was the base class for the gradient, hessian, and QFI base classes. |
+| [`qiskit.opflow.gradients.GradientBase`](/api/qiskit/0.46/qiskit.opflow.gradients.GradientBase) and [`qiskit.opflow.gradients.Gradient`](/api/qiskit/0.46/qiskit.opflow.gradients.Gradient) | [`qiskit.algorithms.gradients.BaseSamplerGradient`](/api/qiskit/0.46/qiskit.algorithms.gradients.BaseSamplerGradient) or [`qiskit.algorithms.gradients.BaseEstimatorGradient`](/api/qiskit/0.46/qiskit.algorithms.gradients.BaseEstimatorGradient), and specific subclasses per method, as explained above. |
+| [`qiskit.opflow.gradients.HessianBase`](/api/qiskit/0.46/qiskit.opflow.gradients.HessianBase) and [`qiskit.opflow.gradients.Hessian`](/api/qiskit/0.46/qiskit.opflow.gradients.Hessian) | No replacement. The new gradient framework does not work with hessians as independent objects. |
+| [`qiskit.opflow.gradients.QFIBase`](/api/qiskit/0.46/qiskit.opflow.gradients.QFIBase) and [`qiskit.opflow.gradients.QFI`](/api/qiskit/0.46/qiskit.opflow.gradients.QFI) | The new [`qiskit.algorithms.gradients.QFI`](/api/qiskit/0.46/qiskit.algorithms.gradients.QFI) class extends QGT, so the corresponding base class is [`qiskit.algorithms.gradients.BaseQGT`](/api/qiskit/0.46/qiskit.algorithms.gradients.BaseQGT) |
+| [`qiskit.opflow.gradients.CircuitGradient`](/api/qiskit/0.46/qiskit.opflow.gradients.CircuitGradient) | No replacement. This class was used to convert between circuit and gradient [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) and this functionality is no longer necessary. |
+| [`qiskit.opflow.gradients.CircuitQFI`](/api/qiskit/0.46/qiskit.opflow.gradients.CircuitQFI) | No replacement. This class was used to convert between circuit and QFI [`qiskit.opflow.primitive_ops.PrimitiveOp`](/api/qiskit/0.46/qiskit.opflow.primitive_ops.PrimitiveOp) and this functionality is no longer necessary. |
+| [`qiskit.opflow.gradients.NaturalGradient`](/api/qiskit/0.46/qiskit.opflow.gradients.NaturalGradient) | No replacement. The same functionality can be achieved with the QFI module. |
 
 ### Example 1: Finite differences batched gradient
 

--- a/docs/api/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/api/migration-guides/qiskit-quantum-instance.mdx
@@ -5,27 +5,27 @@ description: Stop using the deprecated Qiskit `QuantumInstance` class
 
 # QuantumInstance migration guide
 
-The [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) is a utility class that allows the joint
+The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) is a utility class that allows the joint
 configuration of the circuit transpilation and execution steps, and provides functions
 at a higher level of abstraction for a more convenient integration with algorithms.
 These include measurement error mitigation, splitting and combining execution to
 conform to job limits,
 and ensuring reliable circuit execution with additional job management tools.
 
-The [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) class is being deprecated for several reasons:
-* The functionality of [`qiskit.utils.QuantumInstance.execute`](../qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to the different implementations of the [`qiskit.primitives`](../qiskit/primitives) base classes.
-* With the direct implementation of transpilation at the primitives level, the algorithms no longer need to manage that aspect of execution, and thus [`qiskit.utils.QuantumInstance.transpile`](../qiskit/0.46/qiskit.utils.QuantumInstance#transpile) is no longer required by the workflow. If desired, custom transpilation routines can still be performed at the user level through the [`qiskit.transpiler`](../qiskit/transpiler) module (see the table below).
+The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class is being deprecated for several reasons:
+* The functionality of [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to the different implementations of the [`qiskit.primitives`](/api/qiskit/primitives) base classes.
+* With the direct implementation of transpilation at the primitives level, the algorithms no longer need to manage that aspect of execution, and thus [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) is no longer required by the workflow. If desired, custom transpilation routines can still be performed at the user level through the [`qiskit.transpiler`](/api/qiskit/transpiler) module (see the table below).
 
-The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) class:
+The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class:
 
 | QuantumInstance method | Alternative |
 | --- | --- |
-| [`qiskit.utils.QuantumInstance.execute`](../qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](../qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](../qiskit/qiskit.primitives.Estimator#run) |
-| [`qiskit.utils.QuantumInstance.transpile`](../qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](../qiskit/compiler#qiskit.compiler.transpile) |
-| [`qiskit.utils.QuantumInstance.assemble`](../qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](../qiskit/compiler#qiskit.compiler.assemble) |
+| [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](/api/qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](/api/qiskit/qiskit.primitives.Estimator#run) |
+| [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) |
+| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) |
 
-The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](../qiskit/0.46/qiskit.utils.QuantumInstance#execute) to
-[`qiskit.primitives`](../qiskit/primitives) migration path.
+The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) to
+[`qiskit.primitives`](/api/qiskit/primitives) migration path.
 
 <Admonition type="caution">
   **Background on the Qiskit primitives**
@@ -34,30 +34,30 @@ The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execut
 
   There are two types of primitives: Sampler and Estimator.
 
-  Qiskit provides reference implementations in [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator). Additionally,
-  [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator) are
+  Qiskit provides reference implementations in [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator). Additionally,
+  [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator) are
   wrappers for `backend.run()` that follow the primitives interface.
 
-  Providers can implement these primitives as subclasses of [`qiskit.primitives.BaseSampler`](../qiskit/0.46/qiskit.primitives.BaseSampler) and [`qiskit.primitives.BaseEstimator`](../qiskit/0.46/qiskit.primitives.BaseEstimator), respectively.
-  Qiskit Runtime ([`qiskit_ibm_runtime`](../qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService)) and Aer ([`qiskit_aer.primitives`](https://qiskit.org/ecosystem/aer/apidocs/aer_primitives.html)) are examples of native implementations of primitives.
+  Providers can implement these primitives as subclasses of [`qiskit.primitives.BaseSampler`](/api/qiskit/0.46/qiskit.primitives.BaseSampler) and [`qiskit.primitives.BaseEstimator`](/api/qiskit/0.46/qiskit.primitives.BaseEstimator), respectively.
+  Qiskit Runtime ([`qiskit_ibm_runtime`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService)) and Aer ([`qiskit_aer.primitives`](https://qiskit.org/ecosystem/aer/apidocs/aer_primitives.html)) are examples of native implementations of primitives.
 
   This guide uses the following naming convention:
 
-  - *Primitives* - Any Sampler or Estimator implementation using base classes [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and a [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator).
-  - *Reference primitives* -  [`qiskit.primitives.Sampler`](../qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](../qiskit/qiskit.primitives.Estimator) are reference implementations that come with Qiskit.
+  - *Primitives* - Any Sampler or Estimator implementation using base classes [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) and a [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator).
+  - *Reference primitives* -  [`qiskit.primitives.Sampler`](/api/qiskit/qiskit.primitives.Sampler) and [`qiskit.primitives.Estimator`](/api/qiskit/qiskit.primitives.Estimator) are reference implementations that come with Qiskit.
   - *Aer primitives* - The [Aer](https://qiskit.org/ecosystem/aer) primitive implementations [`qiskit_aer.primitives.Sampler`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Sampler.html) and [`qiskit_aer.primitives.Estimator`](https://qiskit.org/ecosystem/aer/stubs/qiskit_aer.primitives.Estimator.html).
-  - *Qiskit Runtime primitives* - The Qiskit Runtime primitive implementations [`qiskit_ibm_runtime.Sampler`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`](../qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator).
-  - *`Backend` primitives* - Instances of [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator). These allow any processor to implement primitive interfaces.
+  - *Qiskit Runtime primitives* - The Qiskit Runtime primitive implementations [`qiskit_ibm_runtime.Sampler`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Sampler) and [`qiskit_ibm_runtime.Estimator`](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Estimator).
+  - *`Backend` primitives* - Instances of [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) and [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator). These allow any processor to implement primitive interfaces.
 
 </Admonition>
 
 ## Choose the right primitive for your task
 
-The [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) was designed to be an abstraction of transpile and run.
-It took inspiration from [`qiskit.execute_function.execute`](../qiskit/0.46/execute#qiskit.execute_function.execute) but retained configuration information that could be set
+The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) was designed to be an abstraction of transpile and run.
+It took inspiration from [`qiskit.execute_function.execute`](/api/qiskit/0.46/execute#qiskit.execute_function.execute) but retained configuration information that could be set
 at the algorithm level to save the user from defining the same parameters for every transpile or execute call.
 
-The [`qiskit.primitives`](../qiskit/primitives) classes share some of these features, but unlike the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
+The [`qiskit.primitives`](/api/qiskit/primitives) classes share some of these features, but unlike the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
 there are multiple primitive classes, and each is optimized for a specific
 purpose. Selecting the right primitive (`Sampler` or `Estimator`) requires some knowledge about
 **what** it is expected to do and **where** or **how** it is expected to run.
@@ -69,7 +69,7 @@ purpose. Selecting the right primitive (`Sampler` or `Estimator`) requires some 
   - The `Sampler` takes in circuits, measures them, and returns their  **quasi-probability distributions**.
 </Admonition>
 
-To determine which primitive to use instead of [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), you should ask
+To determine which primitive to use instead of [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), you should ask
 yourself two questions:
 
 1. What is the minimal unit of information used by your algorithm?
@@ -79,7 +79,7 @@ yourself two questions:
 2. How do you want to run your circuits?
 
    This question is not new. In the legacy algorithm workflow, you would set up a
-   [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) with either a real system from a provider, or a simulator.
+   [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) with either a real system from a provider, or a simulator.
    For this migration, this "system selection" process is translated to **where** do you import your primitives from:
    
    * Using **local** statevector simulators for quick prototyping: **Reference primitives**
@@ -87,20 +87,20 @@ yourself two questions:
    * Accessing **runtime-enabled systems** (or cloud simulators): **Qiskit Runtime primitives**
    * Accessing **non runtime-enabled systems** : **`Backend` primitives**
 
-Arguably, the `Sampler` is the closest primitive to [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance), as they
-both execute circuits and provide a result. However, with the [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance),
+Arguably, the `Sampler` is the closest primitive to [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), as they
+both execute circuits and provide a result. However, with the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
 the result data was system-dependent (it could be a counts `dict`, a `numpy.array` for
 statevector simulations, and so on), while `Sampler` normalizes its `SamplerResult` to 
-return a [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) object with the resulting quasi-probability distribution.
+return a [`qiskit.result.QuasiDistribution`](/api/qiskit/qiskit.result.QuasiDistribution) object with the resulting quasi-probability distribution.
 
 The `Estimator` provides a specific abstraction for the expectation value calculation that can replace
- [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) as well as the associated pre- and post-processing steps, usually performed
-with an additional library such as [`qiskit.opflow`](../qiskit/0.46/opflow).
+ [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) as well as the associated pre- and post-processing steps, usually performed
+with an additional library such as [`qiskit.opflow`](/api/qiskit/0.46/opflow).
 
 ## Choose the right primitive for your settings
 
-Certain [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) features are only available in certain primitive implementations.
-The following table summarizes the most common [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance) settings and which
+Certain [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) features are only available in certain primitive implementations.
+The following table summarizes the most common [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) settings and which
 primitives expose a similar setting through their interface:
 
 <Admonition type="caution">
@@ -173,7 +173,7 @@ for sampling is the Sampler primitive.
 
 **a. Reference primitives**
 
-Basic simulation implemented using the [`qiskit.quantum_info`](../qiskit/quantum_info) module. If shots are
+Basic simulation implemented using the [`qiskit.quantum_info`](/api/qiskit/quantum_info) module. If shots are
 specified, the results include shot noise. Note that
 the resulting quasi-probability distribution does not use bitstrings, but integers to identify the states.
 
@@ -202,16 +202,16 @@ Result: SamplerResult(quasi_dists=[{3: 1.0}], metadata=[{'shots': 200}])
 **b. Aer primitives**
 
 This method uses Aer simulation following the statevector method. This is a closer replacement of the
-[`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance)
+[`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance)
 example, as they are access the same simulator. Note that
 the resulting quasi-probability distribution does not use bitstrings but integers to identify the states.
 
 <Admonition type="note">
-  The [`qiskit.result.QuasiDistribution`](../qiskit/qiskit.result.QuasiDistribution) class that is returned as part of the [`qiskit.primitives.SamplerResult`](../qiskit/qiskit.primitives.SamplerResult)
+  The [`qiskit.result.QuasiDistribution`](/api/qiskit/qiskit.result.QuasiDistribution) class that is returned as part of the [`qiskit.primitives.SamplerResult`](/api/qiskit/qiskit.primitives.SamplerResult)
   exposes two methods to convert the result keys from integer to binary strings / hexadecimal:
 
-    - [`qiskit.result.QuasiDistribution.binary_probabilities`](../qiskit/qiskit.result.QuasiDistribution#binary_probabilities)
-    - [`qiskit.result.QuasiDistribution.hex_probabilities`](../qiskit/qiskit.result.QuasiDistribution#hex_probabilities)
+    - [`qiskit.result.QuasiDistribution.binary_probabilities`](/api/qiskit/qiskit.result.QuasiDistribution#binary_probabilities)
+    - [`qiskit.result.QuasiDistribution.hex_probabilities`](/api/qiskit/qiskit.result.QuasiDistribution#hex_probabilities)
 </Admonition>
 
 ```python
@@ -245,13 +245,13 @@ Binary quasi-dist:  {'11': 1.0}
 ### Example 2: Expectation value calculation with local noisy simulation
 
 While this example does not include a direct call to `QuantumInstance.execute()`, it shows
-how to migrate from a [`qiskit.utils.QuantumInstance`](../qiskit/0.46/qiskit.utils.QuantumInstance)-based to a [`qiskit.primitives`](../qiskit/primitives)-based
+how to migrate from a [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance)-based to a [`qiskit.primitives`](/api/qiskit/primitives)-based
 workflow.
 
 **QuantumInstance**
 
 The most common use case for computing expectation values with the Quantum Instance was as in combination with the
-[`qiskit.opflow`](../qiskit/0.46/opflow) library. You can see more information in the [opflow migration guide](./qiskit-opflow-module).
+[`qiskit.opflow`](/api/qiskit/0.46/opflow) library. You can see more information in the [opflow migration guide](./qiskit-opflow-module).
 
 ```python
 from qiskit import QuantumCircuit
@@ -427,7 +427,7 @@ When using the primitives:
 * You cannot explicitly access their transpilation routine.
 * The mechanism to apply custom transpilation passes to the Aer, Runtime, and `Backend` primitives is to pre-transpile
     locally and set `skip_transpilation=True` in the corresponding primitive.
-* The only primitives that accept a custom **bound** transpiler pass manager are instances of [`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator).
+* The only primitives that accept a custom **bound** transpiler pass manager are instances of [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator).
     If a `bound_pass_manager` is defined, the `skip_transpilation=True` option does **not** skip this bound pass.
 
     <Admonition type="caution">
@@ -438,10 +438,10 @@ When using the primitives:
     </Admonition>
 
 Note that the primitives do handle parameter bindings, so that even if a `bound_pass_manager` is defined in a
-[`qiskit.primitives.BackendSampler`](../qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](../qiskit/qiskit.primitives.BackendEstimator), you do not have to manually assign parameters as expected in the QuantumInstance workflow.
+[`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler) or [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator), you do not have to manually assign parameters as expected in the QuantumInstance workflow.
 
-The two-stage transpilation was added to the `QuantumInstance` to allow running pulse-efficient transpilation passes with the [`qiskit.opflow.converters.CircuitSampler`](../qiskit/0.46/qiskit.opflow.converters.CircuitSampler) class. The following
-example shows how to migrate this use case, where the `QuantumInstance.execute()` method is called by the [`qiskit.opflow.converters.CircuitSampler`](../qiskit/0.46/qiskit.opflow.converters.CircuitSampler) code.
+The two-stage transpilation was added to the `QuantumInstance` to allow running pulse-efficient transpilation passes with the [`qiskit.opflow.converters.CircuitSampler`](/api/qiskit/0.46/qiskit.opflow.converters.CircuitSampler) class. The following
+example shows how to migrate this use case, where the `QuantumInstance.execute()` method is called by the [`qiskit.opflow.converters.CircuitSampler`](/api/qiskit/0.46/qiskit.opflow.converters.CircuitSampler) code.
 
 **QuantumInstance**
 

--- a/docs/api/migration-guides/qiskit-runtime-examples.mdx
+++ b/docs/api/migration-guides/qiskit-runtime-examples.mdx
@@ -504,7 +504,7 @@ to the following:
 - [Common use cases](qiskit-runtime-use-case)
 - [Migrate `backend.run` options to primitive options](qiskit-runtime-options)
 - [Setting execution options](/guides/runtime-options-overview)
-- [Primitive execution options API reference](../qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options)
+- [Primitive execution options API reference](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.Options)
 - [How to run a session](/guides/run-jobs-session)
 - [Qiskit Runtime local testing mode](/guides/local-testing-mode)
 </Admonition>

--- a/docs/api/migration-guides/v2-primitives.mdx
+++ b/docs/api/migration-guides/v2-primitives.mdx
@@ -471,7 +471,7 @@ print(f"Job {job.job_id()} is still running: {job.status() is JobStatus.RUNNING}
    estimator.options.dynamical_decoupling.enable = True
    ```
 
-3. Review all the [supported options](../qiskit-ibm-runtime/options) and make updates accordingly.
+3. Review all the [supported options](/api/qiskit-ibm-runtime/options) and make updates accordingly.
 4. Group each circuit you want to run with the observables and parameter values you want to apply to the circuit in a tuple (a PUB). For example, use `(circuit1, observable1, parameter_set1)` if you want to run `circuit1` with `observable1` and `parameter_set1`.
 
   1. You might need to reshape your arrays of observables or parameter sets if you want to apply their outer product. For example, an array of observables of shape (4, 1) and an array of parameter sets of shape (1, 6) will give you a result of (4, 6) expectation values. See the [Numpy broadcasting rules](https://numpy.org/doc/stable/user/basics.broadcasting.html) for more details.


### PR DESCRIPTION
This is to prepare for us moving the migration guides to not have `/api` in their URL. When we move those files, all the relative links like `../qiskit` stop working.

The change was generated by find-and-replace, and the link checker will validate it's all good.