### PR TITLE
Don't build PR previews for API docs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -16,6 +16,9 @@ on:
     paths:
       - "docs/**/*"
       - "public/images/**/*"
+      # PR previews don't build API docs.
+      - "!docs/api/**/*"
+      - "!public/images/api/**/*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Don't waste resources.

From [GH Action's documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore):

> If you want to both include and exclude path patterns for a single event, use the paths filter prefixed with the ! character to indicate which paths should be excluded.
>
> The order that you define paths patterns matters:
>
> - A matching negative pattern (prefixed with !) after a positive match will exclude the path.
> - A matching positive pattern after a negative match will include the path again.