### PR TITLE
Add links to release notes

### DIFF
--- a/docs/guides/circuit-library.ipynb
+++ b/docs/guides/circuit-library.ipynb
@@ -14,9 +14,9 @@
    "id": "6f257ff9-15c4-48d8-9503-7f0ab16a91b2",
    "metadata": {},
    "source": [
-    "The Qiskit SDK includes a library of popular circuits to use as building blocks in your own programs. Using pre-defined circuits saves time researching, writing code, and debugging. The library includes popular circuits in quantum computing, circuits that are difficult to simulate classically, and circuits useful for quantum hardware benchmarking.\n",
+    "The Qiskit SDK includes a library of popular circuits to use as building blocks in your own programs. Using pre-defined circuits saves time researching, writing code, and debugging. The library includes popular circuits in quantum computing, circuits that are difficult to simulate classically, and circuits useful for quantum hardware benchmarking. \n",
     "\n",
-    "This page lists the different circuit categories the library provides. For a full list of circuits, see the [circuit library API documentation](/api/qiskit/circuit_library)."
+    "This page lists the different circuit categories the library provides. For a full list of circuits, see the [circuit library API documentation](/api/qiskit/circuit_library).  To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)"
    ]
   },
   {

--- a/docs/guides/circuit-library.ipynb
+++ b/docs/guides/circuit-library.ipynb
@@ -14,7 +14,7 @@
    "id": "6f257ff9-15c4-48d8-9503-7f0ab16a91b2",
    "metadata": {},
    "source": [
-    "The Qiskit SDK includes a library of popular circuits to use as building blocks in your own programs. Using pre-defined circuits saves time researching, writing code, and debugging. The library includes popular circuits in quantum computing, circuits that are difficult to simulate classically, and circuits useful for quantum hardware benchmarking. \n",
+    "The Qiskit SDK includes a library of popular circuits to use as building blocks in your own programs. Using pre-defined circuits saves time researching, writing code, and debugging. The library includes popular circuits in quantum computing, circuits that are difficult to simulate classically, and circuits useful for quantum hardware benchmarking.",
     "\n",
     "This page lists the different circuit categories the library provides. For a full list of circuits, see the [circuit library API documentation](/api/qiskit/circuit_library).  To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)"
    ]

--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -379,7 +379,7 @@
     "## Next steps\n",
     "\n",
     "<Admonition type=\"tip\" title=\"Recommendations\">\n",
-    "  - To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/) \n",
+    "  - To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)",
     "  - See an example of dynamic circuits in the [Repeat until success](https://learning.quantum.ibm.com/tutorial/repeat-until-success) tutorial.\n",
     "  -  Review the [circuit library API](/api/qiskit/circuit_library) reference.\n",
     "</Admonition>"

--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -14,7 +14,7 @@
     "- For loop - [`QuantumCircuit.for_loop`](../api/qiskit/qiskit.circuit.QuantumCircuit#for_loop)\n",
     "- While loop - [`QuantumCircuit.while_loop`](../api/qiskit/qiskit.circuit.QuantumCircuit#while_loop)\n",
     "\n",
-    "Each of these methods returns a [context manager](https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers) and is typically used in a `with` statement. In the rest of this guide, we will explain each of these constructs and how to use them.\n",
+    "Each of these methods returns a [context manager](https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers) and is typically used in a `with` statement. In the rest of this guide, we will explain each of these constructs and how to use them.  To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)\n",
     "\n",
     "<Admonition type=\"caution\">\n",
     "  There are some limitations of classical feedforward and control flow operations on quantum hardware that might impact your program. For more information, see [Hardware considerations and limitations for classical feedforward and control flow](./dynamic-circuits-considerations).\n",

--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -379,7 +379,8 @@
     "## Next steps\n",
     "\n",
     "<Admonition type=\"tip\" title=\"Recommendations\">\n",
-    "  -  See an example of dynamic circuits in the [Repeat until success](https://learning.quantum.ibm.com/tutorial/repeat-until-success) tutorial.\n",
+    "  - To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/) \n",
+    "  - See an example of dynamic circuits in the [Repeat until success](https://learning.quantum.ibm.com/tutorial/repeat-until-success) tutorial.\n",
     "  -  Review the [circuit library API](/api/qiskit/circuit_library) reference.\n",
     "</Admonition>"
    ]

--- a/docs/guides/construct-circuits.ipynb
+++ b/docs/guides/construct-circuits.ipynb
@@ -21,7 +21,7 @@
    "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
    "metadata": {},
    "source": [
-    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits. "
+    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits."
    ]
   },
   {

--- a/docs/guides/construct-circuits.ipynb
+++ b/docs/guides/construct-circuits.ipynb
@@ -13,7 +13,7 @@
    "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
    "metadata": {},
    "source": [
-    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits."
+    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits.  To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)"
    ]
   },
   {

--- a/docs/guides/construct-circuits.ipynb
+++ b/docs/guides/construct-circuits.ipynb
@@ -21,7 +21,7 @@
    "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
    "metadata": {},
    "source": [
-    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits.  "
+    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits. "
    ]
   },
   {

--- a/docs/guides/construct-circuits.ipynb
+++ b/docs/guides/construct-circuits.ipynb
@@ -10,10 +10,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b8e2fc2d",
+   "metadata": {},
+   "source": [
+    "_To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c50d8e43-ae82-4e41-8d17-a37332d1bf6d",
    "metadata": {},
    "source": [
-    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits.  To learn what's included in the latest release, review the [Qiskit SDK release notes.](/api/qiskit/release-notes/)"
+    "This page takes a closer look at the [`QuantumCircuit`](/api/qiskit/qiskit.circuit.QuantumCircuit) class in the Qiskit SDK, including some more advanced methods you can use to create quantum circuits.  "
    ]
   },
   {

--- a/docs/guides/synthesize-unitary-operators.mdx
+++ b/docs/guides/synthesize-unitary-operators.mdx
@@ -5,6 +5,13 @@ description: On the implementation of arbitrary unitary matrices on qubits
 
 # Synthesize unitary operations
 
+## What's required
+
+Running the code in this topic requires Qiskit SDK 1.0 or later, with visualization support ( pip install 'qiskit[visualization]' ).
+To learn about the latest changes to Qiskit SDK 1.0, review the most recent [release notes.](/api/qiskit/release-notes)
+
+## Introduction
+
 A unitary operation describes a norm-preserving change to a quantum system.
 For $n$ qubits this change is described by a $2^n \times 2^n$ dimensional, complex matrix $U$ whose adjoint equals the inverse, that is $U^\dagger U = \mathbb{1}$.
 
@@ -15,7 +22,7 @@ For general unitary matrices, synthesis is a complex task with computational cos
 Therefore, if you know an efficient decomposition for the unitary you would like to implement, it will likely be better than a general synthesis.
 
 <Admonition type="note">
-    If no decomposition is available, the Qiskit SDK provides you with the tools to find one. 
+    If no decomposition is available, the Qiskit SDK provides you with the tools to find one.
     However, note that this generally generates deep circuits that may be unsuitable to run on noisy quantum computers.
 </Admonition>
 
@@ -61,7 +68,7 @@ circuit.draw("mpl")
 
 However, after re-synthesizing with the following code, it only needs a single CX gate. (Here we use the `QuantumCircuit.decompose()` method to better visualize the gates used to re-synthesize the unitary.)
 
-```python 
+```python
 from qiskit.quantum_info import Operator
 
 # compute unitary matrix of circuit

--- a/docs/guides/synthesize-unitary-operators.mdx
+++ b/docs/guides/synthesize-unitary-operators.mdx
@@ -5,9 +5,9 @@ description: On the implementation of arbitrary unitary matrices on qubits
 
 # Synthesize unitary operations
 
-## What's required
+### What's required
 
-Running the code in this topic requires Qiskit SDK 1.0 or later, with visualization support ( pip install 'qiskit[visualization]' ).
+Running the code in this topic requires Qiskit SDK 1.0 or later, with visualization support ( `pip install qiskit[visualization]` ).
 To learn about the latest changes to Qiskit SDK 1.0, review the most recent [release notes.](/api/qiskit/release-notes)
 
 ## Introduction


### PR DESCRIPTION
closes #1538

How do we want these links to appear?  Here are some different ways I could add them, but all of these options seem a little heavy-handed and will be hard to properly maintain:

- In the intro: https://qiskit.github.io/documentation/pr-1782/guides/circuit-library
- At the very top in italics: https://qiskit.github.io/documentation/pr-1782/guides/construct-circuits
- At the bottom in Next steps (also note that I have the link in the intro section, where I think that people would miss it): https://qiskit.github.io/documentation/pr-1782/guides/classical-feedforward-and-control-flow
- As part of a "what's required" section https://qiskit.github.io/documentation/pr-1782/guides/synthesize-unitary-operators
