### PR TITLE
Remove tutorials folder from notebook-testing.toml

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -29,7 +29,6 @@ notebooks_normal_test = [
     "docs/guides/simulate-stabilizer-circuits.ipynb",
     "docs/guides/operator-class.ipynb",
     "docs/guides/error-mitigation-and-suppression-techniques.ipynb",        
-    "tutorials/explore-composer/explore-composer.ipynb",
     "docs/guides/error-mitigation-and-suppression-techniques.ipynb",
 ]
 
@@ -41,10 +40,6 @@ notebooks_exclude = [
 # The following notebooks submit jobs that can be mocked with a simulator
 notebooks_that_submit_jobs = [
     "docs/guides/primitive-input-output.ipynb",
-    "tutorials/chsh-inequality/chsh-inequality.ipynb",
-    "tutorials/grovers-algorithm/grovers.ipynb",
-    "tutorials/quantum-approximate-optimization-algorithm/qaoa.ipynb",
-    "tutorials/variational-quantum-eigensolver/vqe.ipynb",
 ]
 
 # The following notebooks submit jobs that are too big to mock with a simulator (or use functions that aren't supported on sims)


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1788. The `tutorials/` entries were accidentally added back due to a bad merge conflict.