### PR TITLE
V2 additions to backend primitives section

### DIFF
--- a/docs/guides/get-started-with-primitives.mdx
+++ b/docs/guides/get-started-with-primitives.mdx
@@ -337,7 +337,7 @@ backend primitives are designed to run locally in the user's machine.
 
 - The [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2) class requires a backend that supports the `memory` option.
 
-- The backend primitives V2 interfaces expose custom `Sampler` and `Estimator` `Options` for that are different to the Runtime implementations.
+- The backend primitives V2 interfaces expose custom [`Sampler`](/api/qiskit/qiskit.primitives.BackendSamplerV2) and [`Estimator`](/api/qiskit/qiskit.primitives.BackendEstimatorV2) `Options` that are different from the Runtime implementations.
 
 
 ## Next steps

--- a/docs/guides/get-started-with-primitives.mdx
+++ b/docs/guides/get-started-with-primitives.mdx
@@ -264,13 +264,32 @@ print(f"  > Metadata: {result.metadata[0]}")
 <span id="backend"></span>
 ## Get started with the backend primitives
 
-The `Sampler` primitive can be run with any provider by using [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler). Likewise, the `Estimator` primitive can be run with any provider using [`qiskit.primitives.BackendEstimator`](../api/qiskit/qiskit.primitives.BackendEstimator). Equivalent implementations in V2 are coming soon.
+Unlike provider-specific primitives, backend primitives are generic implementations that can be used with an arbitrary 
+`backend` object, as long as it implements the [`Backend`](/api/qiskit/qiskit.providers.Backend) interface.
+
+The `Sampler` primitive can be run with any provider by using [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2)
+or the legacy V1 implementation, [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler). 
+Likewise, the `Estimator` primitive can be run with any provider using [`qiskit.primitives.BackendEstimatorV2`](../api/qiskit/qiskit.primitives.BackendEstimatorV2), 
+or the legacy V1 implementation, [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator).
 
 Some providers implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#provider) for more details).
 
 ### Example: BackendEstimator
 
+<Tabs>
+  <TabItem value="BackendEstimatorV2" label="BackendEstimator V2">
 ```python
+from qiskit.primitives import BackendEstimatorV2
+from <some_qiskit_provider> import QiskitProvider
+
+provider = QiskitProvider()
+backend = provider.get_backend('backend_name')
+estimator = BackendEstimatorV2(backend)
+```
+  </TabItem>
+
+  <TabItem value="BackendEstimatorV1" label="BackendEstimator (V1)">
+  ```python
 from qiskit.primitives import BackendEstimator
 from <some_qiskit_provider> import QiskitProvider
 
@@ -278,10 +297,25 @@ provider = QiskitProvider()
 backend = provider.get_backend('backend_name')
 estimator = BackendEstimator(backend)
 ```
+  </TabItem>
+</Tabs>
 
 ### Example: BackendSampler
 
+<Tabs>
+  <TabItem value="BackendSamplerV2" label="BackendSampler V2">
 ```python
+from qiskit.primitives import BackendSamplerV2
+from <some_qiskit_provider> import QiskitProvider
+
+provider = QiskitProvider()
+backend = provider.get_backend('backend_name')
+sampler = BackendSamplerV2(backend)
+```
+  </TabItem>
+
+  <TabItem value="BackendSamplerV1" label="BackendSampler (V1)">
+  ```python
 from qiskit.primitives import BackendSampler
 from <some_qiskit_provider> import QiskitProvider
 
@@ -289,6 +323,22 @@ provider = QiskitProvider()
 backend = provider.get_backend('backend_name')
 sampler = BackendSampler(backend)
 ```
+  </TabItem>
+</Tabs>
+
+### Similarities and differences between backend and Runtime primitives (V2)
+
+- The inputs to [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2) and [`qiskit.primitives.BackendEstimatorV2`](../api/qiskit/qiskit.primitives.BackendEstimatorV2)
+follow the same PUB format as the primitives in Qiskit Runtime, so do the outputs, see (link to https://docs.quantum.ibm.com/guides/primitive-input-output). 
+However, there can be differences in the fields of the returned metadata.
+
+- The [`qiskit.primitives.BackendEstimatorV2`](/api/qiskit/qiskit.primitives.BackendEstimatorV2) class offers no measurement or gate error mitigation implementations out-of-the-box, as
+backend primitives are designed to run locally in the user's machine. 
+
+- The [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2) class requires a backend that supports the `memory` option.
+
+- The backend primitives V2 interfaces expose custom `Sampler` and `Estimator` `Options` for that are different to the Runtime implementations. 
+
 
 ## Next steps
 

--- a/docs/guides/get-started-with-primitives.mdx
+++ b/docs/guides/get-started-with-primitives.mdx
@@ -264,15 +264,15 @@ print(f"  > Metadata: {result.metadata[0]}")
 <span id="backend"></span>
 ## Get started with the backend primitives
 
-Unlike provider-specific primitives, backend primitives are generic implementations that can be used with an arbitrary 
+Unlike provider-specific primitives, backend primitives are generic implementations that can be used with an arbitrary
 `backend` object, as long as it implements the [`Backend`](/api/qiskit/qiskit.providers.Backend) interface.
 
-The `Sampler` primitive can be run with any provider by using [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2)
-or the legacy V1 implementation, [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler). 
-Likewise, the `Estimator` primitive can be run with any provider using [`qiskit.primitives.BackendEstimatorV2`](../api/qiskit/qiskit.primitives.BackendEstimatorV2), 
-or the legacy V1 implementation, [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator).
+- The `Sampler` primitive can be run with any provider by using [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2)
+or the deprecated V1 implementation, [`qiskit.primitives.BackendSampler`](/api/qiskit/qiskit.primitives.BackendSampler).
+- The `Estimator` primitive can be run with any provider by using [`qiskit.primitives.BackendEstimatorV2`](../api/qiskit/qiskit.primitives.BackendEstimatorV2),
+or the deprecated V1 implementation, [`qiskit.primitives.BackendEstimator`](/api/qiskit/qiskit.primitives.BackendEstimator).
 
-Some providers implement primitives natively (see [the Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#provider) for more details).
+Some providers implement primitives natively.  See the [Qiskit Ecosystem page](https://qiskit.github.io/ecosystem#provider) for details.
 
 ### Example: BackendEstimator
 
@@ -329,15 +329,15 @@ sampler = BackendSampler(backend)
 ### Similarities and differences between backend and Runtime primitives (V2)
 
 - The inputs to [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2) and [`qiskit.primitives.BackendEstimatorV2`](../api/qiskit/qiskit.primitives.BackendEstimatorV2)
-follow the same PUB format as the primitives in Qiskit Runtime, so do the outputs, see (link to https://docs.quantum.ibm.com/guides/primitive-input-output). 
+follow the same PUB format as the primitives in Qiskit Runtime, so do the outputs, see [Primitive inputs and outputs](primitive-input-output) for details.
 However, there can be differences in the fields of the returned metadata.
 
 - The [`qiskit.primitives.BackendEstimatorV2`](/api/qiskit/qiskit.primitives.BackendEstimatorV2) class offers no measurement or gate error mitigation implementations out-of-the-box, as
-backend primitives are designed to run locally in the user's machine. 
+backend primitives are designed to run locally in the user's machine.
 
 - The [`qiskit.primitives.BackendSamplerV2`](/api/qiskit/qiskit.primitives.BackendSamplerV2) class requires a backend that supports the `memory` option.
 
-- The backend primitives V2 interfaces expose custom `Sampler` and `Estimator` `Options` for that are different to the Runtime implementations. 
+- The backend primitives V2 interfaces expose custom `Sampler` and `Estimator` `Options` for that are different to the Runtime implementations.
 
 
 ## Next steps


### PR DESCRIPTION
This PR is a proposal to partially address https://github.com/Qiskit/documentation/issues/846. The issue was written pre-backend primitives V2, when there were more differences in the interface (*) between runtime and backend primitives, so proposing a separate guide seemed reasonable at the time. Now (V2), I think the differences are small enough to keep the backend primitives section as an appendix to the get-started page, where I just added the usual V1-V2 tabs and a section at the end explaining differences. 

This is just a rough proposal and it has been a while since I've written a guide, so feel free to edit it to fit the style/conventions that are used now.

---

(*) Backend primitives handled different kinds of pass managers to run before and after parameter binding, but V2 primitives no longer do any transpilation, so the way you run and configure backend and runtime primitives is almost the same. I didn't add the V1 explanation for the interface differences because V1 primitives are deprecated since qiskit 1.2 (released yesterday) and I think it would clutter the page and confuse users to add an explanation of how they worked now.