### PR TITLE
Add deprecation notice and further instructions to QuantumInstance migration guide

### DIFF
--- a/docs/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/migration-guides/qiskit-quantum-instance.mdx
@@ -12,20 +12,29 @@ These include measurement error mitigation, splitting and combining execution to
 conform to job limits,
 and ensuring reliable circuit execution with additional job management tools.
 
-The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class is being deprecated for several reasons:
-* The functionality of [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to the different implementations of the [`qiskit.primitives`](/api/qiskit/primitives) base classes.
-* With the direct implementation of transpilation at the primitives level, the algorithms no longer need to manage that aspect of execution, and thus [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) is no longer required by the workflow. If desired, custom transpilation routines can still be performed at the user level through the [`qiskit.transpiler`](/api/qiskit/transpiler) module (see the table below).
+The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class is being deprecated because
+the functionality of [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to 
+the different implementations of the [`qiskit.primitives`](/api/qiskit/primitives) base classes.
 
 The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class:
 
 | QuantumInstance method | Alternative |
 | --- | --- |
 | [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](/api/qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](/api/qiskit/qiskit.primitives.Estimator#run) |
-| [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) |
-| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) |
+| [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) or [`qiskit.transpiler.pass_manager.PassManager.run`](/api/qiskit/qiskit.transpiler.pass_manager.PassManager#run)|
+| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) [DEPRECATED: no longer part of the workflow]|
 
 The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) to
 [`qiskit.primitives`](/api/qiskit/primitives) migration path.
+
+<Admonition type="caution">
+  **Deprecation Notice**
+
+  This guide preceeds the introduction of Primitives V2. It was drafted with the intention to guide users from `QuantumInstance` to 
+  the Primitives V1 interface. Following the introduction of Primitives V2, some providers have deprecated Primitives V1 
+  implementations in favor of the V2 alternatives. If you are interested in following this guide, we recommend combining it with the
+  [migrate to V2 primitives] guide to bring your code to the most updated state.
+</Admonition>
 
 <Admonition type="caution">
   **Background on the Qiskit primitives**

--- a/docs/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/migration-guides/qiskit-quantum-instance.mdx
@@ -5,6 +5,15 @@ description: Stop using the deprecated Qiskit `QuantumInstance` class
 
 # QuantumInstance migration guide
 
+<Admonition type="caution">
+  **Deprecation Notice**
+
+  This guide precedes the introduction of the V2 primitives interface. It was created to guide users from `QuantumInstance` to
+  the V1 primitives interface. Following the introduction of the V2 primitives, some providers have deprecated V1 primitive
+  implementations in favor of the V2 alternatives. If you are interested in following this guide, we recommend combining it with the
+  [migrate to V2 primitives] guide to bring your code to the most updated state.
+</Admonition>
+
 The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) is a utility class that allows the joint
 configuration of the circuit transpilation and execution steps, and provides functions
 at a higher level of abstraction for a more convenient integration with algorithms.
@@ -13,7 +22,7 @@ conform to job limits,
 and ensuring reliable circuit execution with additional job management tools.
 
 The [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class is being deprecated because
-the functionality of [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to 
+the functionality of [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) has been delegated to
 the different implementations of the [`qiskit.primitives`](/api/qiskit/primitives) base classes.
 
 The following table summarizes the migration alternatives for the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance) class:
@@ -22,19 +31,10 @@ The following table summarizes the migration alternatives for the [`qiskit.utils
 | --- | --- |
 | [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](/api/qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](/api/qiskit/qiskit.primitives.Estimator#run) |
 | [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) or [`qiskit.transpiler.pass_manager.PassManager.run`](/api/qiskit/qiskit.transpiler.pass_manager.PassManager#run)|
-| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) [DEPRECATED: no longer part of the workflow]|
+| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) [Deprecated: no longer part of the workflow]|
 
 The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) to
 [`qiskit.primitives`](/api/qiskit/primitives) migration path.
-
-<Admonition type="caution">
-  **Deprecation Notice**
-
-  This guide preceeds the introduction of Primitives V2. It was drafted with the intention to guide users from `QuantumInstance` to 
-  the Primitives V1 interface. Following the introduction of Primitives V2, some providers have deprecated Primitives V1 
-  implementations in favor of the V2 alternatives. If you are interested in following this guide, we recommend combining it with the
-  [migrate to V2 primitives] guide to bring your code to the most updated state.
-</Admonition>
 
 <Admonition type="caution">
   **Background on the Qiskit primitives**
@@ -99,7 +99,7 @@ yourself two questions:
 Arguably, the `Sampler` is the closest primitive to [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance), as they
 both execute circuits and provide a result. However, with the [`qiskit.utils.QuantumInstance`](/api/qiskit/0.46/qiskit.utils.QuantumInstance),
 the result data was system-dependent (it could be a counts `dict`, a `numpy.array` for
-statevector simulations, and so on), while `Sampler` normalizes its `SamplerResult` to 
+statevector simulations, and so on), while `Sampler` normalizes its `SamplerResult` to
 return a [`qiskit.result.QuasiDistribution`](/api/qiskit/qiskit.result.QuasiDistribution) object with the resulting quasi-probability distribution.
 
 The `Estimator` provides a specific abstraction for the expectation value calculation that can replace

--- a/docs/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/migration-guides/qiskit-quantum-instance.mdx
@@ -30,7 +30,7 @@ The following table summarizes the migration alternatives for the [`qiskit.utils
 | QuantumInstance method | Alternative |
 | --- | --- |
 | [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](/api/qiskit/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](/api/qiskit/qiskit.primitives.Estimator#run) |
-| [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) or [`qiskit.transpiler.pass_manager.PassManager.run`](/api/qiskit/qiskit.transpiler.pass_manager.PassManager#run)|
+| [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) or [`qiskit.transpiler.pass_manager.PassManager.run`](/api/qiskit/qiskit.transpiler.PassManager#run)|
 | [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) [Deprecated: no longer part of the workflow]|
 
 The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) to


### PR DESCRIPTION
This is a proposal to address https://github.com/Qiskit/documentation/issues/1696, which doesn't correspond with my original reply.

While updating to the changes in ISA handling doesn't seem to complicated, I realized that updating the guide to use Primitives V2 seems very strange to me (because that is not how the migration was done at the time). The current guide is a (in my opinion, valid) reflection of what the motivations were with primitives V1, and the reason why it was appreciated was because it reflected well the evolution of the code. I also think that it is commonly understood that migration guides are written at a specific point in time, and may require "chaining" with a further migration guide to reach the current state of the package. So, instead of migrating everything to V2, I propose adding a warning at the beginning of the guide pointing to the V1 to V2 migration guide. 

Once again, this is just a proposal, and I am happy to rethink this.