### PR TITLE
Fix wording from 1799

### DIFF
--- a/docs/guides/execution-modes-faq.mdx
+++ b/docs/guides/execution-modes-faq.mdx
@@ -61,7 +61,7 @@ Yes. This reduces unwanted cost if a user forgets to close their session.
     Can I change the interactive timeout (ITTL) or the maximum timeout of a session?
   </summary>
 
-You cannot change the interactive timeout value. You can change the maximum timeout value of a session (see [Specify the session length](run-jobs-session#specify-length)), but it must be below the system-defined maximum. Ask your administrator to contact IBM support if you need a different interactive TTL or system maximum TTL.
+You cannot change the interactive timeout value. You can change the maximum timeout value of a session (see [Specify the session length](run-jobs-session#specify-length)), but it must be less than the system-defined maximum. Ask your administrator to contact IBM support if you need a different interactive TTL or system maximum TTL.
 
 </details>
 

--- a/docs/guides/execution-modes-faq.mdx
+++ b/docs/guides/execution-modes-faq.mdx
@@ -61,7 +61,8 @@ Yes. This reduces unwanted cost if a user forgets to close their session.
     Can I change the interactive timeout (ITTL) or the maximum timeout of a session?
   </summary>
 
-No, you cannot change the interactive or maximum timeout values. You can, however, ask your administrator to contact IBM support to request for a change.
+You cannot change the interactive timeout value. You can change the maximum timeout value of a session (see [Specify the session length](run-jobs-session#specify-length)), but it must be below the system-defined maximum. Ask your administrator to contact IBM support if you need a different interactive TTL or system maximum TTL.
+
 </details>
 
 <details>


### PR DESCRIPTION
#1799 says you cannot change a session's max TTL. What it really meant to say was you cannot change the _system defined_ max TTL. You can, however, set a limit that's lower than the system ceiling. 

Thanks @beckykd for spotting this!