### PR TITLE
Revert to Serverless 0.14.2

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -5,4 +5,4 @@ qiskit[all]~=1.1
 qiskit-aer~=0.14.2
 qiskit-ibm-runtime~=0.26.0
 qiskit-ibm-provider~=0.11.0
-qiskit-serverless~=0.15.0
+qiskit-serverless~=0.14.2


### PR DESCRIPTION
Serverless 0.15 no longer supports Python 3.9 and 3.10, which messes up our CI. We'll add this back after checking in with the Serverless team.