### PR TITLE
Restore Serverless 0.15.2 and test notebooks when changing requirements

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.11"
 
     - name: Install Python packages
       shell: bash

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           # Install Linux deps if the specific guides were changed, or
           # if all files are being tested.
-          install-linux-deps: ${{ steps.linux-changed-files.outputs.any_changed || !steps.all-changed-files.outputs.any_changed }}
+          install-linux-deps: ${{ steps.linux-changed-files.outputs.any_changed == 'true' || steps.all-changed-files.outputs.any_changed == 'false' }}
           ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
 
       - name: Check lint

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -99,9 +99,17 @@ jobs:
               args.extend(files.split("\n"))
           subprocess.run(args, check=True)
 
+      - name: Detect changed notebooks
+        id: changed-notebooks
+        if: "!cancelled()"
+        run: |
+          echo "CHANGED_NOTEBOOKS<<EOF" >> $GITHUB_OUTPUT
+          git diff --name-only >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Upload executed notebooks
         if: "!cancelled()"
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks
-          path: ${{ steps.all-changed-files.outputs.all_changed_files }}
+          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS }}

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -92,7 +92,9 @@ jobs:
         run: |
           import subprocess
           files = """${{ steps.all-changed-files.outputs.all_changed_files }}"""
-          args = ["tox", "--"] + files.split("\n") + ["--write"]
+          args = ["tox", "--", "--write"]
+          if files:
+              args.extend(files.split("\n"))
           subprocess.run(args, check=True)
 
       - name: Upload executed notebooks

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/set-up-notebook-testing
         with:
-          install-linux-deps: ${{ steps.linux-changed-files.outputs.any_changed }}
+          # Install Linux deps if the specific guides were changed, or
+          # if all files are being tested.
+          install-linux-deps: ${{ steps.linux-changed-files.outputs.any_changed || !steps.all-changed-files.outputs.any_changed }}
           ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
 
       - name: Check lint

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "docs/**/*.ipynb"
       - "!docs/api/**/*"
+      - "scripts/nb-tester/**/*"
   workflow_dispatch:
 jobs:
   execute:

--- a/scripts/nb-tester/pyproject.toml
+++ b/scripts/nb-tester/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "qiskit-docs-notebook-tester"
 version = "0.0.1"
 description = "Tool for the Qiskit docs team to test their notebooks"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 dependencies = [
   "qiskit-ibm-runtime",

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -5,4 +5,4 @@ qiskit[all]~=1.1
 qiskit-aer~=0.14.2
 qiskit-ibm-runtime~=0.26.0
 qiskit-ibm-provider~=0.11.0
-qiskit-serverless~=0.14.2
+qiskit-serverless~=0.15.2

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -3,6 +3,6 @@
 
 qiskit[all]~=1.1
 qiskit-aer~=0.14.2
-qiskit-ibm-runtime~=0.26.0
+qiskit-ibm-runtime~=0.27.0
 qiskit-ibm-provider~=0.11.0
 qiskit-serverless~=0.15.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-env_list = py3
+env_list = py311
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1826.

## Switches to Python 3.11

Qiskit Serverless requires Python 3.11+ now, even though Qiskit SDK still supports 3.9 and 3.10. While I'm talking to the Serverless team, it seems very unlikely they are going to change their mind on this due to their own constraints.

Unfortunately, this means that we need to always use Python 3.11 with our repository so that we can install serverless for the files that use it. Our other alternative is to stop testing the files with Serverless, but that seems even worse.

The risk with using 3.11 in CI rather than 3.9 is that we may use syntax not in Python 3.9 and 3.10. However, given the actual history of our docs, this seems unlikely: we don't use new Python syntax like type hints. If we do use Python 3.11-syntax, it's not the end of the world.

## Tests all notebooks on changes to requirements.txt

This was an oversight that we would not test the notebooks when changing requirements.txt. So, we merged a change that worked locally but broke CI. Now, we test all notebooks when the nb-tester program and config changes.

## Also upgrades Runtime

This is necessary to make Serverless happy. According to https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/release-notes#0270-2024-08-08, there are no breaking changes. CI also shows everything passes.