### PR TITLE
Fix artifact upload when no changes made

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks
-          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS }}
+          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS || 'no-changes' }}
 
   make_issue:
     name: Make issue on failure

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -112,4 +112,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks
-          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS }}
+          path: ${{ steps.changed-notebooks.outputs.CHANGED_NOTEBOOKS || 'no-changes' }}

--- a/docs/guides/hello-world.ipynb
+++ b/docs/guides/hello-world.ipynb
@@ -5,7 +5,7 @@
    "id": "552b1077",
    "metadata": {},
    "source": [
-    "# Hello world\n",
+    "# Hello world EXPERIMENT\n",
     "\n",
     "This example contains two parts. You will first create a simple quantum program and run it on a quantum processing unit (QPU).  Because actual quantum research requires much more robust programs, in the second section ([Scale to large numbers of qubits](#scale-to-large-numbers-of-qubits)), you will scale the simple program up to utility level.  You can also follow along with the Hello World episode of the Coding with Qiskit 1.0 video series.\n",
     "\n",

--- a/docs/guides/hello-world.ipynb
+++ b/docs/guides/hello-world.ipynb
@@ -5,7 +5,7 @@
    "id": "552b1077",
    "metadata": {},
    "source": [
-    "# Hello world EXPERIMENT\n",
+    "# Hello world\n",
     "\n",
     "This example contains two parts. You will first create a simple quantum program and run it on a quantum processing unit (QPU).  Because actual quantum research requires much more robust programs, in the second section ([Scale to large numbers of qubits](#scale-to-large-numbers-of-qubits)), you will scale the simple program up to utility level.  You can also follow along with the Hello World episode of the Coding with Qiskit 1.0 video series.\n",
     "\n",


### PR DESCRIPTION
The artifact upload was failing because `path` was set to the empty string. It's fine to give an invalid file path like `no-changes`, so long as we give something. The action will warn but not fail in this case.