### PR TITLE
Fix images in Qiskit release notes for historical versions

### DIFF
--- a/scripts/js/commands/api/convertApiDocsToHistorical.ts
+++ b/scripts/js/commands/api/convertApiDocsToHistorical.ts
@@ -44,22 +44,19 @@ const readArgs = (): Arguments => {
 zxMain(async () => {
   const args = readArgs();
 
-  const pkgName = Pkg.VALID_NAMES.find((pkgName) => pkgName === args.package);
-  if (pkgName === undefined) {
-    throw new Error(`Unrecognized package: ${args.package}`);
-  }
+  const pkg = await Pkg.fromArgs(args.package, "ignored", "ignored", "latest");
 
-  const packageFile = await readFile(`docs/api/${pkgName}/_package.json`, {
+  const packageFile = await readFile(`docs/api/${pkg.name}/_package.json`, {
     encoding: "utf8",
   });
   const packageInfo = JSON.parse(packageFile);
   const versionMatch = packageInfo.version.match(/^(\d+\.\d+)/);
   const versionWithoutPatch = versionMatch[0];
 
-  const projectNewHistoricalFolder = `docs/api/${pkgName}/${versionWithoutPatch}`;
+  const projectNewHistoricalFolder = `docs/api/${pkg.name}/${versionWithoutPatch}`;
   if (await pathExists(projectNewHistoricalFolder)) {
     console.error(
-      `${pkgName} has already a historical version ${versionWithoutPatch}.`,
+      `${pkg.name} has already a historical version ${versionWithoutPatch}.`,
       `Manually delete the existing folder if you intend to overwrite it.`,
     );
     process.exit(1);
@@ -67,15 +64,19 @@ zxMain(async () => {
 
   await mkdirp(projectNewHistoricalFolder);
 
-  await copyApiDocsAndUpdateLinks(pkgName, versionWithoutPatch);
+  await copyApiDocsAndUpdateLinks(pkg.name, versionWithoutPatch);
   await generateJsonFiles(
-    pkgName,
+    pkg.name,
     packageInfo.version,
     versionWithoutPatch,
     projectNewHistoricalFolder,
   );
-  await copyImages(pkgName, versionWithoutPatch);
-  await copyObjectsInv(pkgName, versionWithoutPatch);
+  await copyImages(
+    pkg.name,
+    pkg.hasSeparateReleaseNotes(),
+    versionWithoutPatch,
+  );
+  await copyObjectsInv(pkg.name, versionWithoutPatch);
   await generateHistoricalRedirects();
 });
 
@@ -143,12 +144,22 @@ async function generateJsonFiles(
   await writeFile(`${projectNewHistoricalFolder}/_toc.json`, tocFile + "\n");
 }
 
-async function copyImages(pkgName: string, versionWithoutPatch: string) {
+async function copyImages(
+  pkgName: string,
+  hasSeparateReleaseNotes: boolean,
+  versionWithoutPatch: string,
+) {
   console.log("Copying images");
   const imageDirSource = `public/images/api/${pkgName}/`;
   const imageDirDest = `public/images/api/${pkgName}/${versionWithoutPatch}`;
   await mkdirp(imageDirDest);
-  await $`find ${imageDirSource}/* -maxdepth 0 -type f | grep -v "release_notes" | xargs -I {} cp -a {} ${imageDirDest}`;
+
+  // If the project only has a single release notes file, we should not copy the release notes images.
+  if (hasSeparateReleaseNotes) {
+    await $`find ${imageDirSource}/* -maxdepth 0 -type f | xargs -I {} cp -a {} ${imageDirDest}`;
+  } else {
+    await $`find ${imageDirSource}/* -maxdepth 0 -type f | grep -v "release_notes" | xargs -I {} cp -a {} ${imageDirDest}`;
+  }
 }
 
 async function copyObjectsInv(pkgName: string, versionWithoutPatch: string) {


### PR DESCRIPTION
Before, we never copied images for the release notes file to the historical API folder. For example, if we had the file `public/images/qiskit/release_notes_0_0.png`, we would not copy it over to `public/images/qiskit/1.1/release_notes_0_0.png` when we convert 1.1 from the latest release to instead be a historical release stored at `qiskit/1.1`. 

That is the right behavior for Runtime and Provider, because they only have a single `release_notes.mdx` file. However, it does not work correctly with Qiskit, which has one release note file per release.

This PR differentiates between the two use cases. It keeps things generic by using our `Pkg.hasSeparateReleaseNotes` mechanism.