### PR TITLE
Add blog link to the SDK v1.2 latest-updates blurb

### DIFF
--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -31,7 +31,7 @@ Important deprecations:
 
 Remember, because this a minor release, it will not introduce breaking changes for users moving from Qiskit SDK v1.0. Any deprecations announced with this release refer only to things that will now start throwing deprecation warnings. None of these will be removed until the release of Qiskit v2.0, pursuant to Qiskit’s official [deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md#).
 
-For more details, explore the [v1.2 release notes](/api/qiskit/release-notes/1.2).
+For more details, read the post about the release on the [IBM Quantum blog](https://www.ibm.com/quantum/blog/qiskit-1-2-release-summary), and explore the [v1.2 release notes](/api/qiskit/release-notes/1.2).
 
 {/* use url format /api/qiskit/release-notes/X.X to link to the specific X.X version of the release notes */}
 


### PR DESCRIPTION
Now that [the blog](https://www.ibm.com/quantum/blog/qiskit-1-2-release-summary) is available, add a link to the release summary in the latest-updates file.