### PR TITLE
Use consistent name for Qiskit Runtime Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read on for more information about how to support this project:
 This is the quickest, easiest, and most helpful way to contribute to this project and improve the quality of Qiskit&reg; and IBM Quantum&trade; documentation. There are a few different ways to report issues, depending on where it was found:
 
 - For problems you've found in the [Qiskit SDK API Reference](https://docs.quantum.ibm.com/api/qiskit) section, open an issue in the Qiskit repo [here](https://github.com/Qiskit/qiskit/issues/new/choose).
-- For problems you've found in the [Qiskit Runtime IBM Client](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) section, open an issue in the Qiskit IBM Runtime repo [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
+- For problems you've found in the [Qiskit Runtime Client](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) section, open an issue in the Qiskit IBM Runtime repo [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 - For problems you've found in any other section of [docs](https://docs.quantum.ibm.com), open a content bug issue [here](https://github.com/Qiskit/documentation/issues/new/choose).
 
 ### 2. Suggest new content

--- a/docs/api/qiskit-ibm-runtime/0.14/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.14/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.15/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.15/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.16/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.16/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.17/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.17/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.18/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.18/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.19/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.19/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.20/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.20/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.21/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.21/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.22/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.22/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.23/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.23/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.24/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.24/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.25/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.25/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.26/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.26/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.27/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.27/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/dev/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/dev/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime IBM Client",
+  "title": "Qiskit Runtime Client",
   "children": [
     {
       "title": "API index",

--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -35,9 +35,9 @@ For more details, read the post about the release on the [IBM Quantum blog](http
 
 {/* use url format /api/qiskit/release-notes/X.X to link to the specific X.X version of the release notes */}
 
-### Qiskit Runtime IBM Client 0.28.0
+### Qiskit Runtime Client 0.28.0
 
-*To see the release notes for all versions, visit the [Qiskit Runtime IBM Client release notes](/api/qiskit-ibm-runtime/release-notes).*
+*To see the release notes for all versions, visit the [Qiskit Runtime Client release notes](/api/qiskit-ibm-runtime/release-notes).*
 
 **Highlights from the 0.28.0 (2024-08-15) version release**
 
@@ -63,7 +63,7 @@ On the IBM Quantum blog, we take a deep dive into the new beta release with a sp
 
 {/* no other release notes available yet */}
 
-## Qiskit IBM Runtime service updates
+## Qiskit Runtime service updates
 
 This summary of the latest changes to the Qiskit Runtime service applies to anyone using Qiskit Runtime, regardless of how you communicate with the service (using qiskit-ibm-runtime or otherwise), or which version of the client SDK you use.
 
@@ -90,7 +90,7 @@ Probabilistic error amplification (PEA) error mitigation method is now available
 
 ### 28 March 2024
 
-Qiskit Runtime primitives now support OpenQASM 3 as the input format for circuits and standard JSON output format. See [Qiskit IBM Runtime REST API](/api/runtime) for examples.
+Qiskit Runtime primitives now support OpenQASM 3 as the input format for circuits and standard JSON output format. See [Qiskit Runtime REST API](/api/runtime) for examples.
 
 ## IBM Quantum blog: Defining — and citing — the Qiskit SDK
 

--- a/docs/guides/save-jobs.ipynb
+++ b/docs/guides/save-jobs.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "## Save results to disk\n",
     "\n",
-    "You may also want to save results to disk. To do this, use Python's built-in JSON library with Qiskit IBM Runtime's encoders."
+    "You may also want to save results to disk. To do this, use Python's built-in JSON library with Qiskit Runtime's encoders."
    ]
   },
   {

--- a/docs/migration-guides/qiskit-runtime-from-ibmq-provider.mdx
+++ b/docs/migration-guides/qiskit-runtime-from-ibmq-provider.mdx
@@ -1,6 +1,6 @@
 ---
-title: Migrate from qiskit_ibm_provider
-description: How to migrate `backend.run()` from Qiskit IBM Provider to Qiskit IBM Runtime
+title: Migrate from qiskit-ibmq-provider
+description: How to migrate `backend.run()` from qiskit-ibmq-provider to Qiskit Runtime
 ---
 
 # Migrate from `qiskit_ibmq_provider`

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -98,7 +98,7 @@ export class Pkg {
     if (name === "qiskit-ibm-runtime") {
       return new Pkg({
         ...args,
-        title: "Qiskit Runtime IBM Client",
+        title: "Qiskit Runtime Client",
         name: "qiskit-ibm-runtime",
         githubSlug: "qiskit/qiskit-ibm-runtime",
       });

--- a/scripts/js/lib/api/specialCaseResults.ts
+++ b/scripts/js/lib/api/specialCaseResults.ts
@@ -12,7 +12,7 @@
 
 import { HtmlToMdResultWithUrl } from "./HtmlToMdResult.js";
 
-export const RUNTIME_INDEX_META = `title: Qiskit Runtime IBM Client API Docs
+export const RUNTIME_INDEX_META = `title: Qiskit Runtime Client API Docs
 description: API documentation for the qiskit-ibm-runtime client`;
 
 export const TRANSPILER_SERVICE_INDEX_META = `title: Qiskit Transpiler Service Client Docs


### PR DESCRIPTION
We were being inconsistent with calling Runtime "Qiskit Runtime IBM Client" but "Qiskit IBM Runtime REST API". We also don't use IBM with "Qiskit Transpiler Service Client" and "Qiskit SDK". So, `@jyu00` and `@javabster` proposed that we simplify to remove the redundant IBM.

This PR updates the left page titles we use. A closed source PR will update the top dropdown.

We don't update the index pages for Runtime API docs because those are auto-generated.