### PR TITLE
Change internal link checker's Qiskit SDK strategy

### DIFF
--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -35,11 +35,10 @@ jobs:
       - name: Check internal links
         run: >
           npm run check:internal-links --
-          --qiskit-release-notes
           --current-apis
           --dev-apis
           --historical-apis
-          --skip-broken-historical
+          --qiskit-legacy-release-notes
       - name: Check for orphan pages
         run: npm run check:orphan-pages -- --apis
       - name: Check metadata

--- a/README.md
+++ b/README.md
@@ -229,11 +229,7 @@ To check internal links:
 npm run check:internal-links
 
 # You can add any of the below arguments to also check API docs.
-npm run check:internal-links -- --current-apis --dev-apis --historical-apis --qiskit-release-notes
-
-# However, `--historical-apis` currently has failing versions, so you may
-# want to add `--skip-broken-historical`.
-npm run check:internal-links -- --historical-apis --skip-broken-historical
+npm run check:internal-links -- --current-apis --dev-apis --historical-apis --qiskit-legacy-release-notes
 
 # Or, run all the checks. Although this only checks non-API docs.
 npm run check
@@ -243,10 +239,10 @@ To check external links:
 
 ```bash
 # Specify the files you want after `--`
-npm run check:external-links -- docs/run/index.md docs/run/circuit-execution.mdx
+npm run check:external-links -- docs/guides/index.md docs/guides/circuit-execution.mdx
 
 # You can also use globs
-npm run check:external-links -- 'docs/run/*' '!docs/run/index.mdx'
+npm run check:external-links -- 'docs/guides/*' '!docs/guides/index.mdx'
 ```
 
 ## Check for orphan pages

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -62,7 +62,7 @@ const readArgs = (): Arguments => {
       type: "boolean",
       default: false,
       description:
-        "Also check historical releases that are known to still fail (currently Qiskit <0.46). " +
+        "Also check historical releases that are known to still fail (currently all of Qiskit). " +
         "Intended to be used alongside `--historical-apis`.",
     })
     .option("qiskit-legacy-release-notes", {
@@ -146,9 +146,9 @@ async function determineFileBatches(args: Arguments): Promise<FileBatch[]> {
     {
       check: args.historicalApis,
       hasSeparateReleaseNotes: true,
-      // Qiskit docs are broken on <0.46.
-      skipVersions: (version) =>
-        !args.includeBrokenHistorical && +version < 0.46,
+      // Qiskit docs are broken for all historical versions. We should
+      // fix 0.46+ and only skip <0.46 after that.
+      skipVersions: () => !args.includeBrokenHistorical,
     },
   );
 

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -62,7 +62,7 @@ const readArgs = (): Arguments => {
       type: "boolean",
       default: false,
       description:
-        "Also check historical releases that are known to still fail (currently all of Qiskit). " +
+        "Also check historical releases that are known to still fail (currently Qiskit <0.46). " +
         "Intended to be used alongside `--historical-apis`.",
     })
     .option("qiskit-legacy-release-notes", {
@@ -146,9 +146,9 @@ async function determineFileBatches(args: Arguments): Promise<FileBatch[]> {
     {
       check: args.historicalApis,
       hasSeparateReleaseNotes: true,
-      // Qiskit docs are broken for all historical versions. We should
-      // fix 0.46+ and only skip <0.46 after that.
-      skipVersions: () => !args.includeBrokenHistorical,
+      // Qiskit docs are broken on <0.46.
+      skipVersions: (version) =>
+        !args.includeBrokenHistorical && +version < 0.46,
     },
   );
 

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -261,7 +261,7 @@ async function determineHistoricalFileBatches(
     ];
     const toLoad = [...extraGlobsToLoad];
 
-    // Also check the relesae note file for this version, if the package has
+    // Also check the release note file for this version, if the package has
     // separate release notes per version.
     //
     // Qiskit legacy release notes (< 0.46) have their own FileBatch, so we don't

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -85,7 +85,7 @@ export const ALWAYS_IGNORED_URLS = new Set([
 type FilesToIgnores = { [id: string]: string[] };
 
 const _QPY_IGNORES = Object.fromEntries(
-  ["", "dev/"].map((vers) => [
+  ["", "dev/", "0.46/", "1.0/", "1.1/"].map((vers) => [
     `docs/api/qiskit/${vers}qpy.mdx`,
     [
       "#f1",
@@ -135,7 +135,7 @@ const _RUNTIME_OBJECT_INV = Object.fromEntries(
 );
 
 const _QISKIT_OBJECT_INV = Object.fromEntries(
-  ["", "dev/"].map((vers) => [
+  ["", "dev/", "0.46/", "1.0/", "1.1/"].map((vers) => [
     `public/api/qiskit/${vers}objects.inv`,
     [
       `/api/qiskit/${vers}utils#qiskit.utils.optionals.HAS_AER`,
@@ -188,6 +188,7 @@ const FILES_TO_IGNORES__SHOULD_FIX: FilesToIgnores = {
   "docs/api/qiskit/release-notes/1.0.mdx": [
     "/api/qiskit/1.0/utils#qiskit.utils.optionals.HAS_SYMENGINE",
   ],
+  "docs/api/qiskit/0.46/qiskit.algorithms.optimizers.NFT.mdx": ["#id1", "#id2"],
   ..._QPY_IGNORES,
   // Runtime
   "docs/api/qiskit-ibm-runtime/release-notes.mdx": [


### PR DESCRIPTION
This is to unblock https://github.com/Qiskit/documentation/issues/495. Our goal is to fix all broken links for Qiskit 0.46+, whereas we don't plan to fix <0.46. So, we want our script to make it ergonomic to check 0.46+.

This PR results in us now checking 0.46, 1.0, and 1.1 docs. It does that with two changes:

1. Rename `--skip-broken-historical` to `--include-broken-historical` so that, by default, `--historical-apis` "just works".
1. `--qiskit-release-notes` is renamed to `--qiskit-legacy-release-notes`. 
    - It now only checks <0.46. 
    - `--current-apis` will check the release notes for the latest version, whereas before you had to remember to  specify `--qiskit-release-notes`
    - For Qiskit 0.46+, `--historical-apis` will check the release note for each version, whereas before you had to remember to specify `--qiskit-release-notes`



| Option                          | Checks                                                  |
|--------------------------------:|:--------------------------------------------------------|
| `--current-apis`                | Current API docs, including latest Qiskit release note |
| `--qiskit-legacy-release-notes` | Only Qiskit release notes < 0.46                        |
| `--historical-apis`             | All Runtime and Transpiler historical; Qiskit 0.46+, including those release notes        |
| `--historical-apis --include-broken-historical`             | All historical, including Qiskit historical release notes        |