### PR TITLE
Fix cspell not outputting errors for MDX files

### DIFF
--- a/scripts/js/commands/checkSpelling.ts
+++ b/scripts/js/commands/checkSpelling.ts
@@ -46,10 +46,9 @@ zxMain(async () => {
   const args = readArgs();
   const cspellCmd = ["npx", "cspell", "--no-progress", "--config", args.config];
 
-  await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx`;
-
+  await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx`.pipe(process.stdout);
   if (args.apis) {
-    await $`${cspellCmd} docs/api/**/*.mdx`;
+    await $`${cspellCmd} docs/api/**/*.mdx`.pipe(process.stdout);
   }
 
   await checkAllNotebooks(args.config);


### PR DESCRIPTION
Zx does not log `stdout` by default, but it does stderr. So, the MDX files weren't getting their stdout logs shown. My bad!

Closes https://github.com/Qiskit/documentation/issues/1846.