### PR TITLE
Deprecation warning no longer exists

### DIFF
--- a/docs/guides/local-testing-mode.ipynb
+++ b/docs/guides/local-testing-mode.ipynb
@@ -120,11 +120,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5cba81b8-058e-4626-a72b-fad91a00410c",
-   "metadata": {
-    "tags": [
-     "ignore-warnings"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from qiskit_aer import AerSimulator\n",


### PR DESCRIPTION
Remove tag from cell and verify that the notebook runs properly.

Closes #1845 