### PR TITLE
Adding documentation about Qiskit Transpiler Service limits

### DIFF
--- a/docs/guides/ai-transpiler-passes.mdx
+++ b/docs/guides/ai-transpiler-passes.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI transpiler passes
+title: AI-powered transpiler passes
 description: What are the AI transpiler passes and how to use them
 ---
 
@@ -10,7 +10,7 @@ The AI-powered transpiler passes are experimental passes that work as a drop-in 
 
 <Admonition type="note">
     This is an experimental feature available only to the IBM Quantum Premium Plan.
-    The AI-powered transpiler passes are in beta release status, subject to change.
+    The AI-powered transpiler passes are in preview release status, subject to change.
     If you have feedback or want to contact the developer team, please use this [Qiskit Slack Workspace channel](https://qiskit.slack.com/archives/C06KF8YHUAU).
 </Admonition>
 
@@ -102,6 +102,9 @@ The following custom collection passes for Cliffords, Linear Functions and Permu
 
 These custom collection passes limit the sizes of the collected sub-circuits so they are supported by the AI-powered synthesis passes. Therefore, it is recommended to use them after the routing passes and before the synthesis passes for a better overall optimization.
 
+## Limits
+
+Refer to the [Qiskit Transpiler Service documentatione](./qiskit-transpiler-service#install-transpiler-service) to know more about the limits that apply to the AI-powered transpiler passes.
 
 ## Citation
 

--- a/docs/guides/qiskit-transpiler-service.mdx
+++ b/docs/guides/qiskit-transpiler-service.mdx
@@ -94,6 +94,16 @@ The following examples demonstrate how to transpile circuits using the Qiskit Tr
     transpiled_circuit = cloud_transpiler_service.run(circuit)
     ```
 
+## Limits of the Qiskit Transpiler Service
+
+The service has some limits enabled, here we list the most relevant ones:
+
+- The Qiskit Transpiler Service allows to transpile up to 1 million two-qubit gates in either `ai` mode `ai="true"`, `ai="false"` or `ai="auto"`.
+- The maximum time allowed to run a transpilation process is 30 mins.
+- The maximum time to retrieve a transpilation result from the service after the transpilation process ends is 20 mins. After 20 mins your job will be removed.
+- The maximum time a set of circuits can live in the internal queues while waiting to be transpiled is 120 mins. After that time, if the job has not been transpiled, it will be discarded.
+- The maximum number of qubits is not really fixed. Though, the service has been only tested up to 900+ qubits.
+
 ## Citation
 
 If you use any AI-powered feature from the Qiskit Transpiler Service in your research, use the following recommended citation:


### PR DESCRIPTION
Adding to the documentation the limits enabled for the Qiskit Transpiler Service in terms of supported N of gates, N of qubits, and different timeouts