### PR TITLE
Skip emails in internal link checker

### DIFF
--- a/scripts/js/lib/links/extractLinks.ts
+++ b/scripts/js/lib/links/extractLinks.ts
@@ -49,6 +49,9 @@ export async function parseLinks(
   const externalLinks = new Set<string>();
 
   const addLink = (link: string): void => {
+    // We cannot check that email addresses are valid.
+    if (link.startsWith("mailto:")) return;
+
     if (link.startsWith("http")) {
       externalLinks.add(link);
     } else {

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -35,14 +35,9 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://quantumcomputing.stackexchange.com/help/how-to-ask",
   "https://quantumcomputing.stackexchange.com/questions/",
   "https://quantumcomputing.stackexchange.com/questions/12721/how-to-calculate-destabilizer-group-of-toric-and-other-codes",
-  "mailto:tellibm@us.ibm.com",
 ];
 
-const ALWAYS_IGNORED_URLS__SHOULD_FIX: string[] = [
-  "mailto:qiskit_ibm@algorithmiq.fi",
-  "mailto:support@qedma.com",
-  "mailto:sales@qunasys.com",
-];
+const ALWAYS_IGNORED_URLS__SHOULD_FIX: string[] = [];
 
 export const ALWAYS_IGNORED_URLS = new Set([
   ...ALWAYS_IGNORED_URLS__EXPECTED,


### PR DESCRIPTION
There is no easy way to check that an email address actually exists. Closes https://github.com/Qiskit/documentation/issues/1950.