### PR TITLE
Add back page toc on intro-to-qiskit

### DIFF
--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,19 +1,17 @@
 ---
 title: Introduction to Qiskit
 description: What is Qiskit? This document provides an introduction to the Qiskit stack.
-in_page_toc_show: false
 ---
 
 # Introduction to Qiskit
 
-
-The name "Qiskit" is a general term referring to a collection of software for executing programs on quantum computers. Most notably among these software tools is the open-source Qiskit SDK, and the runtime environment (accessed using Qiskit Runtime) through which you can execute workloads on IBM&reg; quantum computers. As quantum technology evolves, so does Qiskit, with new capabilities released every year that expand this core collection of quantum software.
+The name "Qiskit" is a general term referring to a collection of software for executing programs on quantum computers. Most notably among these software tools is the open-source Qiskit SDK, and the runtime environment (accessed using Qiskit Runtime) through which you can execute workloads on IBM&reg; quantum processing units (QPUs). As quantum technology evolves, so does Qiskit, with new capabilities released every year that expand this core collection of quantum software.
 
 In addition, many open-source projects are part of the broader Qiskit ecosystem. These software tools are not part of Qiskit itself, but rather interface with Qiskit and can provide valuable additional functionality.
 
 ![All Qiskit pattern steps are shown (Map problem, Optimize for hardware, Execute on hardware, and Post-process results). All steps, except for 'Execute on hardware', use the Qiskit SDK. 'Optimizing for hardware' additionally uses the Qiskit Transpiler Service.  'Executing on hardware' uses only the Qiskit Runtime Service.](/images/qiskit-patterns/patterns.svg)
 
-IBM&reg; is committed to the responsible development of quantum computing. Learn more and review our responsible quantum principles in the [Responsible quantum computing and inclusive tech](/responsible-quantum-computing) topic.
+IBM is committed to the responsible development of quantum computing. Learn more and review our responsible quantum principles in the [Responsible quantum computing and inclusive tech](/responsible-quantum-computing) topic.
 
 ## The Qiskit SDK
 


### PR DESCRIPTION
Page is getting long and could use the navigational guides. Also restores the option for a reader to vote on the page's helpfulness, and to report a bug on GitHub.