### PR TITLE
Notes on fetching errors from Qiskit Functions

### DIFF
--- a/docs/guides/functions.ipynb
+++ b/docs/guides/functions.ipynb
@@ -280,6 +280,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fetching error messages\n",
+    "\n",
+    "If a program status is `ERROR`, use `job.result()` to fetch the error message to help debug as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(job.result())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7c8c3e5d-1de2-4fed-be03-d134dc3fd907",
    "metadata": {},
    "source": [

--- a/docs/guides/functions.ipynb
+++ b/docs/guides/functions.ipynb
@@ -282,7 +282,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Fetching error messages\n",
+    "### Fetch error messages\n",
     "\n",
     "If a program status is `ERROR`, use `job.result()` to fetch the error message to help debug as follows:"
    ]

--- a/docs/guides/ibm-circuit-function.ipynb
+++ b/docs/guides/ibm-circuit-function.ipynb
@@ -252,6 +252,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02295f5d",
+   "metadata": {},
+   "source": [
+    "## Fetching error messages\n",
+    "\n",
+    "If your workload status is `ERROR`, use `job.result()` to fetch the error message to help debug as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4070e592",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(job.result())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "32db1269",
    "metadata": {},
    "source": [


### PR DESCRIPTION
If a user's Qiskit Function errors, they need a traceback to identify how to fix their workload submission. 

Adding a few lines to Qiskit Functions docs to clarify how to pull this