### PR TITLE
Add performance blog announcement to the latest updates file

### DIFF
--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -5,7 +5,7 @@ description: The latest updates from Qiskit and IBM Quantum, including the lates
 
 # Latest updates
 
-*Last updated 16 September 2024*
+*Last updated 18 September 2024*
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
 Keep up with the latest and greatest from Qiskit and IBM Quantum&trade;! Gathered here are the the most recent Qiskit package release summaries, documentation updates, blogs, community events, and more.
@@ -126,11 +126,27 @@ Users can purchase licenses for the following functions contributed by our partn
 To get started, explore the [Qiskit Functions documentation](./functions).
 
 
-## IBM Quantum blog: Qiskit Serverless sets the stage for Qiskit Functions in the cloud
+## IBM Quantum blog
 
 *Browse all blogs at the [IBM Quantum blog page](https://www.ibm.com/quantum/blog).*
 
 {/* Bring over the Quantum news (blog) announcement post */}
+
+###  Qiskit: The most performant quantum software development kit
+
+Using a new open-source suite of over 1,000 benchmarking tests developed by leading universities, national labs, and researchers at IBM, we found that Qiskit is second-to-none in terms of the speed and quality demonstrated for most test tasks.
+
+When measured against the closest leading quantum software development kits, Qiskit showed its overall speed in both its ability to build and manipulate quantum circuits, as well its speed in synthesizing and transpiling them.
+
+In regards to quality, Qiskit transpiled circuits with the lowest number of 2Q gates — meaning it needs to perform far fewer operations when running circuits on hardware, thereby generating less noise and superior results.
+
+Finally, Qiskit was the only software that was able to complete all tests that can be completed using current quantum hardware. (Note: A small number of tests are currently impossible to complete with today's quantum processors.)
+
+We're also pleased to share that the benchmarking suite used for these tests, named Benchpress, is now available as [an open-source package](https://github.com/qiskit/benchpress). You can now use the Benchpress package to perform your own analysis of quantum SDK performance.
+
+Head to the [IBM Quantum blog](https://www.ibm.com/quantum/blog/qiskit-performance) for a deeper dive on the performance results!
+
+### Qiskit Serverless sets the stage for Qiskit Functions in the cloud
 
 [This week on the IBM Quantum blog](https://www.ibm.com/quantum/blog/qiskit-serverless), we're taking a fresh look at Qiskit Serverless, a programming model that empowers users to leverage both quantum and classical resources in a cloud environment. We've made a number of improvements to Qiskit Serverless since its debut at IBM Quantum Summit 2023, and have recently expanded and updated the [Qiskit Serverless documentation](/guides/serverless) to simplify the process of getting started with it.
 


### PR DESCRIPTION
Because we've had two new blogs released at about the same time, I am including both blog announcements rather than deleting the one that is only one day old. Normally we would only include one blog announcement at a time on the latest updates page.