### PR TITLE
Remove mention of QCTRL performance strategy

### DIFF
--- a/docs/guides/configure-error-mitigation.mdx
+++ b/docs/guides/configure-error-mitigation.mdx
@@ -56,15 +56,6 @@ basis. Specific error mitigation methods are not guaranteed to be
 applied at each resilience level.
 </Admonition>
 
-<Admonition type="note">
-  If using an IBM Cloud&reg; Qiskit Runtime service instance with Q-CTRL performance management enabled, do not specify runtime optimization or resilience levels, as the strategy includes an automatic preset.
-
-  Setting `optimization_level` or `resilience_level` equal to 0 will result in an
-  execution error. Levels 1, 2, and 3 are permitted but will not impact performance.
-  Setting other options will likewise not impact performance, and it may result in a
-  runtime warning. For more information visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
-</Admonition>
-
 ## Configure Estimator with resilience levels
 
 You can use resilience levels to specify error mitigation techniques, or you can set custom techniques individually as described in [Custom error settings.](#advanced-error) You cannot specify resilience levels in Sampler. However, you can set custom techniques individually.
@@ -196,7 +187,6 @@ For instructions to turn off all error mitigation, see the [Turn off all error s
 
 <Admonition type="tip" title="Recommendations">
   - Walk through an example that uses error mitigation in the [Cost function lesson](https://learning.quantum.ibm.com/course/variational-algorithm-design/cost-functions#primitives) in IBM Quantum Learning.
-  - Learn more about [Q-CTRL](https://docs.q-ctrl.com/q-ctrl-embedded).
   - Learn more about [error mitigation and error suppression techniques.](error-mitigation-and-suppression-techniques)
   - [Configure error suppression.](configure-error-suppression)
   - Explore other [options.](runtime-options-overview)

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -11,7 +11,7 @@ In addition, many open-source projects are part of the broader Qiskit ecosystem.
 
 ![All Qiskit pattern steps are shown (Map problem, Optimize for hardware, Execute on hardware, and Post-process results). All steps, except for 'Execute on hardware', use the Qiskit SDK. 'Optimizing for hardware' additionally uses the Qiskit Transpiler Service.  'Executing on hardware' uses only the Qiskit Runtime Service.](/images/qiskit-patterns/patterns.svg)
 
-IBM is committed to the responsible development of quantum computing. Learn more and review our responsible quantum principles in the [Responsible quantum computing and inclusive tech](/responsible-quantum-computing) topic.
+IBM is committed to the responsible development of quantum computing. Learn more and review our responsible quantum principles in the [Responsible quantum computing](/responsible-quantum-computing) topic.
 
 ## The Qiskit SDK
 

--- a/docs/guides/setup-channel.mdx
+++ b/docs/guides/setup-channel.mdx
@@ -200,10 +200,6 @@ Alternatively, you can also access quantum processors with REST APIs, enabling y
       If you are an administrator who needs to set up Qiskit Runtime on Cloud for your organization, refer to [Plan Qiskit Runtime for an organization](https://cloud.ibm.com/docs/quantum-computing?topic=quantum-computing-quickstart-org).
     </Admonition>
 
-    <Admonition type="note">
-     When selecting a performance strategy there are two options available. One from IBM (default) another from Q-CTRL. The IBM performance strategy allows you to leverage all of the standard options available with [Qiskit Runtime](../api/qiskit-ibm-runtime) and the Q-CTRL strategy uses an automated preset.  To learn more about the Q-CTRL option, visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
-    </Admonition>
-
 1. Find your access credentials.
     1. Find your API key. From the [API keys page](https://cloud.ibm.com/iam/apikeys), view or create your API key, then copy it to a secure location so you can use it for authentication.
     2. Find your Cloud Resource Name (CRN). Open the [Instances page](https://cloud.ibm.com/quantum/instances) and click your instance. In the page that opens, click the icon to copy your CRN. Save it in a secure location so you can use it for authentication.
@@ -216,10 +212,6 @@ Alternatively, you can also access quantum processors with REST APIs, enabling y
 
    service = QiskitRuntimeService(channel="ibm_cloud", token="<IBM Cloud API key>", instance="<IBM Cloud CRN>")
    ```
-
-   <Admonition type="note">
-     If you set up your instance in step 3 to include Q-CTRL performance management, when initializing the `QiskitRuntimeService()` you should include the additional argument `channel_strategy="q-ctrl"`. To learn more about Q-CTRL performance management strategy visit the [Q-CTRL documentation](https://docs.q-ctrl.com/q-ctrl-embedded).
-   </Admonition>
 
    You can optionally use the `save_account()` method to save your credentials for easy access later on, before initializing the service.
 


### PR DESCRIPTION
As of 18 Sep the Q-CTRL performance strategy will be deprecated. Removing mention of it in our docs.

Sneaking in a typo fix I found on the index page.