### PR TITLE
Fix some missing footnotes

### DIFF
--- a/docs/api/qiskit/0.19/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.19/qiskit.aqua.components.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -51,6 +53,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -53,6 +55,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
@@ -28,6 +28,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **1**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
@@ -49,6 +51,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
     In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
 
     **References**
+
+    <span id="id4" />
 
     **1**
 

--- a/docs/api/qiskit/0.28/qpy.mdx
+++ b/docs/api/qiskit/0.28/qpy.mdx
@@ -220,13 +220,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id3" />[3](#f3) Finally, if type is `i` it represents an integer which is an `int64_t`.
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **[2](#id2)**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id3)**
 

--- a/docs/api/qiskit/0.29/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.29/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.29/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.29/qiskit.aqua.components.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.29/qpy.mdx
+++ b/docs/api/qiskit/0.29/qpy.mdx
@@ -250,13 +250,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id3" />[3](#f3) Finally, if type is `i` it represents an integer which is an `int64_t`.
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **[2](#id2)**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id3)**
 

--- a/docs/api/qiskit/0.30/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.30/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.30/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.30/qiskit.aqua.components.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.30/qpy.mdx
+++ b/docs/api/qiskit/0.30/qpy.mdx
@@ -250,13 +250,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id3" />[3](#f3) Finally, if type is `i` it represents an integer which is an `int64_t`.
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **[2](#id2)**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id3)**
 

--- a/docs/api/qiskit/0.31/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.31/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.31/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.31/qiskit.aqua.components.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.31/qpy.mdx
+++ b/docs/api/qiskit/0.31/qpy.mdx
@@ -250,13 +250,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id3" />[3](#f3) Finally, if type is `i` it represents an integer which is an `int64_t`.
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **[2](#id2)**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id3)**
 

--- a/docs/api/qiskit/0.32/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.32/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.32/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.32/qiskit.aqua.components.optimizers.NFT.mdx
@@ -30,6 +30,8 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.32/qpy.mdx
+++ b/docs/api/qiskit/0.32/qpy.mdx
@@ -250,13 +250,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id3" />[3](#f3) Finally, if type is `i` it represents an integer which is an `int64_t`.
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **[2](#id2)**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id3)**
 

--- a/docs/api/qiskit/0.33/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.33/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.33/qpy.mdx
+++ b/docs/api/qiskit/0.33/qpy.mdx
@@ -374,13 +374,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id10" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id7))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id10)**
 

--- a/docs/api/qiskit/0.35/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.35/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.35/qpy.mdx
+++ b/docs/api/qiskit/0.35/qpy.mdx
@@ -430,13 +430,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id6" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id2),[2](#id4))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id6)**
 

--- a/docs/api/qiskit/0.36/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.36/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.36/qpy.mdx
+++ b/docs/api/qiskit/0.36/qpy.mdx
@@ -430,13 +430,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id6" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id1)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id2),[2](#id4))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id6)**
 

--- a/docs/api/qiskit/0.37/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.37/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.37/qpy.mdx
+++ b/docs/api/qiskit/0.37/qpy.mdx
@@ -663,13 +663,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/docs/api/qiskit/0.38/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.38/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.38/qpy.mdx
+++ b/docs/api/qiskit/0.38/qpy.mdx
@@ -663,13 +663,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/docs/api/qiskit/0.39/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.39/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.39/qpy.mdx
+++ b/docs/api/qiskit/0.39/qpy.mdx
@@ -663,13 +663,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/docs/api/qiskit/0.40/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.40/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.40/qpy.mdx
+++ b/docs/api/qiskit/0.40/qpy.mdx
@@ -700,13 +700,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/docs/api/qiskit/0.41/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.41/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.41/qpy.mdx
+++ b/docs/api/qiskit/0.41/qpy.mdx
@@ -700,13 +700,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/docs/api/qiskit/0.42/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.42/qiskit.algorithms.optimizers.NFT.mdx
@@ -32,6 +32,8 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **References**
 
+  <span id="id2" />
+
   **[1](#id1)**
 
   K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.

--- a/docs/api/qiskit/0.42/qpy.mdx
+++ b/docs/api/qiskit/0.42/qpy.mdx
@@ -700,13 +700,19 @@ struct {
 
 this matches the internal C representation of Python’s complex type. <span id="id7" />[3](#f3)
 
+<span id="f1" />
+
 **[1](#id2)**
 
 [https://tools.ietf.org/html/rfc1700](https://tools.ietf.org/html/rfc1700)
 
+<span id="f2" />
+
 **2([1](#id3),[2](#id5))**
 
 [https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
+
+<span id="f3" />
 
 **[3](#id7)**
 

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -62,7 +62,7 @@ const readArgs = (): Arguments => {
       type: "boolean",
       default: false,
       description:
-        "Also check historical releases that are known to still fail (currently Qiskit <0.46). " +
+        "Also check historical releases that are known to still fail (currently Qiskit <0.45). " +
         "Intended to be used alongside `--historical-apis`.",
     })
     .option("qiskit-legacy-release-notes", {
@@ -147,9 +147,9 @@ async function determineFileBatches(args: Arguments): Promise<FileBatch[]> {
     {
       check: args.historicalApis,
       hasSeparateReleaseNotes: true,
-      // Qiskit docs are broken on <0.46.
+      // Qiskit docs are broken on <0.45.
       skipVersions: (version) =>
-        !args.includeBrokenHistorical && +version < 0.46,
+        !args.includeBrokenHistorical && +version < 0.45,
     },
   );
 

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -276,7 +276,7 @@ export function removeColonSpans($main: Cheerio<any>): void {
 
 export function handleFootnotes($: CheerioAPI, $main: Cheerio<any>): void {
   $main
-    .find(".footnote, .footnote-reference")
+    .find(".footnote, .footnote-reference, .footnote dt.label")
     .toArray()
     .forEach((footnote) => {
       const $footnote = $(footnote);

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -104,7 +104,7 @@ function _qiskitUtilsData(): FilesToIgnores {
   // Qiskit docs used .. py:data:: incorrectly. We didn't fix these versions of the docs
   // because it is too tedious.
   const objectsInv = Object.fromEntries(
-    ["1.0/", "1.1/"].map((vers) => [
+    ["0.45/", "1.0/", "1.1/"].map((vers) => [
       `public/api/qiskit/${vers}objects.inv`,
       [
         `/api/qiskit/${vers}utils#qiskit.utils.optionals.HAS_AER`,
@@ -144,8 +144,20 @@ function _qiskitUtilsData(): FilesToIgnores {
     ]),
   );
   const utilsFile = Object.fromEntries(
-    ["1.0/", "1.1/"].map((vers) => [
-      `docs/api/qiskit/${vers}utils.mdx`,
+    [
+      "0.37",
+      "0.38",
+      "0.39",
+      "0.40",
+      "0.41",
+      "0.42",
+      "0.43",
+      "0.44",
+      "0.45",
+      "1.0",
+      "1.1",
+    ].map((vers) => [
+      `docs/api/qiskit/${vers}/utils.mdx`,
       [
         "#qiskit.utils.optionals.HAS_TESTTOOLS",
         "#qiskit.utils.optionals.HAS_GRAPHVIZ",
@@ -166,7 +178,7 @@ function _patternsReorg(): FilesToIgnores {
   // We have redirects for all these files. It's best to update API docs to point directly to the new URL,
   // but we don't bother updating old docs.
   const qiskit = Object.fromEntries(
-    ["", "0.46/", "1.0/", "1.1/"].flatMap((vers) => [
+    ["", "0.45/", "0.46/", "1.0/", "1.1/"].flatMap((vers) => [
       [
         `docs/api/qiskit/${vers}qiskit.circuit.QuantumCircuit.mdx`,
         ["/build/circuit-construction"],


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/1955. 

In older versions of Sphinx, footnotes looked like this:

```html
<dl class="footnote brackets">
<dt class="label" id="id2"><span class="brackets"><a class="fn-backref" href="#id1">1</a></span></dt>
```

This PR also adds ignores for 0.45 so that it's green. We don't plan to fix those issues, which are only broken anchor links.