### PR TITLE
Fix code examples in "Manage Qiskit Serverless compute and data resources"

### DIFF
--- a/docs/guides/serverless-manage-resources.ipynb
+++ b/docs/guides/serverless-manage-resources.ipynb
@@ -40,7 +40,7 @@
     "    \"\"\"Transpiles an abstract circuit (or list of circuits) into an ISA circuit for a given backend.\"\"\"\n",
     "    pass_manager = generate_preset_pass_manager(\n",
     "        optimization_level=optimization_level,\n",
-    "\t\tbackend=service.backend(backend)\n",
+    "        backend=service.backend(backend)\n",
     "    )\n",
     "    isa_circuit = pass_manager.run(circuit)\n",
     "    return isa_circuit"
@@ -179,6 +179,7 @@
     "\n",
     "# Upload the tar to Serverless data directory\n",
     "from qiskit_serverless import IBMServerlessClient\n",
+    "\n",
     "serverless = IBMServerlessClient()\n",
     "serverless.file_upload(filename)"
    ]

--- a/docs/guides/serverless-manage-resources.ipynb
+++ b/docs/guides/serverless-manage-resources.ipynb
@@ -27,17 +27,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# /source_files/transpile_remote.py\n",
+    "%%writefile ./source_files/transpile_remote.py\n",
     "\n",
     "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
+    "from qiskit_ibm_runtime import QiskitRuntimeService\n",
     "from qiskit_serverless import distribute_task\n",
+    "\n",
+    "service = QiskitRuntimeService()\n",
     "\n",
     "@distribute_task(target={\"cpu\": 1})\n",
     "def transpile_remote(circuit, optimization_level, backend):\n",
-    "    \"\"\"Transpiles an abstract circuit into an ISA circuit for a given backend.\"\"\"\n",
+    "    \"\"\"Transpiles an abstract circuit (or list of circuits) into an ISA circuit for a given backend.\"\"\"\n",
     "    pass_manager = generate_preset_pass_manager(\n",
     "        optimization_level=optimization_level,\n",
-    "\t\tbackend=backend\n",
+    "\t\tbackend=service.backend(backend)\n",
     "    )\n",
     "    isa_circuit = pass_manager.run(circuit)\n",
     "    return isa_circuit"
@@ -48,20 +51,32 @@
    "id": "a5914f1d-f898-4db4-8d1e-ccc8081883b9",
    "metadata": {},
    "source": [
-    "In this example, you decorated the `transpile_remote()` method with `@distribute_task(target={\"cpu\": 1})`. When run, this creates an asynchronous parallel worker task with a single CPU core, and returns with a reference to track the worker. To fetch the result, pass the reference to the `get()` method:"
+    "In this example, you decorated the `transpile_remote()` function with `@distribute_task(target={\"cpu\": 1})`. When run, this creates an asynchronous parallel worker task with a single CPU core, and returns with a reference to track the worker. To fetch the result, pass the reference to the `get()` function."
    ]
   },
   {
-   "cell_type": "markdown",
    "id": "74fdcd4a-01cd-46ca-aa24-2a8a3605346f",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```python\n",
-    "from qiskit_serverless import get\n",
+    "%%writefile --append ./source_files/transpile_remote.py\n",
     "\n",
-    "transpile_worker_reference = transpile_remote(circuit, optimization_level, backend)\n",
+    "from qiskit_serverless import get, get_arguments, save_result\n",
+    "\n",
+    "arguments = get_arguments()\n",
+    "circuit = arguments.get(\"circuit\")\n",
+    "optimization_level = arguments.get(\"optimization_level\")\n",
+    "backend = arguments.get(\"backend\")\n",
+    "\n",
+    "transpile_worker_reference = transpile_remote(\n",
+    "    circuit,\n",
+    "    optimization_level,\n",
+    "    backend\n",
+    ")\n",
     "result = get(transpile_worker_reference)\n",
-    "```"
+    "save_result(result)"
    ]
   },
   {
@@ -69,22 +84,25 @@
    "id": "268d5ef6-12cf-4ba5-95a3-f7460e4b3bfc",
    "metadata": {},
    "source": [
-    "You can also create and run multiple parallel tasks as follows:"
+    "You can also create and run multiple parallel tasks as follows."
    ]
   },
   {
-   "cell_type": "markdown",
    "id": "ac99b4a0-4a42-4c43-869d-265344b70359",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```python\n",
+    "%%writefile --append ./source_files/transpile_remote.py\n",
+    "\n",
     "transpile_worker_references = [\n",
     "    transpile_remote(circuit, optimization_level, backend)\n",
-    "    for circuit in circuit_list\n",
+    "    for circuit in arguments.get(\"circuit_list\")\n",
     "]\n",
     "\n",
     "results = get(transpile_worker_references)\n",
-    "```"
+    "save_result(results)  # Overwrites any previously saved results"
    ]
   },
   {
@@ -108,79 +126,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%writefile --append ./source_files/transpile_remote.py\n",
+    "\n",
     "@distribute_task(target={\n",
     "    \"cpu\": 16,\n",
-    "    \"mem\": 32 * 1024 * 1024 * 1024\n",
+    "    \"mem\": 2 * 1024 * 1024 * 1024\n",
     "})\n",
     "def transpile_remote(circuit, optimization_level, backend):\n",
     "    return None"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6fff174-301f-47ca-b7c6-69bb5298fd14",
-   "metadata": {},
-   "source": [
-    "## Automatic QPU selection\n",
-    "\n",
-    "This example demonstrates how to use `IBMQPUSelector` to automate the process of selecting which qubits to use from a set of available QPUs. Instead of manually selecting a QPU, Qiskit Serverless automatically allocates a QPU according to desired criteria. `IBMQPUSelector`s are imported from server-side `qiskit_serverless_tools.selectors` modules, and must be invoked from your uploaded program.\n",
-    "\n",
-    "Here, `IBMLeastNoisyQPUSelector` finds the QPU that yields the least-noisy qubit subgraph for the input circuit, from among the QPUs available to you through your IBM Quantum account.\n",
-    "\n",
-    "For each `IBMQPUSelector`, the context is set in the constructor. All `IBMQPUSelectors` require Qiskit Runtime credentials. The `IBMLeastNoisyQPUSelector` requires a circuit and transpile options specifying how the circuit should be optimized for each QPU, to determine the most optimal QPU and qubit layout.\n",
-    "\n",
-    "All `IBMQPUSelectors` implement a `get_backend` method, which retrieves the optimal QPU with respect to the given context. The `get_backend` method also allows for additional filtering of the QPUs. It is implemented using the same interface as the [QiskitRuntimeService.backends](/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService#backends) method."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9b38d02-1c4b-4598-abc8-f2ff2f3c1d23",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "# source_files/transpile_parallel.py\n",
-    "\n",
-    "from qiskit_ibm_runtime import QiskitRuntimeService\n",
-    "from qiskit.circuit.random import random_circuit\n",
-    "from qiskit_serverless_tools.selectors import IBMLeastNoisyQPUSelector\n",
-    "\n",
-    "service = QiskitRuntimeService(channel='ibm_quantum', token=API_TOKEN)\n",
-    "\n",
-    "abstract_circuit = random_circuit(\n",
-    "    num_qubits=100, depth=4, measure=True\n",
-    ")\n",
-    "\n",
-    "selector = IBMLeastNoisyQPUSelector(\n",
-    "    service, circuit=abstract_circuit, transpile_options={\"optimization_level\": 3}\n",
-    ")\n",
-    "backend = selector.get_backend(min_num_qubits=127)\n",
-    "target_circuit = selector.optimized_circuit\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8eda9b3e-31c3-4783-b5f6-a72bd31e41b6",
-   "metadata": {},
-   "source": [
-    "You can also use the `IBMLeastBusyQPUSelector` to find a QPU that can support the circuit width but with the shortest queue."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10bdb211-0d53-4269-aa92-51ecf494bd63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# source_files/transpile_parallel.py\n",
-    "\n",
-    "from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager\n",
-    "from qiskit_serverless_tools.selectors import IBMLeastBusyQPUSelector\n",
-    "\n",
-    "backend = IBMLeastBusyQPUSelector(service).get_backend(min_num_qubits=127)\n",
-    "pm = generate_preset_pass_manager(optimization_level=3, backend=backend)\n",
-    "target_circuit = pm.run(abstract_circuit)"
    ]
   },
   {
@@ -220,11 +173,13 @@
     "\n",
     "# Create a tar\n",
     "filename = \"transpile_demo.tar\"\n",
-    "file = tarfile.open(filename,\"w\")\n",
-    "file.add(\"source_files/transpile_remote.py\")\n",
+    "file = tarfile.open(filename, \"w\")\n",
+    "file.add(\"./source_files/transpile_remote.py\")\n",
     "file.close()\n",
     "\n",
     "# Upload the tar to Serverless data directory\n",
+    "from qiskit_serverless import IBMServerlessClient\n",
+    "serverless = IBMServerlessClient()\n",
     "serverless.file_upload(filename)"
    ]
   },
@@ -267,42 +222,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
    "id": "ef649b2a-ed95-4dd2-89d9-61438faa7c1e",
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 10.2k/10.2k [00:00<00:00, 10.0MiB/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "downloaded_3d3c4bf6_transpile_demo.tar\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# transpile_parallel.py\n",
+    "%%writefile ./source_files/extract_tarfile.py\n",
     "\n",
     "import tarfile\n",
+    "from qiskit_serverless import IBMServerlessClient\n",
     "\n",
+    "serverless = IBMServerlessClient(token=\"<YOUR_IBM_QUANTUM_TOKEN>\")\n",
     "files = serverless.files()\n",
     "demo_file = files[0]\n",
     "downloaded_tar = serverless.file_download(demo_file)\n",
     "\n",
-    "print(downloaded_tar)\n",
+    "\n",
     "with tarfile.open(downloaded_tar, 'r') as tar:\n",
     "    tar.extractall()"
    ]


### PR DESCRIPTION
This makes the code examples runnable. Unfortunately we can't add tests just yet (will happen in #1960), but this does mean users will be able to run all the code on the page.

I've removed the section on automatic QPU selection after discussion with the serverless team. This feature is being developed but isn't ready just yet. We'll add the section back in when it's ready.
