### PR TITLE
Increase timeout for PR previews

### DIFF
--- a/scripts/pr-previews/poll_deployment.py
+++ b/scripts/pr-previews/poll_deployment.py
@@ -24,8 +24,8 @@ from utils import configure_logging
 logger = logging.getLogger(__name__)
 
 INITIAL_DELAY_S = 20
-TIMEOUT_S = 75
-RETRY_INTERVAL_S = 5
+TIMEOUT_S = 180
+RETRY_INTERVAL_S = 10
 
 
 def create_parser() -> ArgumentParser:


### PR DESCRIPTION
I had a [job](https://github.com/Qiskit/documentation/actions/runs/10999772330/job/30540690617?pr=2015) fail even though the [deployment](https://github.com/Qiskit/documentation/actions/runs/10999819575) succeeded. The script just timed out a little early. This PR bumps the timeout to 3mins, and increases the interval a bit to reduce the number of requests we make.
