### PR TITLE
Wait for docker pull in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |
           ./start --apis &
-          sleep 5
+          sleep 1
       - name: Check that pages render
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,14 @@ jobs:
         with:
           files: docs/**/*.{md,mdx,ipynb}
           separator: "\n"
+      - name: Pull preview image
+        if: steps.changed-docs-files.outputs.any_changed == 'true'
+        run: ./start --pull-only
       - name: Start local Docker preview
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |
           ./start --apis &
-          sleep 20
+          sleep 5
       - name: Check that pages render
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: |

--- a/docs/guides/bit-ordering.mdx
+++ b/docs/guides/bit-ordering.mdx
@@ -3,7 +3,7 @@ title: Bit-ordering in the Qiskit SDK
 description: Learn about Qiskit SDK's ordering conventions and why we chose them
 ---
 
-# Bit-ordering in the Qiskit SDK!
+# Bit-ordering in the Qiskit SDK
 
 If you have a set of $n$ bits (or qubits), you'll usually label each bit $0
 \rightarrow n-1$. Different softwares and resources must choose how they order

--- a/docs/guides/bit-ordering.mdx
+++ b/docs/guides/bit-ordering.mdx
@@ -3,7 +3,7 @@ title: Bit-ordering in the Qiskit SDK
 description: Learn about Qiskit SDK's ordering conventions and why we chose them
 ---
 
-# Bit-ordering in the Qiskit SDK
+# Bit-ordering in the Qiskit SDK!
 
 If you have a set of $n$ bits (or qubits), you'll usually label each bit $0
 \rightarrow n-1$. Different softwares and resources must choose how they order

--- a/start
+++ b/start
@@ -27,6 +27,10 @@ def skip_apis() -> tuple[str]:
     return ("-v", "/home/node/app/docs/api")
 
 def main() -> None:
+    if "--pull-only" in sys.argv:
+        subprocess.run(["docker", "pull", IMAGE], check=True)
+        sys.exit(0)
+
     print(
         "Warning: this may be using an outdated version of the app. Run "
         + f"`docker pull {IMAGE}` to check for updates.",


### PR DESCRIPTION
CI can fail if `docker pull ...` takes longer than expected. This PR adds a `--pull-only` option to `./start`, then waits for it to complete in CI.
