### PR TITLE
Update ibm cf parameter names

### DIFF
--- a/docs/guides/ibm-circuit-function.ipynb
+++ b/docs/guides/ibm-circuit-function.ipynb
@@ -88,7 +88,7 @@
     "pubs = [(circuit, observable)]\n",
     "\n",
     "job = function.run(\n",
-    "  backend=backend.name,  # Or `backend=backend_name`, if you didn't initialize a backend object\n",
+    "  backend_name=backend.name,  # Or `backend=backend_name`, if you didn't initialize a backend object\n",
     "  pubs=pubs\n",
     ")"
    ]
@@ -150,9 +150,8 @@
    "source": [
     "| Name      | Type                       | Description                                                                                                                                                                                                                         | Required | Default                                                                  | Example                                  |\n",
     "|-----------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------|------------------------------------------|\n",
-    "| backend   | str                        | Name of the backend to make the query.                                                                                                                                                                                              | Yes      | N/A                                                                      | `ibm_fez`                                |\n",
+    "| backend_name   | str                        | Name of the backend to make the query.                                                                                                                                                                                              | Yes      | N/A                                                                      | `ibm_fez`                                |\n",
     "| pubs      | Iterable[EstimatorPubLike] | An iterable of PUB-like (primitive unified bloc) objects, such as tuples `(circuit, observables)` or `(circuit, observables, parameter_values)`. See [Overview of PUBs](/guides/primitive-input-output#overview-of-pubs) for more information. The circuits don’t need to be ISA circuits. | Yes      | N/A                                                                      | (circuit, observables, parameter_values) |\n",
-    "| precision | float                      | The target precision for expectation value estimates of each run Estimator PUB that does not specify its own precision.                                                                                                             | No       | 0.015625                                                                 | 0.1                                      |\n",
     "| options   | dict                       | Input options. See the **Options** section for more details.                                                                                                                                                                                | No       | See the **Options** section for details.                                                   | `{\"optimization_level\": 3}`                |\n",
     "| instance  | str                        | The hub/group/project to use in that format.                                                                                                                                                                                        | No       | One is randomly picked if your account has access to multiple instances. | `hub1/group1/project1`                   |"
    ]
@@ -201,7 +200,7 @@
     "options = {\"mitigation_level\": 2}\n",
     "\n",
     "job = function.run(\n",
-    "  backend=backend.name,\n",
+    "  backend_name=backend.name,\n",
     "  pubs=pubs,\n",
     "  options=options\n",
     ")"


### PR DESCRIPTION
As an effort to unify the interfaces of all circuit functions, IBM circuit function has renamed the `backend` parameter to `backend_name`, and removed `precision` (since there is already `default_precision` in the options). This PR updates the docs accordingly. 