### PR TITLE
Check all historical Qiskit internal links

### DIFF
--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -35,7 +35,6 @@ interface Arguments {
   devApis: boolean;
   historicalApis: boolean;
   qiskitLegacyReleaseNotes: boolean;
-  includeBrokenHistorical: boolean;
 }
 
 const readArgs = (): Arguments => {
@@ -57,13 +56,6 @@ const readArgs = (): Arguments => {
       description:
         "Check the links in the historical API docs, e.g. `api/qiskit/0.46`. " +
         "Warning: this is slow.",
-    })
-    .option("include-broken-historical", {
-      type: "boolean",
-      default: false,
-      description:
-        "Also check historical releases that are known to still fail (currently Qiskit <0.43). " +
-        "Intended to be used alongside `--historical-apis`.",
     })
     .option("qiskit-legacy-release-notes", {
       type: "boolean",
@@ -115,6 +107,7 @@ const QISKIT_GLOBS_TO_LOAD = [
   "docs/guides/construct-circuits.ipynb",
   "docs/guides/bit-ordering.mdx",
   "docs/guides/pulse.ipynb",
+  "docs/guides/primitives.mdx",
   "docs/guides/configure-qiskit-local.mdx",
 ];
 
@@ -148,9 +141,6 @@ async function determineFileBatches(args: Arguments): Promise<FileBatch[]> {
     {
       check: args.historicalApis,
       hasSeparateReleaseNotes: true,
-      // Qiskit docs are broken on <0.43.
-      skipVersions: (version) =>
-        !args.includeBrokenHistorical && +version < 0.43,
     },
   );
 

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -153,6 +153,8 @@ function _qiskitUtilsData(): FilesToIgnores {
   );
   const utilsFile = Object.fromEntries(
     [
+      "0.35",
+      "0.36",
       "0.37",
       "0.38",
       "0.39",


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1955.

We remove `--include-broken-historical` since that no longer makes sense. However, we still keep the `skipVersions` mechanism in the code itself to facilitate temporarily changing the script locally to only check certain versions.