### PR TITLE
Fix broken anchor link in NFT Qiskit class

### DIFF
--- a/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                                         |                                     |
+  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                                         |                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.24/qiskit.aqua.components.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                                         |                                     |
-  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                                         |                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                               |                                     |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                              |                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                               |                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.algorithms.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.algorithms.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                               |                                     |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                              |                                                                                                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                               |                                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                                         |                                     |
+  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                                         |                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.25/qiskit.aqua.components.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                                         |                                     |
-  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                                         |                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                               |                                     |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                              |                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                               |                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.algorithms.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.algorithms.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                               |                                     |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                              |                                                                                                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                               |                                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                                         |                                     |
+  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                                         |                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.26/qiskit.aqua.components.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                                         |                                     |
-  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                                         |                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                               |                                     |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                              |                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                               |                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.algorithms.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.algorithms.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                               |                                     |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                              |                                                                                                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                               |                                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                                         |                                     |
+  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                                         |                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.27/qiskit.aqua.components.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                                         |                                     |
-  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                                         |                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
@@ -28,263 +28,247 @@ python_api_name: qiskit.algorithms.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32, options=None, **kwargs)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-    *   **options** (`Optional`\[`dict`]) – A dictionary of solver options.
-    *   **kwargs** – additional kwargs for scipy.optimize.minimize.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, …])                            | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | Return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                               |                                                |
-  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level                   |
-  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level                 |
-  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level            |
-  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored                      |
-  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required                     |
-  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported                    |
-  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored                    |
-  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required                   |
-  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported                  |
-  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored               |
-  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required              |
-  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported             |
-  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                                 |
-  | [`settings`](#qiskit.algorithms.optimizers.NFT.settings "qiskit.algorithms.optimizers.NFT.settings")                                                          | The optimizer settings in a dictionary format. |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-    Return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### settings
-
-  <Attribute id="qiskit.algorithms.optimizers.NFT.settings">
-    The optimizer settings in a dictionary format.
-
-    The settings can for instance be used for JSON-serialization (if all settings are serializable, which e.g. doesn’t hold per default for callables), such that the optimizer object can be reconstructed as
-
-    ```python
-    settings = optimizer.settings
-    # JSON serialize and send to another server
-    optimizer = OptimizerClass(**settings)
-    ```
-
-    **Return type**
-
-    `Dict`\[`str`, `Any`]
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32, options=None, **kwargs)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+  *   **options** (`Optional`\[`dict`]) – A dictionary of solver options.
+  *   **kwargs** – additional kwargs for scipy.optimize.minimize.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                              |                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, …])                            | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | Return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                               |                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level                   |
+| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level                 |
+| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level            |
+| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored                      |
+| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required                     |
+| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported                    |
+| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored                    |
+| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required                   |
+| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported                  |
+| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored               |
+| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required              |
+| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported             |
+| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                                 |
+| [`settings`](#qiskit.algorithms.optimizers.NFT.settings "qiskit.algorithms.optimizers.NFT.settings")                                                          | The optimizer settings in a dictionary format. |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+  Return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### settings
+
+<Attribute id="qiskit.algorithms.optimizers.NFT.settings">
+  The optimizer settings in a dictionary format.
+
+  The settings can for instance be used for JSON-serialization (if all settings are serializable, which e.g. doesn’t hold per default for callables), such that the optimizer object can be reconstructed as
+
+  ```python
+  settings = optimizer.settings
+  # JSON serialize and send to another server
+  optimizer = OptimizerClass(**settings)
+  ```
+
+  **Return type**
+
+  `Dict`\[`str`, `Any`]
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 

--- a/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.algorithms.optimizers.NFT.mdx
@@ -29,246 +29,246 @@ python_api_name: qiskit.algorithms.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32, options=None, **kwargs)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+    *   **options** (`Optional`\[`dict`]) – A dictionary of solver options.
+    *   **kwargs** – additional kwargs for scipy.optimize.minimize.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                              |                                                                                                                                                                                                                                       |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, …])                            | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | Return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                               |                                                |
+  | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+  | [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level                   |
+  | [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level                 |
+  | [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level            |
+  | [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored                      |
+  | [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required                     |
+  | [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported                    |
+  | [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored                    |
+  | [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required                   |
+  | [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported                  |
+  | [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored               |
+  | [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required              |
+  | [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported             |
+  | [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                                 |
+  | [`settings`](#qiskit.algorithms.optimizers.NFT.settings "qiskit.algorithms.optimizers.NFT.settings")                                                          | The optimizer settings in a dictionary format. |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
+    Return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### settings
+
+  <Attribute id="qiskit.algorithms.optimizers.NFT.settings">
+    The optimizer settings in a dictionary format.
+
+    The settings can for instance be used for JSON-serialization (if all settings are serializable, which e.g. doesn’t hold per default for callables), such that the optimizer object can be reconstructed as
+
+    ```python
+    settings = optimizer.settings
+    # JSON serialize and send to another server
+    optimizer = OptimizerClass(**settings)
+    ```
+
+    **Return type**
+
+    `Dict`\[`str`, `Any`]
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.algorithms.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32, options=None, **kwargs)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-  *   **options** (`Optional`\[`dict`]) – A dictionary of solver options.
-  *   **kwargs** – additional kwargs for scipy.optimize.minimize.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                              |                                                                                                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.algorithms.optimizers.NFT.__init__ "qiskit.algorithms.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, …])                            | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.algorithms.optimizers.NFT.get_support_level "qiskit.algorithms.optimizers.NFT.get_support_level")()                            | Return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.algorithms.optimizers.NFT.gradient_num_diff "qiskit.algorithms.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.algorithms.optimizers.NFT.optimize "qiskit.algorithms.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.algorithms.optimizers.NFT.print_options "qiskit.algorithms.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.algorithms.optimizers.NFT.set_max_evals_grouped "qiskit.algorithms.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.algorithms.optimizers.NFT.set_options "qiskit.algorithms.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.algorithms.optimizers.NFT.wrap_function "qiskit.algorithms.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                               |                                                |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| [`bounds_support_level`](#qiskit.algorithms.optimizers.NFT.bounds_support_level "qiskit.algorithms.optimizers.NFT.bounds_support_level")                      | Returns bounds support level                   |
-| [`gradient_support_level`](#qiskit.algorithms.optimizers.NFT.gradient_support_level "qiskit.algorithms.optimizers.NFT.gradient_support_level")                | Returns gradient support level                 |
-| [`initial_point_support_level`](#qiskit.algorithms.optimizers.NFT.initial_point_support_level "qiskit.algorithms.optimizers.NFT.initial_point_support_level") | Returns initial point support level            |
-| [`is_bounds_ignored`](#qiskit.algorithms.optimizers.NFT.is_bounds_ignored "qiskit.algorithms.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored                      |
-| [`is_bounds_required`](#qiskit.algorithms.optimizers.NFT.is_bounds_required "qiskit.algorithms.optimizers.NFT.is_bounds_required")                            | Returns is bounds required                     |
-| [`is_bounds_supported`](#qiskit.algorithms.optimizers.NFT.is_bounds_supported "qiskit.algorithms.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported                    |
-| [`is_gradient_ignored`](#qiskit.algorithms.optimizers.NFT.is_gradient_ignored "qiskit.algorithms.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored                    |
-| [`is_gradient_required`](#qiskit.algorithms.optimizers.NFT.is_gradient_required "qiskit.algorithms.optimizers.NFT.is_gradient_required")                      | Returns is gradient required                   |
-| [`is_gradient_supported`](#qiskit.algorithms.optimizers.NFT.is_gradient_supported "qiskit.algorithms.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported                  |
-| [`is_initial_point_ignored`](#qiskit.algorithms.optimizers.NFT.is_initial_point_ignored "qiskit.algorithms.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored               |
-| [`is_initial_point_required`](#qiskit.algorithms.optimizers.NFT.is_initial_point_required "qiskit.algorithms.optimizers.NFT.is_initial_point_required")       | Returns is initial point required              |
-| [`is_initial_point_supported`](#qiskit.algorithms.optimizers.NFT.is_initial_point_supported "qiskit.algorithms.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported             |
-| [`setting`](#qiskit.algorithms.optimizers.NFT.setting "qiskit.algorithms.optimizers.NFT.setting")                                                             | Return setting                                 |
-| [`settings`](#qiskit.algorithms.optimizers.NFT.settings "qiskit.algorithms.optimizers.NFT.settings")                                                          | The optimizer settings in a dictionary format. |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.algorithms.optimizers.NFT.get_support_level" signature="get_support_level()">
-  Return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.algorithms.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.algorithms.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.algorithms.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### settings
-
-<Attribute id="qiskit.algorithms.optimizers.NFT.settings">
-  The optimizer settings in a dictionary format.
-
-  The settings can for instance be used for JSON-serialization (if all settings are serializable, which e.g. doesn’t hold per default for callables), such that the optimizer object can be reconstructed as
-
-  ```python
-  settings = optimizer.settings
-  # JSON serialize and send to another server
-  optimizer = OptimizerClass(**settings)
-  ```
-
-  **Return type**
-
-  `Dict`\[`str`, `Any`]
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.algorithms.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
@@ -27,225 +27,225 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
   **Notes**
 
   In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+
+  ### \_\_init\_\_
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+    **Parameters**
+
+    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+    *   **disp** (`bool`) – disp
+    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+    **Notes**
+
+    In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+  </Function>
+
+  ## Methods
+
+  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+  ## Attributes
+
+  |                                                                                                                                                                         |                                     |
+  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+  ### bounds\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+    Returns bounds support level
+  </Attribute>
+
+  ### get\_support\_level
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+    return support level dictionary
+  </Function>
+
+  ### gradient\_num\_diff
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+    **Parameters**
+
+    *   **x\_center** (*ndarray*) – point around which we compute the gradient
+    *   **f** (*func*) – the function of which the gradient is to be computed.
+    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+    *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+    **Returns**
+
+    the gradient computed
+
+    **Return type**
+
+    grad
+  </Function>
+
+  ### gradient\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+    Returns gradient support level
+  </Attribute>
+
+  ### initial\_point\_support\_level
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+    Returns initial point support level
+  </Attribute>
+
+  ### is\_bounds\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+    Returns is bounds ignored
+  </Attribute>
+
+  ### is\_bounds\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+    Returns is bounds required
+  </Attribute>
+
+  ### is\_bounds\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+    Returns is bounds supported
+  </Attribute>
+
+  ### is\_gradient\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+    Returns is gradient ignored
+  </Attribute>
+
+  ### is\_gradient\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+    Returns is gradient required
+  </Attribute>
+
+  ### is\_gradient\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+    Returns is gradient supported
+  </Attribute>
+
+  ### is\_initial\_point\_ignored
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+    Returns is initial point ignored
+  </Attribute>
+
+  ### is\_initial\_point\_required
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+    Returns is initial point required
+  </Attribute>
+
+  ### is\_initial\_point\_supported
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+    Returns is initial point supported
+  </Attribute>
+
+  ### optimize
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+    Perform optimization.
+
+    **Parameters**
+
+    *   **num\_vars** (*int*) – Number of parameters to be optimized.
+    *   **objective\_function** (*callable*) – A function that computes the objective function.
+    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+    **Returns**
+
+    **point, value, nfev**
+
+    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+    **Raises**
+
+    **ValueError** – invalid input
+  </Function>
+
+  ### print\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+    Print algorithm-specific options.
+  </Function>
+
+  ### set\_max\_evals\_grouped
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+    Set max evals grouped
+  </Function>
+
+  ### set\_options
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+    Sets or updates values in the options dictionary.
+
+    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+    **Parameters**
+
+    **kwargs** (*dict*) – options, given as name=value.
+  </Function>
+
+  ### setting
+
+  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+    Return setting
+  </Attribute>
+
+  ### wrap\_function
+
+  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+    Wrap the function to implicitly inject the args at the call of the function.
+
+    **Parameters**
+
+    *   **function** (*func*) – the target function
+    *   **args** (*tuple*) – the args to be injected
+
+    **Returns**
+
+    wrapper
+
+    **Return type**
+
+    function\_wrapper
+  </Function>
 </Class>
-
-### \_\_init\_\_
-
-<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-  **Parameters**
-
-  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-  *   **disp** (`bool`) – disp
-  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-  **Notes**
-
-  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-</Function>
-
-## Methods
-
-|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-## Attributes
-
-|                                                                                                                                                                         |                                     |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-### bounds\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-  Returns bounds support level
-</Attribute>
-
-### get\_support\_level
-
-<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-  return support level dictionary
-</Function>
-
-### gradient\_num\_diff
-
-<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-  **Parameters**
-
-  *   **x\_center** (*ndarray*) – point around which we compute the gradient
-  *   **f** (*func*) – the function of which the gradient is to be computed.
-  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-  *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-  **Returns**
-
-  the gradient computed
-
-  **Return type**
-
-  grad
-</Function>
-
-### gradient\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-  Returns gradient support level
-</Attribute>
-
-### initial\_point\_support\_level
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-  Returns initial point support level
-</Attribute>
-
-### is\_bounds\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-  Returns is bounds ignored
-</Attribute>
-
-### is\_bounds\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-  Returns is bounds required
-</Attribute>
-
-### is\_bounds\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-  Returns is bounds supported
-</Attribute>
-
-### is\_gradient\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-  Returns is gradient ignored
-</Attribute>
-
-### is\_gradient\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-  Returns is gradient required
-</Attribute>
-
-### is\_gradient\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-  Returns is gradient supported
-</Attribute>
-
-### is\_initial\_point\_ignored
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-  Returns is initial point ignored
-</Attribute>
-
-### is\_initial\_point\_required
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-  Returns is initial point required
-</Attribute>
-
-### is\_initial\_point\_supported
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-  Returns is initial point supported
-</Attribute>
-
-### optimize
-
-<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-  Perform optimization.
-
-  **Parameters**
-
-  *   **num\_vars** (*int*) – Number of parameters to be optimized.
-  *   **objective\_function** (*callable*) – A function that computes the objective function.
-  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-  **Returns**
-
-  **point, value, nfev**
-
-  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-  **Raises**
-
-  **ValueError** – invalid input
-</Function>
-
-### print\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-  Print algorithm-specific options.
-</Function>
-
-### set\_max\_evals\_grouped
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-  Set max evals grouped
-</Function>
-
-### set\_options
-
-<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-  Sets or updates values in the options dictionary.
-
-  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-  **Parameters**
-
-  **kwargs** (*dict*) – options, given as name=value.
-</Function>
-
-### setting
-
-<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-  Return setting
-</Attribute>
-
-### wrap\_function
-
-<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-  Wrap the function to implicitly inject the args at the call of the function.
-
-  **Parameters**
-
-  *   **function** (*func*) – the target function
-  *   **args** (*tuple*) – the args to be injected
-
-  **Returns**
-
-  wrapper
-
-  **Return type**
-
-  function\_wrapper
-</Function>
 

--- a/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
+++ b/docs/api/qiskit/0.28/qiskit.aqua.components.optimizers.NFT.mdx
@@ -26,242 +26,226 @@ python_api_name: qiskit.aqua.components.optimizers.NFT
 
   **Notes**
 
-  In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id5).
-
-  **References**
-
-  <span id="id2" />
-
-  **1**
-
-  K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-
-  ### \_\_init\_\_
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
-    Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
-
-    **Parameters**
-
-    *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
-    *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
-    *   **disp** (`bool`) – disp
-    *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
-
-    **Notes**
-
-    In this optimization method, the optimization function have to satisfy three conditions written in [\[1\]\_](#id6).
-
-    **References**
-
-    <span id="id4" />
-
-    **1**
-
-    K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
-  </Function>
-
-  ## Methods
-
-  |                                                                                                                                                                        |                                                                                                                                                                                                                                       |
-  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
-  | [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
-  | [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
-  | [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
-  | [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
-  | [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
-  | [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
-  | [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
-
-  ## Attributes
-
-  |                                                                                                                                                                         |                                     |
-  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-  | [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
-  | [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
-  | [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
-  | [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
-  | [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
-  | [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
-  | [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
-  | [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
-  | [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
-  | [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
-  | [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
-  | [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
-  | [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
-
-  ### bounds\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
-    Returns bounds support level
-  </Attribute>
-
-  ### get\_support\_level
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
-    return support level dictionary
-  </Function>
-
-  ### gradient\_num\_diff
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
-    We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
-
-    **Parameters**
-
-    *   **x\_center** (*ndarray*) – point around which we compute the gradient
-    *   **f** (*func*) – the function of which the gradient is to be computed.
-    *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
-    *   **max\_evals\_grouped** (*int*) – max evals grouped
-
-    **Returns**
-
-    the gradient computed
-
-    **Return type**
-
-    grad
-  </Function>
-
-  ### gradient\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
-    Returns gradient support level
-  </Attribute>
-
-  ### initial\_point\_support\_level
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
-    Returns initial point support level
-  </Attribute>
-
-  ### is\_bounds\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
-    Returns is bounds ignored
-  </Attribute>
-
-  ### is\_bounds\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
-    Returns is bounds required
-  </Attribute>
-
-  ### is\_bounds\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
-    Returns is bounds supported
-  </Attribute>
-
-  ### is\_gradient\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
-    Returns is gradient ignored
-  </Attribute>
-
-  ### is\_gradient\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
-    Returns is gradient required
-  </Attribute>
-
-  ### is\_gradient\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
-    Returns is gradient supported
-  </Attribute>
-
-  ### is\_initial\_point\_ignored
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
-    Returns is initial point ignored
-  </Attribute>
-
-  ### is\_initial\_point\_required
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
-    Returns is initial point required
-  </Attribute>
-
-  ### is\_initial\_point\_supported
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
-    Returns is initial point supported
-  </Attribute>
-
-  ### optimize
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
-    Perform optimization.
-
-    **Parameters**
-
-    *   **num\_vars** (*int*) – Number of parameters to be optimized.
-    *   **objective\_function** (*callable*) – A function that computes the objective function.
-    *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
-    *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
-    *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
-
-    **Returns**
-
-    **point, value, nfev**
-
-    point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
-
-    **Raises**
-
-    **ValueError** – invalid input
-  </Function>
-
-  ### print\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
-    Print algorithm-specific options.
-  </Function>
-
-  ### set\_max\_evals\_grouped
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
-    Set max evals grouped
-  </Function>
-
-  ### set\_options
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
-    Sets or updates values in the options dictionary.
-
-    The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
-
-    **Parameters**
-
-    **kwargs** (*dict*) – options, given as name=value.
-  </Function>
-
-  ### setting
-
-  <Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
-    Return setting
-  </Attribute>
-
-  ### wrap\_function
-
-  <Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
-    Wrap the function to implicitly inject the args at the call of the function.
-
-    **Parameters**
-
-    *   **function** (*func*) – the target function
-    *   **args** (*tuple*) – the args to be injected
-
-    **Returns**
-
-    wrapper
-
-    **Return type**
-
-    function\_wrapper
-  </Function>
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
 </Class>
+
+### \_\_init\_\_
+
+<Function id="qiskit.aqua.components.optimizers.NFT.__init__" signature="__init__(maxiter=None, maxfev=1024, disp=False, reset_interval=32)">
+  Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
+  **Parameters**
+
+  *   **maxiter** (`Optional`\[`int`]) – Maximum number of iterations to perform.
+  *   **maxfev** (`int`) – Maximum number of function evaluations to perform.
+  *   **disp** (`bool`) – disp
+  *   **reset\_interval** (`int`) – The minimum estimates directly once in `reset_interval` times.
+
+  **Notes**
+
+  In this optimization method, the optimization function have to satisfy three conditions written in K. M. Nakanishi, K. Fujii, and S. Todo. 2019. Sequential minimal optimization for quantum-classical hybrid algorithms. arXiv preprint arXiv:1903.12166.
+</Function>
+
+## Methods
+
+|                                                                                                                                                                        |                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`__init__`](#qiskit.aqua.components.optimizers.NFT.__init__ "qiskit.aqua.components.optimizers.NFT.__init__")(\[maxiter, maxfev, disp, reset\_interval])              | Built out using scipy framework, for details, please refer to [https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). |
+| [`get_support_level`](#qiskit.aqua.components.optimizers.NFT.get_support_level "qiskit.aqua.components.optimizers.NFT.get_support_level")()                            | return support level dictionary                                                                                                                                                                                                       |
+| [`gradient_num_diff`](#qiskit.aqua.components.optimizers.NFT.gradient_num_diff "qiskit.aqua.components.optimizers.NFT.gradient_num_diff")(x\_center, f, epsilon\[, …]) | We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.                                                                                                                             |
+| [`optimize`](#qiskit.aqua.components.optimizers.NFT.optimize "qiskit.aqua.components.optimizers.NFT.optimize")(num\_vars, objective\_function\[, …])                   | Perform optimization.                                                                                                                                                                                                                 |
+| [`print_options`](#qiskit.aqua.components.optimizers.NFT.print_options "qiskit.aqua.components.optimizers.NFT.print_options")()                                        | Print algorithm-specific options.                                                                                                                                                                                                     |
+| [`set_max_evals_grouped`](#qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped "qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped")(limit)           | Set max evals grouped                                                                                                                                                                                                                 |
+| [`set_options`](#qiskit.aqua.components.optimizers.NFT.set_options "qiskit.aqua.components.optimizers.NFT.set_options")(\*\*kwargs)                                    | Sets or updates values in the options dictionary.                                                                                                                                                                                     |
+| [`wrap_function`](#qiskit.aqua.components.optimizers.NFT.wrap_function "qiskit.aqua.components.optimizers.NFT.wrap_function")(function, args)                          | Wrap the function to implicitly inject the args at the call of the function.                                                                                                                                                          |
+
+## Attributes
+
+|                                                                                                                                                                         |                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [`bounds_support_level`](#qiskit.aqua.components.optimizers.NFT.bounds_support_level "qiskit.aqua.components.optimizers.NFT.bounds_support_level")                      | Returns bounds support level        |
+| [`gradient_support_level`](#qiskit.aqua.components.optimizers.NFT.gradient_support_level "qiskit.aqua.components.optimizers.NFT.gradient_support_level")                | Returns gradient support level      |
+| [`initial_point_support_level`](#qiskit.aqua.components.optimizers.NFT.initial_point_support_level "qiskit.aqua.components.optimizers.NFT.initial_point_support_level") | Returns initial point support level |
+| [`is_bounds_ignored`](#qiskit.aqua.components.optimizers.NFT.is_bounds_ignored "qiskit.aqua.components.optimizers.NFT.is_bounds_ignored")                               | Returns is bounds ignored           |
+| [`is_bounds_required`](#qiskit.aqua.components.optimizers.NFT.is_bounds_required "qiskit.aqua.components.optimizers.NFT.is_bounds_required")                            | Returns is bounds required          |
+| [`is_bounds_supported`](#qiskit.aqua.components.optimizers.NFT.is_bounds_supported "qiskit.aqua.components.optimizers.NFT.is_bounds_supported")                         | Returns is bounds supported         |
+| [`is_gradient_ignored`](#qiskit.aqua.components.optimizers.NFT.is_gradient_ignored "qiskit.aqua.components.optimizers.NFT.is_gradient_ignored")                         | Returns is gradient ignored         |
+| [`is_gradient_required`](#qiskit.aqua.components.optimizers.NFT.is_gradient_required "qiskit.aqua.components.optimizers.NFT.is_gradient_required")                      | Returns is gradient required        |
+| [`is_gradient_supported`](#qiskit.aqua.components.optimizers.NFT.is_gradient_supported "qiskit.aqua.components.optimizers.NFT.is_gradient_supported")                   | Returns is gradient supported       |
+| [`is_initial_point_ignored`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored "qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored")          | Returns is initial point ignored    |
+| [`is_initial_point_required`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_required "qiskit.aqua.components.optimizers.NFT.is_initial_point_required")       | Returns is initial point required   |
+| [`is_initial_point_supported`](#qiskit.aqua.components.optimizers.NFT.is_initial_point_supported "qiskit.aqua.components.optimizers.NFT.is_initial_point_supported")    | Returns is initial point supported  |
+| [`setting`](#qiskit.aqua.components.optimizers.NFT.setting "qiskit.aqua.components.optimizers.NFT.setting")                                                             | Return setting                      |
+
+### bounds\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.bounds_support_level">
+  Returns bounds support level
+</Attribute>
+
+### get\_support\_level
+
+<Function id="qiskit.aqua.components.optimizers.NFT.get_support_level" signature="get_support_level()">
+  return support level dictionary
+</Function>
+
+### gradient\_num\_diff
+
+<Function id="qiskit.aqua.components.optimizers.NFT.gradient_num_diff" signature="gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1)" modifiers="static">
+  We compute the gradient with the numeric differentiation in the parallel way, around the point x\_center.
+
+  **Parameters**
+
+  *   **x\_center** (*ndarray*) – point around which we compute the gradient
+  *   **f** (*func*) – the function of which the gradient is to be computed.
+  *   **epsilon** (*float*) – the epsilon used in the numeric differentiation.
+  *   **max\_evals\_grouped** (*int*) – max evals grouped
+
+  **Returns**
+
+  the gradient computed
+
+  **Return type**
+
+  grad
+</Function>
+
+### gradient\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.gradient_support_level">
+  Returns gradient support level
+</Attribute>
+
+### initial\_point\_support\_level
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.initial_point_support_level">
+  Returns initial point support level
+</Attribute>
+
+### is\_bounds\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_ignored">
+  Returns is bounds ignored
+</Attribute>
+
+### is\_bounds\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_required">
+  Returns is bounds required
+</Attribute>
+
+### is\_bounds\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_bounds_supported">
+  Returns is bounds supported
+</Attribute>
+
+### is\_gradient\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_ignored">
+  Returns is gradient ignored
+</Attribute>
+
+### is\_gradient\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_required">
+  Returns is gradient required
+</Attribute>
+
+### is\_gradient\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_gradient_supported">
+  Returns is gradient supported
+</Attribute>
+
+### is\_initial\_point\_ignored
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_ignored">
+  Returns is initial point ignored
+</Attribute>
+
+### is\_initial\_point\_required
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_required">
+  Returns is initial point required
+</Attribute>
+
+### is\_initial\_point\_supported
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.is_initial_point_supported">
+  Returns is initial point supported
+</Attribute>
+
+### optimize
+
+<Function id="qiskit.aqua.components.optimizers.NFT.optimize" signature="optimize(num_vars, objective_function, gradient_function=None, variable_bounds=None, initial_point=None)">
+  Perform optimization.
+
+  **Parameters**
+
+  *   **num\_vars** (*int*) – Number of parameters to be optimized.
+  *   **objective\_function** (*callable*) – A function that computes the objective function.
+  *   **gradient\_function** (*callable*) – A function that computes the gradient of the objective function, or None if not available.
+  *   **variable\_bounds** (*list\[(float, float)]*) – List of variable bounds, given as pairs (lower, upper). None means unbounded.
+  *   **initial\_point** (*numpy.ndarray\[float]*) – Initial point.
+
+  **Returns**
+
+  **point, value, nfev**
+
+  point: is a 1D numpy.ndarray\[float] containing the solution value: is a float with the objective function value nfev: number of objective function calls made if available or None
+
+  **Raises**
+
+  **ValueError** – invalid input
+</Function>
+
+### print\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.print_options" signature="print_options()">
+  Print algorithm-specific options.
+</Function>
+
+### set\_max\_evals\_grouped
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_max_evals_grouped" signature="set_max_evals_grouped(limit)">
+  Set max evals grouped
+</Function>
+
+### set\_options
+
+<Function id="qiskit.aqua.components.optimizers.NFT.set_options" signature="set_options(**kwargs)">
+  Sets or updates values in the options dictionary.
+
+  The options dictionary may be used internally by a given optimizer to pass additional optional values for the underlying optimizer/optimization function used. The options dictionary may be initially populated with a set of key/values when the given optimizer is constructed.
+
+  **Parameters**
+
+  **kwargs** (*dict*) – options, given as name=value.
+</Function>
+
+### setting
+
+<Attribute id="qiskit.aqua.components.optimizers.NFT.setting">
+  Return setting
+</Attribute>
+
+### wrap\_function
+
+<Function id="qiskit.aqua.components.optimizers.NFT.wrap_function" signature="wrap_function(function, args)" modifiers="static">
+  Wrap the function to implicitly inject the args at the call of the function.
+
+  **Parameters**
+
+  *   **function** (*func*) – the target function
+  *   **args** (*tuple*) – the args to be injected
+
+  **Returns**
+
+  wrapper
+
+  **Return type**
+
+  function\_wrapper
+</Function>
 


### PR DESCRIPTION
The citation was improperly configured in Qiskit 0.24-0.28 and it caused a broken anchor link. This required manually fixing the HTML. I simplified the code to inline the citation.