### PR TITLE
Removed unnecessary imports from circuit drawer example code

### DIFF
--- a/docs/api/qiskit/qiskit.visualization.circuit_drawer.mdx
+++ b/docs/api/qiskit/qiskit.visualization.circuit_drawer.mdx
@@ -109,7 +109,7 @@ python_api_name: qiskit.visualization.circuit_drawer
   **Example**
 
   ```python
-  from qiskit import QuantumRegister
+  from qiskit import QuantumCircuit
   qc = QuantumCircuit(1, 1)
   qc.h(0)
   qc.measure(0, 0)

--- a/docs/api/qiskit/qiskit.visualization.circuit_drawer.mdx
+++ b/docs/api/qiskit/qiskit.visualization.circuit_drawer.mdx
@@ -109,7 +109,7 @@ python_api_name: qiskit.visualization.circuit_drawer
   **Example**
 
   ```python
-  from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+  from qiskit import QuantumRegister
   qc = QuantumCircuit(1, 1)
   qc.h(0)
   qc.measure(0, 0)


### PR DESCRIPTION
Simple fix, just removed imports that aren't used to make the code block work.