### PR TITLE
Improve fork behavior for notebook job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,26 +46,51 @@ jobs:
         run: npm test
 
       - name: Get all changed docs files
-        id: changed-docs-files
+        id: all-changed-files
         uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: docs/**/*.{md,mdx,ipynb}
           separator: "\n"
+      - name: Get all changed notebooks
+        id: all-changed-notebooks
+        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
+        with:
+          files: "docs/**/*.ipynb"
+          separator: "\n"
+
       - name: Pull preview image
         if: steps.changed-docs-files.outputs.any_changed == 'true'
         run: ./start --pull-only
       - name: Start local Docker preview
-        if: steps.changed-docs-files.outputs.any_changed == 'true'
+        if: steps.all-changed-files.outputs.any_changed == 'true'
         run: |
           ./start --apis &
           sleep 1
       - name: Check that pages render
-        if: steps.changed-docs-files.outputs.any_changed == 'true'
+        if: steps.all-changed-files.outputs.any_changed == 'true'
         run: |
-          echo "${{ steps.changed-docs-files.outputs.all_changed_files }}" > changed.txt
+          echo "${{ steps.all-changed-files.outputs.all_changed_files }}" > changed.txt
           npm run check:pages-render -- --from-file changed.txt
 
       - name: Setup Python environment
         uses: ./.github/actions/set-up-notebook-testing
       - name: nb-tester tests
         run: tox -e nb-tester
+      - name: Lint notebooks
+        shell: python
+        run: |
+          import subprocess, sys
+          files = """${{ steps.all-changed-notebooks.outputs.all_changed_notebooks }}"""
+          args = ["tox", "-e", "lint", "--"] + files.split("\n")
+          try:
+            subprocess.run(args, check=True)
+          except:
+            print(
+              "To fix, install `tox` and run `tox -e fix`.\n\n"
+              "Alternatively, you can download the fixed notebook from CI by going to this PR's "
+              "\"Execute notebooks\" job, clicking \"Summary\" on the upper-left "
+              "of this page, and downloading the \"Executed notebooks\" artifact."
+              "\n\n"
+              "For more information, see https://github.com/Qiskit/documentation/blob/main/README.md#lint-notebooks"
+            )
+            sys.exit(1)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           separator: "\n"
 
       - name: Pull preview image
-        if: steps.changed-docs-files.outputs.any_changed == 'true'
+        if: steps.all-changed-files.outputs.any_changed == 'true'
         run: ./start --pull-only
       - name: Start local Docker preview
         if: steps.all-changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -57,7 +57,6 @@ jobs:
           ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
 
       - name: Execute notebooks
-        if: ${{ success() && !cancelled() }}
         shell: python
         env:
           PR_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
@@ -75,14 +74,12 @@ jobs:
 
       - name: Detect changed notebooks
         id: changed-notebooks
-        if: ${{ success() && !cancelled() }}
         run: |
           echo "CHANGED_NOTEBOOKS<<EOF" >> $GITHUB_OUTPUT
           git diff --name-only >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload executed notebooks
-        if: ${{ success() && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -25,37 +25,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Exit early on forks
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        shell: python
-        run: |
-          raise SystemExit(
-            "We can't run this test on pull requests from forks."
-            "\n\n"
-            "If you have write access to Qiskit/documentation, push to a new "
-            "branch there and make your pull request from that branch instead."
-            "\n\n"
-            "If you don't have write access, you must test out the notebook "
-            "locally using the instructions in "
-            "https://github.com/Qiskit/documentation#execute-notebooks."
-            "When this PR is approved, a maintainer will merge it to a new "
-            "branch in Qiskit/documentation, then make a PR from that branch "
-            "into main so it can pass CI."
-          )
-
-      - name: Get all changed files
-        id: all-changed-files
+      - name: Get all changed notebooks
+        id: all-changed-notebooks
         uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: "docs/**/*.ipynb"
           separator: "\n"
-
       - name: Get changed config files
         id: changed-config
         uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: "scripts/nb-tester/**/*"
-
       - name: Check for notebooks that require Linux
         id: linux-changed-files
         uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
@@ -76,46 +56,33 @@ jobs:
           install-linux-deps: ${{ steps.linux-changed-files.outputs.any_changed == 'true' || steps.changed-config.outputs.any_changed == 'true' }}
           ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
 
-      - name: Check lint
-        shell: python
-        run: |
-          import subprocess, sys
-          files = """${{ steps.all-changed-files.outputs.all_changed_files }}"""
-          args = ["tox", "-e", "lint", "--"] + files.split("\n")
-          try:
-            subprocess.run(args, check=True)
-          except:
-            print(
-              "To fix, install `tox` and run `tox -e fix` or download the fixed "
-              "notebook from this run by clicking \"Summary\" on the upper-left "
-              "of this page, and downloading the \"Executed notebooks\" artifact."
-              "\n\n"
-              "For more information, see https://github.com/Qiskit/documentation/blob/main/README.md#lint-notebooks"
-            )
-            sys.exit(1)
-
       - name: Execute notebooks
-        if: "!cancelled()"
+        if: ${{ success() && !cancelled() }}
         shell: python
+        env:
+          PR_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
+          import os
           import subprocess
-          changed_notebooks = """${{ steps.all-changed-files.outputs.all_changed_files }}"""
+          changed_notebooks = """${{ steps.all-changed-notebooks.outputs.all_changed_files }}"""
           changed_config = """${{ steps.changed-config.outputs.all_changed_files }}"""
           args = ["tox", "--", "--write"]
           if changed_notebooks and not changed_config:
               args.extend(changed_notebooks.split("\n"))
+          if os.environ["PR_REPOSITORY"] != os.environ["GITHUB_REPOSITORY"]:
+              args.append("--is-fork")
           subprocess.run(args, check=True)
 
       - name: Detect changed notebooks
         id: changed-notebooks
-        if: "!cancelled()"
+        if: ${{ success() && !cancelled() }}
         run: |
           echo "CHANGED_NOTEBOOKS<<EOF" >> $GITHUB_OUTPUT
           git diff --name-only >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload executed notebooks
-        if: "!cancelled()"
+        if: ${{ success() && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: Executed notebooks

--- a/docs/guides/ibm-circuit-function.ipynb
+++ b/docs/guides/ibm-circuit-function.ipynb
@@ -422,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3"
   },
   "title": "IBM Circuit function"
  },

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -353,18 +353,17 @@ async def _main() -> None:
 
     if paths and args.is_fork:
         print(
-            "We can't run notebook tests on pull requests from forks becaus of how GitHub Secrets work."
+            "⛔️ We can't run notebook tests on pull requests from forks becaus of how GitHub Secrets work."
             "\n\n"
             "If you have write access to Qiskit/documentation, push to a new "
             "branch there and make your pull request from that branch instead."
             "\n\n"
-            "If you don't have write access, you should test out the notebook "
-            "locally using the instructions in "
+            "If you don't have write access, you should locally test out the notebooks you're modifying "
+            "by using the instructions in "
             "https://github.com/Qiskit/documentation#execute-notebooks. "
             "When this PR is approved, a maintainer will merge it to a new "
             "branch in Qiskit/documentation, then make a PR from that branch "
-            "into main so it can pass CI.",
-            file=sys.stderr,
+            "into main so it can pass CI.\n",
         )
         sys.exit(1)
 

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -18,7 +18,6 @@ import asyncio
 import sys
 import textwrap
 import platform
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +52,7 @@ warnings.filterwarnings("ignore", message="Options {.*} have no effect in local 
 warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
 """
 
+
 @dataclass
 class Config:
     args: argparse.Namespace
@@ -63,7 +63,7 @@ class Config:
 
     @property
     def all_job_submitting_notebooks(self) -> list[str]:
-       return [*self.notebooks_that_submit_jobs, *self.notebooks_no_mock]
+        return [*self.notebooks_that_submit_jobs, *self.notebooks_no_mock]
 
     @property
     def all_notebooks_to_test(self) -> list[str]:
@@ -116,7 +116,9 @@ class Config:
                 )
                 continue
 
-            if self.args.only_submit_jobs and not matches(path, self.all_job_submitting_notebooks):
+            if self.args.only_submit_jobs and not matches(
+                path, self.all_job_submitting_notebooks
+            ):
                 print(
                     f"ℹ️ Skipping {path} as it doesn't submit jobs and the --only-submit-jobs flag is set."
                 )
@@ -179,6 +181,7 @@ def extract_warnings(notebook: nbformat.NotebookNode) -> list[NotebookWarning]:
                 )
     return notebook_warnings
 
+
 async def execute_notebook(path: Path, config: Config) -> bool:
     """
     Wrapper function for `_execute_notebook` to print status and write result
@@ -205,7 +208,7 @@ async def execute_notebook(path: Path, config: Config) -> bool:
         )
         return False
 
-    if (skip_reason := config.should_skip_writing(path)):
+    if skip_reason := config.should_skip_writing(path):
         print(f"✅ No problems in {path} (not written as {skip_reason})")
         return True
 
@@ -213,11 +216,13 @@ async def execute_notebook(path: Path, config: Config) -> bool:
     print(f"✅ No problems in {path} (written)")
     return True
 
+
 async def _execute_in_kernel(kernel: AsyncKernelClient, code: str) -> None:
     """Execute code in kernel and raise if it fails"""
     response = await kernel.execute_interactive(code, store_history=False)
     if response.get("content", {}).get("status", "") == "error":
         raise Exception("Error running initialization code")
+
 
 async def _execute_notebook(filepath: Path, config: Config) -> nbformat.NotebookNode:
     """
@@ -312,7 +317,7 @@ def get_args() -> argparse.Namespace:
         help=(
             "Run notebooks that submit jobs to IBM Quantum and wait indefinitely "
             "for jobs to complete. Warning: this has a real cost because it uses "
-            "quantum resources! Only use this argument occasionally and intentionally." 
+            "quantum resources! Only use this argument occasionally and intentionally."
         ),
     )
     parser.add_argument(
@@ -321,11 +326,19 @@ def get_args() -> argparse.Namespace:
         help=(
             "Same as --submit-jobs, but only runs notebooks that submit jobs. "
             "Setting this option implicitly sets --submit-jobs."
-        )
+        ),
     )
     parser.add_argument(
         "--config-path",
         help="Path to a TOML file containing the globs for detecting and sorting notebooks",
+    )
+    parser.add_argument(
+        "--is-fork",
+        action="store_true",
+        help=(
+            "Set to true when running on forks in CI, since authentication cannot work there. "
+            "The program will fail with a helpful message if any of the notebooks cannot be executed."
+        ),
     )
     args = parser.parse_args()
     if args.only_submit_jobs:
@@ -334,8 +347,26 @@ def get_args() -> argparse.Namespace:
 
 
 async def _main() -> None:
-    config = Config.from_args(get_args())
-    paths = config.notebooks_to_execute()
+    args = get_args()
+    config = Config.from_args(args)
+    paths = list(config.notebooks_to_execute())
+
+    if paths and args.is_fork:
+        print(
+            "We can't run notebook tests on pull requests from forks becaus of how GitHub Secrets work."
+            "\n\n"
+            "If you have write access to Qiskit/documentation, push to a new "
+            "branch there and make your pull request from that branch instead."
+            "\n\n"
+            "If you don't have write access, you should test out the notebook "
+            "locally using the instructions in "
+            "https://github.com/Qiskit/documentation#execute-notebooks. "
+            "When this PR is approved, a maintainer will merge it to a new "
+            "branch in Qiskit/documentation, then make a PR from that branch "
+            "into main so it can pass CI.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Execute notebooks
     start_time = datetime.now()
@@ -346,6 +377,7 @@ async def _main() -> None:
     if not all(results):
         sys.exit(1)
     sys.exit(0)
+
 
 def main():
     if platform.system() == "Windows":

--- a/scripts/nb-tester/test/test_notebook_classification.py
+++ b/scripts/nb-tester/test/test_notebook_classification.py
@@ -9,12 +9,13 @@ def test_all_notebooks_are_classified():
         filenames=None,
         write=False,
         submit_jobs=True,
-        config_path="scripts/config/notebook-testing.toml"
+        config_path="scripts/config/notebook-testing.toml",
     )
     config = Config.from_args(args)
 
     unclassified = [
-        path for path in Path(".").glob("[!.]*/**/*.ipynb")
+        path
+        for path in Path(".").glob("[!.]*/**/*.ipynb")
         if not matches(path, config.all_notebooks)
     ]
 


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1649.

1. Don't run the last three steps if earlier steps failed.
    - We were missing `if: success()`
2. Move the lint job to normal CI. 
    - This is useful because it means we won't accidentally merge something with bad linting. That was possible before because the Execute notebooks job is expected to fail on forks, although it is still important the lint job passes.
    - We already were setting up the Python environment in main CI, so there is not much downside to this
3. Don't fail CI if none of the notebooks could have been tested anyways because they're not mockable, e.g. `hello-world`.

Now the failure looks like this:

<img width="1253" alt="Screenshot 2024-10-01 at 2 46 44 PM" src="https://github.com/user-attachments/assets/fa9cba38-644a-4ff8-a403-81ccf5c6dd27">
