### PR TITLE
Add clarifications to execution modes docs

### DIFF
--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -69,3 +69,12 @@ When a job is failed or canceled, the reported usage is as follows:
 The interactive time to live (ITTL) in batch mode is one second for all instances.
 
 The ITTL for a session on the Open Plan instance is one second. For Premium Plan users, the ITTL is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.
+
+
+| Execution mode | Instance type (Open or Premium Plan) | ITTL |
+| --- | --- | --- |
+| Batch mode | all instances (both Open and Premium Plan) | 1 sec |
+| Session mode | Open Plan | 1 sec |
+| Session mode | Premium Plan | 60 sec* |
+
+*\* Certain Premium Plan instances might be specially configured to have a different ITTL.*

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -20,7 +20,7 @@ The `mode` option requires `qiskit-ibm-runtime` 0.24 or later.
 The differences are summarized in the following table:
 
 |     Mode     |                  Usage                  |                                                                                                        Benefit                                                                                                        |
-|:------------:|:---------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Job mode     | Quantum computation only.               | Easiest to use when running a small experiment. Might run sooner than batch mode.                                                                                                                                     |
 | Batch mode   | Quantum computation only.               | The entire batch of jobs is scheduled together and there is no additional queuing time for each. Jobs in a batch are usually run close together.                                                                     |
 | Session mode | Both classical and quantum computation. | Dedicated and exclusive access to the QPU during the session active window, and no other users’ or QPU jobs can run. This is particularly useful for workloads that don’t have all inputs ready at the outset.  |
@@ -61,4 +61,11 @@ When a job is failed or canceled, the reported usage is as follows:
 
 * Job or batch mode: the reported usage is the time the QPU was locked for executing your workload until the time it failed or was canceled. Therefore, if the failure or cancellation occurred before the lock, the reported usage is zero. Otherwise, the workload's reported usage is the value that Qiskit Runtime returns as `consumed`. Thus, some failed jobs do not appear in your reported usage and others do.
 
-* Session mode: the reported usage is the wall-clock time from the when the first job started executing in the session until the session terminates, regardless of the number of jobs that fail or are cancelled.
+* Session mode: the reported usage is the wall-clock time from the when the first job started executing in the session until the session terminates, regardless of the number of jobs that fail or are canceled.
+
+<span id="ittl-by-mode"></span>
+## Interactive time to live (ITTL)
+
+The interactive time to live (ITTL) in batch mode is one second for all instances.
+
+The ITTL for a session on the Open Plan instance is one second. For Premium Plan users, the ITTL is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -68,13 +68,12 @@ When a job is failed or canceled, the reported usage is as follows:
 
 The [interactive time to live (ITTL)](/guides/max-execution-time#session-maximum-execution-time) in batch mode is one second for all instances.
 
-The ITTL for a session on the Open Plan instance is one second. For Premium Plan users, the ITTL is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.
+The ITTL for a session (Premium Plan users only) is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.
 
 
 | Execution mode | Instance type (Open or Premium Plan) | ITTL |
 | --- | --- | --- |
-| Batch mode | all instances (both Open and Premium Plan) | 1 sec |
-| Session mode | Open Plan | 1 sec |
+| Batch mode | Both Open and Premium Plan | 1 sec |
 | Session mode | Premium Plan | 60 sec* |
 
 *\* Certain Premium Plan instances might be specially configured to have a different ITTL.*

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -66,7 +66,7 @@ When a job is failed or canceled, the reported usage is as follows:
 <span id="ittl-by-mode"></span>
 ## Interactive time to live (ITTL)
 
-The interactive time to live (ITTL) in batch mode is one second for all instances.
+The [interactive time to live (ITTL)](/guides/max-execution-time#session-maximum-execution-time) in batch mode is one second for all instances.
 
 The ITTL for a session on the Open Plan instance is one second. For Premium Plan users, the ITTL is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.
 

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -66,7 +66,7 @@ When a job is failed or canceled, the reported usage is as follows:
 <span id="ittl-by-mode"></span>
 ## Interactive time to live (ITTL)
 
-The [interactive time to live (ITTL)](/guides/max-execution-time#session-maximum-execution-time) in batch mode is one second for all instances.
+The [ITTL](/guides/max-execution-time#session-maximum-execution-time) in batch mode is one second for all instances.
 
 The ITTL for a session (Premium Plan users only) is 60 seconds, unless there is an instance-specific configuration that dictates a different ITTL.
 

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -78,3 +78,5 @@ The ITTL for a session on the Open Plan instance is one second. For Premium Plan
 | Session mode | Premium Plan | 60 sec* |
 
 *\* Certain Premium Plan instances might be specially configured to have a different ITTL.*
+
+Note that you can also programmatically query the ITTL; see details on the [Maximum execution time](/guides/max-execution-time#session-maximum-execution-time) page.

--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -78,4 +78,6 @@ The ITTL for a session (Premium Plan users only) is 60 seconds, unless there is 
 
 *\* Certain Premium Plan instances might be specially configured to have a different ITTL.*
 
-Note that you can also programmatically query the ITTL; see details on the [Maximum execution time](/guides/max-execution-time#session-maximum-execution-time) page.
+<Admonition type="note">
+You can also programmatically query the ITTL; see details on the [Maximum execution time](/guides/max-execution-time#session-maximum-execution-time) page.
+</Admonition>

--- a/docs/guides/run-jobs-session.mdx
+++ b/docs/guides/run-jobs-session.mdx
@@ -31,6 +31,10 @@ service = QiskitRuntimeService()
 You can open a runtime session by using the context manager `with Session(...)` or by initializing the `Session`
 class. When you start a session,  you must specify a QPU by passing a `backend` object. The session starts when its first job begins execution.
 
+<Admonition type="note">
+If you open a session but do not submit any jobs to it for 30 minutes, the session will automatically close.
+</Admonition>
+
 
 **Session class**
 

--- a/docs/guides/run-jobs-session.mdx
+++ b/docs/guides/run-jobs-session.mdx
@@ -32,7 +32,7 @@ You can open a runtime session by using the context manager `with Session(...)` 
 class. When you start a session,  you must specify a QPU by passing a `backend` object. The session starts when its first job begins execution.
 
 <Admonition type="note">
-If you open a session but do not submit any jobs to it for 30 minutes, the session will automatically close.
+If you open a session but do not submit any jobs to it for 30 minutes, the session automatically closes.
 </Admonition>
 
 


### PR DESCRIPTION
Clarify ITTL.
Add note that a session will auto-close if nothing has been submitted to it in 30 minutes.