### PR TITLE
Fix rendering of times symbol on job limits page

### DIFF
--- a/docs/guides/job-limits.mdx
+++ b/docs/guides/job-limits.mdx
@@ -18,7 +18,7 @@ Certain primitive options increase the circuit size.  The described limits are c
 
 At most, **5 million** executions are allowed.  The number of executions is the number of circuits times the number of shots, where the circuits are those generated after PUB elements are broadcasted.
 
-For example, if you have a PUB with one circuit, observables with shape (1, 6), and parameters with shape (4, 1), this would render $4 x 6 = 24$ circuits (or fewer, if some observables commute). If you requested 2,000 shots, then the total number of executions is $24 x 2,000 = 48,000$.
+For example, if you have a PUB with one circuit, observables with shape (1, 6), and parameters with shape (4, 1), this would render $4 \times 6 = 24$ circuits (or fewer, if some observables commute). If you requested 2,000 shots, then the total number of executions is $24 \times 2,000 = 48,000$.
 
 <span id="per-qubit"></span>
 ## Maximum number of low-level instructions per qubit


### PR DESCRIPTION
The unicode times symbol was rendering as an $x$. Trying to replace it with $\times$.