### PR TITLE
Fix some job limits wording

### DIFF
--- a/docs/guides/job-limits.mdx
+++ b/docs/guides/job-limits.mdx
@@ -9,8 +9,8 @@ When you send a job to an IBM&reg; QPU, it is first sent to the job validation s
 
 <Admonition type="note">
 Certain primitive options increase the circuit size.  The described limits are checked _after_ the expected increase in circuit size. In particular, these options increase circuit size:
-  - Dynamical decoupling introduces additional single-qubit gates that are included in the instructions for the [Maximum number of low-level instructions per qubit](#per-qubit) limit.
-  - Gate-folding ZNE introduces additional two-qubit gates relevant to the [Maximum number of two-qubit gates per job](#2-qubit-limit) limit. The number of two-qubit gates is multiplied by the largest noise factor requested in gate-folding ZNE.
+  - Dynamical decoupling and gate-folding ZNE introduce additional gates that are included in the instructions for the [Maximum number of low-level instructions per qubit](#per-qubit) limit.
+  - Gate-folding ZNE introduces additional two-qubit gates relevant to the [Maximum number of two-qubit gates per job](#2-qubit-limit) limit. The number of two-qubit gates is multiplied by the sum of noise factors requested in gate-folding ZNE.
 </Admonition>
 
 <span id="max-shots"></span>
@@ -23,7 +23,7 @@ For example, if you have a PUB with one circuit, observables with shape (1, 6), 
 <span id="per-qubit"></span>
 ## Maximum number of low-level instructions per qubit
 
-The service permits up to **32 million control-system instructions per qubit**. This ensures that the user circuits fit within the control system's instruction memory.  The following table describes how the system translates instruction set architecture (ISA) circuit instructions to control system instructions when calculating this limit.
+The service permits up to **26.8 million control-system instructions per qubit**. This ensures that the user circuits fit within the control system's instruction memory.  The following table describes how the system translates instruction set architecture (ISA) circuit instructions to control system instructions when calculating this limit.
 
 | Instruction | Count |
 |-------------|-------|


### PR DESCRIPTION
This PR makes the small changes to the job limits page:
- Both DD and gate folding ZNE contributes to per-qubit limit
- We use the sum of all noise factors, not just the largest, when calculating 
- We apply a 20% buffer to instruction memory, so it's 0.8*2**20