### PR TITLE
Fix primitive import naming

### DIFF
--- a/docs/guides/bit-ordering.mdx
+++ b/docs/guides/bit-ordering.mdx
@@ -58,7 +58,7 @@ with bit $0$ being `0`, and bit $1$ being `1`. This is interpreted as the
 decimal integer `2` (measured with probability `1.0`).
 
 ```python
-from qiskit.primitives import Samplerv2 as Sampler
+from qiskit.primitives import SamplerV2 as Sampler
 qc.measure_all()
 
 job = sampler.run([qc])

--- a/docs/guides/run-jobs-batch.mdx
+++ b/docs/guides/run-jobs-batch.mdx
@@ -32,7 +32,7 @@ class. When you start a batch,  you must specify a QPU by passing a `backend` ob
 **Batch class**
 
 ``` python
-from qiskit_ibm_runtime import Batch, Samplerv2 as Sampler, Estimatorv2 as Estimator
+from qiskit_ibm_runtime import Batch, SamplerV2 as Sampler, EstimatorV2 as Estimator
 
 backend = service.least_busy(operational=True, simulator=False)
 batch = Batch(backend=backend)
@@ -47,7 +47,7 @@ batch.close()
 The context manager automatically opens and closes the batch.
 
 ``` python
-from qiskit_ibm_runtime import Batch, Samplerv2 as Sampler, Estimatorv2 as Estimator
+from qiskit_ibm_runtime import Batch, SamplerV2 as Sampler, EstimatorV2 as Estimator
 
 backend = service.least_busy(operational=True, simulator=False)
 with Batch(backend=backend):

--- a/docs/guides/run-jobs-session.mdx
+++ b/docs/guides/run-jobs-session.mdx
@@ -35,7 +35,7 @@ class. When you start a session,  you must specify a QPU by passing a `backend` 
 **Session class**
 
 ``` python
-from qiskit_ibm_runtime import Session, Samplerv2 as Sampler, Estimatorv2 as Estimator
+from qiskit_ibm_runtime import Session, SamplerV2 as Sampler, EstimatorV2 as Estimator
 
 backend = service.least_busy(operational=True, simulator=False)
 session = Session(backend=backend)
@@ -48,7 +48,7 @@ sampler = Sampler(mode=session)
 The context manager automatically opens and closes the session.
 
 ``` python
-from qiskit_ibm_runtime import Session, Samplerv2 as Sampler, Estimatorv2 as Estimator
+from qiskit_ibm_runtime import Session, SamplerV2 as Sampler, EstimatorV2 as Estimator
 
 backend = service.least_busy(operational=True, simulator=False)
 with Session(backend=backend):


### PR DESCRIPTION
Quick fix for #2074, used the following command.

```
sd '(Sampler|Estimator)v2' '${1}V2' **/*
```
