### PR TITLE
Fix broken anchor link from execution modes rewrite

### DIFF
--- a/docs/guides/execution-modes.mdx
+++ b/docs/guides/execution-modes.mdx
@@ -17,6 +17,8 @@ The `mode` option requires `qiskit-ibm-runtime` 0.24 or later.
 
 [**Session mode**](sessions): A dedicated window for running a multi-job workload. This allows users to experiment with variational algorithms in a more predictable way and even run multiple experiments simultaneously, taking advantage of parallelism in the stack. Use sessions for iterative workloads or experiments that require dedicated access.  To run in session mode, specify `mode=session` when instantiating a primitive, or run the job in a session context manager. Learn more about sessions in the [Introduction to sessions,](/guides/sessions) and see [Run jobs in a session](run-jobs-session) for examples.
 
+<span id="sessions-versus-batch-usage" />
+
 ## Choose batch or sessions mode
 
 Generally, you can use batch mode unless you have workloads that don’t have all inputs ready at the outset.


### PR DESCRIPTION
This broke the Runtime release notes.