### PR TITLE
Fix external link checker exception handling

### DIFF
--- a/scripts/js/lib/links/ExternalLink.test.ts
+++ b/scripts/js/lib/links/ExternalLink.test.ts
@@ -20,21 +20,38 @@ test("ExternalLink constructor ignores anchors", () => {
 });
 
 test.describe("ExternalLink.check()", () => {
+  let originalFetch: typeof global.fetch;
+
+  test.beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  test.afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
   test("valid link", async () => {
-    let link = new ExternalLink("https://github.com/Qiskit", [
-      "/testorigin.mdx",
-    ]);
+    global.fetch = () => Promise.resolve(new Response());
+    let link = new ExternalLink("https://good-link.com", ["/testorigin.mdx"]);
     const result = await link.check();
     expect(result).toBeUndefined();
   });
 
-  test("Validate existing external links", async () => {
-    let link = new ExternalLink("https://ibm.com/FakePageDoesNotExist", [
-      "/testorigin.mdx",
-    ]);
+  test("invalid link", async () => {
+    global.fetch = () => Promise.resolve(new Response("", { status: 404 }));
+    let link = new ExternalLink("https://bad-link.com", ["/testorigin.mdx"]);
     const result = await link.check();
     expect(result).toEqual(
-      "❌ Could not find link 'https://ibm.com/FakePageDoesNotExist'. Appears in:\n    /testorigin.mdx",
+      "❌ Could not find link 'https://bad-link.com'. Appears in:\n    /testorigin.mdx",
+    );
+  });
+
+  test("exception handling", async () => {
+    global.fetch = () => Promise.reject(new Error("some issue"));
+    let link = new ExternalLink("https://bad-link.com", ["/testorigin.mdx"]);
+    const result = await link.check();
+    expect(result).toEqual(
+      "❌ Failed to fetch 'https://bad-link.com': some issue. Appears in:\n    /testorigin.mdx",
     );
   });
 });

--- a/scripts/js/lib/links/ExternalLink.ts
+++ b/scripts/js/lib/links/ExternalLink.ts
@@ -43,8 +43,8 @@ export class ExternalLink {
       if (response.status >= 300) {
         error = `Could not find link '${this.value}'`;
       }
-    } catch (error) {
-      error = `Failed to fetch '${this.value}': ${(error as Error).message}`;
+    } catch (err) {
+      error = `Failed to fetch '${this.value}': ${(err as Error).message}`;
     }
 
     if (!error) {


### PR DESCRIPTION
We weren't properly catching errors due to reusing the symbol `error`. That resulted in a test recently saying that a link we expected to 404 was instead a valid link.

This PR also improves the tests to be deterministic by mocking `fetch()`. This removes the risk of flakiness and makes our test faster.