### PR TITLE
Correct net effect of CNOT gates with correct bit ordering

### DIFF
--- a/docs/api/qiskit/qiskit.circuit.library.CXGate.mdx
+++ b/docs/api/qiskit/qiskit.circuit.library.CXGate.mdx
@@ -62,9 +62,7 @@ $$
   In the computational basis, this gate flips the target qubit if the control qubit is in the $|1\rangle$ state. In this sense it is similar to a classical XOR gate.
 
 $$
-`|a, b\rangle \rightarrow |a, a \oplus b\rangle`
-
-
+|a, b\rangle \rightarrow |a\oplus b, b\rangle
 $$
 
   Create new CX gate.


### PR DESCRIPTION
The current documentation for the `CXGate` states that its effect is:
$$|a,b\rangle\to|a,a\oplus b\rangle$$
However, this is the effect using the textbook bit ordering. But for instance, the `CXGate` sends $|0,1\rangle$ to $|1,1\rangle$. Indeed, the actual effect of the `CXGate` is:
$$|a,b\rangle\to|a\oplus b,b\rangle$$
This PR fixes this in the documentation of the `CXGate`.