### PR TITLE
Algorithmiq TEM documentation: change parameter in example

### DIFF
--- a/docs/guides/algorithmiq-tem.ipynb
+++ b/docs/guides/algorithmiq-tem.ipynb
@@ -175,10 +175,8 @@
     "instance = \"<IQP_HUB/IQP_GROUP/IQP_PROJECT>\"\n",
     "\n",
     "pub = (qc, [observable])\n",
-    "options = {\n",
-    "    \"max_execution_time\": 60,\n",
-    "}\n",
-    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name, options=options)"
+    "\n",
+    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name)"
    ]
   },
   {

--- a/docs/guides/algorithmiq-tem.ipynb
+++ b/docs/guides/algorithmiq-tem.ipynb
@@ -177,7 +177,7 @@
     "pub = (qc, [observable])\n",
     "options = {\"default_precision\": 0.02}\n",
     "\n",
-    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name, options = options)"
+    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name, options=options)"
    ]
   },
   {

--- a/docs/guides/algorithmiq-tem.ipynb
+++ b/docs/guides/algorithmiq-tem.ipynb
@@ -175,8 +175,9 @@
     "instance = \"<IQP_HUB/IQP_GROUP/IQP_PROJECT>\"\n",
     "\n",
     "pub = (qc, [observable])\n",
+    "options = {\"default_precision\": 0.02}\n",
     "\n",
-    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name)"
+    "job = tem.run(pubs=[pub], instance=instance, backend_name=backend_name, options = options)"
    ]
   },
   {


### PR DESCRIPTION
Updating the Algorithmiq TEM documentation in the Example section. The parameter `max_execution_time` was removed. 