### PR TITLE
Add instructions for `CodeCellPlaceholder` component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ translations
 scripts/js/lib/api/testdata
 .mypy_cache
 public/images
+README.md

--- a/README.md
+++ b/README.md
@@ -680,7 +680,13 @@ There is a specific use case where you want to show instructions for different o
 
 This component only works in notebooks. Notebook code cells are always at the
 top-level of content, but sometimes you'll want to have them nested in other
-components, such as in tabs or in a list. To use this component, add a tag
+components, such as in tabs or in a list. While you could write your code
+as a markdown block, it's usually preferable to keep the code as a code block
+so that it is executed and its code can be later used in the notebook. The
+CodeCellPlaceholder component allows you to still use a code block, but move
+it to render somewhere else in the notebook.
+
+To use this component, add a tag
 starting with `id-` to the cell you'd like to move, then add a
 `<CodeCellPlaceholder tag="id-tag" />` component with the same tag somewhere in
 your markdown. This will move that code cell into the place of the component.

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ starting with `id-` to the cell you'd like to move, then add a
 `<CodeCellPlaceholder tag="id-tag" />` component with the same tag somewhere in
 your markdown. This will move that code cell into the place of the component.
 
-You can then use this component anywhere in your mdx. While you can move code
+You can then use this component anywhere in your markdown. While you can move code
 cells anywhere, try to keep them relatively close to their position in the
 notebook and preserve their order to avoid confusion.
 

--- a/README.md
+++ b/README.md
@@ -695,21 +695,44 @@ You can then use this component anywhere in your mdx. While you can move code
 cells anywhere, try to keep them relatively close to their position in the
 notebook and preserve their order to avoid confusion.
 
-```mdx
-Here's a list where the second list element is a code cell.
-The cell with tag "id-move-to-list" will be moved inside this list.
+Here's an example of what this might look like in your notebook source.
 
-- List item 1
-- <CodeCellPlaceholder tag="id-move-to-list" />
-
-Here's a code cell inside a `Tabs` component.
-The cell with tag "id-move-to-tabs" will be moved inside these tabs.
-
-<Tabs>
-  <TabItem value="code" label="Code cell
-    <CodeCellPlaceholder tag="id-move-to-tabs" />
-  </TabItem>
-</Tabs>
+```json
+{
+ "cell_type": "markdown",
+ "source": [
+  "This is a notebook markdown cell.",
+  "\n",
+  "<Tabs>\n",
+  "<TabItem value=\"Example\" label=\"Example\">\n",
+  "  This `TabItem` contains a notebook code cell\n",
+  "  <CodeCellPlaceholder tag=\"id-example-cell\" />\n",
+  "</TabItem>\n",
+  "</Tabs>"
+ ]
+},
+{
+ "cell_type": "code",
+ "execution_count": 1,
+ "metadata": {
+  "tags": [
+   "id-example-cell"
+  ]
+ },
+ "outputs": [
+  {
+   "data": {
+    "text/plain": [
+     "Hello, world!"
+    ]
+   },
+  }
+ ],
+ "source": [
+  "# This is a code cell\n",
+  "print(\"Hello, world!\")"
+ ]
+}
 ```
 
 ## Proper marking and attribution

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ By default, the title is the `type` capitalized. You can customize it by setting
 </Admonition>
 ```
 
-We also have a specialized admonition for Qiskit Code Assistant prompt suggestions.
+We also have a specialized admonition for Qiskit Code Assistant prompt suggestions. Warning: avoid a trailing comma on the last entry in `prompts`!
 
 ```mdx
 <CodeAssistantAdmonition

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ We also have a specialized admonition for Qiskit Code Assistant prompt suggestio
   prompts={[
     "# Print the version of Qiskit we're using",
     "# Return True if the version of Qiskit is 1.0 or greater",
-    "# Install Qiskit 1.0.2",
+    "# Install Qiskit 1.0.2"
   ]}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ CodeCellPlaceholder component allows you to still use a code block, but move
 it to render somewhere else in the notebook.
 
 To use this component, add a tag
-starting with `id-` to the cell you'd like to move, then add a
+starting with `id-` to the code cell you'd like to move, then add a
 `<CodeCellPlaceholder tag="id-tag" />` component with the same tag somewhere in
 your markdown. This will move that code cell into the place of the component.
 

--- a/README.md
+++ b/README.md
@@ -699,19 +699,6 @@ Here's an example of what this might look like in your notebook source.
 
 ```json
 {
- "cell_type": "markdown",
- "source": [
-  "This is a notebook markdown cell.",
-  "\n",
-  "<Tabs>\n",
-  "<TabItem value=\"Example\" label=\"Example\">\n",
-  "  This `TabItem` contains a notebook code cell\n",
-  "  <CodeCellPlaceholder tag=\"id-example-cell\" />\n",
-  "</TabItem>\n",
-  "</Tabs>"
- ]
-},
-{
  "cell_type": "code",
  "execution_count": 1,
  "metadata": {
@@ -731,6 +718,19 @@ Here's an example of what this might look like in your notebook source.
  "source": [
   "# This is a code cell\n",
   "print(\"Hello, world!\")"
+ ]
+},
+{
+ "cell_type": "markdown",
+ "source": [
+  "This is a notebook markdown cell.",
+  "\n",
+  "<Tabs>\n",
+  "<TabItem value=\"Example\" label=\"Example\">\n",
+  "  This `TabItem` contains a notebook code cell\n",
+  "  <CodeCellPlaceholder tag=\"id-example-cell\" />\n",
+  "</TabItem>\n",
+  "</Tabs>"
  ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -592,6 +592,19 @@ By default, the title is the `type` capitalized. You can customize it by setting
 </Admonition>
 ```
 
+We also have a specialized admonition for Qiskit Code Assistant prompt suggestions.
+
+```mdx
+<CodeAssistantAdmonition
+  tagLine="Need help? Try asking Qiskit Code Assistant."
+  prompts={[
+    "# Print the version of Qiskit we're using",
+    "# Return True if the version of Qiskit is 1.0 or greater",
+    "# Install Qiskit 1.0.2",
+  ]}
+/>
+```
+
 ### Definition Tooltip
 
 To use a `DefinitionTooltip`, use the following syntax:
@@ -661,6 +674,36 @@ There is a specific use case where you want to show instructions for different o
     command
   </TabItem>
 </OperatingSystemTabs>
+```
+
+### CodeCellPlaceholder
+
+This component only works in notebooks. Notebook code cells are always at the
+top-level of content, but sometimes you'll want to have them nested in other
+components, such as in tabs or in a list. To use this component, add a tag
+starting with `id-` to the cell you'd like to move, then add a
+`<CodeCellPlaceholder tag="id-tag" />` component with the same tag somewhere in
+your markdown. This will move that code cell into the place of the component.
+
+You can then use this component anywhere in your mdx. While you can move code
+cells anywhere, try to keep them relatively close to their position in the
+notebook and preserve their order to avoid confusion.
+
+```mdx
+Here's a list where the second list element is a code cell.
+The cell with tag "id-move-to-list" will be moved inside this list.
+
+- List item 1
+- <CodeCellPlaceholder tag="id-move-to-list" />
+
+Here's a code cell inside a `Tabs` component.
+The cell with tag "id-move-to-tabs" will be moved inside these tabs.
+
+<Tabs>
+  <TabItem value="code" label="Code cell
+    <CodeCellPlaceholder tag="id-move-to-tabs" />
+  </TabItem>
+</Tabs>
 ```
 
 ## Proper marking and attribution


### PR DESCRIPTION
Closes #2173. Also documents the `CodeAssistantAdmonition` component.