### PR TITLE
Use sentence case capitalization for API names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read on for more information about how to support this project:
 This is the quickest, easiest, and most helpful way to contribute to this project and improve the quality of Qiskit&reg; and IBM Quantum&trade; documentation. There are a few different ways to report issues, depending on where it was found:
 
 - For problems you've found in the [Qiskit SDK API Reference](https://docs.quantum.ibm.com/api/qiskit) section, open an issue in the Qiskit repo [here](https://github.com/Qiskit/qiskit/issues/new/choose).
-- For problems you've found in the [Qiskit Runtime Client](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) section, open an issue in the Qiskit IBM Runtime repo [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
+- For problems you've found in the [Qiskit Runtime client](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) section, open an issue in the Qiskit IBM Runtime repo [here](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 - For problems you've found in any other section of [docs](https://docs.quantum.ibm.com), open a content bug issue [here](https://github.com/Qiskit/documentation/issues/new/choose).
 
 ### 2. Suggest new content

--- a/docs/api/qiskit-addon-cutting/_toc.json
+++ b/docs/api/qiskit-addon-cutting/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Circuit Cutting",
+  "title": "Circuit cutting",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-addon-cutting/release-notes.mdx
+++ b/docs/api/qiskit-addon-cutting/release-notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Circuit Cutting release notes
-description: Changes made to Circuit Cutting
+title: Circuit cutting release notes
+description: Changes made to Circuit cutting
 in_page_toc_max_heading_level: 2
 ---
 
@@ -8,7 +8,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="id1" />
 
-# Circuit Cutting release notes
+# Circuit cutting release notes
 
 <span id="release-notes-0-9-0" />
 

--- a/docs/api/qiskit-addon-mpf/_toc.json
+++ b/docs/api/qiskit-addon-mpf/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Multi-Product Formulas",
+  "title": "Multi-product formulas",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-addon-mpf/release-notes.mdx
+++ b/docs/api/qiskit-addon-mpf/release-notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Multi-Product Formulas release notes
-description: Changes made to Multi-Product Formulas
+title: Multi-product formulas release notes
+description: Changes made to Multi-product formulas
 in_page_toc_max_heading_level: 2
 ---
 
@@ -8,5 +8,5 @@ in_page_toc_max_heading_level: 2
 
 <span id="id1" />
 
-# Multi-Product Formulas release notes
+# Multi-product formulas release notes
 

--- a/docs/api/qiskit-addon-obp/_toc.json
+++ b/docs/api/qiskit-addon-obp/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Operator Backpropagation",
+  "title": "Operator backpropagation",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-addon-obp/release-notes.mdx
+++ b/docs/api/qiskit-addon-obp/release-notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Operator Backpropagation release notes
-description: Changes made to Operator Backpropagation
+title: Operator backpropagation release notes
+description: Changes made to Operator backpropagation
 in_page_toc_max_heading_level: 2
 ---
 
@@ -8,7 +8,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="id1" />
 
-# Operator Backpropagation release notes
+# Operator backpropagation release notes
 
 <span id="release-notes-0-1-0" />
 

--- a/docs/api/qiskit-addon-sqd/_toc.json
+++ b/docs/api/qiskit-addon-sqd/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Sample-Based Quantum Diagonalization",
+  "title": "Sample-based quantum diagonalization",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-addon-sqd/release-notes.mdx
+++ b/docs/api/qiskit-addon-sqd/release-notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sample-Based Quantum Diagonalization release notes
-description: Changes made to Sample-Based Quantum Diagonalization
+title: Sample-based quantum diagonalization release notes
+description: Changes made to Sample-based quantum diagonalization
 in_page_toc_max_heading_level: 2
 ---
 
@@ -8,7 +8,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="id1" />
 
-# Sample-Based Quantum Diagonalization release notes
+# Sample-based quantum diagonalization release notes
 
 <span id="release-notes-0-7-0" />
 

--- a/docs/api/qiskit-addon-utils/_toc.json
+++ b/docs/api/qiskit-addon-utils/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Addon Utilities",
+  "title": "Qiskit addon utilities",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-addon-utils/release-notes.mdx
+++ b/docs/api/qiskit-addon-utils/release-notes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Qiskit Addon Utilities release notes
-description: Changes made to Qiskit Addon Utilities
+title: Qiskit addon utilities release notes
+description: Changes made to Qiskit addon utilities
 in_page_toc_max_heading_level: 2
 ---
 
@@ -8,7 +8,7 @@ in_page_toc_max_heading_level: 2
 
 <span id="id1" />
 
-# Qiskit Addon Utilities release notes
+# Qiskit addon utilities release notes
 
 <span id="release-notes-0-1-0" />
 

--- a/docs/api/qiskit-ibm-runtime/0.14/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.14/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.15/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.15/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.16/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.16/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.17/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.17/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.18/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.18/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.19/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.19/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.20/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.20/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.21/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.21/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.22/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.22/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.23/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.23/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.24/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.24/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.25/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.25/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.26/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.26/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.27/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.27/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.28/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.28/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.29/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.29/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/0.30/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.30/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/dev/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/dev/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Runtime Client",
+  "title": "Qiskit Runtime client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-runtime/release-notes.mdx
+++ b/docs/api/qiskit-ibm-runtime/release-notes.mdx
@@ -1,12 +1,12 @@
 ---
-title: Qiskit Runtime Client release notes
-description: Changes made to Qiskit Runtime Client
+title: Qiskit Runtime client release notes
+description: Changes made to Qiskit Runtime client
 in_page_toc_max_heading_level: 2
 ---
 
 <span id="qiskit-runtime-ibm-client-release-notes" />
 
-# Qiskit Runtime Client release notes
+# Qiskit Runtime client release notes
 
 <span id="id1" />
 

--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -35,9 +35,9 @@ For more details, read the post about the release on the [IBM Quantum blog](http
 
 {/* use url format /api/qiskit/release-notes/X.X to link to the specific X.X version of the release notes */}
 
-### Qiskit Runtime Client 0.28.0
+### Qiskit Runtime client 0.28.0
 
-*To see the release notes for all versions, visit the [Qiskit Runtime Client release notes](/api/qiskit-ibm-runtime/release-notes).*
+*To see the release notes for all versions, visit the [Qiskit Runtime client release notes](/api/qiskit-ibm-runtime/release-notes).*
 
 **Highlights from the 0.28.0 (2024-08-15) version release**
 
@@ -53,7 +53,7 @@ For more details, read the post about the release on the [IBM Quantum blog](http
 See the full [0.28.0 release notes](/api/qiskit-ibm-runtime/release-notes#0280-2024-08-15).
 {/* use url format /api/qiskit-ibm-runtime/release-notes#0XYZ to link to the specific 0.XY.Z version of the release notes */}
 
-### Qiskit Transpiler Service Client v0.3.0
+### Qiskit Transpiler Service client v0.3.0
 
 We’re pleased to share that the beta release of the Qiskit Transpiler Service is now available to all IBM Quantum&trade; Premium Plan users.
 
@@ -63,7 +63,7 @@ On the IBM Quantum blog, we take a deep dive into the new beta release with a sp
 
 {/* no other release notes available yet */}
 
-### Qiskit Functions Catalog Service Client v0.1.0
+### Qiskit Functions Catalog Service client v0.1.0
 
 Introducing the Qiskit Functions preview, for IBM Quantum Premium Plan users. To get started, `pip install qiskit-ibm-catalog`, and explore the [Qiskit Functions documentation](/guides/functions). With the Qiskit Functions Catalog client, you can submit workloads to abstracted services designed to accelerate your research - sign in with your existing IBM Quantum Platform credentials.
 
@@ -189,7 +189,7 @@ Updates to the infrastructure and design of the documentation include the follow
 - We fixed GitHub source code links for functions using decorators - thanks to the open-source contributor who opened an issue for this!
 - When you change the version in the left sidebar of the API reference docs, you arrive at the equivalent page in the new version. If the page does not exist in the new version, you land on the index page.
 - We improved the design and color of the warning banner for when you access outdated API pages to make it more obvious that newer docs are available. The banner persists as you scroll down the page.
-- Source code links and release notes have been added to the [Qiskit Transpiler Service Client API documentation](/api/qiskit-ibm-transpiler).
+- Source code links and release notes have been added to the [Qiskit Transpiler Service client API documentation](/api/qiskit-ibm-transpiler).
 - Code blocks that write to a file now display the file path; see examples in this [Qiskit Serverless guide](/guides/serverless-first-program).
 - Tips to use the Qiskit Code Assistant now appear throughout the guides.
 

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -107,7 +107,7 @@ export class Pkg {
     if (name === "qiskit-ibm-runtime") {
       return new Pkg({
         ...args,
-        title: "Qiskit Runtime Client",
+        title: "Qiskit Runtime client",
         githubSlug: "qiskit/qiskit-ibm-runtime",
         kebabCaseAndShortenUrls: false,
       });
@@ -116,7 +116,7 @@ export class Pkg {
     if (name === "qiskit-ibm-transpiler") {
       return new Pkg({
         ...args,
-        title: "Qiskit Transpiler Service Client",
+        title: "Qiskit Transpiler Service client",
         githubSlug: "qiskit/qiskit-ibm-transpiler",
         kebabCaseAndShortenUrls: false,
       });
@@ -125,7 +125,7 @@ export class Pkg {
     if (name === "qiskit-addon-obp") {
       return new Pkg({
         ...args,
-        title: "Operator Backpropagation",
+        title: "Operator backpropagation",
         githubSlug: "Qiskit/qiskit-addon-obp",
         kebabCaseAndShortenUrls: true,
       });
@@ -133,7 +133,7 @@ export class Pkg {
     if (name === "qiskit-addon-mpf") {
       return new Pkg({
         ...args,
-        title: "Multi-Product Formulas",
+        title: "Multi-product formulas",
         githubSlug: "Qiskit/qiskit-addon-mpf",
         kebabCaseAndShortenUrls: true,
       });
@@ -141,7 +141,7 @@ export class Pkg {
     if (name === "qiskit-addon-sqd") {
       return new Pkg({
         ...args,
-        title: "Sample-Based Quantum Diagonalization",
+        title: "Sample-based quantum diagonalization",
         githubSlug: "Qiskit/qiskit-addon-sqd",
         kebabCaseAndShortenUrls: true,
       });
@@ -149,7 +149,7 @@ export class Pkg {
     if (name === "qiskit-addon-cutting") {
       return new Pkg({
         ...args,
-        title: "Circuit Cutting",
+        title: "Circuit cutting",
         githubSlug: "Qiskit/qiskit-addon-cutting",
         kebabCaseAndShortenUrls: true,
       });
@@ -157,7 +157,7 @@ export class Pkg {
     if (name === "qiskit-addon-utils") {
       return new Pkg({
         ...args,
-        title: "Qiskit Addon Utilities",
+        title: "Qiskit addon utilities",
         githubSlug: "Qiskit/qiskit-addon-utils",
         kebabCaseAndShortenUrls: true,
       });


### PR DESCRIPTION
This changes the left sidebar and the release notes heading, per the IBM style guide.