### PR TITLE
Regen API docs to remove broken external links

### DIFF
--- a/docs/api/qiskit-ibm-runtime/0.30/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.30/_toc.json
@@ -669,4 +669,3 @@
   ],
   "collapsed": true
 }
-

--- a/docs/api/qiskit-ibm-transpiler/0.3/_toc.json
+++ b/docs/api/qiskit-ibm-transpiler/0.3/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client",
+  "title": "Qiskit Transpiler Service client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-transpiler/0.4/_toc.json
+++ b/docs/api/qiskit-ibm-transpiler/0.4/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client",
+  "title": "Qiskit Transpiler Service client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-transpiler/0.5/_toc.json
+++ b/docs/api/qiskit-ibm-transpiler/0.5/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client",
+  "title": "Qiskit Transpiler Service client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-transpiler/0.6/_toc.json
+++ b/docs/api/qiskit-ibm-transpiler/0.6/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client",
+  "title": "Qiskit Transpiler Service client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-transpiler/_toc.json
+++ b/docs/api/qiskit-ibm-transpiler/_toc.json
@@ -1,5 +1,5 @@
 {
-  "title": "Qiskit Transpiler Service Client",
+  "title": "Qiskit Transpiler Service client",
   "children": [
     {
       "title": "API index",

--- a/docs/api/qiskit-ibm-transpiler/release-notes.mdx
+++ b/docs/api/qiskit-ibm-transpiler/release-notes.mdx
@@ -1,12 +1,12 @@
 ---
-title: Qiskit Transpiler Service Client release notes
-description: Changes made to Qiskit Transpiler Service Client
+title: Qiskit Transpiler Service client release notes
+description: Changes made to Qiskit Transpiler Service client
 in_page_toc_max_heading_level: 2
 ---
 
 <span id="qiskit-ibm-transpiler-release-notes" />
 
-# Qiskit Transpiler Service Client release notes
+# Qiskit Transpiler Service client release notes
 
 <span id="id1" />
 

--- a/docs/api/qiskit/0.19/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.19/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.24/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.24/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.25/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.25/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.26/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.26/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.27/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.27/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.28/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.28/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.29/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.29/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.30/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.30/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.31/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.31/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 

--- a/docs/api/qiskit/0.32/qiskit.optimization.applications.ising.tsp.mdx
+++ b/docs/api/qiskit/0.32/qiskit.optimization.applications.ising.tsp.mdx
@@ -12,7 +12,7 @@ python_api_name: qiskit.optimization.applications.ising.tsp
 
 # qiskit.optimization.applications.ising.tsp
 
-Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. It supports only EUC\_2D edge weight type. See [https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/](https://wwwproxy.iwr.uni-heidelberg.de/groups/comopt/software/TSPLIB95/) and [http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html](http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/index.html) Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
+Convert symmetric TSP instances into Pauli list Deal with TSPLIB format. Design the tsp object w as a two-dimensional np.array e.g., w\[i, j] = x means that the length of a edge between i and j is x Note that the weights are symmetric, i.e., w\[j, i] = x always holds.
 
 **Functions**
 


### PR DESCRIPTION
Generated with `npm run regen-apis`. I changed the Box artifacts for the Qiskit docs to not have the broken links. Closes https://github.com/Qiskit/documentation/issues/2187.

Also applies https://github.com/Qiskit/documentation/pull/2195 to qiskit-ibm-transpiler - I forgot to regen. 