### PR TITLE
Fix hash capitalization in API links

### DIFF
--- a/scripts/js/lib/api/updateLinks.test.ts
+++ b/scripts/js/lib/api/updateLinks.test.ts
@@ -26,10 +26,11 @@ test.describe("updateLinks", () => {
 [link3](qiskit_ibm_runtime.RuntimeJob.job#wut)
 [link4](../stubs/qiskit_ibm_runtime.RuntimeJob)
 [link5](../apidocs/qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob)
-[link6](qiskit_ibm_runtime.RuntimeJob)
-[link7](#qiskit_ibm_runtime.RuntimeJob.job)
-[link8](https://qiskit.org/documentation/apidoc/algorithms.html)
-[link9](https://qiskit.org/documentation/stubs/qiskit.circuit.BreakLoopOp.html#assemble)
+[link6](../apidocs/qiskit_ibm_runtime.RuntimeJob#SOME_VAR)
+[link7](qiskit_ibm_runtime.RuntimeJob)
+[link8](#qiskit_ibm_runtime.RuntimeJob.job)
+[link9](https://qiskit.org/documentation/apidoc/algorithms.html)
+[link10](https://qiskit.org/documentation/stubs/qiskit.circuit.BreakLoopOp.html#assemble)
         `,
       meta: {
         apiType: "class",
@@ -92,10 +93,11 @@ test.describe("updateLinks", () => {
 [link3](qiskit_ibm_runtime.RuntimeJob#job)
 [link4](qiskit_ibm_runtime.RuntimeJob)
 [link5](qiskit_ibm_runtime.RuntimeJob)
-[link6](qiskit_ibm_runtime.RuntimeJob)
-[link7](#qiskit_ibm_runtime.RuntimeJob.job)
-[link8](/api/qiskit/algorithms)
-[link9](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)\n`,
+[link6](qiskit_ibm_runtime.RuntimeJob#some_var)
+[link7](qiskit_ibm_runtime.RuntimeJob)
+[link8](#qiskit_ibm_runtime.RuntimeJob.job)
+[link9](/api/qiskit/algorithms)
+[link10](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)\n`,
         meta: {
           apiName: "qiskit_ibm_runtime.RuntimeJob",
           apiType: "class",
@@ -143,10 +145,11 @@ test.describe("updateLinks", () => {
 [link3](runtime-job#job)
 [link4](runtime-job)
 [link5](runtime-job)
-[link6](runtime-job)
-[link7](#qiskit_ibm_runtime.RuntimeJob.job)
-[link8](/api/qiskit/algorithms)
-[link9](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)\n`,
+[link6](runtime-job#some_var)
+[link7](runtime-job)
+[link8](#qiskit_ibm_runtime.RuntimeJob.job)
+[link9](/api/qiskit/algorithms)
+[link10](/api/qiskit/qiskit.circuit.BreakLoopOp#assemble)\n`,
         meta: {
           apiName: "qiskit_ibm_runtime.RuntimeJob",
           apiType: "class",

--- a/scripts/js/lib/api/updateLinks.ts
+++ b/scripts/js/lib/api/updateLinks.ts
@@ -81,17 +81,21 @@ export function normalizeUrl(
     "/",
   );
 
+  // Default case. We'll then check if the hash should be transformed
+  // for a few edge cases.
+  url = hash ? `${normalizedUrlWithoutHash}#${hash}` : normalizedUrlWithoutHash;
+
   // qiskit_ibm_runtime.RuntimeJob
   // qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob
   if (itemNames.has(page)) {
     if (hash === page) {
-      return normalizedUrlWithoutHash;
+      url = normalizedUrlWithoutHash;
     }
 
     // qiskit_ibm_runtime.RuntimeJob#qiskit_ibm_runtime.RuntimeJob.job -> qiskit_ibm_runtime.RuntimeJob#job
     if (hash?.startsWith(`${page}.`)) {
       const member = removePrefix(hash, `${page}.`);
-      return `${normalizedUrlWithoutHash}#${member}`;
+      url = `${normalizedUrlWithoutHash}#${member}`;
     }
   }
 
@@ -104,20 +108,10 @@ export function normalizeUrl(
     const normalizedParentName = kwargs.kebabCaseAndShorten
       ? kebabCaseAndShortenPage(parentName, kwargs.pkgName)
       : parentName;
-    return [...initialUrlParts, normalizedParentName].join("/") + "#" + member;
+    url = [...initialUrlParts, normalizedParentName].join("/") + "#" + member;
   }
 
-  if (!hash) return normalizedUrlWithoutHash;
-
-  // Anchors generated from markdown headings are always lower case but, if these
-  // headings are API references, Sphinx sometimes expects them to include
-  // uppercase characters.
-  //
-  // As a heuristic, we assume URLs containing periods are anchors to HTML id
-  // tags (which preserve Sphinx's original casing), and anchors with no periods
-  // are from markdown headings (which must be lower-cased). This seems to work ok.
-  const normalizedHash = hash.includes(".") ? hash : hash.toLowerCase();
-  return `${normalizedUrlWithoutHash}#${normalizedHash}`;
+  return lowerCaseIfMarkdownAnchor(url);
 }
 
 export function relativizeLink(link: Link): Link | undefined {


### PR DESCRIPTION
Fixes https://github.com/Qiskit/documentation/pull/2177. We weren't normalizing the hash in all cases.