### PR TITLE
Ensure `./start` is always up-to-date by using image digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can preview the docs locally by following these two steps:
 
 The preview application does not include the top nav bar. Instead, navigate to the folder you want with the links in the home page. You can return to the home page at any time by clicking "IBM Quantum Documentation Preview" in the top-left of the header.
 
-Warning: `./start` does not check if there is a new version of the docs application available. You can run `docker pull qiskit/documentation` to update to the latest version of the app. It will also ignore the API docs to speed things up, if you want to view them, run `./start --apis`.
+Maintainers: when you release a new version of the image, you need to update the image digest in `./start` by following the instructions at the top of the file and opening a pull request.
 
 ### API docs authors: How to preview your changes
 

--- a/start
+++ b/start
@@ -15,8 +15,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
+IMAGE_DIGEST = "sha256:2ad7c6dbdca288077ef1c752384edc578e5b42fe0b311c75b94ba1733b2b8529"
+
 PWD = Path(__file__).parent
-IMAGE = "icr.io/qc-open-source-docs-public/preview:latest"
+IMAGE = f"icr.io/qc-open-source-docs-public/preview@{IMAGE_DIGEST}"
 
 
 def skip_apis() -> tuple[str]:
@@ -31,11 +34,6 @@ def main() -> None:
         subprocess.run(["docker", "pull", IMAGE], check=True)
         sys.exit(0)
 
-    print(
-        "Warning: this may be using an outdated version of the app. Run "
-        + f"`docker pull {IMAGE}` to check for updates.",
-        file=sys.stderr,
-    )
     # Keep this aligned with the Dockerfile at the root of the repository.
     cmd = [
         "docker",


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1611. Now users don't have to manually run `docker pull` to get the latest version of the image. The responsibility moves from everyday users to the maintainers of the Docker image; we now need to open a PR to update the digest.

The approach of using a digest—rather than a tag—works great because it is auto-computed by Docker. The publisher can still keep simply publishing the `:latest` tag without having to manually set the digest. 

## Does not change PR previews

PR previews will continue to use `:latest` for `icr.io/qc-open-source-docs-prod/preview-builder`. They don't persist the image across jobs, so they will already have the latest image every time.

Note that security best practices recommend using digests rather than tags when building and deploying apps. However, the security risk is minimal enough for this preview app with GitHub Pages that we don't follow that best practice here because it would be too annoying to have to update the image digest & the security risk is low.