### PR TITLE
Add `skip_reset_qubits` option for DD

### DIFF
--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -53,7 +53,7 @@ Options can be defined before a primitive is constructed and passed to the primi
 <span id="options-table"></span>
 ### Available options
 
-The following table documents options from the latest version of qiskit-ibm-runtime. To see older option versions, visit the [qiskit-ibm-runtime API reference](/api/qiskit-ibm-runtime) and select a historical version.
+The following table documents options from the latest version of `qiskit-ibm-runtime`. To see older option versions, visit the [`qiskit-ibm-runtime` API reference](/api/qiskit-ibm-runtime) and select a historical version.
 
 <Admonition type="caution" title="Important">
 Scroll to see the full table.

--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -53,7 +53,7 @@ Options can be defined before a primitive is constructed and passed to the primi
 <span id="options-table"></span>
 ### Available options
 
-The following table documents options from the latest version of `qiskit-ibm-runtime`. To see older option versions, visit the [`qiskit-ibm-runtime` API reference](/api/qiskit-ibm-runtime) and select a historical version.
+The following table documents options from the latest version of `qiskit-ibm-runtime`. To see older option versions, visit the [`qiskit-ibm-runtime` API reference](/api/qiskit-ibm-runtime) and select a previous version.
 
 <Admonition type="caution" title="Important">
 Scroll to see the full table.

--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -53,6 +53,8 @@ Options can be defined before a primitive is constructed and passed to the primi
 <span id="options-table"></span>
 ### Available options
 
+The following table documents options from the latest version of qiskit-ibm-runtime. To see older option versions, visit the [qiskit-ibm-runtime API reference](/api/qiskit-ibm-runtime) and select a historical version.
+
 <Admonition type="caution" title="Important">
 Scroll to see the full table.
 </Admonition>

--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -68,6 +68,7 @@ Scroll to see the full table.
 |                      | sequence_type            |                         | `'XX'`/`'XpXm'`/`'XY4'`                                                         | `'XX'`                      |                      |
 |                      | extra_slack_distribution |                         | `'middle'`/`'edges'`                                                                  | `'middle'`                  |                      |
 |                      | scheduling_method        |                         | `'asap'`/`'alap'`                                                                      | `'alap'`                    |                      |
+|                      | skip_reset_qubits        |                         | `True`/`False`                                                                                   | `False`                 |                    |
 | [environment](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EnvironmentOptions)          |                          |     |             |                                  | environment          |
 |                      | log_level                |                         |`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`                 |`WARNING`                          |                      |
 |                      | callback                 |                         |Callable function that receives Job ID and Job result.                             |`None`                           |                      |
@@ -116,6 +117,7 @@ Scroll to see the full table.
 |                      | sequence_type            |                         | `'XX'`/`'XpXm'`/`'XY4'`                                                                         | `'XX'`                 |                    |
 |                      | extra_slack_distribution |                         | `'middle'`/`'edges'`                                                                          | `'middle'`                  |                    |
 |                      | scheduling_method        |                         | `'asap'`/`'alap'`                                                                            | `'alap'`                    |                    |
+|                      | skip_reset_qubits        |                         | `True`/`False`                                                                                   | `False`                 |                    |
 | [environment](../api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.EnvironmentOptions)          |                          |                         |              |                                  |                    |
 |                      | log_level                |                         |`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`                                             |`WARNING`                          |   environment   |
 |                      | callback                 |                         |Callable function that receives Job ID and Job result.                                    |`None`                           |                    |


### PR DESCRIPTION
qiskit-ibm-runtime 0.32.0 released today includes a new DD option `skip_reset_qubits`.
https://github.com/Qiskit/qiskit-ibm-runtime/releases/tag/0.32.0
https://github.com/Qiskit/qiskit-ibm-runtime/pull/1981