### PR TITLE
Link checker parses headings inside component

### DIFF
--- a/scripts/js/lib/links/extractLinks.test.ts
+++ b/scripts/js/lib/links/extractLinks.test.ts
@@ -29,6 +29,16 @@ test("parseAnchors()", () => {
 
   ## \`code-header\`
 
+  ## Header.with periods-and wild! punctuation?? and numbers 1234 8 (parentheses)
+
+  ## header_using\_underscores
+
+  ## UpperCase Should Be lowercase
+
+  ## repeated
+  ## repeated
+  ## repeated
+
   <Function id="mdx.component.testId" name="testId" signature="testId">
     Convert to dictionary.
 
@@ -36,15 +46,26 @@ test("parseAnchors()", () => {
 
     \`Dict\`
   </Function>
+
+  <Class>
+      ### Header inside a component
+  </Class>
   `);
   expect(result).toEqual(
     new Set([
       "#my-top-level-heading",
       "#header-2",
       "#code-header",
+      "#headerwith-periods-and-wild-punctuation-and-numbers-1234-8-parentheses",
+      "#header_using_underscores",
+      "#uppercase-should-be-lowercase",
       "#this-is-a-hardcoded-anchor",
       "#another_span",
       "#mdx.component.testId",
+      "#header-inside-a-component",
+      "#repeated",
+      "#repeated-1",
+      "#repeated-2",
     ]),
   );
 });


### PR DESCRIPTION
The link checker was failing to detect inline class methods (related to https://github.com/Qiskit/documentation/issues/2210) because it does not peek inside `<Class>` components.

To fix this, we now use our own parsing code for headings. 

It's possible there will be future edge cases this PR does not account for in its heading parsing. Our link checker will fail in that case and we can forward fix.