### PR TITLE
Add qiskit-addon-aqc-tensor to addons.mdx

### DIFF
--- a/docs/guides/addons.mdx
+++ b/docs/guides/addons.mdx
@@ -9,6 +9,13 @@ Qiskit addons are a collection of research capabilities for enabling algorithm d
 
 ## Addons for mapping
 
+### Approximate quantum compilation with tensor networks
+
+Approximate quantum compilation with tensor networks (AQC-Tensor) enables the construction of high-fidelity circuits with reduced depth.
+
+- Visit the [GitHub repository.](https://github.com/Qiskit/qiskit-addon-aqc-tensor)
+- Read the [documentation.](https://qiskit.github.io/qiskit-addon-aqc-tensor)
+
 ### Multi-product formulas
 
 Multi-product formulas (MPF) reduce the Trotter error of Hamiltonian dynamics through a weighted combination of several circuit executions.


### PR DESCRIPTION
This adds qiskit-addon-aqc-tensor to the docs page.

Notes:

- Currently, this addon's tutorial is phrased as step 2 of a Qiskit pattern.  However, after gaining experience with it, I believe it actually fits in better as step 1.  I plan to update the tutorial, but in the meantime I've proposed it here under "Addons for mapping."
- I wrote a new description for it here, motivated by the desire to be consistent with both (i) unitary AQC, which will likely be added soon, and (ii) the phrasing as a "step 1" operation.