### PR TITLE
Fix metadata for Runtime 0.32

### DIFF
--- a/docs/api/qiskit-ibm-runtime/0.32/_toc.json
+++ b/docs/api/qiskit-ibm-runtime/0.32/_toc.json
@@ -522,4 +522,3 @@
   ],
   "collapsed": true
 }
-

--- a/docs/api/qiskit-ibm-runtime/0.32/debug_tools.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/debug_tools.mdx
@@ -1,6 +1,6 @@
 ---
-title: debug_tools (latest version)
-description: API reference for qiskit_ibm_runtime.debug_tools in the latest version of qiskit-ibm-runtime
+title: debug_tools (v0.32)
+description: API reference for qiskit_ibm_runtime.debug_tools in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.debug_tools

--- a/docs/api/qiskit-ibm-runtime/0.32/execution_span.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/execution_span.mdx
@@ -1,6 +1,6 @@
 ---
-title: execution_span (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span in the latest version of qiskit-ibm-runtime
+title: execution_span (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.execution_span

--- a/docs/api/qiskit-ibm-runtime/0.32/fake_provider.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/fake_provider.mdx
@@ -1,6 +1,6 @@
 ---
-title: fake_provider (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider in the latest version of qiskit-ibm-runtime
+title: fake_provider (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.fake_provider

--- a/docs/api/qiskit-ibm-runtime/0.32/index.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Qiskit Runtime client API documentation (latest version)
-description: Index of all the modules in the latest version of qiskit-ibm-runtime.
+title: Qiskit Runtime client API documentation (v0.32)
+description: Index of all the modules in qiskit-ibm-runtime v0.32.
 ---
 
 # qiskit-ibm-runtime API reference

--- a/docs/api/qiskit-ibm-runtime/0.32/noise_learner.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/noise_learner.mdx
@@ -1,6 +1,6 @@
 ---
-title: noise_learner (latest version)
-description: API reference for qiskit_ibm_runtime.noise_learner in the latest version of qiskit-ibm-runtime
+title: noise_learner (v0.32)
+description: API reference for qiskit_ibm_runtime.noise_learner in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.noise_learner

--- a/docs/api/qiskit-ibm-runtime/0.32/noise_learner_result.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/noise_learner_result.mdx
@@ -1,6 +1,6 @@
 ---
-title: noise_learner_result (latest version)
-description: API reference for qiskit_ibm_runtime.utils.noise_learner_result in the latest version of qiskit-ibm-runtime
+title: noise_learner_result (v0.32)
+description: API reference for qiskit_ibm_runtime.utils.noise_learner_result in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.utils.noise_learner_result

--- a/docs/api/qiskit-ibm-runtime/0.32/options.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/options.mdx
@@ -1,6 +1,6 @@
 ---
-title: options (latest version)
-description: API reference for qiskit_ibm_runtime.options in the latest version of qiskit-ibm-runtime
+title: options (v0.32)
+description: API reference for qiskit_ibm_runtime.options in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.options

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Batch.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Batch.mdx
@@ -1,6 +1,6 @@
 ---
-title: Batch (latest version)
-description: API reference for qiskit_ibm_runtime.Batch in the latest version of qiskit-ibm-runtime
+title: Batch (v0.32)
+description: API reference for qiskit_ibm_runtime.Batch in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.Batch

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Estimator.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Estimator.mdx
@@ -1,6 +1,6 @@
 ---
-title: Estimator (latest version)
-description: API reference for qiskit_ibm_runtime.Estimator in the latest version of qiskit-ibm-runtime
+title: Estimator (v0.32)
+description: API reference for qiskit_ibm_runtime.Estimator in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: attribute
 python_api_name: qiskit_ibm_runtime.Estimator

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.EstimatorV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.EstimatorV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: EstimatorV2 (latest version)
-description: API reference for qiskit_ibm_runtime.EstimatorV2 in the latest version of qiskit-ibm-runtime
+title: EstimatorV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.EstimatorV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.EstimatorV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.IBMBackend.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.IBMBackend.mdx
@@ -1,6 +1,6 @@
 ---
-title: IBMBackend (latest version)
-description: API reference for qiskit_ibm_runtime.IBMBackend in the latest version of qiskit-ibm-runtime
+title: IBMBackend (v0.32)
+description: API reference for qiskit_ibm_runtime.IBMBackend in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.IBMBackend

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.QiskitRuntimeService.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.QiskitRuntimeService.mdx
@@ -1,6 +1,6 @@
 ---
-title: QiskitRuntimeService (latest version)
-description: API reference for qiskit_ibm_runtime.QiskitRuntimeService in the latest version of qiskit-ibm-runtime
+title: QiskitRuntimeService (v0.32)
+description: API reference for qiskit_ibm_runtime.QiskitRuntimeService in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.QiskitRuntimeService

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeDecoder.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeDecoder.mdx
@@ -1,6 +1,6 @@
 ---
-title: RuntimeDecoder (latest version)
-description: API reference for qiskit_ibm_runtime.RuntimeDecoder in the latest version of qiskit-ibm-runtime
+title: RuntimeDecoder (v0.32)
+description: API reference for qiskit_ibm_runtime.RuntimeDecoder in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.RuntimeDecoder

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeEncoder.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeEncoder.mdx
@@ -1,6 +1,6 @@
 ---
-title: RuntimeEncoder (latest version)
-description: API reference for qiskit_ibm_runtime.RuntimeEncoder in the latest version of qiskit-ibm-runtime
+title: RuntimeEncoder (v0.32)
+description: API reference for qiskit_ibm_runtime.RuntimeEncoder in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.RuntimeEncoder

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeJob.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeJob.mdx
@@ -1,6 +1,6 @@
 ---
-title: RuntimeJob (latest version)
-description: API reference for qiskit_ibm_runtime.RuntimeJob in the latest version of qiskit-ibm-runtime
+title: RuntimeJob (v0.32)
+description: API reference for qiskit_ibm_runtime.RuntimeJob in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.RuntimeJob

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeJobV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.RuntimeJobV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: RuntimeJobV2 (latest version)
-description: API reference for qiskit_ibm_runtime.RuntimeJobV2 in the latest version of qiskit-ibm-runtime
+title: RuntimeJobV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.RuntimeJobV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.RuntimeJobV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Sampler.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Sampler.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sampler (latest version)
-description: API reference for qiskit_ibm_runtime.Sampler in the latest version of qiskit-ibm-runtime
+title: Sampler (v0.32)
+description: API reference for qiskit_ibm_runtime.Sampler in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: attribute
 python_api_name: qiskit_ibm_runtime.Sampler

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.SamplerV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.SamplerV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: SamplerV2 (latest version)
-description: API reference for qiskit_ibm_runtime.SamplerV2 in the latest version of qiskit-ibm-runtime
+title: SamplerV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.SamplerV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.SamplerV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Session.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.Session.mdx
@@ -1,6 +1,6 @@
 ---
-title: Session (latest version)
-description: API reference for qiskit_ibm_runtime.Session in the latest version of qiskit-ibm-runtime
+title: Session (v0.32)
+description: API reference for qiskit_ibm_runtime.Session in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.Session

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.Neat.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.Neat.mdx
@@ -1,6 +1,6 @@
 ---
-title: Neat (latest version)
-description: API reference for qiskit_ibm_runtime.debug_tools.Neat in the latest version of qiskit-ibm-runtime
+title: Neat (v0.32)
+description: API reference for qiskit_ibm_runtime.debug_tools.Neat in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.debug_tools.Neat

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.NeatPubResult.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.NeatPubResult.mdx
@@ -1,6 +1,6 @@
 ---
-title: NeatPubResult (latest version)
-description: API reference for qiskit_ibm_runtime.debug_tools.NeatPubResult in the latest version of qiskit-ibm-runtime
+title: NeatPubResult (v0.32)
+description: API reference for qiskit_ibm_runtime.debug_tools.NeatPubResult in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.debug_tools.NeatPubResult

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.NeatResult.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.debug_tools.NeatResult.mdx
@@ -1,6 +1,6 @@
 ---
-title: NeatResult (latest version)
-description: API reference for qiskit_ibm_runtime.debug_tools.NeatResult in the latest version of qiskit-ibm-runtime
+title: NeatResult (v0.32)
+description: API reference for qiskit_ibm_runtime.debug_tools.NeatResult in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.debug_tools.NeatResult

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.DoubleSliceSpan.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.DoubleSliceSpan.mdx
@@ -1,6 +1,6 @@
 ---
-title: DoubleSliceSpan (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span.DoubleSliceSpan in the latest version of qiskit-ibm-runtime
+title: DoubleSliceSpan (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span.DoubleSliceSpan in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.execution_span.DoubleSliceSpan

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ExecutionSpan.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ExecutionSpan.mdx
@@ -1,6 +1,6 @@
 ---
-title: ExecutionSpan (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span.ExecutionSpan in the latest version of qiskit-ibm-runtime
+title: ExecutionSpan (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span.ExecutionSpan in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.execution_span.ExecutionSpan

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ExecutionSpans.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ExecutionSpans.mdx
@@ -1,6 +1,6 @@
 ---
-title: ExecutionSpans (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span.ExecutionSpans in the latest version of qiskit-ibm-runtime
+title: ExecutionSpans (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span.ExecutionSpans in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.execution_span.ExecutionSpans

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ShapeType.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.ShapeType.mdx
@@ -1,6 +1,6 @@
 ---
-title: ShapeType (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span.ShapeType in the latest version of qiskit-ibm-runtime
+title: ShapeType (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span.ShapeType in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: data
 python_api_name: qiskit_ibm_runtime.execution_span.ShapeType

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.SliceSpan.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.execution_span.SliceSpan.mdx
@@ -1,6 +1,6 @@
 ---
-title: SliceSpan (latest version)
-description: API reference for qiskit_ibm_runtime.execution_span.SliceSpan in the latest version of qiskit-ibm-runtime
+title: SliceSpan (v0.32)
+description: API reference for qiskit_ibm_runtime.execution_span.SliceSpan in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.execution_span.SliceSpan

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAlgiers.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAlgiers.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeAlgiers (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeAlgiers in the latest version of qiskit-ibm-runtime
+title: FakeAlgiers (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeAlgiers in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeAlgiers

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAlmadenV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAlmadenV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeAlmadenV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeAlmadenV2 in the latest version of qiskit-ibm-runtime
+title: FakeAlmadenV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeAlmadenV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeAlmadenV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeArmonkV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeArmonkV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeArmonkV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeArmonkV2 in the latest version of qiskit-ibm-runtime
+title: FakeArmonkV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeArmonkV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeArmonkV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAthensV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAthensV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeAthensV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeAthensV2 in the latest version of qiskit-ibm-runtime
+title: FakeAthensV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeAthensV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeAthensV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAuckland.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeAuckland.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeAuckland (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeAuckland in the latest version of qiskit-ibm-runtime
+title: FakeAuckland (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeAuckland in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeAuckland

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBelemV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBelemV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBelemV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBelemV2 in the latest version of qiskit-ibm-runtime
+title: FakeBelemV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBelemV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBelemV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBoeblingenV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2 in the latest version of qiskit-ibm-runtime
+title: FakeBoeblingenV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBoeblingenV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBogotaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBogotaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBogotaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBogotaV2 in the latest version of qiskit-ibm-runtime
+title: FakeBogotaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBogotaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBogotaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBrisbane.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBrisbane.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBrisbane (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBrisbane in the latest version of qiskit-ibm-runtime
+title: FakeBrisbane (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBrisbane in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBrisbane

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBrooklynV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBrooklynV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBrooklynV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBrooklynV2 in the latest version of qiskit-ibm-runtime
+title: FakeBrooklynV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBrooklynV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBrooklynV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeBurlingtonV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2 in the latest version of qiskit-ibm-runtime
+title: FakeBurlingtonV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeBurlingtonV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCairoV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCairoV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeCairoV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeCairoV2 in the latest version of qiskit-ibm-runtime
+title: FakeCairoV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeCairoV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeCairoV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCambridgeV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCambridgeV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeCambridgeV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeCambridgeV2 in the latest version of qiskit-ibm-runtime
+title: FakeCambridgeV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeCambridgeV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeCambridgeV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCasablancaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCasablancaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeCasablancaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeCasablancaV2 in the latest version of qiskit-ibm-runtime
+title: FakeCasablancaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeCasablancaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeCasablancaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCusco.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeCusco.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeCusco (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeCusco in the latest version of qiskit-ibm-runtime
+title: FakeCusco (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeCusco in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeCusco

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeEssexV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeEssexV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeEssexV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeEssexV2 in the latest version of qiskit-ibm-runtime
+title: FakeEssexV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeEssexV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeEssexV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeFractionalBackend.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeFractionalBackend.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeFractionalBackend (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeFractionalBackend in the latest version of qiskit-ibm-runtime
+title: FakeFractionalBackend (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeFractionalBackend in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeFractionalBackend

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeGeneva.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeGeneva.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeGeneva (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeGeneva in the latest version of qiskit-ibm-runtime
+title: FakeGeneva (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeGeneva in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeGeneva

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeGuadalupeV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2 in the latest version of qiskit-ibm-runtime
+title: FakeGuadalupeV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeGuadalupeV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeHanoiV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeHanoiV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeHanoiV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeHanoiV2 in the latest version of qiskit-ibm-runtime
+title: FakeHanoiV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeHanoiV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeHanoiV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeJakartaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeJakartaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeJakartaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeJakartaV2 in the latest version of qiskit-ibm-runtime
+title: FakeJakartaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeJakartaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeJakartaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeJohannesburgV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2 in the latest version of qiskit-ibm-runtime
+title: FakeJohannesburgV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeJohannesburgV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKawasaki.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKawasaki.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeKawasaki (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeKawasaki in the latest version of qiskit-ibm-runtime
+title: FakeKawasaki (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeKawasaki in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeKawasaki

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKolkataV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKolkataV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeKolkataV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeKolkataV2 in the latest version of qiskit-ibm-runtime
+title: FakeKolkataV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeKolkataV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeKolkataV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKyiv.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKyiv.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeKyiv (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeKyiv in the latest version of qiskit-ibm-runtime
+title: FakeKyiv (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeKyiv in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeKyiv

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKyoto.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeKyoto.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeKyoto (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeKyoto in the latest version of qiskit-ibm-runtime
+title: FakeKyoto (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeKyoto in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeKyoto

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLagosV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLagosV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeLagosV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeLagosV2 in the latest version of qiskit-ibm-runtime
+title: FakeLagosV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeLagosV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeLagosV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLimaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLimaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeLimaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeLimaV2 in the latest version of qiskit-ibm-runtime
+title: FakeLimaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeLimaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeLimaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLondonV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeLondonV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeLondonV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeLondonV2 in the latest version of qiskit-ibm-runtime
+title: FakeLondonV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeLondonV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeLondonV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeManhattanV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeManhattanV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeManhattanV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeManhattanV2 in the latest version of qiskit-ibm-runtime
+title: FakeManhattanV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeManhattanV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeManhattanV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeManilaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeManilaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeManilaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeManilaV2 in the latest version of qiskit-ibm-runtime
+title: FakeManilaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeManilaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeManilaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMelbourneV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMelbourneV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeMelbourneV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeMelbourneV2 in the latest version of qiskit-ibm-runtime
+title: FakeMelbourneV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeMelbourneV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeMelbourneV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMontrealV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMontrealV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeMontrealV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeMontrealV2 in the latest version of qiskit-ibm-runtime
+title: FakeMontrealV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeMontrealV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeMontrealV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMumbaiV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeMumbaiV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeMumbaiV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeMumbaiV2 in the latest version of qiskit-ibm-runtime
+title: FakeMumbaiV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeMumbaiV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeMumbaiV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeNairobiV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeNairobiV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeNairobiV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeNairobiV2 in the latest version of qiskit-ibm-runtime
+title: FakeNairobiV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeNairobiV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeNairobiV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOsaka.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOsaka.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeOsaka (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeOsaka in the latest version of qiskit-ibm-runtime
+title: FakeOsaka (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeOsaka in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeOsaka

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOslo.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOslo.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeOslo (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeOslo in the latest version of qiskit-ibm-runtime
+title: FakeOslo (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeOslo in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeOslo

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOurenseV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeOurenseV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeOurenseV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeOurenseV2 in the latest version of qiskit-ibm-runtime
+title: FakeOurenseV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeOurenseV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeOurenseV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeParisV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeParisV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeParisV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeParisV2 in the latest version of qiskit-ibm-runtime
+title: FakeParisV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeParisV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeParisV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePeekskill.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePeekskill.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakePeekskill (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakePeekskill in the latest version of qiskit-ibm-runtime
+title: FakePeekskill (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakePeekskill in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakePeekskill

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePerth.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePerth.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakePerth (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakePerth in the latest version of qiskit-ibm-runtime
+title: FakePerth (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakePerth in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakePerth

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakePoughkeepsieV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2 in the latest version of qiskit-ibm-runtime
+title: FakePoughkeepsieV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakePoughkeepsieV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePrague.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakePrague.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakePrague (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakePrague in the latest version of qiskit-ibm-runtime
+title: FakePrague (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakePrague in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakePrague

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeProviderForBackendV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2 in the latest version of qiskit-ibm-runtime
+title: FakeProviderForBackendV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeProviderForBackendV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeQuebec.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeQuebec.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeQuebec (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeQuebec in the latest version of qiskit-ibm-runtime
+title: FakeQuebec (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeQuebec in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeQuebec

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeQuitoV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeQuitoV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeQuitoV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeQuitoV2 in the latest version of qiskit-ibm-runtime
+title: FakeQuitoV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeQuitoV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeQuitoV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeRochesterV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeRochesterV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeRochesterV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeRochesterV2 in the latest version of qiskit-ibm-runtime
+title: FakeRochesterV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeRochesterV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeRochesterV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeRomeV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeRomeV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeRomeV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeRomeV2 in the latest version of qiskit-ibm-runtime
+title: FakeRomeV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeRomeV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeRomeV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSantiagoV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSantiagoV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeSantiagoV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeSantiagoV2 in the latest version of qiskit-ibm-runtime
+title: FakeSantiagoV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeSantiagoV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeSantiagoV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSherbrooke.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSherbrooke.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeSherbrooke (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeSherbrooke in the latest version of qiskit-ibm-runtime
+title: FakeSherbrooke (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeSherbrooke in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeSherbrooke

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSingaporeV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSingaporeV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeSingaporeV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeSingaporeV2 in the latest version of qiskit-ibm-runtime
+title: FakeSingaporeV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeSingaporeV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeSingaporeV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSydneyV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeSydneyV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeSydneyV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeSydneyV2 in the latest version of qiskit-ibm-runtime
+title: FakeSydneyV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeSydneyV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeSydneyV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeTorino.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeTorino.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeTorino (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeTorino in the latest version of qiskit-ibm-runtime
+title: FakeTorino (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeTorino in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeTorino

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeTorontoV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeTorontoV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeTorontoV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeTorontoV2 in the latest version of qiskit-ibm-runtime
+title: FakeTorontoV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeTorontoV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeTorontoV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeValenciaV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeValenciaV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeValenciaV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeValenciaV2 in the latest version of qiskit-ibm-runtime
+title: FakeValenciaV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeValenciaV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeValenciaV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeVigoV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeVigoV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeVigoV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeVigoV2 in the latest version of qiskit-ibm-runtime
+title: FakeVigoV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeVigoV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeVigoV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeWashingtonV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeWashingtonV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeWashingtonV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeWashingtonV2 in the latest version of qiskit-ibm-runtime
+title: FakeWashingtonV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeWashingtonV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeWashingtonV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeYorktownV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.fake_provider.FakeYorktownV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: FakeYorktownV2 (latest version)
-description: API reference for qiskit_ibm_runtime.fake_provider.FakeYorktownV2 in the latest version of qiskit-ibm-runtime
+title: FakeYorktownV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.fake_provider.FakeYorktownV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.fake_provider.FakeYorktownV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.noise_learner.NoiseLearner.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.noise_learner.NoiseLearner.mdx
@@ -1,6 +1,6 @@
 ---
-title: NoiseLearner (latest version)
-description: API reference for qiskit_ibm_runtime.noise_learner.NoiseLearner in the latest version of qiskit-ibm-runtime
+title: NoiseLearner (v0.32)
+description: API reference for qiskit_ibm_runtime.noise_learner.NoiseLearner in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.noise_learner.NoiseLearner

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.DynamicalDecouplingOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.DynamicalDecouplingOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: DynamicalDecouplingOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.DynamicalDecouplingOptions in the latest version of qiskit-ibm-runtime
+title: DynamicalDecouplingOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.DynamicalDecouplingOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.DynamicalDecouplingOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.EnvironmentOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.EnvironmentOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: EnvironmentOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.EnvironmentOptions in the latest version of qiskit-ibm-runtime
+title: EnvironmentOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.EnvironmentOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.EnvironmentOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.EstimatorOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.EstimatorOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: EstimatorOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.EstimatorOptions in the latest version of qiskit-ibm-runtime
+title: EstimatorOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.EstimatorOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.EstimatorOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ExecutionOptionsV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ExecutionOptionsV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: ExecutionOptionsV2 (latest version)
-description: API reference for qiskit_ibm_runtime.options.ExecutionOptionsV2 in the latest version of qiskit-ibm-runtime
+title: ExecutionOptionsV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.options.ExecutionOptionsV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.ExecutionOptionsV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.LayerNoiseLearningOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.LayerNoiseLearningOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: LayerNoiseLearningOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.LayerNoiseLearningOptions in the latest version of qiskit-ibm-runtime
+title: LayerNoiseLearningOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.LayerNoiseLearningOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.LayerNoiseLearningOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.MeasureNoiseLearningOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.MeasureNoiseLearningOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: MeasureNoiseLearningOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.MeasureNoiseLearningOptions in the latest version of qiskit-ibm-runtime
+title: MeasureNoiseLearningOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.MeasureNoiseLearningOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.MeasureNoiseLearningOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.NoiseLearnerOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.NoiseLearnerOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: NoiseLearnerOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.NoiseLearnerOptions in the latest version of qiskit-ibm-runtime
+title: NoiseLearnerOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.NoiseLearnerOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.NoiseLearnerOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.PecOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.PecOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: PecOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.PecOptions in the latest version of qiskit-ibm-runtime
+title: PecOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.PecOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.PecOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ResilienceOptionsV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ResilienceOptionsV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: ResilienceOptionsV2 (latest version)
-description: API reference for qiskit_ibm_runtime.options.ResilienceOptionsV2 in the latest version of qiskit-ibm-runtime
+title: ResilienceOptionsV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.options.ResilienceOptionsV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.ResilienceOptionsV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SamplerExecutionOptionsV2.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SamplerExecutionOptionsV2.mdx
@@ -1,6 +1,6 @@
 ---
-title: SamplerExecutionOptionsV2 (latest version)
-description: API reference for qiskit_ibm_runtime.options.SamplerExecutionOptionsV2 in the latest version of qiskit-ibm-runtime
+title: SamplerExecutionOptionsV2 (v0.32)
+description: API reference for qiskit_ibm_runtime.options.SamplerExecutionOptionsV2 in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.SamplerExecutionOptionsV2

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SamplerOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SamplerOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: SamplerOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.SamplerOptions in the latest version of qiskit-ibm-runtime
+title: SamplerOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.SamplerOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.SamplerOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SimulatorOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.SimulatorOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: SimulatorOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.SimulatorOptions in the latest version of qiskit-ibm-runtime
+title: SimulatorOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.SimulatorOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.SimulatorOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.TwirlingOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.TwirlingOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: TwirlingOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.TwirlingOptions in the latest version of qiskit-ibm-runtime
+title: TwirlingOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.TwirlingOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.TwirlingOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ZneOptions.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.options.ZneOptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: ZneOptions (latest version)
-description: API reference for qiskit_ibm_runtime.options.ZneOptions in the latest version of qiskit-ibm-runtime
+title: ZneOptions (v0.32)
+description: API reference for qiskit_ibm_runtime.options.ZneOptions in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.options.ZneOptions

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.ConvertISAToClifford.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.ConvertISAToClifford.mdx
@@ -1,6 +1,6 @@
 ---
-title: ConvertISAToClifford (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.ConvertISAToClifford in the latest version of qiskit-ibm-runtime
+title: ConvertISAToClifford (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.ConvertISAToClifford in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.ConvertISAToClifford

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.ConvertIdToDelay.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.ConvertIdToDelay.mdx
@@ -1,6 +1,6 @@
 ---
-title: ConvertIdToDelay (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.ConvertIdToDelay in the latest version of qiskit-ibm-runtime
+title: ConvertIdToDelay (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.ConvertIdToDelay in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.ConvertIdToDelay

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis.mdx
@@ -1,6 +1,6 @@
 ---
-title: ALAPScheduleAnalysis (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis in the latest version of qiskit-ibm-runtime
+title: ALAPScheduleAnalysis (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.ALAPScheduleAnalysis

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis.mdx
@@ -1,6 +1,6 @@
 ---
-title: ASAPScheduleAnalysis (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis in the latest version of qiskit-ibm-runtime
+title: ASAPScheduleAnalysis (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.ASAPScheduleAnalysis

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder.mdx
@@ -1,6 +1,6 @@
 ---
-title: BlockBasePadder (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder in the latest version of qiskit-ibm-runtime
+title: BlockBasePadder (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.BlockBasePadder

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations.mdx
@@ -1,6 +1,6 @@
 ---
-title: DynamicCircuitInstructionDurations (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations in the latest version of qiskit-ibm-runtime
+title: DynamicCircuitInstructionDurations (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.DynamicCircuitInstructionDurations

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay.mdx
@@ -1,6 +1,6 @@
 ---
-title: PadDelay (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay in the latest version of qiskit-ibm-runtime
+title: PadDelay (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.PadDelay

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling.mdx
@@ -1,6 +1,6 @@
 ---
-title: PadDynamicalDecoupling (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling in the latest version of qiskit-ibm-runtime
+title: PadDynamicalDecoupling (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling.PadDynamicalDecoupling

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.transpiler.passes.scheduling.mdx
@@ -1,6 +1,6 @@
 ---
-title: scheduling (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling in the latest version of qiskit-ibm-runtime
+title: scheduling (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes.scheduling in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.transpiler.passes.scheduling

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.utils.noise_learner_result.LayerError.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.utils.noise_learner_result.LayerError.mdx
@@ -1,6 +1,6 @@
 ---
-title: LayerError (latest version)
-description: API reference for qiskit_ibm_runtime.utils.noise_learner_result.LayerError in the latest version of qiskit-ibm-runtime
+title: LayerError (v0.32)
+description: API reference for qiskit_ibm_runtime.utils.noise_learner_result.LayerError in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.utils.noise_learner_result.LayerError

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.utils.noise_learner_result.PauliLindbladError.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.utils.noise_learner_result.PauliLindbladError.mdx
@@ -1,6 +1,6 @@
 ---
-title: PauliLindbladError (latest version)
-description: API reference for qiskit_ibm_runtime.utils.noise_learner_result.PauliLindbladError in the latest version of qiskit-ibm-runtime
+title: PauliLindbladError (v0.32)
+description: API reference for qiskit_ibm_runtime.utils.noise_learner_result.PauliLindbladError in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: class
 python_api_name: qiskit_ibm_runtime.utils.noise_learner_result.PauliLindbladError

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.visualization.draw_execution_spans.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.visualization.draw_execution_spans.mdx
@@ -1,6 +1,6 @@
 ---
-title: draw_execution_spans (latest version)
-description: API reference for qiskit_ibm_runtime.visualization.draw_execution_spans in the latest version of qiskit-ibm-runtime
+title: draw_execution_spans (v0.32)
+description: API reference for qiskit_ibm_runtime.visualization.draw_execution_spans in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: function
 python_api_name: qiskit_ibm_runtime.visualization.draw_execution_spans

--- a/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.visualization.draw_layer_error_map.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/qiskit_ibm_runtime.visualization.draw_layer_error_map.mdx
@@ -1,6 +1,6 @@
 ---
-title: draw_layer_error_map (latest version)
-description: API reference for qiskit_ibm_runtime.visualization.draw_layer_error_map in the latest version of qiskit-ibm-runtime
+title: draw_layer_error_map (v0.32)
+description: API reference for qiskit_ibm_runtime.visualization.draw_layer_error_map in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 1
 python_api_type: function
 python_api_name: qiskit_ibm_runtime.visualization.draw_layer_error_map

--- a/docs/api/qiskit-ibm-runtime/0.32/runtime_service.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/runtime_service.mdx
@@ -1,6 +1,6 @@
 ---
-title: qiskit_ibm_runtime (latest version)
-description: API reference for qiskit_ibm_runtime in the latest version of qiskit-ibm-runtime
+title: qiskit_ibm_runtime (v0.32)
+description: API reference for qiskit_ibm_runtime in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime

--- a/docs/api/qiskit-ibm-runtime/0.32/transpiler.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/transpiler.mdx
@@ -1,6 +1,6 @@
 ---
-title: passes (latest version)
-description: API reference for qiskit_ibm_runtime.transpiler.passes in the latest version of qiskit-ibm-runtime
+title: passes (v0.32)
+description: API reference for qiskit_ibm_runtime.transpiler.passes in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.transpiler.passes

--- a/docs/api/qiskit-ibm-runtime/0.32/visualization.mdx
+++ b/docs/api/qiskit-ibm-runtime/0.32/visualization.mdx
@@ -1,6 +1,6 @@
 ---
-title: visualization (latest version)
-description: API reference for qiskit_ibm_runtime.visualization in the latest version of qiskit-ibm-runtime
+title: visualization (v0.32)
+description: API reference for qiskit_ibm_runtime.visualization in qiskit-ibm-runtime v0.32
 in_page_toc_min_heading_level: 2
 python_api_type: module
 python_api_name: qiskit_ibm_runtime.visualization


### PR DESCRIPTION
Temporary fix for https://github.com/Qiskit/documentation/issues/2269. Change generated with `npm run gen-api`.