### PR TITLE
Stop running save-jobs notebook in CI for now

### DIFF
--- a/docs/guides/save-jobs.ipynb
+++ b/docs/guides/save-jobs.ipynb
@@ -121,10 +121,14 @@
    ],
    "source": [
     "# Get ID of most recent successful job for demonstration.\n",
-    "# This will not work if you've never successfully run a job.\n",
-    "successful_job = next(j for j in service.jobs() if j.status().name == \"DONE\")\n",
-    "job_id = successful_job.job_id()\n",
-    "print(job_id)"
+    "successful_job = next(\n",
+    "    (j for j in service.jobs() if j.status().name == \"DONE\"), None\n",
+    ")\n",
+    "if successful_job is None:\n",
+    "    print(\"No successful jobs run yet!\")\n",
+    "else:\n",
+    "    job_id = successful_job.job_id()\n",
+    "    print(job_id)"
    ]
   },
   {

--- a/docs/guides/save-jobs.ipynb
+++ b/docs/guides/save-jobs.ipynb
@@ -121,14 +121,10 @@
    ],
    "source": [
     "# Get ID of most recent successful job for demonstration.\n",
-    "successful_job = next(\n",
-    "    (j for j in service.jobs() if j.status().name == \"DONE\"), None\n",
-    ")\n",
-    "if successful_job is None:\n",
-    "    print(\"No successful jobs run yet!\")\n",
-    "else:\n",
-    "    job_id = successful_job.job_id()\n",
-    "    print(job_id)"
+    "# This will not work if you've never successfully run a job.\n",
+    "successful_job = next(j for j in service.jobs() if j.status().name == \"DONE\")\n",
+    "job_id = successful_job.job_id()\n",
+    "print(job_id)"
    ]
   },
   {

--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -9,7 +9,6 @@ notebooks_normal_test = [
     "docs/guides/save-circuits.ipynb",
     "docs/guides/dynamic-circuits-considerations.ipynb",
     "docs/guides/get-qpu-information.ipynb",
-    "docs/guides/save-jobs.ipynb",
     "docs/guides/visualize-results.ipynb",
     "docs/guides/common-parameters.ipynb",
     "docs/guides/create-transpiler-plugin.ipynb",
@@ -46,6 +45,7 @@ notebooks_exclude = [
     "docs/guides/ibm-circuit-function.ipynb",
     "docs/guides/qiskit-addons-sqd-get-started.ipynb",
     "docs/guides/fractional-gates.ipynb",
+    "docs/guides/save-jobs.ipynb",
 ]
 
 # The following notebooks submit jobs that can be mocked with a simulator

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -60,6 +60,7 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://journals.aps.org/prapplied/abstract/10.1103/PhysRevApplied.20.064027",
   "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.131.210601",
   "https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.5.033154",
+  "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.92.042303",
   "https://www.cs.bham.ac.uk/~xin/papers/published_tec_sep00_constraint.pdf",
   "https://https://arxiv.org/abs/quant-ph/0403071",
   "https://doi.org/10.1103/PhysRevApplied.5.034007",

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -59,6 +59,7 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.94.052325",
   "https://journals.aps.org/prapplied/abstract/10.1103/PhysRevApplied.20.064027",
   "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.131.210601",
+  "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.92.042303",
   "https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.5.033154",
   "https://www.cs.bham.ac.uk/~xin/papers/published_tec_sep00_constraint.pdf",
   "https://https://arxiv.org/abs/quant-ph/0403071",

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -59,7 +59,6 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.94.052325",
   "https://journals.aps.org/prapplied/abstract/10.1103/PhysRevApplied.20.064027",
   "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.131.210601",
-  "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.92.042303",
   "https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.5.033154",
   "https://www.cs.bham.ac.uk/~xin/papers/published_tec_sep00_constraint.pdf",
   "https://https://arxiv.org/abs/quant-ph/0403071",


### PR DESCRIPTION
The notebook is failing with this:

```
---------------------------------------------------------------------------
StopIteration                             Traceback (most recent call last)
Cell In[2], line 3
      1 # Get ID of most recent successful job for demonstration.
      2 # This will not work if you've never successfully run a job.
----> 3 successful_job = next(jforjinservice.jobs()ifj.status().name=="DONE")
      4 job_id = successful_job.job_id()
      5 print(job_id)

StopIteration: 
```

Also closes https://github.com/Qiskit/documentation/issues/2277 by ignoring a valid link. 