### PR TITLE
Fix runtime version number

### DIFF
--- a/docs/api/qiskit-ibm-runtime/_package.json
+++ b/docs/api/qiskit-ibm-runtime/_package.json
@@ -1,4 +1,4 @@
 {
   "name": "qiskit-ibm-runtime",
-  "version": "0.33.0"
+  "version": "0.33.2"
 }


### PR DESCRIPTION
I used the wrong version when generating 0.33.2 docs.