### PR TITLE
Fix notebook CI

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -54,7 +54,6 @@ notebooks_exclude = [
 notebooks_that_submit_jobs = [
     "docs/guides/primitive-input-output.ipynb",
     "docs/guides/debug-qiskit-runtime-jobs.ipynb",
-    "docs/guides/qiskit-addons-obp-get-started.ipynb",
 ]
 
 # The following notebooks submit jobs that are too big to mock with a simulator (or use functions that aren't supported on sims)
@@ -64,5 +63,6 @@ notebooks_no_mock = [
     "docs/guides/get-started-with-primitives.ipynb",
     "docs/guides/hello-world.ipynb",
     "docs/guides/serverless-manage-resources.ipynb",
-    "docs/guides/noise-learning.ipynb"
+    "docs/guides/noise-learning.ipynb",
+    "docs/guides/qiskit-addons-obp-get-started.ipynb",
 ]


### PR DESCRIPTION
The OBP notebook can't be tested with our mocking technique. This PR fixes CI by ignoring that notebook so it'll only get tested during our fortnightly cron job. Tested by running `tox` locally.
