### PR TITLE
Link checker: Add a method to ignore non-API docs for objects.inv

### DIFF
--- a/scripts/js/lib/links/FileBatch.ts
+++ b/scripts/js/lib/links/FileBatch.ts
@@ -18,6 +18,7 @@ import {
   ALWAYS_IGNORED_URL_PREFIXES,
   FILES_TO_IGNORES,
   IGNORED_FILES,
+  ALWAYS_IGNORED_URL_REGEXES,
 } from "./ignores.js";
 import { parseFile } from "./extractLinks.js";
 
@@ -112,12 +113,14 @@ export function addLinksToMap(
   links: Set<string>,
   linksToOriginFiles: Map<string, string[]>,
 ): void {
+  const ignoreUrlsRegex = new RegExp(ALWAYS_IGNORED_URL_REGEXES.join("|"), "i");
   if (IGNORED_FILES.has(filePath)) return;
   links.forEach((link) => {
     if (
       ALWAYS_IGNORED_URLS.has(link) ||
       ALWAYS_IGNORED_URL_PREFIXES.some((prefix) => link.startsWith(prefix)) ||
-      FILES_TO_IGNORES[filePath]?.includes(link)
+      FILES_TO_IGNORES[filePath]?.includes(link) ||
+      ignoreUrlsRegex.test(link)
     ) {
       return;
     }

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -98,9 +98,10 @@ function _runtimeObjectsInvRegexes(): string[] {
     "primitives",
     "compare",
     "retired",
-  ].flatMap((path) => [
-    `\/api\/qiskit-ibm-runtime\/(0.16|0.15|0.14)\/${path}(\/.*|#.*|$)`,
-  ]);
+  ].map(
+    (path) =>
+      `\/api\/qiskit-ibm-runtime\/(0.16|0.15|0.14)\/${path}(\/.*|#.*|$)`,
+  );
 }
 
 export const ALWAYS_IGNORED_URL_REGEXES: string[] = [

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -76,16 +76,14 @@ function _addonsObjectsInvRegexes(): string[] {
   // Addons have non-API docs in their Sphinx build that translate into invalid links
   // we should ignore
   return ["how-tos", "how_tos", "install", "index", "explanations"]
-    .map(
-      (path) => [
-        // Latest version
-        `\/api\/qiskit-addon-[^\/]+\/${path}(\/.*|#.*|$)`,
-        // Historical versions
-        `\/api\/qiskit-addon-[^\/]+\/[0-9]+\.[0-9]\/${path}(\/.*|#.*|$)`,
-        // Dev version
-        `\/api\/qiskit-addon-[^\/]+\/dev\/${path}(\/.*|#.*|$)`,
-      ],
-    )
+    .map((path) => [
+      // Latest version
+      `\/api\/qiskit-addon-[^\/]+\/${path}(\/.*|#.*|$)`,
+      // Historical versions
+      `\/api\/qiskit-addon-[^\/]+\/[0-9]+\.[0-9]\/${path}(\/.*|#.*|$)`,
+      // Dev version
+      `\/api\/qiskit-addon-[^\/]+\/dev\/${path}(\/.*|#.*|$)`,
+    ])
     .flat();
 }
 

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -14,18 +14,7 @@
 // Ignored files
 // -----------------------------------------------------------------------------------
 
-export const IGNORED_FILES = new Set([
-  "public/api/qiskit-ibm-runtime/0.14/objects.inv",
-  "public/api/qiskit-ibm-runtime/0.15/objects.inv",
-  "public/api/qiskit-ibm-runtime/0.16/objects.inv",
-  "public/api/qiskit-addon-cutting/objects.inv",
-  "public/api/qiskit-addon-aqc-tensor/objects.inv",
-  "public/api/qiskit-addon-mpf/objects.inv",
-  "public/api/qiskit-addon-obp/objects.inv",
-  "public/api/qiskit-addon-sqd/objects.inv",
-  "public/api/qiskit-addon-sqd/0.7/objects.inv",
-  "public/api/qiskit-addon-utils/objects.inv",
-]);
+export const IGNORED_FILES: Set<string> = new Set([]);
 
 // -----------------------------------------------------------------------------------
 // Always ignored URLs - prefer to use more precise ignores
@@ -78,6 +67,52 @@ export const ALWAYS_IGNORED_URLS = new Set([
   ...ALWAYS_IGNORED_URLS__EXPECTED,
   ...ALWAYS_IGNORED_URLS__SHOULD_FIX,
 ]);
+
+// -----------------------------------------------------------------------------------
+// Always ignored URL regex - be careful using this
+// -----------------------------------------------------------------------------------
+
+function _addonsObjectsInvRegexes(): string[] {
+  return ["how-tos", "how_tos", "install", "index", "explanations"]
+    .map(
+      // Addoncs have non-API docs in their Sphinx build that translate into invalid links
+      // we should ignore
+      (path) => [
+        // Latest version
+        `\/api\/qiskit-addon-[^\/]+\/${path}(\/.*|#.*|$)`,
+        // Historical versions
+        `\/api\/qiskit-addon-[^\/]+\/[0-9]+\.[0-9]\/${path}(\/.*|#.*|$)`,
+        // Dev version
+        `\/api\/qiskit-addon-[^\/]+\/dev\/${path}(\/.*|#.*|$)`,
+      ],
+    )
+    .flat();
+}
+
+function _runtimeObjectsInvRegexes(): string[] {
+  return [
+    "errors",
+    "migrate",
+    "cloud",
+    "faqs",
+    "index",
+    "sessions",
+    "primitives",
+    "compare",
+    "retired",
+  ]
+    .map((path) => [
+      `\/api\/qiskit-ibm-runtime\/0.16\/${path}(\/.*|#.*|$)`,
+      `\/api\/qiskit-ibm-runtime\/0.15\/${path}(\/.*|#.*|$)`,
+      `\/api\/qiskit-ibm-runtime\/0.14\/${path}(\/.*|#.*|$)`,
+    ])
+    .flat();
+}
+
+export const ALWAYS_IGNORED_URL_REGEXES: string[] = [
+  ..._addonsObjectsInvRegexes(),
+  ..._runtimeObjectsInvRegexes(),
+];
 
 // -----------------------------------------------------------------------------------
 // Always ignored URL prefixes - be careful using this

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -75,16 +75,14 @@ export const ALWAYS_IGNORED_URLS = new Set([
 function _addonsObjectsInvRegexes(): string[] {
   // Addons have non-API docs in their Sphinx build that translate into invalid links
   // we should ignore
-  return ["how-tos", "how_tos", "install", "index", "explanations"]
-    .map((path) => [
+  return ["how-tos", "how_tos", "install", "index", "explanations"].flatMap(
+    (path) => [
       // Latest version
       `\/api\/qiskit-addon-[^\/]+\/${path}(\/.*|#.*|$)`,
       // Historical versions
       `\/api\/qiskit-addon-[^\/]+\/[0-9]+\.[0-9]\/${path}(\/.*|#.*|$)`,
-      // Dev version
-      `\/api\/qiskit-addon-[^\/]+\/dev\/${path}(\/.*|#.*|$)`,
-    ])
-    .flat();
+    ],
+  );
 }
 
 function _runtimeObjectsInvRegexes(): string[] {
@@ -100,13 +98,9 @@ function _runtimeObjectsInvRegexes(): string[] {
     "primitives",
     "compare",
     "retired",
-  ]
-    .map((path) => [
-      `\/api\/qiskit-ibm-runtime\/0.16\/${path}(\/.*|#.*|$)`,
-      `\/api\/qiskit-ibm-runtime\/0.15\/${path}(\/.*|#.*|$)`,
-      `\/api\/qiskit-ibm-runtime\/0.14\/${path}(\/.*|#.*|$)`,
-    ])
-    .flat();
+  ].flatMap((path) => [
+    `\/api\/qiskit-ibm-runtime\/(0.16|0.15|0.14)\/${path}(\/.*|#.*|$)`,
+  ]);
 }
 
 export const ALWAYS_IGNORED_URL_REGEXES: string[] = [

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -73,10 +73,10 @@ export const ALWAYS_IGNORED_URLS = new Set([
 // -----------------------------------------------------------------------------------
 
 function _addonsObjectsInvRegexes(): string[] {
+  // Addons have non-API docs in their Sphinx build that translate into invalid links
+  // we should ignore
   return ["how-tos", "how_tos", "install", "index", "explanations"]
     .map(
-      // Addons have non-API docs in their Sphinx build that translate into invalid links
-      // we should ignore
       (path) => [
         // Latest version
         `\/api\/qiskit-addon-[^\/]+\/${path}(\/.*|#.*|$)`,

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -69,13 +69,13 @@ export const ALWAYS_IGNORED_URLS = new Set([
 ]);
 
 // -----------------------------------------------------------------------------------
-// Always ignored URL regex - be careful using this
+// Always ignored URL regexes - be careful using this
 // -----------------------------------------------------------------------------------
 
 function _addonsObjectsInvRegexes(): string[] {
   return ["how-tos", "how_tos", "install", "index", "explanations"]
     .map(
-      // Addoncs have non-API docs in their Sphinx build that translate into invalid links
+      // Addons have non-API docs in their Sphinx build that translate into invalid links
       // we should ignore
       (path) => [
         // Latest version
@@ -90,6 +90,8 @@ function _addonsObjectsInvRegexes(): string[] {
 }
 
 function _runtimeObjectsInvRegexes(): string[] {
+  // Runtime has non-API docs in their Sphinx build that translate into invalid links
+  // we should ignore
   return [
     "errors",
     "migrate",


### PR DESCRIPTION
This PR adds a new mechanism to ignore links where we can add a regex expression to ignore all the URLs that match it. It adds regexes for the non-API docs in the addons' and runtime's objects.inv.

Closes #2296