### PR TITLE
Update preview image for `abstract property` support

### DIFF
--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:2ad7c6dbdca288077ef1c752384edc578e5b42fe0b311c75b94ba1733b2b8529"
+IMAGE_DIGEST = "sha256:9d475dd73d574cb420490cdaf203c45f9b211debee2fb8825bae40018e55bcae"
 
 PWD = Path(__file__).parent
 IMAGE = f"icr.io/qc-open-source-docs-public/preview@{IMAGE_DIGEST}"


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2330. Brings in the closed source change needed to render `abstract property`.