### PR TITLE
Escape localhost links as code

### DIFF
--- a/docs/guides/qiskit-code-assistant-local.mdx
+++ b/docs/guides/qiskit-code-assistant-local.mdx
@@ -66,7 +66,7 @@ The Ollama application provides a simple solution to run the GGUF models locally
 1. Install the downloaded file
 1. Launch the installed Ollama application
 
-    <Admonition type="info">The application is running successfully when the Ollama icon appears in the desktop menu bar. You can also verify the service is running by going to http://localhost:11434/.</Admonition>
+    <Admonition type="info">The application is running successfully when the Ollama icon appears in the desktop menu bar. You can also verify the service is running by going to `http://localhost:11434/`.</Admonition>
 
 1. Try Ollama in your terminal and start running models. For example:
 
@@ -186,7 +186,7 @@ Use the VS Code extension and JupyterLab extension for the Qiskit Code Assistant
 With the Qiskit Code Assistant VS Code extension, you can interact with the model and perform code completion while writing your code. This can work well for users looking for assistance writing Qiskit code for their Python applications.
 
 1. Install the [Qiskit Code Assistant VS Code extension](/guides/qiskit-code-assistant-vscode).
-1. In VS Code, go to the **User Settings** and set the **Qiskit Code Assistant: Url** to the URL of your local Ollama deployment (for example, http://localhost:11434).
+1. In VS Code, go to the **User Settings** and set the **Qiskit Code Assistant: Url** to the URL of your local Ollama deployment (for example, `http://localhost:11434`).
 1. Reload VS Code by going to **View > Command Palette...** and selecting **Developer: Reload Window**.
 
 The `granite-8b-qiskit` configured in Ollama should appear in the status bar and is then ready to use.
@@ -196,6 +196,6 @@ The `granite-8b-qiskit` configured in Ollama should appear in the status bar and
 With the Qiskit Code Assistant JupyterLab extension, you can interact with the model and perform code completion directly in your Jupyter Notebook. Users who predominantly work with Jupyter Notebooks can take advantage of this extension to further enhance their experience writing Qiskit code.
 
 1. Install the [Qiskit Code Assistant JupyterLab extension](/guides/qiskit-code-assistant-jupyterlab).
-1. In JupyterLab, go to the **Settings Editor** and set the **Qiskit Code Assistant Service API** to the URL of your local Ollama deployment (for example, http://localhost:11434).
+1. In JupyterLab, go to the **Settings Editor** and set the **Qiskit Code Assistant Service API** to the URL of your local Ollama deployment (for example, `http://localhost:11434`).
 
 The `granite-8b-qiskit` configured in Ollama should appear in the status bar and is then ready to use.


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2335. We decided it's more clear to users to show the links as code rather than normal external links, since they would 404.