### PR TITLE
Add params to nb-tester

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -315,31 +315,30 @@ async def _execute_notebook(filepath: Path, config: Config) -> nbformat.Notebook
     )
 
     await _execute_in_kernel(kernel, PRE_EXECUTE_CODE)
-    # if config.should_patch(filepath):
-    print(vars(config.args))
-    def get_arg(arg, default):
-        return vars(config.args).get(arg.lstrip("-").replace("-", "_"), default)
+    if config.should_patch(filepath):
+        def get_arg(arg, default):
+            return vars(config.args).get(arg.lstrip("-").replace("-", "_"), default)
 
-    backend = get_arg("--backend", "fake_athens")
-    provider = get_arg("--provider", "qiskit_fake_provider")
-    channel = get_arg("--channel", None)
-    token = get_arg("--token", None)
-    url = get_arg("--url", None)
-    name = get_arg("--name", None)
-    instance = get_arg("--instance", None)
-    
-    # Implements a subset of options from QiskitRuntimeService, but in practice any option
-    # can easily be added here
-    backend_cell = generate_backend_cell(
-        backend_name=backend, 
-        provider=provider,
-        channel=channel,
-        token=token,
-        url=url,
-        name=name,
-        instance=instance,
-    )
-    await _execute_in_kernel(kernel, backend_cell)
+        backend = get_arg("--backend", "fake_athens")
+        provider = get_arg("--provider", "qiskit_fake_provider")
+        channel = get_arg("--channel", None)
+        token = get_arg("--token", None)
+        url = get_arg("--url", None)
+        name = get_arg("--name", None)
+        instance = get_arg("--instance", None)
+
+        # Implements a subset of options from QiskitRuntimeService, but in practice any option
+        # can easily be added here
+        backend_cell = generate_backend_cell(
+            backend_name=backend, 
+            provider=provider,
+            channel=channel,
+            token=token,
+            url=url,
+            name=name,
+            instance=instance,
+        )
+        await _execute_in_kernel(kernel, backend_cell)
 
     notebook_client = nbclient.NotebookClient(
         nb=nb,

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -81,7 +81,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService"""
         cell += f"""
 from qiskit.providers.fake_provider import GenericBackendV2
 def patched_least_busy(self, *args, **kwargs):
-    GenericBackendV2(num_qubits=5, control_flow=True)"""
+    return GenericBackendV2(num_qubits=5, control_flow=True)"""
 
     elif provider == "runtime_fake_provider":
         cell += f"""
@@ -448,11 +448,11 @@ def get_args() -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--fake-provider",
-        action="store_true",
-        default=False,
+        "--provider",
+        action="store",
+        default="qiskit_fake_provider",
         help=(
-            "Specify whether to fetch the backend from a fake provider or not"
+            "Specify a provider to run notebook against [qiskit_ibm_provider, qiskit_fake_provider, runtime_fake_provider]"
         )
     )
     parser.add_argument(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -429,7 +429,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         action="store",
-        default="test_eagle",
+        default="fake_athens",
         help=(
             "Specify a backend to run the script against"
         )
@@ -440,6 +440,46 @@ def get_args() -> argparse.Namespace:
         default=False,
         help=(
             "Specify whether to fetch the backend from a fake provider or not"
+        )
+    )
+    parser.add_argument(
+        "--channel",
+        action="store",
+        default="ibm_quantum",
+        help=(
+            "Specify a channel for running the notebook against"
+        )
+    )
+    parser.add_argument(
+        "--token",
+        action="store",
+        default=None,
+        help=(
+            "IBM Cloud API key or IBM Quantum API token"
+        )
+    )
+    parser.add_argument(
+        "--url",
+        action="store",
+        default=None,
+        help=(
+            "The API URL to submit the notebook against"
+        )
+    )
+    parser.add_argument(
+        "--name",
+        action="store",
+        default=None,
+        help=(
+            "Name of the qiskit account to load"
+        )
+    )
+    parser.add_argument(
+        "--instance",
+        action="store",
+        default=None,
+        help=(
+            "The service instance to use"
         )
     )
     args = parser.parse_args()

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -96,7 +96,7 @@ def patched_least_busy(self, *args, **kwargs):
 def patched_least_busy(self, *args, **kwargs):
     service = QiskitRuntimeService({qiskit_runtime_service_args})
     return service.backend("{backend_name}")"""
-        
+
     else:
         raise ValueError(f"Please specify a valid provider. \"{provider}\" is invalid.")
 
@@ -261,7 +261,7 @@ async def execute_notebook(path: Path, config: Config) -> bool:
     Wrapper function for `_execute_notebook` to print status and write result
     """
     if config.should_patch(path):
-        print(f"▶️ Executing {path} (with least_busy patched to return fake backend)")
+        print(f"▶️ Executing {path} (with least_busy patched to {config.args.backend})")
     else:
         print(f"▶️ Executing {path}")
     possible_exceptions = (


### PR DESCRIPTION
Effectively allows the nb-tester script to be run against any backend. Also allows you to pass authentication and configuration directly to QiskitRuntimeService (if preferred).

Here's an example of how you can use the new changes to run a set of notebooks against test_eagle using qiskit_ibm_runtime:

```
test-docs-notebooks --config-path scripts/config/notebook-testing.toml --provider "qiskit_ibm_runtime" --backend "test_eagle2"
```

By default, `--provider` is set to `qiskit_fake_provider`, which runs the same provider code that was present in nb_tester before. By changing the provider, you can also specify "runtime_fake_provider" to use the fake_providers in `qiskit_ibm_runtime.fake_provider`, or "qiskit_ibm_runtime" to rely on real backends, and the credentials provided.

This shouldn't require changes in CI *yet* - it seems like notebook testing CI is able to complete the same number of tests as in main, although it does carry over some errors that I ran into on main too.