### PR TITLE
Add params to nb-tester

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -315,31 +315,30 @@ async def _execute_notebook(filepath: Path, config: Config) -> nbformat.Notebook
     )
 
     await _execute_in_kernel(kernel, PRE_EXECUTE_CODE)
-    # if config.should_patch(filepath):
-    print(vars(config.args))
-    def get_arg(arg, default):
-        return vars(config.args).get(arg.lstrip("-").replace("-", "_"), default)
+    if config.should_patch(filepath):
+        def get_arg(arg, default):
+            return vars(config.args).get(arg.lstrip("-").replace("-", "_"), default)
 
-    backend = get_arg("--backend", "fake_athens")
-    provider = get_arg("--provider", "qiskit_fake_provider")
-    channel = get_arg("--channel", None)
-    token = get_arg("--token", None)
-    url = get_arg("--url", None)
-    name = get_arg("--name", None)
-    instance = get_arg("--instance", None)
-    
-    # Implements a subset of options from QiskitRuntimeService, but in practice any option
-    # can easily be added here
-    backend_cell = generate_backend_cell(
-        backend_name=backend, 
-        provider=provider,
-        channel=channel,
-        token=token,
-        url=url,
-        name=name,
-        instance=instance,
-    )
-    await _execute_in_kernel(kernel, backend_cell)
+        backend = get_arg("--backend", "fake_athens")
+        provider = get_arg("--provider", "qiskit_fake_provider")
+        channel = get_arg("--channel", None)
+        token = get_arg("--token", None)
+        url = get_arg("--url", None)
+        name = get_arg("--name", None)
+        instance = get_arg("--instance", None)
+
+        # Implements a subset of options from QiskitRuntimeService, but in practice any option
+        # can easily be added here
+        backend_cell = generate_backend_cell(
+            backend_name=backend, 
+            provider=provider,
+            channel=channel,
+            token=token,
+            url=url,
+            name=name,
+            instance=instance,
+        )
+        await _execute_in_kernel(kernel, backend_cell)
 
     notebook_client = nbclient.NotebookClient(
         nb=nb,

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -435,7 +435,7 @@ def get_args() -> argparse.Namespace:
         help=(
             "Specify a backend to run the script against, such as 'fake_athens'"
             "or 'athens'. Only relevant when `--provider` is "
-            "`qiskit_ibm_runtime` or `runtime_fake_provider`."
+            "`qiskit-ibm-runtime` or `runtime-fake-provider`."
         )
     )
     generic_backend_options_group = parser.add_argument_group(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -456,7 +456,7 @@ def get_args() -> argparse.Namespace:
         action="store",
         default=None,
         help=(
-            "IBM Cloud API key or IBM Quantum API token"
+            'IBM Cloud API key or IBM Quantum API token. Warning: for security, you should set this via an environment variable, e.g. `--token="${IQP_API_TOKEN}"'
         )
     )
     parser.add_argument(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -81,7 +81,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService"""
         cell += f"""
 from qiskit.providers.fake_provider import GenericBackendV2
 def patched_least_busy(self, *args, **kwargs):
-    GenericBackendV2(num_qubits=5, control_flow=True)"""
+    return GenericBackendV2(num_qubits=5, control_flow=True)"""
 
     elif provider == "runtime_fake_provider":
         cell += f"""
@@ -448,11 +448,11 @@ def get_args() -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--fake-provider",
-        action="store_true",
-        default=False,
+        "--provider",
+        action="store",
+        default="qiskit_fake_provider",
         help=(
-            "Specify whether to fetch the backend from a fake provider or not"
+            "Specify a provider to run notebook against [qiskit_ibm_provider, qiskit_fake_provider, runtime_fake_provider]"
         )
     )
     parser.add_argument(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -65,9 +65,7 @@ def generate_backend_patch(
     """)
 
     if provider == "qiskit-fake-provider":
-        if not generic_backend_kwargs:
-            generic_backend_kwargs = {}
-        qiskit_fake_provider_args = render_kwargs(generic_backend_kwargs)
+        qiskit_fake_provider_args = render_kwargs(generic_backend_kwargs or {})
         patch += dedent(f"""
         from qiskit.providers.fake_provider import GenericBackendV2
         def patched_least_busy(self, *args, **kwargs):
@@ -84,10 +82,7 @@ def generate_backend_patch(
         """)
 
     elif provider == "qiskit-ibm-runtime": 
-        # Generates a set of arguments for QiskitRuntimeService using kwargs
-        if not runtime_service_kwargs:
-            runtime_service_kwargs = {}
-        qiskit_runtime_service_args = render_kwargs(runtime_service_kwargs)
+        qiskit_runtime_service_args = render_kwargs(runtime_service_kwargs or {})
 
         patch += dedent(f"""
         def patched_least_busy(self, *args, **kwargs):
@@ -448,6 +443,7 @@ def get_args() -> argparse.Namespace:
             "`qiskit-ibm-runtime` or `runtime-fake-provider`."
         )
     )
+
     generic_backend_options_group = parser.add_argument_group(
         "qiskit-fake-backend options",
         description=(
@@ -475,6 +471,7 @@ def get_args() -> argparse.Namespace:
             "directives on the target"
         )
     )
+
     runtime_options_group = parser.add_argument_group(
         "qiskit-ibm-runtime options",
         description=(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -46,7 +46,7 @@ warnings.filterwarnings("ignore", message="Session is not supported in local tes
 """
 
 def generate_backend_patch(
-    backend_name, 
+    backend_name: str, 
     provider: Literal["qiskit_ibm_runtime", "qiskit_fake_provider", "runtime_fake_provider"] = "qiskit_ibm_runtime", 
     **kwargs
 ):

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -51,7 +51,7 @@ def generate_backend_patch(
     **kwargs
 ):
     """
-    generate code for fetching a custom backend to inject into a notebook
+    Generate code for fetching a custom backend to inject into a notebook.
     """
 
     # Generates a set of arguments for QiskitRuntimeService using kwargs

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -431,7 +431,7 @@ def get_args() -> argparse.Namespace:
         action="store",
         default="fake_athens",
         help=(
-            "Specify a backend to run the script against"
+            "Specify a backend to run the script against, such as 'fake_athens' or 'athens'. Only relevant when `--provider` is `qiskit_ibm_runtime` or `runtime_fake_provider`."
         )
     )
     parser.add_argument(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -416,7 +416,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "--provider",
         action="store",
-        default="qiskit_fake_provider",
+        default="qiskit-fake-provider",
         choices=["qiskit-ibm-runtime", "qiskit-fake-provider", "runtime-fake-provider"],
         help=(
             "Specify a provider to run notebook against."

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -251,7 +251,7 @@ async def execute_notebook(path: Path, config: Config) -> bool:
     Wrapper function for `_execute_notebook` to print status and write result
     """
     if config.should_patch(path):
-        print(f"▶️ Executing {path} (with least_busy patched to {config.args.backend})")
+        print(f"▶️ Executing {path} (with least_busy patched)")
     else:
         print(f"▶️ Executing {path}")
     possible_exceptions = (

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -49,7 +49,7 @@ def generate_backend_patch(
     backend_name: str, 
     provider: Literal["qiskit_ibm_runtime", "qiskit_fake_provider", "runtime_fake_provider"] = "qiskit_ibm_runtime", 
     **kwargs
-):
+) -> str:
     """
     Generate code for fetching a custom backend to inject into a notebook.
     """

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -43,7 +43,6 @@ import warnings
 
 warnings.filterwarnings("ignore", message="Options {.*} have no effect in local testing mode.")
 warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
-warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
 """
 
 def generate_backend_patch(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -429,7 +429,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         action="store",
-        default="test_eagle",
+        default="fake_athens",
         help=(
             "Specify a backend to run the script against"
         )
@@ -440,6 +440,46 @@ def get_args() -> argparse.Namespace:
         default=False,
         help=(
             "Specify whether to fetch the backend from a fake provider or not"
+        )
+    )
+    parser.add_argument(
+        "--channel",
+        action="store",
+        default="ibm_quantum",
+        help=(
+            "Specify a channel for running the notebook against"
+        )
+    )
+    parser.add_argument(
+        "--token",
+        action="store",
+        default=None,
+        help=(
+            "IBM Cloud API key or IBM Quantum API token"
+        )
+    )
+    parser.add_argument(
+        "--url",
+        action="store",
+        default=None,
+        help=(
+            "The API URL to submit the notebook against"
+        )
+    )
+    parser.add_argument(
+        "--name",
+        action="store",
+        default=None,
+        help=(
+            "Name of the qiskit account to load"
+        )
+    )
+    parser.add_argument(
+        "--instance",
+        action="store",
+        default=None,
+        help=(
+            "The service instance to use"
         )
     )
     args = parser.parse_args()

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -87,9 +87,7 @@ def generate_backend_patch(
     else:
         raise ValueError(f"Please specify a valid provider. \"{provider}\" is invalid.")
 
-    patch += dedent("""
-    QiskitRuntimeService.least_busy = patched_least_busy
-    """)
+    patch += "\nQiskitRuntimeService.least_busy = patched_least_busy\n"
 
     patch += MOCKING_CODE
     return patch

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -57,7 +57,9 @@ def generate_backend_patch(
     """)
 
     if provider == "qiskit-fake-provider":
-        qiskit_fake_provider_args = ", ".join(f"{arg}=\"{val}\"" if val else f"{arg}=None" for arg, val in generic_backend_args.items())
+        qiskit_fake_provider_args = ", ".join(
+            f"{arg}=\"{val}\"" if isinstance(val, str) else f"{arg}={val}" for arg, val in generic_backend_args.items()
+        )
         patch += dedent(f"""
         from qiskit.providers.fake_provider import GenericBackendV2
         def patched_least_busy(self, *args, **kwargs):
@@ -77,7 +79,9 @@ def generate_backend_patch(
         # Generates a set of arguments for QiskitRuntimeService using kwargs
         if not runtime_service_args:
             runtime_service_args = {}
-        qiskit_runtime_service_args = ", ".join(f"{arg}=\"{val}\"" if val else f"{arg}=None" for arg, val in runtime_service_args.items())
+        qiskit_runtime_service_args = ", ".join(
+            f"{arg}=\"{val}\"" if isinstance(val, str) else f"{arg}={val}" for arg, val in generic_backend_args.items()
+        )
 
         patch += dedent(f"""
         def patched_least_busy(self, *args, **kwargs):
@@ -451,7 +455,7 @@ def get_args() -> argparse.Namespace:
     generic_backend_options_group.add_argument(
         "--num-qubits",
         action="store",
-        default="6",
+        default=6,
         help=(
             "Specify the number of qubits for the qiskit generic backend to use"
         )

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -96,7 +96,7 @@ def patched_least_busy(self, *args, **kwargs):
 def patched_least_busy(self, *args, **kwargs):
     service = QiskitRuntimeService({qiskit_runtime_service_args})
     return service.backend("{backend_name}")"""
-        
+
     else:
         raise ValueError(f"Please specify a valid provider. \"{provider}\" is invalid.")
 
@@ -261,7 +261,7 @@ async def execute_notebook(path: Path, config: Config) -> bool:
     Wrapper function for `_execute_notebook` to print status and write result
     """
     if config.should_patch(path):
-        print(f"▶️ Executing {path} (with least_busy patched to return fake backend)")
+        print(f"▶️ Executing {path} (with least_busy patched to {config.args.backend})")
     else:
         print(f"▶️ Executing {path}")
     possible_exceptions = (

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -66,7 +66,7 @@ def generate_backend_patch(
         patch += dedent("""
         from qiskit.providers.fake_provider import GenericBackendV2
         def patched_least_busy(self, *args, **kwargs):
-            return GenericBackendV2(num_qubits=5, control_flow=True)
+            return GenericBackendV2(num_qubits=6, control_flow=True)
         """)
 
     elif provider == "runtime_fake_provider":


### PR DESCRIPTION
Migrating from #2344

Effectively allows the nb-tester script to be run against any backend. Also allows you to pass authentication and configuration directly to QiskitRuntimeService (if preferred).

Here's an example of how you can use the new changes to run a set of notebooks against test_eagle using qiskit_ibm_runtime:

```
test-docs-notebooks --config-path scripts/config/notebook-testing.toml --provider "qiskit_ibm_runtime" --backend "test_eagle2"
```

By default, `--provider` is set to `qiskit_fake_provider`, which runs the same provider code that was present in nb_tester before. By changing the provider, you can also specify "runtime_fake_provider" to use the fake_providers in `qiskit_ibm_runtime.fake_provider`, or "qiskit_ibm_runtime" to rely on real backends, and the credentials provided.

This shouldn't require changes in CI *yet* - it seems like notebook testing CI is able to complete the same number of tests as in main, although it does carry over some errors that I ran into on main too.