### PR TITLE
Warn about using Latex with DefinitionTooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ To use a `DefinitionTooltip`, use the following syntax:
 
 For full list of props, please check [here](https://react.carbondesignsystem.com/?path=/docs/components-definitiontooltip--playground#component-api).
 
-Warning: do not use Latex/math expressions in the same paragraph as a definition tooltip because it will break the styling. Use a new line to separate out the two into separate paragraphs.
+Warning: do not use LaTeX/math expressions in the same paragraph as a definition tooltip because it will break the styling. Use a new line to separate out the two into separate paragraphs.
 
 ### Tabs
 

--- a/README.md
+++ b/README.md
@@ -627,6 +627,8 @@ To use a `DefinitionTooltip`, use the following syntax:
 
 For full list of props, please check [here](https://react.carbondesignsystem.com/?path=/docs/components-definitiontooltip--playground#component-api).
 
+Warning: do not use Latex/math expressions in the same paragraph as a definition tooltip because it will break the styling. Use a new line to separate out the two into separate paragraphs.
+
 ### Tabs
 
 To use a `Tabs` component, use the following syntax:


### PR DESCRIPTION
We recently fixed DefinitionTooltip being broken due to a styling change we had made to fix the scroll behavior of inline Latex. However, we could not easily fix an edge case where you have both a DefinitionTooltip and the Latex in the _same_ paragraph. So, for now, we document the edge case.