### PR TITLE
Execute each notebook in its own temporary directory

### DIFF
--- a/docs/guides/save-circuits.ipynb
+++ b/docs/guides/save-circuits.ipynb
@@ -113,23 +113,6 @@
     "\n",
     "qc[0].draw(\"mpl\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "55d34ab2-1031-49e1-8aea-9794adabd0fc",
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Cleanup the file we created (this cell should be hidden from the user)\n",
-    "import pathlib\n",
-    "\n",
-    "pathlib.Path(\"test.qpy\").unlink()"
-   ]
   }
  ],
  "metadata": {

--- a/docs/guides/save-jobs.ipynb
+++ b/docs/guides/save-jobs.ipynb
@@ -219,23 +219,6 @@
     "\n",
     "result"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "eae94b73-157b-4751-8dd3-add4cc9efec6",
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Cleanup the file we created (this cell should be hidden from the user)\n",
-    "import pathlib\n",
-    "\n",
-    "pathlib.Path(\"result.json\").unlink()"
-   ]
   }
  ],
  "metadata": {

--- a/docs/guides/serverless-first-program.ipynb
+++ b/docs/guides/serverless-first-program.ipynb
@@ -376,27 +376,6 @@
     "\n",
     "</Admonition>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "2992c8d5-f8f5-4602-8705-db1e20383459",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# This cell is hidden from users, it just deletes the working folder we created\n",
-    "import shutil\n",
-    "\n",
-    "shutil.rmtree(\"./source_files/\")"
-   ]
   }
  ],
  "metadata": {

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+import tempfile
 import textwrap
 from textwrap import dedent
 import platform
@@ -33,9 +34,14 @@ from squeaky import clean_notebook
 
 # We always run the following code in the kernel before running the notebook
 PRE_EXECUTE_CODE = """\
-import matplotlib
+# Import with underscores to avoid interfering with user-facing code.
+from os import chdir as _chdir
+from matplotlib import set_loglevel as _set_mpl_loglevel
+
 # See https://github.com/matplotlib/matplotlib/issues/23326#issuecomment-1164772708
-matplotlib.set_loglevel("critical")
+_set_mpl_loglevel("critical")
+
+_chdir("{temp_dir_path}")
 """
 
 def render_kwarg(arg: str, val: any):
@@ -255,15 +261,19 @@ async def execute_notebook(path: Path, config: Config) -> bool:
         print(f"▶️ Executing {path} (with least_busy patched)")
     else:
         print(f"▶️ Executing {path}")
+
+    working_directory = tempfile.TemporaryDirectory()
     possible_exceptions = (
         nbclient.exceptions.CellExecutionError,
         nbclient.exceptions.CellTimeoutError,
     )
     try:
-        nb = await _execute_notebook(path, config)
+        nb = await _execute_notebook(path, config, working_directory.name)
     except possible_exceptions as err:
         print(f"❌ Problem in {path}:\n{err}")
         return False
+    finally:
+        working_directory.cleanup()
 
     notebook_warnings = extract_warnings(nb)
     if notebook_warnings:
@@ -289,12 +299,14 @@ async def _execute_in_kernel(kernel: AsyncKernelClient, code: str) -> None:
         raise Exception("Error running initialization code")
 
 
-async def _execute_notebook(filepath: Path, config: Config) -> nbformat.NotebookNode:
+async def _execute_notebook(
+    filepath: Path, config: Config, working_directory: str
+) -> nbformat.NotebookNode:
     """
     Use nbclient to execute notebook. The steps are:
     1. Read notebook from file
     2. Create a new kernel
-    3. (Optional) Run some custom code to set up the kernel
+    3. Run some custom code to set up the kernel
     4. Execute the notebook inside the kernel
     5. Clean the notebook and return it
     """
@@ -305,7 +317,9 @@ async def _execute_notebook(filepath: Path, config: Config) -> nbformat.Notebook
         extra_arguments=["--InlineBackend.figure_format='svg'"],
     )
 
-    await _execute_in_kernel(kernel, PRE_EXECUTE_CODE)
+    await _execute_in_kernel(
+        kernel, PRE_EXECUTE_CODE.format(temp_dir_path=working_directory)
+    )
     if config.should_patch(filepath):
         # Implements a subset of options from QiskitRuntimeService, but in 
         # practice any option can easily be added here

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -35,13 +35,10 @@ from squeaky import clean_notebook
 # We always run the following code in the kernel before running the notebook
 PRE_EXECUTE_CODE = """\
 # Import with underscores to avoid interfering with user-facing code.
-from os import chdir as _chdir
 from matplotlib import set_loglevel as _set_mpl_loglevel
 
 # See https://github.com/matplotlib/matplotlib/issues/23326#issuecomment-1164772708
 _set_mpl_loglevel("critical")
-
-_chdir("{temp_dir_path}")
 """
 
 def render_kwarg(arg: str, val: any):
@@ -315,11 +312,10 @@ async def _execute_notebook(
     kernel_manager, kernel = await start_new_async_kernel(
         kernel_name="python3",
         extra_arguments=["--InlineBackend.figure_format='svg'"],
+        cwd=working_directory,
     )
 
-    await _execute_in_kernel(
-        kernel, PRE_EXECUTE_CODE.format(temp_dir_path=working_directory)
-    )
+    await _execute_in_kernel(kernel, PRE_EXECUTE_CODE)
     if config.should_patch(filepath):
         # Implements a subset of options from QiskitRuntimeService, but in 
         # practice any option can easily be added here


### PR DESCRIPTION
We have some notebooks that write files to disk. At the moment, running these notebooks through `tox` means these notebooks use the docs repo as their working directory and will write files there. This is problematic for a couple of reasons:

1. Notebooks that write to disk can interfere with eachother. For example, two notebooks may try to write/read from the same file.
2. Notebook failures (or killing the script) will leave working files in the repo.

This PR solves the problem by modifying the script to execute each notebook in its own temporary directory.