### PR TITLE
Ignore valid external link

### DIFF
--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -52,6 +52,7 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.131.210601",
   "https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.5.033154",
   "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.92.042303",
+  "https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.6.033309",
   "https://www.cs.bham.ac.uk/~xin/papers/published_tec_sep00_constraint.pdf",
   "https://https://arxiv.org/abs/quant-ph/0403071",
   "https://doi.org/10.1103/PhysRevApplied.5.034007",


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/2379. The other link https://arxiv.org/abs/2307.17405 is actually broken and I've asked the addons team to fix it.