### PR TITLE
Redesign nb-tester interface

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Execute notebooks
         timeout-minutes: 350
-        run: tox -- --write --only-submit-jobs
+        run: tox -- --write --test-strategy hardware
 
       - name: Detect changed notebooks
         id: changed-notebooks

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -47,7 +47,7 @@ jobs:
           """.strip().split("\n")
           import os
           github_output = os.getenv("GITHUB_OUTPUT")
-          all_files = "${{ steps.all-changed.outputs.all_changed_files }}".split("\n")
+          all_files = """${{ steps.all-changed.outputs.all_changed_files }}""".split("\n")
 
           config_changed = any(path.startswith("scripts/") for path in all_files)
           extra_deps = config_changed or any(path in EXTRA_DEPS_NOTEBOOKS for path in all_files)

--- a/scripts/ci/check-all-notebooks-are-tested.py
+++ b/scripts/ci/check-all-notebooks-are-tested.py
@@ -23,8 +23,8 @@ config_path = Path("scripts/config/notebook-testing.toml")
 config = tomllib.loads(config_path.read_text())
 
 categorized_notebooks = set()
-for group in config.values():
-    for path in group:
+for group in config["groups"].values():
+    for path in group.get("notebooks", []):
         categorized_notebooks.add(Path(path))
 
 uncategorized = [

--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -1,12 +1,12 @@
-default-strategy="ci"
+default-strategy = "ci"
 
 [test-strategies]
 ci = { timeout = 300 }
 
 # For notebooks to be tested in CI "normally" (no mocking)
 [groups.normal]
-test-strategies.ci={}
-test-strategies.hardware={}
+test-strategies.ci = {}
+test-strategies.hardware = {}
 notebooks = [
     "docs/guides/build-noise-models.ipynb",
     "docs/guides/circuit-library.ipynb",
@@ -46,8 +46,8 @@ notebooks = [
 
 # The following notebooks submit jobs that can be mocked with a simulator
 [groups.mockable]
-test-strategies.ci={ provider="qiskit-fake-provider", generic_backend_kwargs={ num_qubits=6 } }
-test-strategies.hardware={}
+test-strategies.ci = { provider="qiskit-fake-provider", generic_backend_kwargs={ num_qubits=6 } }
+test-strategies.hardware = {}
 notebooks = [
     "docs/guides/debug-qiskit-runtime-jobs.ipynb",
     "docs/guides/primitive-input-output.ipynb",
@@ -57,7 +57,7 @@ notebooks = [
 # A job is "too big" if a cell can't run in under 5 mins, or we run out of
 # memory on a reasonable device.
 [groups.cron-job-only]
-test-strategies.hardware={}
+test-strategies.hardware = {}
 notebooks = [
     "docs/guides/get-started-with-primitives.ipynb",
     "docs/guides/hello-world.ipynb",

--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -1,68 +1,83 @@
-# For notebooks to be tested "normally" (no mocking)
-notebooks_normal_test = [
-    "docs/guides/construct-circuits.ipynb",
+default-strategy="ci"
+
+[test-strategies]
+ci = { timeout = 300 }
+
+# For notebooks to be tested in CI "normally" (no mocking)
+[groups.normal]
+test-strategies.ci={}
+test-strategies.hardware={}
+notebooks = [
+    "docs/guides/build-noise-models.ipynb",
     "docs/guides/circuit-library.ipynb",
-    "docs/guides/visualize-circuits.ipynb",
     "docs/guides/classical-feedforward-and-control-flow.ipynb",
-    "docs/guides/operators-overview.ipynb",
-    "docs/guides/pulse.ipynb",
-    "docs/guides/save-circuits.ipynb",
-    "docs/guides/save-jobs.ipynb",
-    "docs/guides/dynamic-circuits-considerations.ipynb",
-    "docs/guides/get-qpu-information.ipynb",
-    "docs/guides/visualize-results.ipynb",
     "docs/guides/common-parameters.ipynb",
+    "docs/guides/construct-circuits.ipynb",
     "docs/guides/create-transpiler-plugin.ipynb",
     "docs/guides/custom-backend.ipynb",
     "docs/guides/custom-transpiler-pass.ipynb",
     "docs/guides/defaults-and-configuration-options.ipynb",
+    "docs/guides/dynamic-circuits-considerations.ipynb",
     "docs/guides/dynamical-decoupling-pass-manager.ipynb",
-    "docs/guides/represent-quantum-computers.ipynb",
-    "docs/guides/set-optimization.ipynb",
-    "docs/guides/transpile-with-pass-managers.ipynb",
-    "docs/guides/transpiler-plugins.ipynb",
-    "docs/guides/transpiler-stages.ipynb",
-    "docs/guides/build-noise-models.ipynb",
-    "docs/guides/local-testing-mode.ipynb",
-    "docs/guides/plot-quantum-states.ipynb",
-    "docs/guides/simulate-with-qiskit-aer.ipynb",
-    "docs/guides/simulate-stabilizer-circuits.ipynb",
-    "docs/guides/operator-class.ipynb",
     "docs/guides/error-mitigation-and-suppression-techniques.ipynb",
+    "docs/guides/get-qpu-information.ipynb",
+    "docs/guides/local-testing-mode.ipynb",
+    "docs/guides/operator-class.ipynb",
+    "docs/guides/operators-overview.ipynb",
+    "docs/guides/plot-quantum-states.ipynb",
+    "docs/guides/pulse.ipynb",
+    "docs/guides/qiskit-addons-aqc-get-started.ipynb",
+    "docs/guides/represent-quantum-computers.ipynb",
+    "docs/guides/save-circuits.ipynb",
+    "docs/guides/save-jobs.ipynb",
     "docs/guides/serverless-first-program.ipynb",
     "docs/guides/serverless-manage-resources.ipynb",
     "docs/guides/serverless-run-first-workload.ipynb",
+    "docs/guides/set-optimization.ipynb",
+    "docs/guides/simulate-stabilizer-circuits.ipynb",
+    "docs/guides/simulate-with-qiskit-aer.ipynb",
     "docs/guides/specify-observables-pauli.ipynb",
-    "docs/guides/qiskit-addons-aqc-get-started.ipynb",
+    "docs/guides/transpile-with-pass-managers.ipynb",
+    "docs/guides/transpiler-plugins.ipynb",
+    "docs/guides/transpiler-stages.ipynb",
+    "docs/guides/visualize-circuits.ipynb",
+    "docs/guides/visualize-results.ipynb",
 ]
 
-# Don't test the following notebooks (this section can include glob patterns)
-notebooks_exclude = [
-    "docs/guides/qedma-qesem.ipynb",
-    "docs/guides/q-ctrl-optimization-solver.ipynb",
-    "docs/guides/q-ctrl-performance-management.ipynb",
-    "docs/guides/algorithmiq-tem.ipynb",
-    "docs/guides/functions.ipynb",
-    "docs/guides/qunasys-quri-chemistry.ipynb",
-    "docs/guides/multiverse-computing-singularity.ipynb",
-    "docs/guides/ibm-circuit-function.ipynb",
-    "docs/guides/qiskit-addons-sqd-get-started.ipynb",
-    "docs/guides/fractional-gates.ipynb",
-]
-
-# The following notebooks submit jobs that can be mocked with a 5Q simulator
-notebooks_that_submit_jobs = [
-    "docs/guides/primitive-input-output.ipynb",
+# The following notebooks submit jobs that can be mocked with a simulator
+[groups.mockable]
+test-strategies.ci={ provider="qiskit-fake-provider", generic_backend_kwargs={ num_qubits=6 } }
+test-strategies.hardware={}
+notebooks = [
     "docs/guides/debug-qiskit-runtime-jobs.ipynb",
+    "docs/guides/primitive-input-output.ipynb",
 ]
 
-# The following notebooks submit jobs that are too big to mock with a 5Q simulator (or use functions that aren't supported on sims)
+# The following notebooks submit jobs that are too big to mock with a simulator (or use functions that aren't supported on sims)
 # A job is "too big" if a cell can't run in under 5 mins, or we run out of
 # memory on a reasonable device.
-notebooks_no_mock = [
+[groups.cron-job-only]
+test-strategies.hardware={}
+notebooks = [
     "docs/guides/get-started-with-primitives.ipynb",
     "docs/guides/hello-world.ipynb",
     "docs/guides/noise-learning.ipynb",
     "docs/guides/qiskit-addons-obp-get-started.ipynb",
     "docs/guides/primitives-examples.ipynb",
 ]
+
+# Don't ever test the following notebooks
+[groups.exclude]
+notebooks = [
+    "docs/guides/algorithmiq-tem.ipynb",
+    "docs/guides/fractional-gates.ipynb",
+    "docs/guides/functions.ipynb",
+    "docs/guides/ibm-circuit-function.ipynb",
+    "docs/guides/multiverse-computing-singularity.ipynb",
+    "docs/guides/q-ctrl-optimization-solver.ipynb",
+    "docs/guides/q-ctrl-performance-management.ipynb",
+    "docs/guides/qedma-qesem.ipynb",
+    "docs/guides/qiskit-addons-sqd-get-started.ipynb",
+    "docs/guides/qunasys-quri-chemistry.ipynb",
+]
+

--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -46,7 +46,7 @@ notebooks = [
 
 # The following notebooks submit jobs that can be mocked with a simulator
 [groups.mockable]
-test-strategies.ci = { provider="qiskit-fake-provider", generic_backend_kwargs={ num_qubits=6 } }
+test-strategies.ci = { patch="qiskit-fake-provider", num_qubits=6 }
 test-strategies.hardware = {}
 notebooks = [
     "docs/guides/debug-qiskit-runtime-jobs.ipynb",

--- a/scripts/nb-tester/README.md
+++ b/scripts/nb-tester/README.md
@@ -60,7 +60,7 @@ variables as extra arguments in the TOML dict.
 There are two ways to provide patches: Through the CLI or through a config file.
 You cannot use both at the same time.
 
-### Set patches through the CLI
+### Set patches through the CLI
 
 Use the `--patch` argument to provide patch information, followed by a list of
 filenames that the patch should apply to. Filenames passed before a `--patch`

--- a/scripts/nb-tester/README.md
+++ b/scripts/nb-tester/README.md
@@ -16,10 +16,6 @@ test-docs-notebooks path/to/notebook.ipynb path/to/another.ipynb
 * To set a time limit for each cell, include the `--cell-timeout` argument,
   followed by the time in seconds.
 
-```
-test-docs-notebooks --write path/to/notebook.ipynb
-```
-
 ## Patches
 
 A key feature of this tool is tricking notebooks into running jobs on a
@@ -37,7 +33,7 @@ You specify patch information as a TOML dict string. This dict _must_ inculde a
 one of our built-in patches (choose from `qiskit-fake-provider`,
 `qiskit-ibm-runtime`, or `qiskit-fake-provider`).
 
-```toml
+```
 { patch="patch-name" }
 ```
 
@@ -48,22 +44,23 @@ code using `.format(**args)`. For example, here's a simplified version of our
 built-in `qiskit-fake-provider` patch:
 
 ```python
+# Example patch file
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit_ibm_runtime import QiskitRuntimeService
 QiskitRuntimeService.least_busy = lambda *_: GenericBackendV2(num_qubits={num_qubits})
 ```
 
-Note the variable `{num_qubits}`. To use this patch, you include the values of
-any variables as extra arguments in the TOML dict.
+Note the variable `{num_qubits}`. To use this patch, include the values of any
+variables as extra arguments in the TOML dict.
 
-```toml
+```
 { patch="qiskit-fake-provider", num_qubits=3 }
 ```
 
 There are two ways to provide patches: Through the CLI or through a config file.
 You cannot use both at the same time.
 
-### Setting patches through the CLI
+### Set patches through the CLI
 
 Use the `--patch` argument to provide patch information, followed by a list of
 filenames that the patch should apply to. Filenames passed before a `--patch`
@@ -96,13 +93,13 @@ This will execute:
 
 </details>
 
-### Setting patches through a config file
+### Set patches through a config file
 
 You can also choose how to patch notebooks through a TOML file. This config
 file contains groups of notebook paths, and each group includes information on
 how to patch that group in different situations, known as "test strategies".
 
-```toml
+```
 # Example config file
 default-strategy = "<strategy-name>"
 
@@ -125,13 +122,13 @@ default-strategy = "main"
 [test-strategies]
 mock = { timeout = 300 }
 
-[groups.no-mock]
+[groups.group1]
 test-strategies.main = {}
 notebooks = [
     "notebook.ipynb",
 ]
 
-[groups.mock]
+[groups.group2]
 test-strategies.main = {}
 test-strategies.mock = { patch="qiskit-fake-provider", num_qubits=6 }
 notebooks = [
@@ -154,10 +151,10 @@ Here's a few different commands you could run:
   ```
 
   This runs the same config file but with test strategy "mock". This will skip
-  `notebook.ipynb`, as it does not have a "mock" strategy defined, and will run
-  `another-notebook.ipynb` with a 6-qubit simulator. The "mock" strategy also
-  has a timeout defined, so each cell will timeout after 300s. You can override
-  this with your own `--timeout` argument.
+  `notebook.ipynb`, as its group does not have a "mock" strategy defined, and
+  will run `another-notebook.ipynb` with a 6-qubit simulator. The "mock"
+  strategy also has a timeout defined, so each cell will timeout after 300s.
+  You can override this with your own `--timeout` argument.
 
 * ```
   test-docs-notebooks notebook.ipynb --config-path config.toml

--- a/scripts/nb-tester/README.md
+++ b/scripts/nb-tester/README.md
@@ -28,7 +28,7 @@ A patch is just Python code that we run in the kernel before executing your
 notebook's code. You can provide your own patch code, or use one of our
 built-in patches.
 
-You specify patch information as a TOML dict string. This dict _must_ inculde a
+You can specify patch information as a TOML dict string. This dict _must_ include a
 `patch` key, which is either a filepath to your custom patch, or the name of
 one of our built-in patches (choose from `qiskit-fake-provider`,
 `qiskit-ibm-runtime`, or `qiskit-fake-provider`).

--- a/scripts/nb-tester/README.md
+++ b/scripts/nb-tester/README.md
@@ -1,0 +1,171 @@
+# Qiskit documentation notebook tester
+
+A tool to execute notebooks for testing, with certain features useful for
+notebooks that run jobs on IBM Quantum backends.
+
+## Basic usage
+
+To use this tool, just run the `test-docs-notebooks` command, followed by a
+list of notebooks you'd like to execute.
+
+```
+test-docs-notebooks path/to/notebook.ipynb path/to/another.ipynb
+```
+
+* To write the executed notebooks to disk, include the `--write` argument.
+* To set a time limit for each cell, include the `--cell-timeout` argument,
+  followed by the time in seconds.
+
+```
+test-docs-notebooks --write path/to/notebook.ipynb
+```
+
+## Patches
+
+A key feature of this tool is tricking notebooks into running jobs on a
+specific backend so we can test them without waiting in a queue. We do this by
+monkey-patching `QiskitRuntimeService.least_busy` to return the backend of our
+choosing. This technique requires notebooks always use `least_busy` to select a
+backend.
+
+A patch is just Python code that we run in the kernel before executing your
+notebook's code. You can provide your own patch code, or use one of our
+built-in patches.
+
+You specify patch information as a TOML dict string. This dict _must_ inculde a
+`patch` key, which is either a filepath to your custom patch, or the name of
+one of our built-in patches (choose from `qiskit-fake-provider`,
+`qiskit-ibm-runtime`, or `qiskit-fake-provider`).
+
+```toml
+{ patch="patch-name" }
+```
+
+To make them more flexible, the patch code can include variables inside curly
+braces. If a patch includes variables, you must provide them as extra arguments
+when specifying the patch. These arguments will be injected into your patch
+code using `.format(**args)`. For example, here's a simplified version of our
+built-in `qiskit-fake-provider` patch:
+
+```python
+from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit_ibm_runtime import QiskitRuntimeService
+QiskitRuntimeService.least_busy = lambda *_: GenericBackendV2(num_qubits={num_qubits})
+```
+
+Note the variable `{num_qubits}`. To use this patch, you include the values of
+any variables as extra arguments in the TOML dict.
+
+```toml
+{ patch="qiskit-fake-provider", num_qubits=3 }
+```
+
+There are two ways to provide patches: Through the CLI or through a config file.
+You cannot use both at the same time.
+
+### Setting patches through the CLI
+
+Use the `--patch` argument to provide patch information, followed by a list of
+filenames that the patch should apply to. Filenames passed before a `--patch`
+argument are not patched.
+
+```
+test-docs-notebooks [filenames] --patch [patch-information] [filenames]
+```
+
+<details><summary>Example usage</summary>
+
+Take the following command as an example.
+
+```
+test-docs-notebooks\
+  notebook.ipynb\
+  --patch\
+  '{ patch="qiskit-fake-provider", num_qubits=6 }'\
+  notebook-2.ipynb\
+  notebook-3.ipynb\
+  --patch\
+  '{ patch="qiskit-ibm-runtime", backend="test-eagle", qiskit_runtime_service_args="" }'\
+  notebook-4.ipynb
+```
+
+This will execute:
+ * `notebook.ipynb` with no patch
+ * `notebook-2.ipynb` and `notebook-3.ipynb` with `least_busy` patched to return a 6-qubit simulator
+ * `notebook-4.ipynb` with `least_busy` patched to return the `test-eagle` cloud backend
+
+</details>
+
+### Setting patches through a config file
+
+You can also choose how to patch notebooks through a TOML file. This config
+file contains groups of notebook paths, and each group includes information on
+how to patch that group in different situations, known as "test strategies".
+
+```toml
+# Example config file
+default-strategy = "<strategy-name>"
+
+[groups.<name>]
+test-strategies.<strategy-name> = { patch="<patch-name>", <patch-args> }
+notebooks = [
+  <notebook-paths>
+]
+```
+
+<details><summary>Example usage</summary>
+
+For example, the following config file has two groups, each with one notebook,
+and two test strategies: "main" and "mock".
+
+```toml
+# config.toml
+default-strategy = "main"
+
+[test-strategies]
+mock = { timeout = 300 }
+
+[groups.no-mock]
+test-strategies.main = {}
+notebooks = [
+    "notebook.ipynb",
+]
+
+[groups.mock]
+test-strategies.main = {}
+test-strategies.mock = { patch="qiskit-fake-provider", num_qubits=6 }
+notebooks = [
+    "another-notebook.ipynb",
+]
+```
+
+Here's a few different commands you could run:
+
+* ```
+  test-docs-notebooks --config-path config.toml
+  ```
+
+  This will run the config file with its default strategy, which
+  is "main". This means both `notebook.ipynb` and `another-notebook.ipynb` will
+  run without patching, as their `test-strategies.main` has no `patch` arg.
+
+* ```
+  test-docs-notebooks --config-path config.toml --test-strategy mock
+  ```
+
+  This runs the same config file but with test strategy "mock". This will skip
+  `notebook.ipynb`, as it does not have a "mock" strategy defined, and will run
+  `another-notebook.ipynb` with a 6-qubit simulator. The "mock" strategy also
+  has a timeout defined, so each cell will timeout after 300s. You can override
+  this with your own `--timeout` argument.
+
+* ```
+  test-docs-notebooks notebook.ipynb --config-path config.toml
+  ```
+
+  You can also provide filenames when using a config file. When filenames are
+  set, the script will only run notebooks passed as the filepath arg. This
+  command will run `notebook.ipynb` but skip `another-notebook.ipynb` as it
+  wasn't passed as a filename arg.
+
+</details>

--- a/scripts/nb-tester/patches/qiskit-fake-provider
+++ b/scripts/nb-tester/patches/qiskit-fake-provider
@@ -1,0 +1,11 @@
+import warnings
+from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+warnings.filterwarnings("ignore", message="Options {{.*}} have no effect in local testing mode.")
+warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
+
+def patched_least_busy(self, *args, **kwargs):
+    return GenericBackendV2(num_qubits={num_qubits})
+
+QiskitRuntimeService.least_busy = patched_least_busy

--- a/scripts/nb-tester/patches/qiskit-ibm-runtime
+++ b/scripts/nb-tester/patches/qiskit-ibm-runtime
@@ -1,0 +1,7 @@
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+def patched_least_busy(self, *args, **kwargs):
+    service = QiskitRuntimeService({qiskit_runtime_service_args})
+    return service.backend("{backend}")
+
+QiskitRuntimeService.least_busy = patched_least_busy

--- a/scripts/nb-tester/patches/runtime-fake-provider
+++ b/scripts/nb-tester/patches/runtime-fake-provider
@@ -1,0 +1,11 @@
+import warnings
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+warnings.filterwarnings("ignore", message="Options {{.*}} have no effect in local testing mode.")
+warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
+
+def patched_least_busy(self, *args, **kwargs):
+    provider = FakeProviderForBackendV2()
+    return provider.backend("{backend}")
+
+QiskitRuntimeService.least_busy = patched_least_busy

--- a/scripts/nb-tester/pyproject.toml
+++ b/scripts/nb-tester/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "nbformat~=5.10.4",
   "ipykernel~=6.29.2",
   "squeaky==0.7.0",
-  "tomli==2.2.1",
 ]
 
 [[project.authors]]

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from textwrap import dedent
 import platform
 from datetime import datetime
 

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/__init__.py
@@ -19,12 +19,12 @@ from textwrap import dedent
 import platform
 from datetime import datetime
 
-from .config import get_notebook_jobs, get_args
+from .config import get_notebook_jobs, get_parser
 from .execute import execute_notebook, cancel_trailing_jobs
 
 
 async def _main() -> None:
-    args = get_args()
+    args = get_parser().parse_args()
     jobs = list(get_notebook_jobs(args))
 
     if not jobs:

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -170,13 +170,13 @@ class Config:
         if patch_name is None:
             return None
 
+        if Path(patch_name).exists():
+            return Path(patch_name).read_text().format(**patch_config)
+
         built_in_patch_dir = importlib.resources.files("patches")
         built_in_patch = built_in_patch_dir / patch_name
         if built_in_patch.exists():
             return built_in_patch.read_text().format(**patch_config)
-
-        if Path(patch_name).exists():
-            return Path(patch_name).read_text().format(**patch_config)
 
         valid_patch_names = list(path.name for path in built_in_patch_dir.iterdir())
         raise ValueError(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -17,7 +17,7 @@ import argparse
 from textwrap import dedent
 from dataclasses import dataclass
 from pathlib import Path
-import tomli
+import tomllib
 from typing import Iterator, Literal
 
 
@@ -59,143 +59,146 @@ def get_notebook_jobs(args: argparse.Namespace) -> Iterator[NotebookJob]:
     """
     config = Config.from_args(args)
 
-    for path in config.notebooks_to_execute():
-        backend_patch = None
-        if config.should_patch(path):
-            # Implements a subset of options from QiskitRuntimeService, but in 
-            # practice any option can easily be added here
-            backend_patch = generate_backend_patch(
-                backend_name=config.args.backend, 
-                provider=config.args.provider,
-                runtime_service_kwargs = {
-                    "channel": config.args.channel,
-                    "token": config.args.token,
-                    "url": config.args.url,
-                    "name": config.args.name,
-                    "instance": config.args.instance,
-                },
-                generic_backend_kwargs = {
-                    "num_qubits": config.args.num_qubits,
-                    "control_flow": config.args.control_flow
-                }
-            )
-        
-        write = Result(True)
-        if reason := config.should_skip_writing(path):
-            write = Result(False, reason)
+    for group in config.groups:
+        for path in group["notebooks"]:
+            if config.cli_filenames and not matches(path, config.cli_filenames):
+                continue
+            if config.test_strategy not in group.get("test-strategies", {}):
+                if matches(path, config.cli_filenames):
+                    # User explicitly defined this path so we'll explain why we're skipping it
+                    print(
+                        f'ℹ️ Skipping {path} (no test strategy "{config.test_strategy}" defined for this notebook)'
+                    )
+                continue
 
-        yield NotebookJob(
-            path=path,
-            pre_execute_code=PRE_EXECUTE_CODE,
-            backend_patch=backend_patch,
-            cell_timeout=-1 if config.args.submit_jobs else 300,
-            write=write,
-        )
+            patch = config.get_patch_for_group(group)
+
+            def should_write(config: Config, patch: str | None):
+                if patch:
+                    return Result(False, "hardware was mocked")
+                if not config.write:
+                    return Result(False, "--write arg not set")
+                return Result(True)
+
+            write = should_write(config, patch)
+
+            yield NotebookJob(
+                path=Path(path),
+                pre_execute_code=PRE_EXECUTE_CODE,
+                backend_patch=patch,
+                cell_timeout=config.cell_timeout,
+                write=write,
+            )
 
 
 @dataclass
 class Config:
-    args: argparse.Namespace
-    notebooks_normal_test: list[str]
-    notebooks_exclude: list[str]
-    notebooks_that_submit_jobs: list[str]
-    notebooks_no_mock: list[str]
-
-    @property
-    def all_job_submitting_notebooks(self) -> list[str]:
-        return [*self.notebooks_that_submit_jobs, *self.notebooks_no_mock]
-
-    @property
-    def all_notebooks_to_test(self) -> list[str]:
-        return [
-            *self.notebooks_normal_test,
-            *self.notebooks_that_submit_jobs,
-            *self.notebooks_no_mock,
-        ]
-
-    @property
-    def all_notebooks(self) -> list[str]:
-        return [
-            *self.all_notebooks_to_test,
-            *self.notebooks_exclude,
-        ]
+    cli_filenames: list[Path]
+    cell_timeout: int
+    test_strategy: str
+    write: bool
+    groups: list[dict]
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> Config:
         """
-        Create config from args, including loading the globs from the TOML file
+        Create config from args, including loading the paths from the TOML file if needed.
         """
-        path = Path(args.config_path)
+        if (args.config_path or args.test_strategy) and args.patch:
+            raise ValueError("Can't set --patch with --config-file or --test-strategy")
+
+        if not args.config_path:
+            patch_info = parse_patch_arg(args.patch)
+            if patch_info != {}:
+                print("Patching all notebooks with:", patch_info)
+            return cls(
+                cli_filenames=args.filenames,
+                cell_timeout=args.cell_timeout,
+                test_strategy="custom",
+                write=args.write,
+                groups=[
+                    {
+                        "name": "main",
+                        "notebooks": args.filenames,
+                        "test-strategies": {"custom": patch_info},
+                    }
+                ],
+            )
+
         try:
-            return cls(args=args, **tomli.loads(path.read_text()))
+            config_path = Path(args.config_path)
+            config_file = tomllib.loads(config_path.read_text())
         except TypeError as err:
             raise ValueError(
-                f"Couldn't read config from {path}; check it exists and the"
+                f"Couldn't read config from {config_path}; check it exists and the"
                 " entries are correct."
             ) from err
 
-    def notebooks_to_execute(self) -> Iterator[Path]:
-        """
-        Yield notebooks to be executed, printing messages for any skipped files.
-        """
-        paths = map(Path, self.args.filenames or self.all_notebooks_to_test)
-        for path in paths:
-            if path.suffix != ".ipynb":
-                print(f"ℹ️ Skipping {path}; file is not `.ipynb` format.")
-                continue
+        groups = [
+            {"name": key, **value} for key, value in config_file["groups"].items()
+        ]
+        test_strategy = args.test_strategy or config_file["default-strategy"]
+        cell_timeout = (
+            args.cell_timeout or
+            config_file.get("test-strategies", {})
+            .get(test_strategy, {})
+            .get("timeout", None)
+        )
+        return cls(
+            cli_filenames=args.filenames,
+            cell_timeout=cell_timeout,
+            test_strategy=test_strategy,
+            write=args.write,
+            groups=groups,
+        )
 
-            if matches(path, self.notebooks_exclude):
-                print(
-                    f"ℹ️ Skipping {path}; to run it, edit `notebooks-exclude` in {self.args.config_path}."
-                )
-                continue
-
-            if not self.args.submit_jobs and matches(path, self.notebooks_no_mock):
-                print(
-                    f"ℹ️ Skipping {path} as it doesn't work with mock hardware; use the --submit-jobs flag to run it."
-                )
-                continue
-
-            if self.args.only_submit_jobs and not matches(
-                path, self.all_job_submitting_notebooks
-            ):
-                print(
-                    f"ℹ️ Skipping {path} as it doesn't submit jobs and the --only-submit-jobs flag is set."
-                )
-                continue
-
-            yield path
-
-    def should_patch(self, path: Path) -> bool:
-        if self.args.submit_jobs:
-            return False
-        return matches(path, self.notebooks_that_submit_jobs)
-
-    def should_skip_writing(self, path: Path) -> bool | str:
-        """Returns False or string with reason for skipping"""
-        if not self.args.write:
-            return "--write arg not set"
-        if self.should_patch(path):
-            return "hardware was mocked"
-        return False
+    def get_patch_for_group(self, group: dict) -> str | None:
+        patch_config = group["test-strategies"].get(self.test_strategy, {})
+        if patch_config == {}:
+            return None
+        return generate_backend_patch(
+            backend_name=patch_config.get("backend", "fake_athens"),
+            provider=patch_config.get("provider", "qiskit-ibm-runtime"),
+            generic_backend_kwargs=patch_config.get("generic_backend_kwargs", None),
+            runtime_service_kwargs=patch_config.get("runtime_service_kwargs", None),
+        )
 
 
-def matches(path: Path, glob_list: list[str]) -> bool:
-    return any(path.match(glob) for glob in glob_list)
+def matches(path: Path | str, glob_list: list[str]) -> bool:
+    return any(Path(path).match(glob) for glob in glob_list)
 
 
+def parse_patch_arg(patch: str | None) -> dict:
+    if not patch:
+        return {}
+    try:
+        patch_info = tomllib.loads(f"patch={patch}")["patch"]
+    except tomllib.TOMLDecodeError as err:
+        raise ValueError(
+            "Problem parsing your --patch argument; "
+            "Make sure it's of the form '{ string=\"value\", number=4, ... }'."
+        ) from err
+    return patch_info
 
-def get_args() -> argparse.Namespace:
+
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="Notebook executor",
-        description="For testing notebooks and updating their outputs",
+        description=dedent(
+            """\
+            For testing notebooks and updating their outputs.
+
+            There are two ways to call this script. The simplest is to just provide a list of filenames and (optionally) a backend that we'll patch qiskit-ibm-runtime's least_busy method to always return.
+            If providing a patch, this will apply all the notebooks.
+
+            The other option is to provide a config file, which lets you set different patches for each notebook. See the README for more information.
+            """
+        ),
     )
     parser.add_argument(
         "filenames",
         help=(
-            "Paths to notebooks. If not provided, the script will search for "
-            "notebooks in `docs/`. To exclude a notebook from this process, add it "
-            "to `notebooks-exclude` in the config file."
+            "Paths to notebooks. If not provided but --config-file is provided, the script will run all notebooks in the config file."
         ),
         nargs="*",
     )
@@ -206,130 +209,26 @@ def get_args() -> argparse.Namespace:
         help="Overwrite notebooks with the results of this script's execution.",
     )
     parser.add_argument(
-        "--submit-jobs",
-        action="store_true",
-        help=(
-            "Run notebooks that submit jobs to IBM Quantum and wait indefinitely "
-            "for jobs to complete. Warning: this has a real cost because it uses "
-            "quantum resources! Only use this argument occasionally and intentionally."
-        ),
+        "--patch",
+        help='If not providing a config file, an optional TOML string with the patch information. For example, \'{ provider="qiskit-ibm-runtime", backend="test-eagle" }\'',
     )
     parser.add_argument(
-        "--only-submit-jobs",
-        action="store_true",
-        help=(
-            "Same as --submit-jobs, but only runs notebooks that submit jobs. "
-            "Setting this option implicitly sets --submit-jobs."
-        ),
+        "--cell-timeout",
+        type=int,
+        help="Maximum number of seconds each cell can run for. This overrides the timeout in your config file if you're using one. For no timeout, set to -1 (This is also the default with no config file).",
     )
     parser.add_argument(
         "--config-path",
-        help="Path to a TOML file containing the globs for detecting and sorting notebooks",
+        help="Path to a TOML file listing the notebooks to execute and the test strategies for each notebook.",
     )
     parser.add_argument(
-        "--provider",
-        action="store",
-        default="qiskit-fake-provider",
-        choices=["qiskit-ibm-runtime", "qiskit-fake-provider", "runtime-fake-provider"],
+        "--test-strategy",
         help=(
-            "Specify a provider to run notebook against."
-        )
+            "If using a config file, the name of the testing strategy to use. "
+            "This affects which notebooks are run and how they're patched."
+        ),
     )
-    parser.add_argument(
-        "--backend",
-        action="store",
-        default="fake_athens",
-        help=(
-            "Specify a backend to run the script against, such as 'fake_athens'"
-            "or 'athens'. Only relevant when `--provider` is "
-            "`qiskit-ibm-runtime` or `runtime-fake-provider`."
-        )
-    )
-
-    generic_backend_options_group = parser.add_argument_group(
-        "qiskit-fake-backend options",
-        description=(
-            "These options change the behavior when --provider=qiskit-fake-backend, "
-            "and are passed as parameters directly to GenericBackendV2. "
-            "See https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2 "
-            "for more details."
-
-        )
-    )
-    generic_backend_options_group.add_argument(
-        "--num-qubits",
-        action="store",
-        type=int,
-        default=6,
-        help=(
-            "Specify the number of qubits for the qiskit generic backend to use"
-        )
-    )
-    generic_backend_options_group.add_argument(
-        "--control-flow",
-        action="store_true",
-        help=(
-            "Specify if the qiskit generic backend should enable control flow"
-            "directives on the target"
-        )
-    )
-
-    runtime_options_group = parser.add_argument_group(
-        "qiskit-ibm-runtime options",
-        description=(
-            "These options change the behavior when --provider=qiskit-ibm-runtime, "
-            "and are passed as parameters directly to QiskitRuntimeService. "
-            "See https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.QiskitRuntimeService "
-            "for more details."
-        )
-    )
-    runtime_options_group.add_argument(
-        "--channel",
-        action="store",
-        default="ibm_quantum",
-        choices=["ibm_cloud", "ibm_quantum", "local"],
-        help=(
-            "Specify a channel for running the notebook against."
-        )
-    )
-    runtime_options_group.add_argument(
-        "--token",
-        action="store",
-        default=None,
-        help=(
-            'IBM Cloud API key or IBM Quantum API token. Warning: for security,' 
-            'you should set this via an environment variable, e.g. '
-            '`--token="${IQP_API_TOKEN}".'
-        )
-    )
-    runtime_options_group.add_argument(
-        "--url",
-        action="store",
-        default=None,
-        help=(
-            "The API URL to submit the notebook against."
-        )
-    )
-    runtime_options_group.add_argument(
-        "--name",
-        action="store",
-        default=None,
-        help=(
-            "Name of the qiskit account to load."
-        )
-    )
-    runtime_options_group.add_argument(
-        "--instance",
-        action="store",
-        default=None,
-        help=(
-            "The service instance to use."
-        )
-    )
-    args = parser.parse_args()
-    if args.only_submit_jobs:
-        args.submit_jobs = True
-    return args
+    return parser
 
 
 def generate_backend_patch(

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -31,7 +31,8 @@ _set_mpl_loglevel("critical")
 """
 
 BUILT_IN_PATCHES = {
-  "qiskit-fake-provider": dedent("""
+    "qiskit-fake-provider": dedent(
+        """
         import warnings
         from qiskit.providers.fake_provider import GenericBackendV2
         from qiskit_ibm_runtime import QiskitRuntimeService
@@ -43,9 +44,10 @@ BUILT_IN_PATCHES = {
             return GenericBackendV2(num_qubits={num_qubits})
 
         QiskitRuntimeService.least_busy = patched_least_busy
-        """),
-
-  "runtime-fake-provider": dedent("""
+        """
+    ),
+    "runtime-fake-provider": dedent(
+        """
         import warnings
         from qiskit_ibm_runtime import QiskitRuntimeService
 
@@ -57,9 +59,10 @@ BUILT_IN_PATCHES = {
             return provider.backend("{backend}")
 
         QiskitRuntimeService.least_busy = patched_least_busy
-        """),
-
-  "qiskit-ibm-runtime": dedent("""
+        """
+    ),
+    "qiskit-ibm-runtime": dedent(
+        """
         from qiskit_ibm_runtime import QiskitRuntimeService
 
         def patched_least_busy(self, *args, **kwargs):
@@ -67,8 +70,10 @@ BUILT_IN_PATCHES = {
             return service.backend("{backend}")
 
         QiskitRuntimeService.least_busy = patched_least_busy
-        """)
+        """
+    ),
 }
+
 
 @dataclass
 class Result:
@@ -163,12 +168,11 @@ class Config:
                     }
                 )
 
-            all_filenames = args.filenames + [
-                filepath for group in groups
-                for filepath in group["notebooks"]
+            cli_filenames = args.filenames + [
+                filepath for group in groups for filepath in group["notebooks"]
             ]
             return cls(
-                cli_filenames=all_filenames,
+                cli_filenames=cli_filenames,
                 cell_timeout=args.cell_timeout,
                 test_strategy="custom",
                 write=args.write,
@@ -203,7 +207,7 @@ class Config:
         )
 
     def get_patch_for_group(self, group: dict) -> str | None:
-        patch_config = group["test-strategies"].get(self.test_strategy, {})
+        patch_config = group["test-strategies"][self.test_strategy]
 
         patch_name = patch_config.get("patch", None)
         if patch_name is None:

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -73,14 +73,12 @@ def get_notebook_jobs(args: argparse.Namespace) -> Iterator[NotebookJob]:
 
             patch = config.get_patch_for_group(group)
 
-            def should_write(config: Config, patch: str | None):
-                if patch:
-                    return Result(False, "hardware was mocked")
-                if not config.write:
-                    return Result(False, "--write arg not set")
-                return Result(True)
-
-            write = should_write(config, patch)
+            if patch:
+                write = Result(False, "hardware was mocked")
+            elif not config.write:
+                write = Result(False, "--write arg not set")
+            else:
+                write = Result(True)
 
             yield NotebookJob(
                 path=Path(path),

--- a/scripts/nb-tester/test/test_get_notebook_jobs.py
+++ b/scripts/nb-tester/test/test_get_notebook_jobs.py
@@ -1,0 +1,232 @@
+from pathlib import Path
+from textwrap import dedent
+from unittest import mock
+
+from qiskit_docs_notebook_tester.config import (
+    get_notebook_jobs,
+    NotebookJob,
+    Result,
+    get_parser,
+    PRE_EXECUTE_CODE,
+)
+
+parser = get_parser()
+
+QISKIT_PROVIDER_PATCH = """
+from qiskit_ibm_runtime import QiskitRuntimeService
+import warnings
+
+warnings.filterwarnings("ignore", message="Options {.*} have no effect in local testing mode.")
+warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
+
+from qiskit.providers.fake_provider import GenericBackendV2
+def patched_least_busy(self, *args, **kwargs):
+    return GenericBackendV2()
+
+QiskitRuntimeService.least_busy = patched_least_busy
+"""
+
+
+def test_no_config_file():
+    filenames = ["path/to/notebook.ipynb", "path/to/another.ipynb"]
+    args = parser.parse_args(filenames)
+    jobs = list(get_notebook_jobs(args))
+    assert jobs == [
+        NotebookJob(
+            path=Path(path),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=None,
+            cell_timeout=None,
+            write=Result(False, "--write arg not set"),
+        )
+        for path in filenames
+    ]
+
+
+def test_no_config_file_no_filenames():
+    args = parser.parse_args([])
+    assert list(get_notebook_jobs(args)) == []
+
+
+def test_cli_patch():
+    args = parser.parse_args(
+        [
+            "path/to/notebook.ipynb",
+            "--write",
+            "--patch",
+            '{ provider="qiskit-ibm-runtime", backend="test-eagle" }',
+        ]
+    )
+    expected_patch = dedent(
+        """
+        from qiskit_ibm_runtime import QiskitRuntimeService
+        import warnings
+
+        warnings.filterwarnings("ignore", message="Options {.*} have no effect in local testing mode.")
+        warnings.filterwarnings("ignore", message="Session is not supported in local testing mode or when using a simulator.")
+
+        def patched_least_busy(self, *args, **kwargs):
+            service = QiskitRuntimeService()
+            return service.backend("test-eagle")
+
+        QiskitRuntimeService.least_busy = patched_least_busy
+        """
+    )
+    jobs = list(get_notebook_jobs(args))
+    # Separate assertions make it easier to see diff in failed tests
+    assert jobs[0].backend_patch == expected_patch
+    assert jobs[0].write.reason == "hardware was mocked"
+    assert jobs == [
+        NotebookJob(
+            path=Path("path/to/notebook.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=expected_patch,
+            cell_timeout=None,
+            write=Result(False, "hardware was mocked"),
+        )
+    ]
+
+
+def test_config_file():
+    args = parser.parse_args(["--write", "--config-path", "path/to/config.toml"])
+    config_file = dedent(
+        """
+        default-strategy="ci"
+        test-strategies.ci = { timeout = 350 }
+        
+        [groups]
+        [groups.default]
+        test-strategies.ci = { provider="qiskit-fake-provider" }
+        notebooks = ["path/to/notebook.ipynb"]
+                         
+        [groups.other]
+        notebooks = ["path/to/another.ipynb"]
+        """
+    )
+    # Patch all read operations to return the config file
+    with mock.patch("pathlib.Path.read_text", lambda _: config_file):
+        jobs = list(get_notebook_jobs(args))
+
+    # Separate assertions make it easier to see diff in failed tests
+    assert jobs[0].backend_patch == QISKIT_PROVIDER_PATCH
+    assert jobs[0].write.reason == "hardware was mocked"
+    assert jobs == [
+        NotebookJob(
+            path=Path("path/to/notebook.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=QISKIT_PROVIDER_PATCH,
+            cell_timeout=350,
+            write=Result(False, "hardware was mocked"),
+        )
+    ]
+
+
+def test_config_file_with_filenames():
+    args = parser.parse_args(
+        ["path/to/notebook.ipynb", "--write", "--config-path", "path/to/config.toml"]
+    )
+    config_file = dedent(
+        """
+        default-strategy="main"
+        
+        [groups]
+        [groups.default]
+        test-strategies.main = {}
+        notebooks = [
+            "path/to/notebook.ipynb",
+            "path/to/another.ipynb",
+        ]
+        """
+    )
+    # Patch all read operations to return the config file
+    with mock.patch("pathlib.Path.read_text", lambda _: config_file):
+        jobs = list(get_notebook_jobs(args))
+    assert jobs == [
+        NotebookJob(
+            path=Path("path/to/notebook.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=None,
+            cell_timeout=None,
+            write=Result(True),
+        )
+    ]
+
+
+def test_config_strategy_selection():
+    args = parser.parse_args(
+        [
+            "--config-path",
+            "path/to/config.toml",
+            "--test-strategy",
+            "other",
+        ]
+    )
+    config_file = dedent(
+        """
+        [groups]
+        [groups.default]
+        test-strategies.main = {}
+        notebooks = [
+            "path/to/notebook.ipynb",
+            "path/to/another.ipynb",
+        ]
+        [groups.other]
+        test-strategies.other = {}
+        notebooks = [
+            "path/to/notebook-in-other-group.ipynb",
+        ]
+        """
+    )
+    # Patch all read operations to return the config file
+    with mock.patch("pathlib.Path.read_text", lambda _: config_file):
+        jobs = list(get_notebook_jobs(args))
+    assert jobs == [
+        NotebookJob(
+            path=Path("path/to/notebook-in-other-group.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=None,
+            cell_timeout=None,
+            write=Result(False, "--write arg not set"),
+        )
+    ]
+
+
+def test_config_with_different_patches_per_notebook():
+    args = parser.parse_args(
+        [
+            "--config-path",
+            "path/to/config.toml",
+            "--test-strategy",
+            "default",
+        ]
+    )
+    config_file = dedent(
+        """
+        [groups]
+        [groups.no-patch]
+        test-strategies.default = {}
+        notebooks = ["path/to/notebook.ipynb"]
+        [groups.patch]
+        test-strategies.default = { provider="qiskit-fake-provider" }
+        notebooks = ["path/to/another.ipynb"]
+        """
+    )
+    # Patch all read operations to return the config file
+    with mock.patch("pathlib.Path.read_text", lambda _: config_file):
+        jobs = list(get_notebook_jobs(args))
+    assert jobs == [
+        NotebookJob(
+            path=Path("path/to/notebook.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=None,
+            cell_timeout=None,
+            write=Result(False, "--write arg not set"),
+        ),
+        NotebookJob(
+            path=Path("path/to/another.ipynb"),
+            pre_execute_code=PRE_EXECUTE_CODE,
+            backend_patch=QISKIT_PROVIDER_PATCH,
+            cell_timeout=None,
+            write=Result(False, "hardware was mocked"),
+        ),
+    ]

--- a/scripts/nb-tester/test/test_get_notebook_jobs.py
+++ b/scripts/nb-tester/test/test_get_notebook_jobs.py
@@ -227,6 +227,7 @@ def test_config_with_different_patches_per_notebook():
         ),
     ]
 
+
 def test_patch_file():
     args = parser.parse_args(
         [
@@ -252,6 +253,7 @@ def test_patch_file():
             write=Result(False, "hardware was mocked"),
         )
     ]
+
 
 def test_patch_file_multiple_groups():
     args = parser.parse_args(


### PR DESCRIPTION
Attempt to simplify the way we control `nb-tester`.

This PR includes the patch information in the config file. Like before, each notebook is part of a group. The new aspect is each group can define how to patch each notebook in different situations.

This PR also adds tests and documentation for the config part of the script. If you exclude the new README and tests, this PR reduces the script size by ~100 LOC.

### Config example

Take the following config file as an example.

```toml
[my-group]
test-strategy.ci = { patch="qiskit_ibm_runtime", backend="test-eagle" }
test-strategy.hardware = {}
notebooks = ["..."]
```

If we run nb-tester against this file with `--test-strategy=ci`, each notebook in the group will be patched with the `test-eagle` device. If we run it with `--test-strategy=hardware`, the notebooks will be run with no patch. Running with a test strategy not defined for that group (e.g. `--test-strategy=new-strat`) means that group will be skipped.

### CLI example

You can also run the script without a config file with the `--patch` arg. In this case, all files listed after the `--patch` argument are part of the same "group". You must include a patch for this group using TOML syntax. For example:

```sh
test-docs-notebooks --patch '{ patch="qiskit-fake-provider", num_qubits=6 }' path/to/file.ipynb
```

***

Closes #2401
