### PR TITLE
Improve `./start` to work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can preview the docs locally by following these two steps:
 
 1. Ensure Docker is running. For example, open Rancher Desktop.
 2. Run `./start` in your terminal, and open http://localhost:3000 in your browser.
-   - On Windows, run `python start` instead.
+   - On Windows, run `python start` instead. Alternatively, use Windows Subsystem for Linux and run `./start`.
 
 The preview application does not include the top nav bar. Instead, navigate to the folder you want with the links in the home page. You can return to the home page at any time by clicking "IBM Quantum Documentation Preview" in the top-left of the header.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can preview the docs locally by following these two steps:
 
 1. Ensure Docker is running. For example, open Rancher Desktop.
 2. Run `./start` in your terminal, and open http://localhost:3000 in your browser.
+   - On Windows, run `python start` instead.
 
 The preview application does not include the top nav bar. Instead, navigate to the folder you want with the links in the home page. You can return to the home page at any time by clicking "IBM Quantum Documentation Preview" in the top-left of the header.
 

--- a/start
+++ b/start
@@ -18,7 +18,10 @@ from pathlib import Path
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
 IMAGE_DIGEST = "sha256:9d475dd73d574cb420490cdaf203c45f9b211debee2fb8825bae40018e55bcae"
 
-PWD = Path(__file__).parent
+# Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
+# https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7
+PWD = Path(__file__).parent.as_posix()
+
 IMAGE = f"icr.io/qc-open-source-docs-public/preview@{IMAGE_DIGEST}"
 
 


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/1607. There are two issues:

1. The shebang will be ignored, so you need to run `python ./start` instead of `./start`
2. Volume mounting with Docker on Windows uses Unix-style path, per https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7