### PR TITLE
Add additional backends for gen3-turbo

### DIFF
--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -149,7 +149,7 @@ Scroll to see the full table.
 
 <span id="experimental-option-note"></span>
 <Admonition type="note">
-Setting `gen3-turbo` enables the next-generation execution path, which provides a great improvement in performance. This option is experimental (subject to change without notice, and stability is not guaranteed) and is only available on `ibm_fez`, `ibm_marrakesh`, and `ibm_torino`.
+Setting `gen3-turbo` enables the next-generation execution path, which provides a great improvement in performance. This option is experimental (subject to change without notice, and stability is not guaranteed) and is only available on `ibm_fez`, `ibm_marrakesh`, `ibm_torino`, `ibm_brisbane`, and `ibm_strasbourg`.
 </Admonition>
 <span id="options-compatibility-table"></span>
 ### Feature compatibility


### PR DESCRIPTION
Add `ibm_brisbane` and `ibm_strasbourg` to the gen3-turbo enabled backend list. 