### PR TITLE
Fix sphinx-alt-text-validator encoding error in Windows

### DIFF
--- a/scripts/image-tester/sphinx_alt_text_validator/verify_images.py
+++ b/scripts/image-tester/sphinx_alt_text_validator/verify_images.py
@@ -41,7 +41,7 @@ def validate_image(file_path: str) -> tuple[str, list[str]]:
 
     invalid_images: list[str] = []
 
-    lines = Path(file_path).read_text().splitlines()
+    lines = Path(file_path).read_text(encoding="utf-8").splitlines()
 
     image_found = False
     options: list[str] = []


### PR DESCRIPTION
The linter had an encoding error when reading the files in Windows:

```bash
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "c:\qiskit-ibm-runtime\tools\verify_images.py", line 108, in <module>
    main()
  File "c:\qiskit-ibm-runtime\tools\verify_images.py", line 83, in main
    results = pool.map(validate_image, files)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\multiprocessing\pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\multiprocessing\pool.py", line 774, in get
    raise self._value
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1420: character maps to <undefined>
```