### PR TITLE
Add nb-tester patch to only select open plan backends

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -6,7 +6,7 @@ ci = { timeout = 300 }
 # For notebooks to be tested in CI "normally" (no mocking)
 [groups.normal]
 test-strategies.ci = {}
-test-strategies.hardware = {}
+test-strategies.hardware = { patch="qiskit-ibm-runtime-open" }
 notebooks = [
     "docs/guides/build-noise-models.ipynb",
     "docs/guides/circuit-library.ipynb",
@@ -47,7 +47,7 @@ notebooks = [
 # The following notebooks submit jobs that can be mocked with a simulator
 [groups.mockable]
 test-strategies.ci = { patch="qiskit-fake-provider", num_qubits=6 }
-test-strategies.hardware = {}
+test-strategies.hardware = { patch="qiskit-ibm-runtime-open" }
 notebooks = [
     "docs/guides/debug-qiskit-runtime-jobs.ipynb",
     "docs/guides/primitive-input-output.ipynb",
@@ -57,7 +57,7 @@ notebooks = [
 # A job is "too big" if a cell can't run in under 5 mins, or we run out of
 # memory on a reasonable device.
 [groups.cron-job-only]
-test-strategies.hardware = {}
+test-strategies.hardware = { patch="qiskit-ibm-runtime-open" }
 notebooks = [
     "docs/guides/get-started-with-primitives.ipynb",
     "docs/guides/hello-world.ipynb",

--- a/scripts/nb-tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/patches/qiskit-ibm-runtime-open
@@ -1,0 +1,10 @@
+# Only select backends available on the open plan
+from qiskit_ibm_runtime import QiskitRuntimeService
+
+QiskitRuntimeService._original_least_busy = QiskitRuntimeService.least_busy
+
+def patched_least_busy(self, *args, **kwargs):
+    open_backends = [b.name for b in self.backends(instance="ibm-q/open/main")]
+    return self._original_least_busy(filters=lambda backend: backend.name in open_backends)
+
+QiskitRuntimeService.least_busy = patched_least_busy


### PR DESCRIPTION
This PR adds a new patch that picks the least busy backend that's also available on the open plan, regardless of which instance you're using.

We need this because we've added the `test_eagle_us-east` device to the instance we use for testing. The problem is that this device is always the least busy, so it'll be selected when we're doing our hardware runs. We can't just switch to the open instance for this test because I'm regularly out of credits and the priority is too low to run all the jobs in our time window.
