### PR TITLE
Allow writing nb-tester results with certain patches

### DIFF
--- a/scripts/nb-tester/README.md
+++ b/scripts/nb-tester/README.md
@@ -166,3 +166,21 @@ Here's a few different commands you could run:
   wasn't passed as a filename arg.
 
 </details>
+
+### Patches and writing to disk
+
+By default, this tool will **not** allow writing patched notebooks to disk.
+This is to reduce the risk of accidentally displaying results from patched
+notebooks to users.
+
+For example, if we write the output of a notebook patched with
+`qiskit-fake-provider`, it will appear the results in the notebook come from
+the least busy IBM Quantum backend when they actually come from a noiseless
+simulator. This could be considered false advertising.
+
+If you have a patch that you know is OK to generate user-facing results, you
+can allow writing results from it by adding the comment `# nb-tester:
+allow-write` anywhere in the patch file. An example of a safe patch is the
+built-in `qiskit-ibm-runtime-open` patch: This only selects a real hardware
+backend that's included in the open plan. We use this to select open-access
+backends but submit jobs using our dedicated testing instance.

--- a/scripts/nb-tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/patches/qiskit-ibm-runtime-open
@@ -1,3 +1,4 @@
+# nb-tester: allow-write
 # Only select backends available on the open plan
 from qiskit_ibm_runtime import QiskitRuntimeService
 

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -74,7 +74,7 @@ def get_notebook_jobs(args: argparse.Namespace) -> Iterator[NotebookJob]:
 
             patch = config.get_patch_for_group(group)
 
-            if patch:
+            if patch and not "# nb-tester: allow-write" in patch:
                 write = Result(False, "hardware was mocked")
             elif not config.write:
                 write = Result(False, "--write arg not set")


### PR DESCRIPTION
By default, nb-tester will **not** allow writing patched notebooks to disk. This is to reduce the risk of accidentally displaying results from patched notebooks to users. For example, if we write the output of a notebook patched with `qiskit-fake-provider`, it will appear the results in the notebook come from the least busy IBM Quantum backend when they actually come from a noiseless simulator. This could be considered false advertising.

However, we do have patches with which it's safe to generate user-facing results. This PR adds the ability to allow writing results from these patches by adding the comment `# nb-tester: allow-write` anywhere in the patch file.

The built-in `qiskit-ibm-runtime-open` patch is an example of such a patch: It only selects a real hardware backend that's included in the open plan. We use this to select open-access backends but submit jobs using our dedicated testing instance.
