### PR TITLE
Fix Qiskit Transpiler Service links

### DIFF
--- a/docs/guides/qiskit-transpiler-service.mdx
+++ b/docs/guides/qiskit-transpiler-service.mdx
@@ -122,5 +122,5 @@ Eprint = {arXiv:2405.13196},
 <Admonition type="tip" title="Recommendations">
     - Learn how to create [AI transpiler passes.](ai-transpiler-passes)
     - Learn [how to transpile circuits](https://learning.quantum.ibm.com/tutorial/submit-transpiled-circuits) as part of Qiskit Patterns workflows using Qiskit Runtime.
-    - Review the [`qiskit-ibm-transpiler` API documentation.](/api/qiskit-ibm-transpiler)
+    - Review the [Qiskit Transpiler Service Python client](/api/qiskit-ibm-transpiler) documentation.
 </Admonition>

--- a/docs/guides/qiskit-transpiler-service.mdx
+++ b/docs/guides/qiskit-transpiler-service.mdx
@@ -122,5 +122,5 @@ Eprint = {arXiv:2405.13196},
 <Admonition type="tip" title="Recommendations">
     - Learn how to create [AI transpiler passes.](ai-transpiler-passes)
     - Learn [how to transpile circuits](https://learning.quantum.ibm.com/tutorial/submit-transpiled-circuits) as part of Qiskit Patterns workflows using Qiskit Runtime.
-    - Review the [Qiskit Transpiler Service API documentation.](https://cloud-transpiler-experimental.quantum-computing.ibm.com/docs)
+    - Review the [`qiskit-ibm-transpiler` API documentation.](/api/qiskit-ibm-transpiler)
 </Admonition>

--- a/docs/guides/transpile-rest-api.mdx
+++ b/docs/guides/transpile-rest-api.mdx
@@ -25,7 +25,7 @@ The steps in this topic describe how to transpile a given QASM circuit and obtai
 
 ## Query the Qiskit Transpiler Service
 
-Query the [Qiskit Transpiler Service REST API](https://cloud-transpiler.quantum-computing.ibm.com/docs) and provide your QASM string as input. See more details in the [API reference documentation](/api/qiskit-transpiler-service-rest).
+Query the Qiskit Transpiler Service REST API and provide your QASM string as input. See more details in the [API reference documentation](/api/qiskit-transpiler-service-rest).
 
 There are two ways to invoke the Qiskit Transpiler Service using REST API: with regular transpilation, and with AI-enhanced transpilation. The following demonstrates both ways to invoke the Qiskit Transpiler Service API.
 

--- a/docs/guides/transpile-rest-api.mdx
+++ b/docs/guides/transpile-rest-api.mdx
@@ -15,17 +15,17 @@ You have two transpilation options:
 
 * Transpile [locally via Qiskit](./defaults-and-configuration-options) before generating the QASM string.
 
-* Use the [Qiskit Transpiler Service API](https://cloud-transpiler.quantum.ibm.com/docs).
+* Use the [Qiskit Transpiler Service Python client](/api/qiskit-ibm-transpiler) or [Qiskit Transpiler Service REST API](/api/qiskit-ibm-transpiler-rest).
 
 <Admonition type="note">
-    [Transpilation is necessary](https://docs.quantum.ibm.com/announcements/product-updates/2024-02-14-qiskit-runtime-primitives-update) prior to submitting a circuit to IBM&reg; QPUs.
+    [Transpilation is necessary](/announcements/product-updates/2024-02-14-qiskit-runtime-primitives-update) prior to submitting a circuit to IBM&reg; QPUs.
 </Admonition>
 
 The steps in this topic describe how to transpile a given QASM circuit and obtain results using the Cloud Transpiler REST API, and include suggestions on how to submit the transpiled quantum circuit to IBM compute resources.  For an example that uses parameterized input, see [Sampler primitive with REST API and parameterized circuits.](/guides/primitives-rest-api#start-sampler-parms)
 
 ## Query the Qiskit Transpiler Service
 
-Query the [Qiskit Transpiler Service API](https://cloud-transpiler.quantum-computing.ibm.com/docs) and provide your QASM string as input. See more details in the [API reference documentation](/api/qiskit-transpiler-service-rest).
+Query the [Qiskit Transpiler Service REST API](https://cloud-transpiler.quantum-computing.ibm.com/docs) and provide your QASM string as input. See more details in the [API reference documentation](/api/qiskit-transpiler-service-rest).
 
 There are two ways to invoke the Qiskit Transpiler Service using REST API: with regular transpilation, and with AI-enhanced transpilation. The following demonstrates both ways to invoke the Qiskit Transpiler Service API.
 

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -24,6 +24,7 @@ import { FileBatch } from "../lib/links/FileBatch.js";
 // checker should assume that they exist in production.
 const SYNTHETIC_FILES: string[] = [
   "docs/errors.mdx",
+  "docs/api/qiskit-ibm-transpiler-rest/index.mdx",
   "docs/api/runtime/index.mdx",
   "docs/api/runtime/tags/jobs.mdx",
   "docs/api/qiskit-transpiler-service-rest/index.mdx",

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -60,6 +60,9 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "http://dx.doi.org/10.1103/PhysRevA.83.012308",
   "https://doi.org/10.1103/PhysRevLett.103.150502",
   "https://doi.org/10.1103/PhysRevA.99.032331",
+  "https://aip.scitation.org/doi/10.1063/1.5019371",
+  "https://aip.scitation.org/doi/10.1063/1.5141835",
+  "https://pubs.aip.org/aip/rsi/article/88/10/104703/836456",
 ];
 
 // These external URLs cause actual 404s and should probably be fixed.


### PR DESCRIPTION
Progress towards https://github.com/Qiskit/documentation/issues/2476. Fixes some QTS links + ignores valid journal links from API docs.