### PR TITLE
Check API images in the api-checks job

### DIFF
--- a/.github/workflows/api-checks.yml
+++ b/.github/workflows/api-checks.yml
@@ -43,3 +43,5 @@ jobs:
         run: npm run check:orphan-pages -- --apis
       - name: Check metadata
         run: npm run check:metadata -- --apis
+      - name: Check images
+        run: npm run check:images -- --apis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: File metadata
         run: npm run check:metadata
       - name: Check images
-        run: npm run check:images -- --apis
+        run: npm run check:images
       - name: Spellcheck
         run: npm run check:spelling
       - name: Check Qiskit bot config

--- a/scripts/js/commands/checkImages.ts
+++ b/scripts/js/commands/checkImages.ts
@@ -79,7 +79,7 @@ async function determineTocFiles(args: Arguments): Promise<string[]> {
   // the API repo should catch it.
   //
   // If an image is missed by the API repo's linter, it will still have an alt text defined,
-  // although it won't be very useful.
+  // although it won't be very useful. That's because Sphinx auto-generates alt text.
   const globs = [
     "docs/**/*.{ipynb,mdx}",
     args.apis ? "!docs/api/*/([0-9]*)/*.mdx" : "!docs/api/**/*.mdx",


### PR DESCRIPTION
This PR moves the check of the alt text check for API docs images to the api--checks job. See https://github.com/Qiskit/documentation/pull/2426#discussion_r1887618361