### PR TITLE
[Suggestion] Don't commit images with low visual change in dev docs sync

### DIFF
--- a/scripts/js/commands/api/syncDevDocs.ts
+++ b/scripts/js/commands/api/syncDevDocs.ts
@@ -19,6 +19,7 @@ import { readApiFullVersion } from "../../lib/apiVersions.js";
 import {
   generateVersion,
   determineMinorVersion,
+  resetVisuallyUnchangedImages,
   Arguments,
 } from "./updateApiDocs.js";
 
@@ -52,9 +53,13 @@ zxMain(async () => {
 
   if (qiskitUrl) {
     await regenDocs("qiskit", qiskitVersion);
+    await resetVisuallyUnchangedImages(`public/images/api/qiskit/dev/`);
   }
   if (runtimeUrl) {
     await regenDocs("qiskit-ibm-runtime", runtimeVersion);
+    await resetVisuallyUnchangedImages(
+      `public/images/api/qiskit-ibm-runtime/dev/`,
+    );
   }
 });
 

--- a/scripts/js/commands/api/updateApiDocs.ts
+++ b/scripts/js/commands/api/updateApiDocs.ts
@@ -159,6 +159,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   });
 }
 
+/**
+ * Create a backup of the new image, restore the original image using Git, then compare the two.
+ * If they're within a similarity threshold, delete the backup and keep the original, otherwise keep the new file.
+ */
 export async function resetVisuallyUnchangedImages(dir: string): Promise<void> {
   const changedImages = (await $`git diff --name-only ${dir}`).stdout
     .trim()


### PR DESCRIPTION
Experiment to avoid diffs for images with basically no change. Threshold was chosen by eyeballing. Here's two examples:

**Example below similarity threshold**
![below-threshold](https://github.com/user-attachments/assets/87987c2d-d8b2-42c4-a07d-652e577db122)

**Example above similarity threshold**
![above-threshold](https://github.com/user-attachments/assets/72d47527-f6b5-449d-b52c-80c65d1848a7)
