### PR TITLE
Fix performance of stale image check

### DIFF
--- a/scripts/js/commands/checkPagesRender.ts
+++ b/scripts/js/commands/checkPagesRender.ts
@@ -96,7 +96,7 @@ zxMain(async () => {
     // This script can be slow, so log progress every 10 files.
     if (numFilesChecked % 10 == 0) {
       console.log(
-        `Checked ${numFilesChecked} / ${files.length} pages ` +
+        `⏳ Checked ${numFilesChecked} / ${files.length} pages ` +
           `(~${mean(renderTimes).toFixed(0)}ms per page)`,
       );
       renderTimes = [];

--- a/scripts/js/commands/checkStaleImages.ts
+++ b/scripts/js/commands/checkStaleImages.ts
@@ -44,7 +44,7 @@ zxMain(async () => {
       "\n\n❌ Some images are unused. They should usually be deleted to reduce our repository size.",
     );
     console.warn(
-      "⚠️ Be careful that some of these images be used in close source. Before deleting files, check for their usage there. If they're unused, add it to the allowlist.",
+      "⚠️ Be careful that some of these images may be used in closed source. Before deleting files, check for their usage there. If they're unused, add it to the allowlist.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2518.

We were before checking every image inside `await Promise.all()` and only logging results at the end. This is too slow to keep that much in memory, and it results in the experience feeling laggy to not get results until the very end.

Instead, it makes more sense to check one image at a time and eagerly report violations. 

Other improvements in this PR:

* Use ripgrep rather than git grep. The downside is requiring users have ripgrep installed, but this is a manual script we run with `npx tsx`, so it should be fine.
* Log progress every 20 images
* Add an allowlist.

<details><summary>example run</summary>

```
❌ image is unused: public/images/migration/dedicated_queue_no_jobs1.jpg
❌ image is unused: public/images/migration/switcher-small2.png
❌ image is unused: public/images/guides/normal_queue_with_providers1.jpg
❌ image is unused: public/images/guides/paulibasis.png
⏳ Checked 20 / 3519 images
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-circuit.png
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-estimator-circuit.png
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-estimator-ideal.png
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-estimator-noisy.png
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-sampler-ideal.png
⏳ Checked 40 / 3519 images
❌ image is unused: public/images/qiskit-ibm-runtime/noisy-sim-sampler-noisy.png
❌ image is unused: public/images/api/qiskit-addon-cutting/qiskit_addon_cutting-instructions-1.svg
```
</details>