### PR TITLE
Remove the primitives incompatibility gen3-turbo+parameter expressions

### DIFF
--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -212,7 +212,6 @@ Due to differences in the device compilation process, certain runtime features c
   - Fractional gates
   - Pulse gates
   - `meas_type=kerneled` or `meas_type=avg_kerneled` (measurement level 1)
-  - Parameter expressions with arithmetic operations
 
   </TabItem>
 


### PR DESCRIPTION
`gen3-turbo` mode now supports parameter expressions. This PR removes the claim that we don't.