### PR TITLE
Fix historical pages to latest qiskit-ibm-transpiler

### DIFF
--- a/scripts/config/historical-pages-to-latest.json
+++ b/scripts/config/historical-pages-to-latest.json
@@ -19238,24 +19238,24 @@
   },
   "qiskit-ibm-transpiler": {
     "0.3": {
-      "qiskit-transpiler-service-ai-ai-clifford-synthesis": "/qiskit-ibm-transpiler-ai-ai-clifford-synthesis",
-      "qiskit-transpiler-service-ai-ai-linear-function-synthesis": "/qiskit-ibm-transpiler-ai-ai-linear-function-synthesis",
-      "qiskit-transpiler-service-ai-ai-permutation-synthesis": "/qiskit-ibm-transpiler-ai-ai-permutation-synthesis",
-      "qiskit-transpiler-service-ai-ai-routing": "/qiskit-ibm-transpiler-ai-ai-routing",
-      "qiskit-transpiler-service-ai-collect-cliffords": "/qiskit-ibm-transpiler-ai-collect-cliffords",
-      "qiskit-transpiler-service-ai-collect-linear-functions": "/qiskit-ibm-transpiler-ai-collect-linear-functions",
-      "qiskit-transpiler-service-ai-collect-permutations": "/qiskit-ibm-transpiler-ai-collect-permutations",
-      "qiskit-transpiler-service-transpiler-service-transpiler-service": "/qiskit-ibm-transpiler-transpiler-service-transpiler-service"
+      "qiskit-transpiler-service-ai-ai-clifford-synthesis": "/ai-ai-clifford-synthesis",
+      "qiskit-transpiler-service-ai-ai-linear-function-synthesis": "/ai-ai-linear-function-synthesis",
+      "qiskit-transpiler-service-ai-ai-permutation-synthesis": "/ai-ai-permutation-synthesis",
+      "qiskit-transpiler-service-ai-ai-routing": "/ai-ai-routing",
+      "qiskit-transpiler-service-ai-collect-cliffords": "/ai-collect-cliffords",
+      "qiskit-transpiler-service-ai-collect-linear-functions": "/ai-collect-linear-functions",
+      "qiskit-transpiler-service-ai-collect-permutations": "/ai-collect-permutations",
+      "qiskit-transpiler-service-transpiler-service-transpiler-service": "/transpiler-service-transpiler-service"
     },
     "0.4": {
-      "qiskit-transpiler-service-ai-ai-clifford-synthesis": "/qiskit-ibm-transpiler-ai-ai-clifford-synthesis",
-      "qiskit-transpiler-service-ai-ai-linear-function-synthesis": "/qiskit-ibm-transpiler-ai-ai-linear-function-synthesis",
-      "qiskit-transpiler-service-ai-ai-permutation-synthesis": "/qiskit-ibm-transpiler-ai-ai-permutation-synthesis",
-      "qiskit-transpiler-service-ai-ai-routing": "/qiskit-ibm-transpiler-ai-ai-routing",
-      "qiskit-transpiler-service-ai-collect-cliffords": "/qiskit-ibm-transpiler-ai-collect-cliffords",
-      "qiskit-transpiler-service-ai-collect-linear-functions": "/qiskit-ibm-transpiler-ai-collect-linear-functions",
-      "qiskit-transpiler-service-ai-collect-permutations": "/qiskit-ibm-transpiler-ai-collect-permutations",
-      "qiskit-transpiler-service-transpiler-service-transpiler-service": "/qiskit-ibm-transpiler-transpiler-service-transpiler-service"
+      "qiskit-transpiler-service-ai-ai-clifford-synthesis": "/ai-ai-clifford-synthesis",
+      "qiskit-transpiler-service-ai-ai-linear-function-synthesis": "/ai-ai-linear-function-synthesis",
+      "qiskit-transpiler-service-ai-ai-permutation-synthesis": "/ai-ai-permutation-synthesis",
+      "qiskit-transpiler-service-ai-ai-routing": "/ai-ai-routing",
+      "qiskit-transpiler-service-ai-collect-cliffords": "/ai-collect-cliffords",
+      "qiskit-transpiler-service-ai-collect-linear-functions": "/ai-collect-linear-functions",
+      "qiskit-transpiler-service-ai-collect-permutations": "/ai-collect-permutations",
+      "qiskit-transpiler-service-transpiler-service-transpiler-service": "/transpiler-service-transpiler-service"
     },
     "0.5": {},
     "0.6": {},

--- a/scripts/js/commands/api/generateHistoricalRedirects.ts
+++ b/scripts/js/commands/api/generateHistoricalRedirects.ts
@@ -96,7 +96,7 @@ async function getRedirectsForVersion(
       pageName.includes("qiskit-transpiler-service")
     ) {
       redirects[pageName] =
-        `/${pageName.replace("qiskit-transpiler-service", "qiskit-ibm-transpiler")}`;
+        `/${pageName.replace("qiskit-transpiler-service-", "")}`;
       continue;
     }
 


### PR DESCRIPTION
Fix `historical-pages-to-latest.json` for transpiler after https://github.com/Qiskit/documentation/pull/2588
