### PR TITLE
Remove meas level 1 limit on gen3 engine

### DIFF
--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -211,7 +211,6 @@ Due to differences in the device compilation process, certain runtime features c
   - Dynamic circuits
   - Fractional gates
   - Pulse gates
-  - `meas_type=kerneled` or `meas_type=avg_kerneled` (measurement level 1)
 
   </TabItem>
 


### PR DESCRIPTION
Gen3 execution path now supports measurement level 1. Removing the restriction from `gen3-turbo` list. 