### PR TITLE
Remove temporary ignores

### DIFF
--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -67,8 +67,6 @@ const ALWAYS_IGNORED_URLS__EXPECTED = [
   "https://ieeexplore.ieee.org/document/1323804",
   "https://ieeexplore.ieee.org/document/880982",
   "https://ieeexplore.ieee.org/document/657661",
-  "/guides/choose-execution-mode",
-  "/guides/execution-modes#session-mode",
 ];
 
 // These external URLs cause actual 404s and should probably be fixed.


### PR DESCRIPTION
The last generation of the runtime API docs ([here](https://github.com/Qiskit/documentation/pull/2620)), needed to set two temporary ignores. This PR removes them as they are not necessary anymore.