### PR TITLE
method get_job_by_id() missing in Qiskit Function Intro

### DIFF
--- a/docs/guides/functions.ipynb
+++ b/docs/guides/functions.ipynb
@@ -363,6 +363,8 @@
    "source": [
     "### List previously run jobs run with Qiskit Functions\n",
     "\n",
+    "PLACEHOLDER: need to add catalog.get_job_by_id()\n",
+    "\n",
     "You can use `jobs()` to list all jobs submitted to Qiskit Functions:"
    ]
   },


### PR DESCRIPTION
Closes #2627 which was opened by @johannesgreiner. Johannes, can you provide more info on the fix please?