### PR TITLE
Add `networkx` requirement

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -13,3 +13,4 @@ qiskit-addon-aqc-tensor~=0.1.2
 qiskit-addon-obp~=0.1.0
 scipy~=1.15.1
 pyscf~=2.8.0; sys.platform != 'win32'
+networkx~=3.4.2


### PR DESCRIPTION
Parital fix for #2638.

We've resisted adding this requirement for a while, but `docs/guides/q-ctrl-optimization-solver.ipynb` uses some features of networkx that rustworkx doesn't have (e.g. `random_regular_graph`). It's possible there are suitable replacements, but I don't know enough about the domain or graph theory to work that out. I think this is the best solution for now.
