### PR TITLE
Update versioning and platform support for 2.0

### DIFF
--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -238,7 +238,7 @@ Additionally, Qiskit only supports the CPython implementation of the Python lang
 
 ### Qiskit v2.x
 
-In the Qiskit v2.x release series the supported platforms are:
+In the Qiskit v2.x release series, the supported platforms are:
 
 <details>
   <summary>

--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -236,6 +236,56 @@ Qiskit strives to support as many operating systems as possible, but due to limi
 
 Additionally, Qiskit only supports the CPython implementation of the Python language. Running with other Python interpreters such as PyPy is not supported.
 
+### Qiskit 2.x
+
+In the Qiskit 2.x release series the supported platforms are:
+
+<details>
+  <summary>
+    Tier 1
+  </summary>
+  Tier 1 operating systems are fully tested as part of the development processes to ensure any proposed change will function correctly. Pre-compiled binaries are built, tested, and published to PyPI as part of the release process. Typically, as long as there is a functioning Python environment installed, Qiskit can be installed on these operating systems without needing to install further dependencies.
+
+  Tier 1 operating systems:
+
+  - Linux x86_64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification).
+  - macOS x86_64 (10.12 or later)
+  - macOS ARM64 (11.0 or newer)
+  - Windows 64-bit (Windows 10 and later supported)
+  - Linux AArch64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
+</details>
+
+<details>
+  <summary>
+    Tier 2
+  </summary>
+  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with just a functioning Python environment.
+
+  Tier 2 operating systems:
+
+  -
+
+</details>
+
+<details>
+  <summary>
+    Tier 3
+  </summary>
+  Tier 3 operating systems are not tested as part of the development process. Pre-compiled binaries are built and published to PyPI as part of the release process but are not tested. They may not be installable with just a functioning Python environment and might require a C/C++ compiler or additional programs to build dependencies from source as part of the installation process. Support for these operating systems are best effort only.
+
+  Tier 3 operating systems:
+
+  - Linux ppc64le (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/)packaging specification)
+  - Linux s390x (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
+</details>
+
+Starting in Qiskit 2.0.0 only 64 bit platforms are supported and 32 bit platforms are not supported. You will not be able to build from source
+on 32 bit platforms either, as internally the Qiskit Rust code assumes a 64 bit pointer width.
+
+### Qiskit 1.x
+
+In the Qiskit 1.x release series the supported platforms are:
+
 <details>
   <summary>
     Tier 1

--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -259,12 +259,7 @@ In the Qiskit v2.x release series the supported platforms are:
   <summary>
     Tier 2
   </summary>
-  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
-
-  Tier 2 operating systems:
-
-  -
-
+  *There are currently no Tier 2 operating systems.* Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
 </details>
 
 <details>

--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -236,9 +236,9 @@ Qiskit strives to support as many operating systems as possible, but due to limi
 
 Additionally, Qiskit only supports the CPython implementation of the Python language. Running with other Python interpreters such as PyPy is not supported.
 
-### Qiskit 2.x
+### Qiskit v2.x
 
-In the Qiskit 2.x release series the supported platforms are:
+In the Qiskit v2.x release series the supported platforms are:
 
 <details>
   <summary>
@@ -259,7 +259,7 @@ In the Qiskit 2.x release series the supported platforms are:
   <summary>
     Tier 2
   </summary>
-  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with just a functioning Python environment.
+  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
 
   Tier 2 operating systems:
 
@@ -271,7 +271,7 @@ In the Qiskit 2.x release series the supported platforms are:
   <summary>
     Tier 3
   </summary>
-  Tier 3 operating systems are not tested as part of the development process. Pre-compiled binaries are built and published to PyPI as part of the release process but are not tested. They may not be installable with just a functioning Python environment and might require a C/C++ compiler or additional programs to build dependencies from source as part of the installation process. Support for these operating systems are best effort only.
+  Tier 3 operating systems are not tested as part of the development process. Pre-compiled binaries are built and published to PyPI as part of the release process but are not tested. They may not be installable with only a functioning Python environment and might require a C/C++ compiler or additional programs to build dependencies from source as part of the installation process. Support for these operating systems are best effort only.
 
   Tier 3 operating systems:
 
@@ -279,12 +279,12 @@ In the Qiskit 2.x release series the supported platforms are:
   - Linux s390x (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
 </details>
 
-Starting in Qiskit 2.0.0 only 64 bit platforms are supported and 32 bit platforms are not supported. You will not be able to build from source
-on 32 bit platforms either, as internally the Qiskit Rust code assumes a 64 bit pointer width.
+Starting in Qiskit v2.0.0, only 64-bit platforms are supported and 32-bit platforms are not supported. You will not be able to build from source
+on 32-bit platforms either, as internally the Qiskit Rust code assumes a 64-bit pointer width.
 
-### Qiskit 1.x
+### Qiskit v1.x
 
-In the Qiskit 1.x release series the supported platforms are:
+In the Qiskit v1.x release series, the supported platforms are:
 
 <details>
   <summary>

--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -259,7 +259,7 @@ In the Qiskit v2.x release series, the supported platforms are:
   <summary>
     Tier 2
   </summary>
-  *There are currently no Tier 2 operating systems.* Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
+  *There are no Tier 2 operating systems in the Qiskit v2.x release series.* Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
 </details>
 
 <details>

--- a/docs/open-source/qiskit-sdk-version-strategy.mdx
+++ b/docs/open-source/qiskit-sdk-version-strategy.mdx
@@ -28,10 +28,10 @@ A tentative release schedule is included below:
 
 ![Tentative Qiskit release schedule](/images/guides/install/release_schedule.avif)
 
-For an up-to-date release schedule, refer to the Qiskit Github project's [milestones list](https://github.com/Qiskit/qiskit/milestones), which will always contain the current release plan.
+For an up-to-date release schedule, refer to the Qiskit GitHub project's [milestones list](https://github.com/Qiskit/qiskit/milestones), which will always contain the current release plan.
 
 With the release of a new major version, the previous major version is supported
-for at least six months with only bu fixes, and one year for security fixes. During
+for at least six months with only bug fixes, and one year for security fixes. During
 this time only patch releases are published for this major version.
 A final patch version is published when support is dropped, and that release
 also documents the end of support for that major version series. A longer

--- a/docs/open-source/qiskit-sdk-version-strategy.mdx
+++ b/docs/open-source/qiskit-sdk-version-strategy.mdx
@@ -31,8 +31,9 @@ A tentative release schedule is included below:
 For an up-to-date release schedule, refer to the Qiskit Github project's [milestones list](https://github.com/Qiskit/qiskit/milestones), which will always contain the current release plan.
 
 With the release of a new major version, the previous major version is supported
-for at least six months; only bug and security fixes are accepted during this time and only patch releases are published for this major version. A final
-patch version is published when support is dropped, and that release 
+for at least six months with only bu fixes, and one year for security fixes. During
+this time only patch releases are published for this major version.
+A final patch version is published when support is dropped, and that release
 also documents the end of support for that major version series. A longer
 support window is needed for the previous major version as this gives downstream
 Qiskit consumers and their users a chance to migrate their code.


### PR DESCRIPTION
This commit updates the documentation for the pending 2.0.0 release to include the changes to platform support for Qiskit 2.0 and the versioning strategy.

Closes #2570