### PR TITLE
Document why we use primitives in a regular guide

### DIFF
--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -6,7 +6,7 @@ description: Introduction to primitives in Qiskit and Qiskit Runtime, and an exp
 
 # Introduction to primitives
 
-## Why does Qkiskit use primitives?
+## Why does Qiskit use primitives?
 
 The `backend.run` interface was the primary access point to quantum hardware and simulators offered by IBM&reg;, as well as third-party providers that integrate with Qiskit. The evolution of user access patterns for quantum processing units (QPUs) led to the Qiskit primitives (`Sampler` and `Estimator`) superseding this interface.
 
@@ -24,7 +24,7 @@ the Qiskit [primitives interface](/primitives), which is optimized for two core 
 expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
 again to help developers to focus more on innovation and less on data conversion.
 
-## What is a primitve?
+## What is a primitive?
 
 Computing systems are built on multiple layers of abstraction. Abstractions allow you to focus on a
 particular level of detail relevant to the task at hand. The closer you get to the hardware,

--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -20,7 +20,7 @@ to operate on a familiar data format and focus on the bigger picture.
 
 As access to QPUs became more widespread, and with more quantum algorithms being developed,
 again the need for a higher-level abstraction emerged. In response, IBM introduced
-the Qiskit [primitives interface](/primitives), which is optimized for two core tasks in quantum algorithm development:
+the Qiskit primitives interface, which is optimized for two core tasks in quantum algorithm development:
 expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
 again to help developers to focus more on innovation and less on data conversion.
 

--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -8,21 +8,16 @@ description: Introduction to primitives in Qiskit and Qiskit Runtime, and an exp
 
 ## Why does Qiskit use primitives?
 
-The `backend.run` interface was the primary access point to quantum hardware and simulators offered by IBM&reg;, as well as third-party providers that integrate with Qiskit. The evolution of user access patterns for quantum processing units (QPUs) led to the Qiskit primitives (`Sampler` and `Estimator`) superseding this interface.
-
-<span id="qpu-access-patterns"></span>
-### User access patterns for QPUs
-
 Similar to the early days of classical computers, when developers had to manipulate CPU registers directly, the early interface to QPUs simply returned the raw data from the control electronics.
 This was not a big issue when QPUs lived in labs and only allowed direct access by researchers.
-Acknowledging that most developers would not and should not be familiar with distilling such raw data into 0s and 1s, IBM&reg; introduced `backend.run`, a first abstraction for accessing QPUs in the cloud. This allowed developers
+Acknowledging that most developers would not and should not be familiar with distilling such raw data into 0s and 1s, Qiskit introduced `backend.run`, a first abstraction for accessing QPUs in the cloud. This allowed developers
 to operate on a familiar data format and focus on the bigger picture.
 
 As access to QPUs became more widespread, and with more quantum algorithms being developed,
-again the need for a higher-level abstraction emerged. In response, IBM introduced
-the Qiskit primitives interface, which is optimized for two core tasks in quantum algorithm development:
+again the need for a higher-level abstraction emerged. In response, Qiskit introduced
+the primitives interface, which is optimized for two core tasks in quantum algorithm development:
 expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
-again to help developers to focus more on innovation and less on data conversion.
+again to help developers to focus more on innovation and less on data conversion. The primitives interface supersedes the `backend.run` interface, since `Sampler` provides the same direct hardware access that was offered by `backend.run`. 
 
 ## What is a primitive?
 

--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -6,6 +6,26 @@ description: Introduction to primitives in Qiskit and Qiskit Runtime, and an exp
 
 # Introduction to primitives
 
+## Why does Qkiskit use primitives?
+
+The `backend.run` interface was the primary access point to quantum hardware and simulators offered by IBM&reg;, as well as third-party providers that integrate with Qiskit. The evolution of user access patterns for quantum processing units (QPUs) led to the Qiskit primitives (`Sampler` and `Estimator`) superseding this interface.
+
+<span id="qpu-access-patterns"></span>
+### User access patterns for QPUs
+
+Similar to the early days of classical computers, when developers had to manipulate CPU registers directly, the early interface to QPUs simply returned the raw data from the control electronics.
+This was not a big issue when QPUs lived in labs and only allowed direct access by researchers.
+Acknowledging that most developers would not and should not be familiar with distilling such raw data into 0s and 1s, IBM&reg; introduced `backend.run`, a first abstraction for accessing QPUs in the cloud. This allowed developers
+to operate on a familiar data format and focus on the bigger picture.
+
+As access to QPUs became more widespread, and with more quantum algorithms being developed,
+again the need for a higher-level abstraction emerged. In response, IBM introduced
+the Qiskit [primitives interface](/primitives), which is optimized for two core tasks in quantum algorithm development:
+expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
+again to help developers to focus more on innovation and less on data conversion.
+
+## What is a primitve?
+
 Computing systems are built on multiple layers of abstraction. Abstractions allow you to focus on a
 particular level of detail relevant to the task at hand. The closer you get to the hardware,
 the lower the level of abstraction you need (for example, you might

--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -2,10 +2,12 @@
 title: Introduction to primitives
 description: Introduction to primitives in Qiskit and Qiskit Runtime, and an explanation of available primitives
 
+
 ---
 
 # Introduction to primitives
 
+<span id="qpu-access-patterns"></span>
 ## Why did Qiskit introduce primitives?
 
 Similar to the early days of classical computers, when developers had to manipulate CPU registers directly, the early interface to QPUs simply returned the raw data from the control electronics.
@@ -17,7 +19,7 @@ As access to QPUs became more widespread, and with more quantum algorithms being
 again the need for a higher-level abstraction emerged. In response, Qiskit introduced
 the primitives interface, which is optimized for two core tasks in quantum algorithm development:
 expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
-again to help developers to focus more on innovation and less on data conversion. The primitives interface supersedes the `backend.run` interface, since `Sampler` provides the same direct hardware access that was offered by `backend.run`. 
+again to help developers to focus more on innovation and less on data conversion. The primitives interface supersedes the `backend.run` interface, since `Sampler` provides the same direct hardware access that was offered by `backend.run`.
 
 ## What is a primitive?
 

--- a/docs/guides/primitives.mdx
+++ b/docs/guides/primitives.mdx
@@ -6,7 +6,7 @@ description: Introduction to primitives in Qiskit and Qiskit Runtime, and an exp
 
 # Introduction to primitives
 
-## Why does Qiskit use primitives?
+## Why did Qiskit introduce primitives?
 
 Similar to the early days of classical computers, when developers had to manipulate CPU registers directly, the early interface to QPUs simply returned the raw data from the control electronics.
 This was not a big issue when QPUs lived in labs and only allowed direct access by researchers.

--- a/docs/migration-guides/external-providers-primitives-v2.mdx
+++ b/docs/migration-guides/external-providers-primitives-v2.mdx
@@ -9,7 +9,7 @@ description: Migrate to the primitives interface in external providers
 ## Why should third-party providers implement primitives?
 
 The Qiskit SDK is built to support third parties in creating external providers of quantum resources.
-The evolution of [user access patterns for QPUs](/migration-guides/qiskit-runtime#why-migrate-to-qiskit-runtime-primitives)
+The evolution of [user access patterns for QPUs](/guides/primitives#qpu-access-patterns)
 led to the Qiskit primitives (`Sampler` and `Estimator`) superseding the `backend.run` interface.
 To ensure Qiskit users can seamlessly transition between providers, all third-party providers should
 implement native support of the primitives for performant access to their hardware or simulators.

--- a/docs/migration-guides/qiskit-runtime.mdx
+++ b/docs/migration-guides/qiskit-runtime.mdx
@@ -17,24 +17,13 @@ examples to help you migrate code from the legacy `backend.run` interface to use
 - Because both `backend.run` and the "version 1" primitives are being deprecated, this guide uses only the V2 primitives.
 </Admonition>
 
-The `qiskit-ibm-runtime` package provides cloud access to the IBM&reg; QPUs (quantum processing units) through the primitives interface. The `backend.run` interface coexisted with the original (V1) primitives model as the dedicated “direct hardware access” entry point.  With the introduction of the V2 primitives interface, the new `SamplerV2` class now fulfills that role. Consequentially, `backend.run` and `qiskit-ibm-provider`, which only exposed the `backend.run` interface, are no longer supported.
+The `qiskit-ibm-runtime` package provides cloud access to the IBM&reg; quantum processing units  (QPUs) through the primitives interface. The `backend.run` interface coexisted with the original (V1) primitives model as the dedicated “direct hardware access” entry point.  With the introduction of the V2 primitives interface, the new `SamplerV2` class fulfills that role. Consequentially, `backend.run` and `qiskit-ibm-provider`, which only exposed the `backend.run` interface, are no longer supported.
 
 The Qiskit Runtime primitives implement the reference Sampler V2 and Estimator V2 interfaces found in `qiskit.primitives`, and enable capabilities not available with the legacy `backend.run` interface. These capabilities include application of advanced processing techniques for error suppression and mitigation in Estimator, the ability to efficiently sweep between arrays of parameter value sets or observables in both Sampler and Estimator, and access to the new local testing mode. Additionally, Qiskit Runtime lets users run iterative algorithm circuits back to back (session mode) or in collections of circuits without having to re-queue each job (batch mode). This results in more efficient quantum processor use and reduces the time spent running complex computations.
 
 ## Why migrate to Qiskit Runtime primitives?
 
-Similar to the early days of classical computers, when developers had to manipulate CPU registers directly,
-the early interface to QPUs simply returned the raw data coming out of the control electronics.
-This was not a huge issue when QPUs lived in labs and only allowed direct access by researchers.
-Acknowledging that most developers would not and should not be familiar with distilling such raw data into
-0s and 1s, IBM introduced `backend.run`, a first abstraction for accessing QPUs in the cloud. This allowed developers
-to operate on a familiar data format and focus on the bigger picture.
-
-As access to QPUs became more widespread, and with more quantum algorithms being developed,
-again the need for a higher-level abstraction emerged. In response, IBM introduced
-the Qiskit [primitives interface](/guides/primitives), which are optimized for two core tasks in quantum algorithm development:
-expectation value estimation (`Estimator`) and circuit sampling (`Sampler`). The goal is once
-again to help developers to focus more on innovation and less on data conversion.
+The `backend.run` interface was the primary access point to quantum hardware and simulators offered by IBM, as well as third-party providers that integrate with Qiskit. The [evolution of user access patterns](/guides/primitives#qpu-access-patterns) for quantum processing units (QPUs) led to the Qiskit primitives (`Sampler` and `Estimator`) superseding this interface.
 
 For backward compatibility, the `backend.run` interface continues to exist in Qiskit. However, it is no longer supported
 in Qiskit Runtime after the deprecation period, as most IBM Quantum&reg; users have migrated to V2 primitives due to their improved


### PR DESCRIPTION
Currently, we only document the "why" of primitives in the migration guides. 