### PR TITLE
Don't run Prettier with `npm run check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,11 +389,11 @@ You can also check that API docs render by using any of these arguments: `npm ru
 
 CI will check on every PR that any changed files render correctly. We also run a weekly cron job to check that every page renders correctly.
 
-## Format README and TypeScript files
+## Format TypeScript files
 
-Run `npm run fmt` to automatically format the README, `.github` folder, and `scripts/` folder. You should run this command if you get the error in CI `run Prettier to fix`.
+Run `npm run fmt` to automatically format the `.github` folder and `scripts/` folder. You should run this command if you get the error in CI `run Prettier to fix`.
 
-To check that formatting is valid without actually making changes, run `npm run check:fmt` or `npm run check`.
+To check that formatting is valid without actually making changes, run `npm run check:fmt`.
 
 ## Regenerate an existing API docs version
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fmt": "prettier --write .",
     "test": "playwright test",
     "typecheck": "tsc",
-    "check": "npm run check:qiskit-bot && npm run check:patterns-index && npm run check:images && npm run check:metadata && npm run check:spelling && npm run check:internal-links && npm run check:orphan-pages && npm run check:stale-images && npm run check:fmt",
+    "check": "npm run check:qiskit-bot && npm run check:patterns-index && npm run check:images && npm run check:metadata && npm run check:spelling && npm run check:internal-links && npm run check:orphan-pages && npm run check:stale-images",
     "check:images": "tsx scripts/js/commands/checkImages.ts",
     "check:metadata": "tsx scripts/js/commands/checkMetadata.ts",
     "check:spelling": "tsx scripts/js/commands/checkSpelling.ts",


### PR DESCRIPTION
A quick win for https://github.com/Qiskit/documentation/issues/2800. We should optimize `npm run check` for content writers, not developers. Content writers don't work on TypeScript.

This speeds up `npm run check` by 3.8s (real) on my Macbook Pro.