### PR TITLE
Refactor checkOrphanPages.ts

### DIFF
--- a/scripts/js/commands/checkOrphanPages.ts
+++ b/scripts/js/commands/checkOrphanPages.ts
@@ -42,8 +42,8 @@ async function main() {
   const args = readArgs();
   const tocFiles = await findTocFiles(args.apis);
 
-  const orphanGroups = await Promise.all(tocFiles.map(findOrphans))
-  const orphans = flatten(orphanGroups)
+  const orphanGroups = await Promise.all(tocFiles.map(findOrphans));
+  const orphans = flatten(orphanGroups);
 
   if (orphans.length > 0) {
     console.error(

--- a/scripts/js/commands/checkOrphanPages.ts
+++ b/scripts/js/commands/checkOrphanPages.ts
@@ -16,7 +16,7 @@ import path from "path";
 import { globby } from "globby";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
-import { flattenDeep } from "lodash-es";
+import { flatten } from "lodash-es";
 
 import { TocEntry } from "../lib/api/generateToc.js";
 
@@ -40,67 +40,63 @@ const readArgs = (): Arguments => {
 
 async function main() {
   const args = readArgs();
+  const tocFiles = await findTocFiles(args.apis);
 
-  const tocFiles = await determineTocFiles(args);
+  const orphanGroups = await Promise.all(tocFiles.map(findOrphans))
+  const orphans = flatten(orphanGroups)
 
-  const orphanPages = [];
-  for (const tocFile of tocFiles) {
-    console.log("Checking toc in:", tocFile);
-    const tocUrls = await getTocUrls(tocFile);
-    const dir = path.dirname(tocFile);
-    const existingUrls = await collectExistingUrls(dir);
-    orphanPages.push(
-      ...existingUrls.filter(
-        (file) => !tocUrls.has(file) && !ALLOWED_ORPHAN_URLS.has(file),
-      ),
-    );
-  }
-  if (orphanPages.length > 0) {
+  if (orphans.length > 0) {
     console.error(
-      "\n There are some orphaned pages!  These files need a home: \n",
-      orphanPages.join("\n"),
+      "\n❌ There are some orphaned pages! These URLs need to be included in a _toc.json: \n",
+      orphans.join("\n"),
     );
     process.exit(1);
   }
   console.log("\nNo orphan pages found ✅\n");
 }
 
-async function getTocUrls(filePath: string): Promise<Set<string>> {
-  const jsonFileContents = await fs.readFile(filePath, "utf-8");
-  const children = JSON.parse(jsonFileContents).children;
-
-  const fileContents = await collectTocFileContents(children);
-  const flatFileContents = flattenDeep(fileContents);
-
-  flatFileContents.push(`${flatFileContents[0]}/index`);
-
-  return new Set(flatFileContents);
+async function findOrphans(tocFile: string): Promise<string[]> {
+  console.log("Checking toc in:", tocFile);
+  const [tocUrls, existentUrls] = await Promise.all([
+    readTocUrls(tocFile),
+    findExistentUrls(path.dirname(tocFile)),
+  ]);
+  return existentUrls.filter(
+    (file) => !tocUrls.has(file) && !ALLOWED_ORPHAN_URLS.has(file),
+  );
 }
 
-async function collectExistingUrls(directory: string): Promise<string[]> {
+async function readTocUrls(filePath: string): Promise<Set<string>> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  const rootEntries = JSON.parse(raw).children;
+  const urls = parseTocUrls(rootEntries);
+  urls.push(`${urls[0]}/index`);
+  return new Set(urls);
+}
+
+async function findExistentUrls(directory: string): Promise<string[]> {
   const fileList = await globby([`${directory}/*.{mdx,ipynb}`]);
   return fileList.map((fileName) =>
     fileName.replace("docs", "").replace(".mdx", "").replace(".ipynb", ""),
   );
 }
 
-async function determineTocFiles(args: Arguments): Promise<string[]> {
+async function findTocFiles(includeApis: boolean): Promise<string[]> {
   const globs = [
     "docs/**/_toc.json",
-    args.apis ? "docs/api/**/_toc.json" : "!docs/api/**",
+    includeApis ? "docs/api/**/_toc.json" : "!docs/api/**",
   ];
-  return await globby(globs);
+  return globby(globs);
 }
 
-function collectTocFileContents(children: TocEntry[]): string[] {
+function parseTocUrls(entries: TocEntry[]): string[] {
   const urls = [];
-
-  for (const child of children) {
-    if ("children" in child) {
-      const childUrls = collectTocFileContents(child.children || []);
+  for (const entry of entries) {
+    if ("children" in entry) {
+      const childUrls = parseTocUrls(entry.children || []);
       urls.push(...childUrls);
-    } else if (child.url !== undefined) {
-      urls.push(child.url);
+    } else if (entry.url !== undefined) {
+      urls.push(entry.url);
     }
   }
   return urls;


### PR DESCRIPTION
I nerd-sniped myself into this change. I was trying to improve the performance of the orphan check for https://github.com/Qiskit/documentation/issues/2800 by using `Promises.all()`, but it turns out it barely makes an improvement.

This PR:

```
❯ hyperfine "npx tsx scripts/js/commands/checkOrphanPages.ts -- --apis" 
Benchmark 1: npx tsx scripts/js/commands/checkOrphanPages.ts -- --apis
  Time (mean ± σ):     587.6 ms ±  14.6 ms    [User: 778.5 ms, System: 155.7 ms]
  Range (min … max):   567.8 ms … 621.2 ms    10 runs
```

Main branch:

```
❯ hyperfine "npx tsx scripts/js/commands/checkOrphanPages.ts -- --apis"
Benchmark 1: npx tsx scripts/js/commands/checkOrphanPages.ts -- --apis
  Time (mean ± σ):     592.6 ms ±  18.8 ms    [User: 781.1 ms, System: 153.7 ms]
  Range (min … max):   570.7 ms … 631.7 ms    10 runs
```

So, this PR solely refactors the code:

* Uses `Promises.all` with `.map()` for more idiomatic code. (The parallization doesn't impact performance much)
* Improves the error message
* Generally uses more concise code, like `jsonFileContents` -> `raw`
* Uses more consistent naming:
    -`findX` means find file paths in file system
    - `readX` means read file X
    - `parseX` means convert a string to something parsed

