### PR TITLE
Use more modern version of changed-files action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get all changed docs files
         id: all-changed-files
-        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: docs/**/*.{md,mdx,ipynb}
           separator: "\n"

--- a/.github/workflows/notebook-test-extended.yml
+++ b/.github/workflows/notebook-test-extended.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get relevant changed files
         id: all-changed
-        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: "{docs/**/*.ipynb,scripts/nb-tester/**/*}"
           separator: "\n"

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get relevant changed files
         id: all-changed
-        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           files: "{docs/**/*.ipynb,scripts/nb-tester/**/*}"
           separator: "\n"


### PR DESCRIPTION
We continue pinning to an exact commit for better security. General context: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised#stepsecurity-harden-runner.