### PR TITLE
Tweaks to C API parser

### DIFF
--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -20,7 +20,7 @@ export type ApiType =
   | "exception"
   | "data"
   | "struct"
-  | "type";
+  | "typedef";
 
 export type Metadata = {
   apiName?: string;

--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -19,7 +19,8 @@ export type ApiType =
   | "function"
   | "exception"
   | "data"
-  | "struct";
+  | "struct"
+  | "type";
 
 export type Metadata = {
   apiName?: string;

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -258,6 +258,10 @@ export class Pkg {
     return this.type == "latest";
   }
 
+  isCApi(): boolean {
+    return this.language === "C";
+  }
+
   isProblematicLegacyQiskit(): boolean {
     return this.name === "qiskit" && +this.versionWithoutPatch < 0.45;
   }

--- a/scripts/js/lib/api/conversionPipeline.ts
+++ b/scripts/js/lib/api/conversionPipeline.ts
@@ -78,10 +78,9 @@ async function determineFilePaths(
     ? undefined
     : ObjectsInv.fromFile(htmlPath));
 
-  const extraFiles =
-    pkg.language == "C"
-      ? ["cdoc/**.html"]
-      : ["apidocs/**.html", "apidoc/**.html", "stubs/**.html"];
+  const extraFiles = pkg.isCApi()
+    ? ["cdoc/**.html"]
+    : ["apidocs/**.html", "apidoc/**.html", "stubs/**.html"];
   const files = await globby(
     [...extraFiles, "release_notes.html", "release-notes.html"],
     {
@@ -110,7 +109,7 @@ async function convertFilesToMarkdown(
       imageDestination: pkg.outputDir("/images"),
       releaseNotesTitle: pkg.releaseNotesTitle(),
       hasSeparateReleaseNotes: pkg.hasSeparateReleaseNotes(),
-      isCApi: pkg.language == "C",
+      isCApi: pkg.isCApi(),
     });
 
     // Avoid creating an empty markdown file for HTML files without content

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -34,7 +34,7 @@ export type ComponentProps = {
   isDedicatedPage?: boolean;
 };
 
-const APITYPE_TO_TAG: Record<Exclude<ApiType, "module">, string> = {
+const API_TYPE_TO_TAG: Record<Exclude<ApiType, "module">, string> = {
   class: "class",
   exception: "class",
   attribute: "attribute",
@@ -55,7 +55,7 @@ export async function processMdxComponent(
   id: string,
   options: { isCApi: boolean },
 ): Promise<[string, string]> {
-  const tagName = APITYPE_TO_TAG[apiType];
+  const tagName = API_TYPE_TO_TAG[apiType];
 
   const $firstSignature = signatures.shift()!;
   const componentProps = prepareProps(

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -43,7 +43,7 @@ const APITYPE_TO_TAG: Record<Exclude<ApiType, "module">, string> = {
   method: "function",
   data: "attribute",
   struct: "class",
-  type: "class",
+  typedef: "class",
 };
 
 export async function processMdxComponent(
@@ -119,7 +119,7 @@ function prepareProps(
     function: prepFunction,
     data: prepAttributeOrProperty,
     struct: prepClassOrException,
-    type: prepClassOrException,
+    typedef: prepClassOrException,
   };
 
   const githubSourceLink = prepareGitHubLink($child, apiType === "method");

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -43,6 +43,7 @@ const APITYPE_TO_TAG: Record<Exclude<ApiType, "module">, string> = {
   method: "function",
   data: "attribute",
   struct: "class",
+  type: "class",
 };
 
 export async function processMdxComponent(
@@ -107,6 +108,7 @@ function prepareProps(
     function: prepFunction,
     data: prepAttributeOrProperty,
     struct: prepClassOrException,
+    type: prepClassOrException,
   };
 
   const githubSourceLink = prepareGitHubLink($child, apiType === "method");

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -72,6 +72,8 @@ function getModulesAndItems(
     (result) => !isEmpty(result.meta.apiName),
   );
 
+  // We group Python packages by module for better organization.
+  // However, C does not have modules.
   const modules = options.isCApi
     ? resultsWithName
     : resultsWithName.filter((result) => result.meta.apiType === "module");

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -31,7 +31,9 @@ type Toc = {
 };
 
 export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
-  const [modules, items] = getModulesAndItems(results);
+  const [modules, items] = getModulesAndItems(results, {
+    isCApi: pkg.language === "C",
+  });
   const tocModules = generateTocModules(modules);
   const tocModulesByTitle = new Map(
     tocModules.map((entry) => [entry.title, entry]),
@@ -64,14 +66,15 @@ export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
 
 function getModulesAndItems(
   results: HtmlToMdResultWithUrl[],
+  options: { isCApi: boolean },
 ): [HtmlToMdResultWithUrl[], HtmlToMdResultWithUrl[]] {
   const resultsWithName = results.filter(
     (result) => !isEmpty(result.meta.apiName),
   );
 
-  const modules = resultsWithName.filter(
-    (result) => result.meta.apiType === "module",
-  );
+  const modules = options.isCApi
+    ? resultsWithName
+    : resultsWithName.filter((result) => result.meta.apiType === "module");
   const items = resultsWithName.filter(
     (result) =>
       result.meta.apiType &&

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -83,6 +83,8 @@ function getModulesAndItems(
         "property",
         "attribute",
         "data",
+        "struct",
+        "type",
       ].includes(result.meta.apiType),
   );
 

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -32,7 +32,7 @@ type Toc = {
 
 export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
   const [modules, items] = getModulesAndItems(results, {
-    isCApi: pkg.language === "C",
+    isCApi: pkg.isCApi(),
   });
   const tocModules = generateTocModules(modules);
   const tocModulesByTitle = new Map(

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -407,6 +407,7 @@ export async function processMembersAndSetMeta(
         priorApiType,
         apiType!,
         id,
+        options,
       );
       $dl.replaceWith(
         `<div>${openTag}\n${bodyElements.join("\n")}\n${closeTag}</div>`,

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -353,7 +353,7 @@ export async function processMembersAndSetMeta(
     // members can be recursive, so we need to pick elements one by one
     const dl = $main
       .find(
-        "dl.py.class, dl.py.property, dl.py.method, dl.py.attribute, dl.py.function, dl.py.exception, dl.py.data, dl.cpp.function, dl.cpp.struct",
+        "dl.py.class, dl.py.property, dl.py.method, dl.py.attribute, dl.py.function, dl.py.exception, dl.py.data, dl.cpp.function, dl.cpp.struct, dl.cpp.type",
       )
       // Components inside tables will not work properly. This happened with `dl.py.data` in /api/qiskit/utils.
       .not("td > dl")
@@ -484,6 +484,7 @@ function getApiType($dl: Cheerio<any>): ApiType | undefined {
     "module",
     "data",
     "struct",
+    "type",
   ]) {
     if ($dl.hasClass(className)) {
       return className as ApiType;

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -475,7 +475,8 @@ function getApiType($dl: Cheerio<any>): ApiType | undefined {
     return "property";
   }
 
-  for (const className of [
+  const apiClassNames = [
+    "type",
     "function",
     "class",
     "exception",
@@ -485,10 +486,11 @@ function getApiType($dl: Cheerio<any>): ApiType | undefined {
     "module",
     "data",
     "struct",
-    "type",
-  ]) {
+  ] as const;
+  for (const className of apiClassNames) {
     if ($dl.hasClass(className)) {
-      return className as ApiType;
+      if (className === "type") return "typedef";
+      return className;
     }
   }
 


### PR DESCRIPTION
This PR makes three changes to the API generation script:

- **Recognize C `typedef` and format as class**

- **Do not use dedicated pages in C API**
  
  In Python APIs, if a class has the same name as the page name, the page will be a "dedicated page" for that class. This commit disables that for the C API. The C API pages are a grouping of structs and associated functions, rather than a class and its methods. This change reflects that in the information heirarchy.

- **Fix TOC for C API**

  C does not have modules, so we can't group pages by module. This commit just lists all C API pages in the TOC.
