### PR TITLE
Refactor API types

### DIFF
--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -10,22 +10,50 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-export type ApiType =
+export type ApiTypeName =
+  // Python API types
   | "class"
   | "method"
   | "property"
   | "attribute"
-  | "module"
   | "function"
   | "exception"
   | "data"
+  // C API types
   | "struct"
+  | "cFunction"
   | "typedef"
   | "enum"
   | "enumerator";
 
+interface ApiType {
+  cssSelector: string;
+  tagName: "class" | "function" | "attribute";
+}
+
+/**
+ * This object defines every API type we support. The key is the name we use to
+ * refer to the API type in this script, the `cssSelector` is the CSS selector
+ * in the Sphinx HTML, and the `tagName` is the tag we transform it to (and how
+ * it'll be displayed on the website).
+ */
+export const API_TYPES: { [K in ApiTypeName]: ApiType } = {
+  class: { cssSelector: "dl.py.class", tagName: "class" },
+  exception: { cssSelector: "dl.py.exception", tagName: "class" },
+  attribute: { cssSelector: "dl.py.attribute", tagName: "attribute" },
+  property: { cssSelector: "dl.py.property", tagName: "attribute" },
+  function: { cssSelector: "dl.py.function", tagName: "function" },
+  cFunction: { cssSelector: "dl.cpp.function", tagName: "function" },
+  method: { cssSelector: "dl.py.method", tagName: "function" },
+  data: { cssSelector: "dl.py.data", tagName: "attribute" },
+  struct: { cssSelector: "dl.cpp.struct", tagName: "class" },
+  typedef: { cssSelector: "dl.cpp.type", tagName: "class" },
+  enum: { cssSelector: "dl.cpp.enum", tagName: "class" },
+  enumerator: { cssSelector: "dl.cpp.enumerator", tagName: "attribute" },
+} as const;
+
 export type Metadata = {
   apiName?: string;
-  apiType?: ApiType;
+  apiType?: ApiTypeName | "module";
   hardcodedFrontmatter?: string;
 };

--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -10,7 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-export type ApiTypeName =
+export type ApiTypeName = ApiObjectName | "module";
+export type ApiObjectName =
   // Python API types
   | "class"
   | "method"
@@ -26,7 +27,7 @@ export type ApiTypeName =
   | "enum"
   | "enumerator";
 
-interface ApiType {
+interface ApiObjectInfo {
   cssSelector: string;
   tagName: "class" | "function" | "attribute";
 }
@@ -37,7 +38,7 @@ interface ApiType {
  * in the Sphinx HTML, and the `tagName` is the tag we transform it to (and how
  * it'll be displayed on the website).
  */
-export const API_TYPES: { [K in ApiTypeName]: ApiType } = {
+export const API_OBJECTS: { [K in ApiObjectName]: ApiObjectInfo } = {
   class: { cssSelector: "dl.py.class", tagName: "class" },
   exception: { cssSelector: "dl.py.exception", tagName: "class" },
   attribute: { cssSelector: "dl.py.attribute", tagName: "attribute" },
@@ -54,6 +55,6 @@ export const API_TYPES: { [K in ApiTypeName]: ApiType } = {
 
 export type Metadata = {
   apiName?: string;
-  apiType?: ApiTypeName | "module";
+  apiType?: ApiTypeName;
   hardcodedFrontmatter?: string;
 };

--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -28,29 +28,29 @@ export type ApiObjectName =
   | "enumerator";
 
 interface ApiObjectInfo {
-  cssSelector: string;
+  htmlSelector: string;
   tagName: "class" | "function" | "attribute";
 }
 
 /**
  * This object defines every API type we support. The key is the name we use to
- * refer to the API type in this script, the `cssSelector` is the CSS selector
+ * refer to the API type in this script, the `htmlSelector` is the HTML selector
  * in the Sphinx HTML, and the `tagName` is the tag we transform it to (and how
  * it'll be displayed on the website).
  */
 export const API_OBJECTS: { [K in ApiObjectName]: ApiObjectInfo } = {
-  class: { cssSelector: "dl.py.class", tagName: "class" },
-  exception: { cssSelector: "dl.py.exception", tagName: "class" },
-  attribute: { cssSelector: "dl.py.attribute", tagName: "attribute" },
-  property: { cssSelector: "dl.py.property", tagName: "attribute" },
-  function: { cssSelector: "dl.py.function", tagName: "function" },
-  cFunction: { cssSelector: "dl.cpp.function", tagName: "function" },
-  method: { cssSelector: "dl.py.method", tagName: "function" },
-  data: { cssSelector: "dl.py.data", tagName: "attribute" },
-  struct: { cssSelector: "dl.cpp.struct", tagName: "class" },
-  typedef: { cssSelector: "dl.cpp.type", tagName: "class" },
-  enum: { cssSelector: "dl.cpp.enum", tagName: "class" },
-  enumerator: { cssSelector: "dl.cpp.enumerator", tagName: "attribute" },
+  class: { htmlSelector: "dl.py.class", tagName: "class" },
+  exception: { htmlSelector: "dl.py.exception", tagName: "class" },
+  attribute: { htmlSelector: "dl.py.attribute", tagName: "attribute" },
+  property: { htmlSelector: "dl.py.property", tagName: "attribute" },
+  function: { htmlSelector: "dl.py.function", tagName: "function" },
+  cFunction: { htmlSelector: "dl.cpp.function", tagName: "function" },
+  method: { htmlSelector: "dl.py.method", tagName: "function" },
+  data: { htmlSelector: "dl.py.data", tagName: "attribute" },
+  struct: { htmlSelector: "dl.cpp.struct", tagName: "class" },
+  typedef: { htmlSelector: "dl.cpp.type", tagName: "class" },
+  enum: { htmlSelector: "dl.cpp.enum", tagName: "class" },
+  enumerator: { htmlSelector: "dl.cpp.enumerator", tagName: "attribute" },
 } as const;
 
 export type Metadata = {

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -16,7 +16,7 @@ import rehypeParse from "rehype-parse";
 import rehypeRemark from "rehype-remark";
 import remarkStringify from "remark-stringify";
 
-import { ApiTypeName, API_TYPES } from "./Metadata.js";
+import { ApiTypeName, ApiObjectName, API_OBJECTS } from "./Metadata.js";
 import {
   getLastPartFromFullIdentifier,
   removeSuffix,
@@ -38,12 +38,12 @@ export async function processMdxComponent(
   $: CheerioAPI,
   signatures: Cheerio<Element>[],
   $dl: Cheerio<any>,
-  priorApiType: ApiTypeName | "module" | undefined,
-  apiType: ApiTypeName,
+  priorApiType: ApiTypeName | undefined,
+  apiType: ApiObjectName,
   id: string,
   options: { isCApi: boolean },
 ): Promise<[string, string]> {
-  const tagName = API_TYPES[apiType].tagName;
+  const tagName = API_OBJECTS[apiType].tagName;
 
   const $firstSignature = signatures.shift()!;
   const componentProps = prepareProps(
@@ -81,8 +81,8 @@ function prepareProps(
   $: CheerioAPI,
   $child: Cheerio<Element>,
   $dl: Cheerio<any>,
-  priorApiType: ApiTypeName | "module" | undefined,
-  apiType: ApiTypeName,
+  priorApiType: ApiTypeName | undefined,
+  apiType: ApiObjectName,
   id: string,
   options: { isCApi: boolean },
 ): ComponentProps {
@@ -95,7 +95,7 @@ function prepareProps(
   const prepAttributeOrProperty = () =>
     prepareAttributeOrPropertyProps($, $child, $dl, githubSourceLink, id);
 
-  const preparePropsPerApiType: Record<ApiTypeName, () => ComponentProps> = {
+  const preparePropsPerApiType: Record<ApiObjectName, () => ComponentProps> = {
     class: prepClassOrException,
     exception: prepClassOrException,
     property: prepAttributeOrProperty,
@@ -158,7 +158,7 @@ function prepareMethodProps(
   $: CheerioAPI,
   $child: Cheerio<any>,
   $dl: Cheerio<any>,
-  priorApiType: ApiTypeName | "module" | undefined,
+  priorApiType: ApiTypeName | undefined,
   githubSourceLink: string | undefined,
   id: string,
 ): ComponentProps {
@@ -327,7 +327,7 @@ export async function createOpeningTag(
     extraSignatures.push(`"${await htmlSignatureToMd(sig!)}"`);
   }
 
-  return `<${tagName} 
+  return `<${tagName}
     id='${props.id}'
     attributeTypeHint='${attributeTypeHint}'
     attributeValue='${attributeValue}'

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -327,7 +327,7 @@ export async function createOpeningTag(
     extraSignatures.push(`"${await htmlSignatureToMd(sig!)}"`);
   }
 
-  return `<${tagName}
+  return `<${tagName} 
     id='${props.id}'
     attributeTypeHint='${attributeTypeHint}'
     attributeValue='${attributeValue}'

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -16,7 +16,7 @@ import rehypeParse from "rehype-parse";
 import rehypeRemark from "rehype-remark";
 import remarkStringify from "remark-stringify";
 
-import { ApiType } from "./Metadata.js";
+import { ApiTypeName, API_TYPES } from "./Metadata.js";
 import {
   getLastPartFromFullIdentifier,
   removeSuffix,
@@ -34,30 +34,16 @@ export type ComponentProps = {
   isDedicatedPage?: boolean;
 };
 
-const API_TYPE_TO_TAG: Record<Exclude<ApiType, "module">, string> = {
-  class: "class",
-  exception: "class",
-  attribute: "attribute",
-  property: "attribute",
-  function: "function",
-  method: "function",
-  data: "attribute",
-  struct: "class",
-  typedef: "class",
-  enum: "class",
-  enumerator: "attribute",
-};
-
 export async function processMdxComponent(
   $: CheerioAPI,
   signatures: Cheerio<Element>[],
   $dl: Cheerio<any>,
-  priorApiType: ApiType | undefined,
-  apiType: Exclude<ApiType, "module">,
+  priorApiType: ApiTypeName | "module" | undefined,
+  apiType: ApiTypeName,
   id: string,
   options: { isCApi: boolean },
 ): Promise<[string, string]> {
-  const tagName = API_TYPE_TO_TAG[apiType];
+  const tagName = API_TYPES[apiType].tagName;
 
   const $firstSignature = signatures.shift()!;
   const componentProps = prepareProps(
@@ -95,8 +81,8 @@ function prepareProps(
   $: CheerioAPI,
   $child: Cheerio<Element>,
   $dl: Cheerio<any>,
-  priorApiType: ApiType | undefined,
-  apiType: Exclude<ApiType, "module">,
+  priorApiType: ApiTypeName | "module" | undefined,
+  apiType: ApiTypeName,
   id: string,
   options: { isCApi: boolean },
 ): ComponentProps {
@@ -109,16 +95,14 @@ function prepareProps(
   const prepAttributeOrProperty = () =>
     prepareAttributeOrPropertyProps($, $child, $dl, githubSourceLink, id);
 
-  const preparePropsPerApiType: Record<
-    Exclude<ApiType, "module">,
-    () => ComponentProps
-  > = {
+  const preparePropsPerApiType: Record<ApiTypeName, () => ComponentProps> = {
     class: prepClassOrException,
     exception: prepClassOrException,
     property: prepAttributeOrProperty,
     attribute: prepAttributeOrProperty,
     method: prepMethod,
     function: prepFunction,
+    cFunction: prepFunction,
     data: prepAttributeOrProperty,
     struct: prepClassOrException,
     typedef: prepClassOrException,
@@ -174,7 +158,7 @@ function prepareMethodProps(
   $: CheerioAPI,
   $child: Cheerio<any>,
   $dl: Cheerio<any>,
-  priorApiType: ApiType | undefined,
+  priorApiType: ApiTypeName | "module" | undefined,
   githubSourceLink: string | undefined,
   id: string,
 ): ComponentProps {

--- a/scripts/js/lib/api/htmlToMd.ts
+++ b/scripts/js/lib/api/htmlToMd.ts
@@ -26,7 +26,7 @@ import { Emphasis, Root, Content } from "mdast";
 
 import { processHtml } from "./processHtml.js";
 import { HtmlToMdResult } from "./HtmlToMdResult.js";
-import { Metadata, ApiType } from "./Metadata.js";
+import { Metadata, ApiTypeName } from "./Metadata.js";
 import { removePrefix, removeSuffix, capitalize } from "../stringUtils.js";
 import { remarkStringifyOptions } from "./commonParserConfig.js";
 
@@ -203,7 +203,7 @@ function findNodeWithProperty(nodeList: any[], propertyName: string) {
 function buildDt(
   h: H,
   node: any,
-  apiType?: ApiType,
+  apiType?: ApiTypeName | "module",
 ): void | Content | Content[] {
   if (apiType === "class" || apiType === "module") {
     return [

--- a/scripts/js/lib/api/htmlToMd.ts
+++ b/scripts/js/lib/api/htmlToMd.ts
@@ -203,7 +203,7 @@ function findNodeWithProperty(nodeList: any[], propertyName: string) {
 function buildDt(
   h: H,
   node: any,
-  apiType?: ApiTypeName | "module",
+  apiType?: ApiTypeName,
 ): void | Content | Content[] {
   if (apiType === "class" || apiType === "module") {
     return [

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -354,7 +354,7 @@ export async function processMembersAndSetMeta(
     const dl = $main
       .find(
         Object.values(API_OBJECTS)
-          .map((x) => x.cssSelector)
+          .map((x) => x.htmlSelector)
           .join(", "),
       )
       // Components inside tables will not work properly. This happened with `dl.py.data` in /api/qiskit/utils.
@@ -478,10 +478,10 @@ function getApiType($dl: Cheerio<any>): ApiObjectName | undefined {
   }
 
   for (const [apiTypeName, apiType] of Object.entries(API_OBJECTS)) {
-    const className = apiType.cssSelector.split(".").pop();
+    const className = apiType.htmlSelector.split(".").pop();
     if (!className)
       throw new Error(
-        `'cssSelector' attribute must be of form 'dl.py.class', found '${apiType}'.`,
+        `'htmlSelector' attribute must be of form '<tag>.<lang>.<apiType>' (e.g. 'dl.py.function'), found '${apiType}'.`,
       );
     if ($dl.hasClass(className)) return apiTypeName as ApiObjectName;
   }

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -16,7 +16,7 @@ import { CheerioAPI, Cheerio, load, Element } from "cheerio";
 import { escapeRegExp } from "lodash-es";
 
 import { Image } from "./HtmlToMdResult.js";
-import { Metadata, ApiTypeName, API_TYPES } from "./Metadata.js";
+import { Metadata, ApiObjectName, API_OBJECTS } from "./Metadata.js";
 import { processMdxComponent } from "./generateApiComponents.js";
 import { externalRedirects } from "../../../config/external-redirects.js";
 
@@ -353,7 +353,7 @@ export async function processMembersAndSetMeta(
     // members can be recursive, so we need to pick elements one by one
     const dl = $main
       .find(
-        Object.values(API_TYPES)
+        Object.values(API_OBJECTS)
           .map((x) => x.cssSelector)
           .join(", "),
       )
@@ -469,7 +469,7 @@ export function updateModuleHeadings($: CheerioAPI, $main: Cheerio<any>): void {
     });
 }
 
-function getApiType($dl: Cheerio<any>): ApiTypeName | undefined {
+function getApiType($dl: Cheerio<any>): ApiObjectName | undefined {
   // Historical versions were generating properties incorrectly as methods.
   // We can fix this by looking at the modifier before the signature.
   // See https://github.com/Qiskit/documentation/issues/1352 for more information.
@@ -477,13 +477,13 @@ function getApiType($dl: Cheerio<any>): ApiTypeName | undefined {
     return "property";
   }
 
-  for (const [apiTypeName, apiType] of Object.entries(API_TYPES)) {
+  for (const [apiTypeName, apiType] of Object.entries(API_OBJECTS)) {
     const className = apiType.cssSelector.split(".").pop();
     if (!className)
       throw new Error(
         `'cssSelector' attribute must be of form 'dl.py.class', found '${apiType}'.`,
       );
-    if ($dl.hasClass(className)) return apiTypeName as ApiTypeName;
+    if ($dl.hasClass(className)) return apiTypeName as ApiObjectName;
   }
 
   return undefined;


### PR DESCRIPTION
Small refactor to keep information about API types in one place. This should make it a little cleaner to add new API types.

In addition to running the regular tests, I also ran `npm run regen-apis` up to Qiskit v0.42.0 then checked the following command had no output.

```
git diff f9acc9098af856cc11eadfa863baf4afa69b959c --name-only | grep -v '\.avif$'
```