### PR TITLE
Rewrite README to use `./check` and `./fix`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,4 @@ translations
 scripts/js/lib/api/testdata
 .mypy_cache
 public/images
-README.md
 mdx-guide.md

--- a/README.md
+++ b/README.md
@@ -72,13 +72,15 @@ git clone --filter=blob:none https://github.com/Qiskit/documentation.git
 
 ### Prerequisites to building the docs locally
 
-These tools will also run in CI, but it can be convenient when iterating to run the tools locally.
+We provide several tools to preview the documentation locally and to run quality checks. While many of these tools run in your PR through CI, we recommend installing them locally for faster iteration.
 
 First, install the below software:
 
 1. [Node.js](https://nodejs.org/en). If you expect to use JavaScript in other projects, consider using [NVM](https://github.com/nvm-sh/nvm). Otherwise, consider using [Homebrew](https://formulae.brew.sh/formula/node) or installing [Node.js directly](https://nodejs.org/en).
 2. [Docker](https://www.docker.com). You must also ensure that it is running.
    - If you cannot use Docker from docker.com, consider using use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop".
+3. [Tox](https://tox.wiki/) to run Python tools.
+   - We recommend using [pipx](https://pipx.pypa.io/stable/), which is a tool to install Python programs while keeping your Python installation clean. After installing pipx, use `pipx install tox`.
 
 Then, install the dependencies with:
 
@@ -104,6 +106,39 @@ API docs authors can preview their changes to one of the APIs by using the `-a` 
 
 1. Run `npm run gen-api -- -p <pkg-name> -v <version> -a <path/to/docs/_build/html>`.
 2. Execute `./start` and open up `http://localhost:3000`, as explained in the prior section.
+
+## Run quality checks
+
+We use multiple tools to ensure that documentation meets high standards. These tools will run automatically in your PR through CI, but it is much faster to run the checks locally.
+
+Use `./fix` to automatically apply fixes, like fixing formatting. Warning: we cannot automatically fix every problem, so you should also run `./check` afterwards.
+
+```sh
+./fix
+```
+
+Use `./check` to validate that there are no issues. If you encounter an error, fix it by following the instructions in the error message, then keep running `./check` and fixing any errors until it fully passes without any error.
+
+```sh
+./check
+```
+
+On Windows, run `python fix` and `python check` instead. Alternatively, use Windows Subsystem for Linux and run `./fix` and `./check`.
+
+### VSCode: optional extensions
+
+You may find it convenient to install the following VSCode extensions to automatically run some of our tools. Setting up these extensions is optional.
+
+- For Jupyter notebooks, add the tool 'squeaky' as a [pre-save
+  hook](https://github.com/frankharkins/squeaky?tab=readme-ov-file#jupyter-pre-save-hook).
+  This will fix and lint your notebooks when you save them.
+- [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
+
+### Advanced: run additional checks
+
+We offer some tools that are not included in `./check` and `./fix`. Likewise, many of the checks skip API docs by default.
+
+Run `npm run` to see a list of all our checks. For any particular check, run `npm run my-check -- --help` for more information and advanced arguments, such as `npm run check:metadata -- --help`.
 
 ## Jupyter notebooks
 
@@ -211,189 +246,11 @@ block is only for testing. Make sure you add the tag `remove-cell`.
 If something ever causes this value to
 change, CI will alert us.
 
-### Lint notebooks
-
-We use [`squeaky`](https://github.com/frankharkins/squeaky) and
-[`ruff`](https://docs.astral.sh/ruff/) to lint our notebooks. First install
-`tox` using [pipx](https://pipx.pypa.io/stable/).
-
-```sh
-pipx install tox
-```
-
-To check if a notebook needs linting:
-
-```sh
-# Check all notebooks in ./docs
-tox -e lint
-```
-
-Some problems can be fixed automatically. To fix these problems, run:
-
-```sh
-# Fix problems in all notebooks
-tox -e fix
-
-# Fix problems in a specific notebook
-tox -e fix -- <path/to/notebook>
-```
-
-If you use the Jupyter notebook editor, consider adding squeaky as a [pre-save
-hook](https://github.com/frankharkins/squeaky?tab=readme-ov-file#jupyter-pre-save-hook).
-This will lint your notebooks as you save them, so you never need to worry
-about it.
-
-## Check for broken links
-
-We have two broken link checkers: for internal links and for external links.
-
-To check internal links:
-
-```bash
-# Only check non-API docs
-npm run check:internal-links
-
-# You can add any of the below arguments to also check API docs.
-npm run check:internal-links -- --current-apis --dev-apis --historical-apis --qiskit-legacy-release-notes
-
-# Or, run all the checks. Although this only checks non-API docs.
-npm run check
-```
-
-To check external links:
-
-```bash
-# Specify the files you want after `--`
-npm run check:external-links -- docs/guides/index.md docs/guides/circuit-execution.mdx
-
-# You can also use globs
-npm run check:external-links -- 'docs/guides/*' '!docs/guides/index.mdx'
-```
-
-## Check for orphan pages
-
-Every file should have a home in one of the `_toc.json` files.
-
-To check for orphaned pages, run:
-
-```bash
-# Only check non-API docs
-npm run check:orphan-pages
-
-# You can also check API docs
-npm run check:orphan-pages -- --apis
-
-# Or, run all the checks. However this will skip the API docs
-npm run check
-```
-
-## Check page metadata
-
-Every file needs to have a `title` and `description`, as explained in [Page Metadata](#page-metadata) The `lint` job in CI will fail with instructions for any bad file.
-
-You can also check for valid metadata locally:
-
-```bash
-# Only check file metadata
-npm run check:metadata
-
-# By default, only the non-API docs are checked. You can add the
-# below argument to also check API docs.
-npm run check:metadata -- --apis
-
-# Or, run all the checks. Although this only checks non-API docs.
-npm run check
-```
-
-## Check images
-
-Every image needs to have alt text for accessibility and must use markdown syntax. To avoid changing the styling of the images, the use of the `<img>` HTML tag is not allowed. The lint job in CI will fail if images do not have alt text defined or if an `<img>` tag is found.
-We also require raster images (PNG, JPEG) to be converted to AVIF format to save space and make the website faster for users. You can convert images to AVIF using [ImageMagick](https://imagemagick.org/index.php).
-
-You can check images locally by running:
-
-```bash
-# Only check images
-npm run check:images
-
-# By default, only the non-API docs are checked. You can add the
-# below argument to also check API docs.
-npm run check:images -- --apis
-
-# Or, run all the checks
-npm run check
-```
-
-## Spellcheck
-
-We use [cSpell](https://cspell.org) to check for spelling. The `lint` job in CI will fail if there are spelling issues.
-
-There are two ways to check spelling locally, rather than needing CI.
-
-1.
-
-```bash
-# Only check spelling
-npm run check:spelling
-
-# Or, run all the checks
-npm run check
-```
-
-2. Use the VSCode extension [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).
-
-### Fix false positives
-
-There are two ways to deal with cSpell incorrectly complaining about a word, such as abbreviations.
-
-1. Ignore the word in the local file:
-
-   - For a markdown file, add a comment to the file, like below. The word is not case-sensitive, and the comment can be placed anywhere.
-
-     ```markdown
-     {/* cspell:ignore hellllooooo, ayyyyy */}
-
-     # Hellllooooo!
-
-     Ayyyyy, this is a fake description.
-     ```
-
-   - For a Jupyter notebook, add the comment inside a markdown cell in the source part. Each line should be surrounded by quotes and end with "\n".
-
-     ```python
-     {
-      "cell_type": "markdown",
-      "id": "552b1077",
-      "metadata": {},
-      "source": [
-       "# Hello world\n",
-       "{/* cspell:ignore helloooooo */}\n"
-      ]
-     },
-     ```
-
-2. If the word is a name, add it to the `scripts/config/cspell/dictionaries/people.txt` file. If it is a scientific or quantum specific word, add it to the `scripts/config/cspell/dictionaries/qiskit.txt` file. If it doesn't fit in either category, add it to the `words` section in `scripts/config/cspell/cSpell.json`. The word is not case-sensitive.
-
-If the word appears in multiple files, prefer the second approach to add it to one of the dictionaries or `cSpell.json`.
-
-## Check that pages render
-
-It's possible to write broken pages that crash when loaded. This is usually due to syntax errors.
-
-To check that all the non-API docs render:
-
-1. Start up the local preview with `./start` by following the instructions at [Preview the docs locally](#preview-the-docs-locally)
-2. In a new tab, `npm run check:pages-render -- --non-api`
-
-You can also check that API docs render by using any of these arguments: `npm run check:pages-render -- --non-api --qiskit-release-notes --current-apis --dev-apis --historical-apis`. Warning that this is exponentially slower.
-
-CI will check on every PR that any changed files render correctly. We also run a weekly cron job to check that every page renders correctly.
-
 ## Format README and TypeScript files
 
 Run `npm run fmt` to automatically format the README, `.github` folder, and `scripts/` folder. You should run this command if you get the error in CI `run Prettier to fix`.
 
-To check that formatting is valid without actually making changes, run `npm run check:fmt` or `npm run check`.
+To check that formatting is valid without actually making changes, run `npm run check:fmt`.
 
 ## Regenerate an existing API docs version
 

--- a/scripts/js/commands/checkPagesRender.ts
+++ b/scripts/js/commands/checkPagesRender.ts
@@ -172,15 +172,14 @@ async function validateDockerRunning(): Promise<void> {
     const response = await fetch(`http://localhost:${PORT}`);
     if (response.status !== 200) {
       console.error(
-        "Failed to access http://localhost:3000. Have you started the Docker server with `./start`? " +
-          "Refer to the README for instructions.",
+        "Failed to access http://localhost:3000. Have you started the Docker server with `./start` in another shell? ",
       );
       process.exit(1);
     }
   } catch (error) {
     console.error(
       "Error when accessing http://localhost:3000. Make sure that you've started the Docker server " +
-        "with `./start`. Refer to the README for instructions.\n\n" +
+        "with `./start` in another shell.\n\n" +
         `${error}`,
     );
     process.exit(1);


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/2800.

We don't want contributors to have to know what the different checks are. They should simply run `./check` and `./fix` and we handle it all for them. If something breaks, we should say in the error message how to fix things.

### Adds instructions to spellcheck

We now tell you how to fix the problem, whereas before you had to read the README.

MDX:

```
❯ npm run check:spelling

> qiskit-documentation@0.1.0 check:spelling
> tsx scripts/js/commands/checkSpelling.ts

docs/guides/index.mdx:6:19 - Unknown word (Qiskitttt)
CSpell: Files checked: 91, Issues found: 1 in 1 file.


---------------

🙅 There are unrecognized words (see above). If the word is a not a typo, there are two ways to allowlist it:

1. Add a comment on a dedicated line near the top of the MDX file, between the page metadata and the H1 heading, such as: {/* cspell:ignore hellllooooo, ayyyyy */}

2. If you expect this word to appear in other files, add it to a dictionary. Add names to the `scripts/config/cspell/dictionaries/people.txt` file. Add scientific or quantum specific words to the `scripts/config/cspell/dictionaries/qiskit.txt` file. If it doesn't fit in either category, add it to the `words` section in `scripts/config/cspell/cSpell. json`. The word is not case-sensitive.
```

Jupyter:

```
❯ npm run check:spelling

> qiskit-documentation@0.1.0 check:spelling
> tsx scripts/js/commands/checkSpelling.ts

CSpell: Files checked: 91, Issues found: 0 in 0 files.
❌ Unrecognized word in docs/guides/hello-world.ipynb: worlddddd


---------------

🙅 There are unrecognized words (see above). If the word is a not a typo, there are two ways to allowlist it:

1. Add a comment on a dedicated line to the first markdown cell in the Jupyter notebook.  (This cell should have the page title.) For example, add the following above the H1 heading: {/* cspell:ignore helloooooo */}

2. If you expect this word to appear in other files, add it to a dictionary. Add names to the `scripts/config/cspell/dictionaries/people.txt` file. Add scientific or quantum specific words to the `scripts/config/cspell/dictionaries/qiskit.txt` file. If it doesn't fit in either category, add it to the `words` section in `scripts/config/cspell/cSpell. json`. The word is not case-sensitive.
```