### PR TITLE
Handle struct members in C API

### DIFF
--- a/scripts/js/lib/api/Metadata.ts
+++ b/scripts/js/lib/api/Metadata.ts
@@ -25,7 +25,8 @@ export type ApiObjectName =
   | "cFunction"
   | "typedef"
   | "enum"
-  | "enumerator";
+  | "enumerator"
+  | "structMember";
 
 interface ApiObjectInfo {
   htmlSelector: string;
@@ -51,6 +52,7 @@ export const API_OBJECTS: { [K in ApiObjectName]: ApiObjectInfo } = {
   typedef: { htmlSelector: "dl.cpp.type", tagName: "class" },
   enum: { htmlSelector: "dl.cpp.enum", tagName: "class" },
   enumerator: { htmlSelector: "dl.cpp.enumerator", tagName: "attribute" },
+  structMember: { htmlSelector: "dl.cpp.var", tagName: "attribute" },
 } as const;
 
 export type Metadata = {

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -108,6 +108,7 @@ function prepareProps(
     typedef: prepClassOrException,
     enum: prepClassOrException,
     enumerator: prepAttributeOrProperty,
+    structMember: prepAttributeOrProperty,
   };
 
   const githubSourceLink = prepareGitHubLink($child, apiType === "method");


### PR DESCRIPTION
This just makes the script recognise struct members, we're still working out how to best display them.
