### PR TITLE
Remove 'Public members' rubric

### DIFF
--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -70,6 +70,7 @@ export async function processHtml(
   removeHtmlExtensionsInRelativeLinks($, $main);
   removePermalinks($main);
   removeDownloadSourceCode($main);
+  removePublicMembersRubric($main);
   removeMatplotlibFigCaptions($main);
   handleSphinxDesignCards($, $main);
   addLanguageClassToCodeBlocks($, $main, options);
@@ -155,6 +156,13 @@ export function removePermalinks($main: Cheerio<any>): void {
 
 export function removeDownloadSourceCode($main: Cheerio<any>): void {
   $main.find("p > a.reference.download.internal").closest("p").remove();
+}
+
+function removePublicMembersRubric($main: Cheerio<any>): void {
+  $main
+    .find("p.breathe-sectiondef-title.rubric")
+    .filter((i, el) => load(el).text() === "Public members")
+    .remove();
 }
 
 export function removeMatplotlibFigCaptions($main: Cheerio<any>): void {

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -158,6 +158,15 @@ export function removeDownloadSourceCode($main: Cheerio<any>): void {
   $main.find("p > a.reference.download.internal").closest("p").remove();
 }
 
+/**
+ * This is because the rubric appears to have the same level at the fields
+ * themselves. We decided the best solution to avoid a confusing information
+ * hierarcy is to remove the rubric.
+ *
+ * A better solution is to implement https://github.com/Qiskit/documentation/issues/1395.
+ * Once implemented, we should rename "Public members" to "Fields" as C does not
+ * have methods and all fields are public (breathe is more targeted towards C++).
+ */
 function removePublicMembersRubric($main: Cheerio<any>): void {
   $main
     .find("p.breathe-sectiondef-title.rubric")


### PR DESCRIPTION
This removes the "Public members" rubric from structs in the C API docs. This is because the rubric appears to have the same level at the fields themselves. We decided the best solution to avoid a confusing information hierarcy is to remove the rubric.
