### PR TITLE
Improve logging for `./check` and `./fix`

### DIFF
--- a/check
+++ b/check
@@ -19,9 +19,9 @@ logger = logging.getLogger(__name__)
 
 # Note that these are ordered from fastest to slowest.
 CHECKS = {
-    "Notebook linters": ["tox", "-e", "lint"],
+    "notebook linters": ["tox", "-e", "lint"],
     "patterns index pages": ["npm", "run", "check:patterns-index"],
-    "Qiskit Bot": ["npm", "run", "check:qiskit-bot"],
+    "Qiskit bot": ["npm", "run", "check:qiskit-bot"],
     "metadata": ["npm", "run", "check:metadata"],
     "images": ["npm", "run", "check:images"],
     "orphan pages": ["npm", "run", "check:orphan-pages"],

--- a/check
+++ b/check
@@ -11,16 +11,34 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from scripts.tool_runner import run_cmd
+import logging
+
+from scripts.tool_runner import configure_logging, run_cmd
+
+logger = logging.getLogger(__name__)
+
+# Note that these are ordered from fastest to slowest.
+CHECKS = {
+    "Notebook linters": ["tox", "-e", "lint"],
+    "patterns index pages": ["npm", "run", "check:patterns-index"],
+    "Qiskit Bot": ["npm", "run", "check:qiskit-bot"],
+    "metadata": ["npm", "run", "check:metadata"],
+    "images": ["npm", "run", "check:images"],
+    "orphan pages": ["npm", "run", "check:orphan-pages"],
+    "spelling": ["npm", "run", "check:spelling"],
+    "internal links": ["npm", "run", "check:internal-links"],
+}
 
 
 def main() -> None:
-    run_cmd(["tox", "-e", "lint"])
-    run_cmd(["npm", "run", "check"])
+    for i, (name, cmd) in enumerate(CHECKS.items()):
+        run_cmd(name, cmd, progress=f"{i + 1}/{len(CHECKS)}")
+    logger.info("🎉 All checks passed!")
 
 
 if __name__ == "__main__":
     try:
+        configure_logging()
         main()
     except KeyboardInterrupt:
         raise SystemExit(1)

--- a/fix
+++ b/fix
@@ -11,15 +11,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from scripts.tool_runner import run_cmd
+from scripts.tool_runner import configure_logging, run_cmd
 
 
 def main() -> None:
-    run_cmd(["tox", "-e", "fix"])
+    run_cmd("Notebook formatters", ["tox", "-e", "fix"], progress=None)
 
 
 if __name__ == "__main__":
     try:
+        configure_logging()
         main()
     except KeyboardInterrupt:
         raise SystemExit(1)

--- a/fix
+++ b/fix
@@ -15,7 +15,7 @@ from scripts.tool_runner import configure_logging, run_cmd
 
 
 def main() -> None:
-    run_cmd("Notebook formatters", ["tox", "-e", "fix"], progress=None)
+    run_cmd("notebook formatters", ["tox", "-e", "fix"], progress=None)
 
 
 if __name__ == "__main__":

--- a/scripts/tool_runner/__init__.py
+++ b/scripts/tool_runner/__init__.py
@@ -10,16 +10,39 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+from __future__ import annotations
+
+import logging
+import textwrap
 import subprocess
 
+logger = logging.getLogger(__name__)
 
-def run_cmd(cmd: list[str]) -> None:
-    """Run a command and error the program (with no stacktrace) if it fails.
 
-    Streams the subprocess output to the parent process's std{out,err}.
+def configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def run_cmd(name: str, cmd: list[str], *, progress: str | None) -> None:
+    """Run a command and log its success or failure.
+
+    If failure, logs the output of the tool and exits the program.
     """
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError:
-        # This avoids adding a noisy stacktrace.
-        raise SystemExit(1)
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        # Merge stderr into stdout so that output is sequential.
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode == 0:
+        progress_formatted = f" ({progress})" if progress else ""
+        logger.info(f"✅ {name}{progress_formatted}")
+        return
+
+    divider = "—" * 50
+    output = textwrap.indent(result.stdout, " " * 2)
+    logger.error(f"❌ {name}\n\n{divider}\n{output}")
+
+    # This ends the program without adding a noisy stacktrace.
+    raise SystemExit(1)


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2800. (Performance improvements are now tracked by https://github.com/Qiskit/documentation/issues/2854)

Success:

```
❯ ./check
✅ Notebook linters (1/8)
✅ patterns index pages (2/8)
✅ Qiskit Bot (3/8)
✅ metadata (4/8)
✅ images (5/8)
✅ orphan pages (6/8)
✅ spelling (7/8)
✅ internal links (8/8)
🎉 All checks passed!
```

For failure, we add a divider and indent by 2 spaces:

```
❯ ./check
✅ Notebook linters (1/8)
❌ patterns index pages

——————————————————————————————————————————————————

  > qiskit-documentation@0.1.0 check:patterns-index
  > tsx scripts/js/commands/checkPatternsIndex.ts

  ❌ The entry /guides/measure-qubits is not present on any index page

  Add the entries in one of the following index pages, or add the URL to the `IGNORED_URLS` list at the beginning of `/scripts/js/commands/checkPatternsIndex.tsx` if it's not used in Workflow:
        ➡️  docs/guides/map-problem-to-circuits.mdx
        ➡️  docs/guides/optimize-for-hardware.mdx
        ➡️  docs/guides/execute-on-hardware.mdx
        ➡️  docs/guides/post-process-results.mdx
        ➡️  docs/guides/intro-to-patterns.mdx
```