### PR TITLE
Fix C API metadata handling

### DIFF
--- a/scripts/js/lib/api/processHtml.test.ts
+++ b/scripts/js/lib/api/processHtml.test.ts
@@ -400,7 +400,16 @@ test.describe("maybeSetModuleMetadata()", () => {
     const html = `<h1>Hello</h1>`;
     const meta: Metadata = {};
     const doc = CheerioDoc.load(html);
-    maybeSetModuleMetadata(doc.$, doc.$main, meta, { isCApi: false });
+    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi: false });
+    doc.expectHtml(html);
+    expect(meta).toEqual({});
+  });
+
+  test("C API index", () => {
+    const html = `<h1>Qiskit C API (qiskit.h)</h1>`;
+    const meta: Metadata = {};
+    const doc = CheerioDoc.load(html);
+    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi: true });
     doc.expectHtml(html);
     expect(meta).toEqual({});
   });
@@ -412,7 +421,7 @@ test.describe("maybeSetModuleMetadata()", () => {
   ): void => {
     const meta: Metadata = {};
     const doc = CheerioDoc.load(html);
-    maybeSetModuleMetadata(doc.$, doc.$main, meta, { isCApi });
+    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi });
     doc.expectHtml(html);
     expect(meta).toEqual({
       apiType: "module",
@@ -442,12 +451,8 @@ test.describe("maybeSetModuleMetadata()", () => {
     );
   });
 
-  test("C API group", () => {
-    checkModuleFound(
-      `<section id="group__QkSparseObservable"><h1>Hello</h1></section>`,
-      "QkSparseObservable",
-      true,
-    );
+  test("C API", () => {
+    checkModuleFound("<h1>QkSparseObservable</h1>", "QkSparseObservable", true);
   });
 });
 

--- a/scripts/js/lib/api/processHtml.test.ts
+++ b/scripts/js/lib/api/processHtml.test.ts
@@ -28,6 +28,7 @@ import {
   convertRubricsToHeaders,
   processMembersAndSetMeta,
   handleFootnotes,
+  maybeSetPythonModuleMetadata,
 } from "./processHtml.js";
 import { Metadata } from "./Metadata.js";
 import { CheerioDoc } from "../testUtils.js";
@@ -395,21 +396,12 @@ test("handleFootnotes()", () => {
     <span class="label"><span class="fn-bracket">[</span><a role="doc-backlink" href="#id2">1</a><span class="fn-bracket">]</span></span></aside></aside>`);
 });
 
-test.describe("maybeSetModuleMetadata()", () => {
+test.describe("maybeSetPythonModuleMetadata()", () => {
   test("not a module", () => {
     const html = `<h1>Hello</h1>`;
     const meta: Metadata = {};
     const doc = CheerioDoc.load(html);
-    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi: false });
-    doc.expectHtml(html);
-    expect(meta).toEqual({});
-  });
-
-  test("C API index", () => {
-    const html = `<h1>Qiskit C API (qiskit.h)</h1>`;
-    const meta: Metadata = {};
-    const doc = CheerioDoc.load(html);
-    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi: true });
+    maybeSetPythonModuleMetadata(doc.$, doc.$main, meta);
     doc.expectHtml(html);
     expect(meta).toEqual({});
   });
@@ -421,7 +413,7 @@ test.describe("maybeSetModuleMetadata()", () => {
   ): void => {
     const meta: Metadata = {};
     const doc = CheerioDoc.load(html);
-    maybeSetModuleMetadata(doc.$, doc.$main, meta, false, { isCApi });
+    maybeSetPythonModuleMetadata(doc.$, doc.$main, meta);
     doc.expectHtml(html);
     expect(meta).toEqual({
       apiType: "module",
@@ -449,10 +441,6 @@ test.describe("maybeSetModuleMetadata()", () => {
       `<section id="module-qiskit_ibm_provider.transpiler.passes.basis"><h1>Hello</h1></section>`,
       "qiskit_ibm_provider.transpiler.passes.basis",
     );
-  });
-
-  test("C API", () => {
-    checkModuleFound("<h1>QkSparseObservable</h1>", "QkSparseObservable", true);
   });
 });
 

--- a/scripts/js/lib/api/processHtml.test.ts
+++ b/scripts/js/lib/api/processHtml.test.ts
@@ -16,7 +16,7 @@ import {
   addLanguageClassToCodeBlocks,
   loadImages,
   handleSphinxDesignCards,
-  maybeSetModuleMetadata,
+  maybeSetPythonModuleMetadata,
   renameAllH1s,
   removeHtmlExtensionsInRelativeLinks,
   removeDownloadSourceCode,
@@ -28,7 +28,6 @@ import {
   convertRubricsToHeaders,
   processMembersAndSetMeta,
   handleFootnotes,
-  maybeSetPythonModuleMetadata,
 } from "./processHtml.js";
 import { Metadata } from "./Metadata.js";
 import { CheerioDoc } from "../testUtils.js";

--- a/scripts/js/lib/api/processHtml.ts
+++ b/scripts/js/lib/api/processHtml.ts
@@ -47,7 +47,6 @@ export async function processHtml(
     determineGithubUrl,
     releaseNotesTitle,
     hasSeparateReleaseNotes,
-    isCApi,
   } = options;
   const $ = load(html);
   const $main = $(`[role='main']`);
@@ -55,6 +54,7 @@ export async function processHtml(
   const isReleaseNotes =
     fileName.endsWith("release_notes.html") ||
     fileName.endsWith("release-notes.html");
+  const isIndex = fileName.endsWith("index.html");
   const images = loadImages(
     $,
     $main,
@@ -84,7 +84,9 @@ export async function processHtml(
 
   const meta: Metadata = {};
   await processMembersAndSetMeta($, $main, meta, options);
-  maybeSetModuleMetadata($, $main, meta, isReleaseNotes, options);
+  if (options.isCApi) maybeSetCMetadata($main, meta, isReleaseNotes, isIndex);
+  else maybeSetPythonModuleMetadata($, $main, meta);
+
   if (meta.apiType === "module") {
     updateModuleHeadings($, $main);
   }
@@ -435,23 +437,25 @@ export async function processMembersAndSetMeta(
   }
 }
 
-export function maybeSetModuleMetadata(
-  $: CheerioAPI,
+function maybeSetCMetadata(
   $main: Cheerio<any>,
   meta: Metadata,
   isReleaseNotes: boolean,
-  options: { isCApi: boolean },
+  isIndex: boolean,
 ): void {
-  if (options.isCApi) {
-    // Every page in the C API should be displayed as a module except the index
-    // and the release notes.
-    const topHeadingText = $main.find("h1").first().text();
-    const isIndex = topHeadingText === "Qiskit C API (qiskit.h)";
-    if (isIndex || isReleaseNotes) return;
-    meta.apiType = "module";
-    meta.apiName = topHeadingText;
-    return;
-  }
+  // Every page in the C API should be displayed as a module except the index
+  // and the release notes.
+  if (isIndex || isReleaseNotes) return;
+  const topHeadingText = $main.find("h1").first().text();
+  meta.apiType = "module";
+  meta.apiName = topHeadingText;
+}
+
+export function maybeSetPythonModuleMetadata(
+  $: CheerioAPI,
+  $main: Cheerio<any>,
+  meta: Metadata,
+): void {
   const modulePrefix = "module-";
   const moduleIdWithPrefix = $main
     .find("span, section, div.section")


### PR DESCRIPTION
Currently, we're looking for an ID attribute starting with `group__` to work out if a page is a module or not. This isn't very robust because the `group__` ID only appears if there's a `doxygengroup` in the page, which isn't always the case.

Instead, this PR treats all pages as modules except the index page and the release notes page, which we identify by their `<h1>`.
