### PR TITLE
Point Qiskit C API release notes to Qiskit release notes

### DIFF
--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -25,7 +25,11 @@ export class ReleaseNotesConfig {
   readonly separatePagesVersions: string[];
   readonly pointToPackage?: string;
 
-  constructor(kwargs: { enabled?: boolean; separatePagesVersions?: string[]; pointToPackage?: string; }) {
+  constructor(kwargs: {
+    enabled?: boolean;
+    separatePagesVersions?: string[];
+    pointToPackage?: string;
+  }) {
     this.enabled = kwargs.enabled ?? true;
     this.separatePagesVersions = kwargs.separatePagesVersions ?? [];
     this.pointToPackage = kwargs.pointToPackage;
@@ -201,7 +205,7 @@ export class Pkg {
         language: "C",
         releaseNotesConfig: new ReleaseNotesConfig({
           enabled: true,
-          pointToPackage: 'qiskit',
+          pointToPackage: "qiskit",
         }),
       });
     }

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -23,10 +23,12 @@ import {
 export class ReleaseNotesConfig {
   readonly enabled: boolean;
   readonly separatePagesVersions: string[];
+  readonly pointToPackage?: string;
 
-  constructor(kwargs: { enabled?: boolean; separatePagesVersions?: string[] }) {
+  constructor(kwargs: { enabled?: boolean; separatePagesVersions?: string[]; pointToPackage?: string; }) {
     this.enabled = kwargs.enabled ?? true;
     this.separatePagesVersions = kwargs.separatePagesVersions ?? [];
+    this.pointToPackage = kwargs.pointToPackage;
   }
 }
 
@@ -198,7 +200,8 @@ export class Pkg {
         kebabCaseAndShortenUrls: true,
         language: "C",
         releaseNotesConfig: new ReleaseNotesConfig({
-          enabled: false,
+          enabled: true,
+          pointToPackage: 'qiskit',
         }),
       });
     }
@@ -275,6 +278,10 @@ export class Pkg {
       ? ` ${this.versionWithoutPatch}`
       : "";
     return `${this.title}${versionStr} release notes`;
+  }
+
+  releaseNotesPackageName(): string {
+    return this.releaseNotesConfig.pointToPackage ?? this.name;
   }
 
   /**

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -23,16 +23,16 @@ import {
 export class ReleaseNotesConfig {
   readonly enabled: boolean;
   readonly separatePagesVersions: string[];
-  readonly pointToPackage?: string;
+  readonly linkToPackage?: string;
 
   constructor(kwargs: {
     enabled?: boolean;
     separatePagesVersions?: string[];
-    pointToPackage?: string;
+    linkToPackage?: string;
   }) {
     this.enabled = kwargs.enabled ?? true;
     this.separatePagesVersions = kwargs.separatePagesVersions ?? [];
-    this.pointToPackage = kwargs.pointToPackage;
+    this.linkToPackage = kwargs.linkToPackage;
   }
 }
 
@@ -205,7 +205,7 @@ export class Pkg {
         language: "C",
         releaseNotesConfig: new ReleaseNotesConfig({
           enabled: true,
-          pointToPackage: "qiskit",
+          linkToPackage: "qiskit",
         }),
       });
     }
@@ -285,7 +285,7 @@ export class Pkg {
   }
 
   releaseNotesPackageName(): string {
-    return this.releaseNotesConfig.pointToPackage ?? this.name;
+    return this.releaseNotesConfig.linkToPackage ?? this.name;
   }
 
   /**

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -228,19 +228,16 @@ function generateOverviewPage(tocModules: TocEntry[]): void {
 
 function generateReleaseNotesEntry(pkg: Pkg): TocEntry | undefined {
   if (!pkg.releaseNotesConfig.enabled) return;
-  const releaseNotesUrl = `/api/${pkg.name}/release-notes`;
+  const releaseNotesUrl = `/api/${pkg.releaseNotesPackageName()}/release-notes`;
   const releaseNotesEntry: TocEntry = {
     title: "Release notes",
   };
-  if (pkg.hasSeparateReleaseNotes()) {
-    releaseNotesEntry.children =
-      pkg.releaseNotesConfig.separatePagesVersions.map((vers) => ({
-        title: vers,
-        url: `${releaseNotesUrl}/${vers}`,
-      }));
-  } else {
-    releaseNotesEntry.url = releaseNotesUrl;
-  }
+  if (!pkg.hasSeparateReleaseNotes()) return { url: releaseNotesUrl, ...releaseNotesEntry };
+  releaseNotesEntry.children =
+    pkg.releaseNotesConfig.separatePagesVersions.map((vers) => ({
+      title: vers,
+      url: `${releaseNotesUrl}/${vers}`,
+    }));
   return releaseNotesEntry;
 }
 

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -233,7 +233,7 @@ function generateReleaseNotesEntry(pkg: Pkg): TocEntry | undefined {
     title: "Release notes",
   };
   if (!pkg.hasSeparateReleaseNotes())
-    return { url: releaseNotesUrl, ...releaseNotesEntry };
+    return { ...releaseNotesEntry, url: releaseNotesUrl };
   releaseNotesEntry.children = pkg.releaseNotesConfig.separatePagesVersions.map(
     (vers) => ({
       title: vers,

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -232,12 +232,14 @@ function generateReleaseNotesEntry(pkg: Pkg): TocEntry | undefined {
   const releaseNotesEntry: TocEntry = {
     title: "Release notes",
   };
-  if (!pkg.hasSeparateReleaseNotes()) return { url: releaseNotesUrl, ...releaseNotesEntry };
-  releaseNotesEntry.children =
-    pkg.releaseNotesConfig.separatePagesVersions.map((vers) => ({
+  if (!pkg.hasSeparateReleaseNotes())
+    return { url: releaseNotesUrl, ...releaseNotesEntry };
+  releaseNotesEntry.children = pkg.releaseNotesConfig.separatePagesVersions.map(
+    (vers) => ({
       title: vers,
       url: `${releaseNotesUrl}/${vers}`,
-    }));
+    }),
+  );
   return releaseNotesEntry;
 }
 


### PR DESCRIPTION
The Qiskit C API release notes should just be a link to the Qiskit release notes. This PR implements that.
