### PR TITLE
Remove empty headings for Functions without ID

### DIFF
--- a/docs/api/qiskit-addon-aqc-tensor/simulation.mdx
+++ b/docs/api/qiskit-addon-aqc-tensor/simulation.mdx
@@ -36,8 +36,6 @@ In each function below, the documentation shows every distinct implementation av
 
   The type of tensor-network state will correspond to the type of the `settings` object. For instance, a [`QiskitAerSimulationSettings`](simulation-aer-qiskit-aer-simulation-settings "qiskit_addon_aqc_tensor.simulation.aer.QiskitAerSimulationSettings") will result in this function returning a [`QiskitAerMPS`](simulation-aer-qiskit-aer-mps "qiskit_addon_aqc_tensor.simulation.aer.QiskitAerMPS").
 
-  ###
-
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="tensornetwork_from_circuit(qc: qiskit.circuit.quantumcircuit.QuantumCircuit, settings: qiskit_addon_aqc_tensor.simulation.aer.simulation.QiskitAerSimulationSettings | plum.type.ModuleType[qiskit_aer.AerSimulator], /, *, out_state: numpy.ndarray | None = None) → qiskit_addon_aqc_tensor.simulation.aer.state.QiskitAerMPS">
     **Parameters**
 
@@ -48,8 +46,6 @@ In each function below, the documentation shows every distinct implementation av
 
     [*TensorNetworkState*](#qiskit_addon_aqc_tensor.simulation.TensorNetworkState "qiskit_addon_aqc_tensor.simulation.abstract.TensorNetworkState")
   </Function>
-
-  ###
 
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="tensornetwork_from_circuit(qc: qiskit.circuit.quantumcircuit.QuantumCircuit, settings: qiskit_addon_aqc_tensor.simulation.quimb.QuimbSimulator, /) → quimb.tensor.Circuit">
     **Parameters**
@@ -94,8 +90,6 @@ In each function below, the documentation shows every distinct implementation av
   *   **settings** ([*TensorNetworkSimulationSettings*](#qiskit_addon_aqc_tensor.simulation.TensorNetworkSimulationSettings "qiskit_addon_aqc_tensor.simulation.abstract.TensorNetworkSimulationSettings"))
   *   **out\_state** ([*ndarray*](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray "(in NumPy v2.1)") *| None*)
 
-  ###
-
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="apply_circuit_to_state(qc: qiskit.circuit.quantumcircuit.QuantumCircuit, psi: qiskit_addon_aqc_tensor.simulation.aer.state.QiskitAerMPS, settings: qiskit_addon_aqc_tensor.simulation.aer.simulation.QiskitAerSimulationSettings | plum.type.ModuleType[qiskit_aer.AerSimulator], /, *, out_state: numpy.ndarray | None = None) → qiskit_addon_aqc_tensor.simulation.aer.state.QiskitAerMPS">
     **Parameters**
 
@@ -108,8 +102,6 @@ In each function below, the documentation shows every distinct implementation av
 
     [*TensorNetworkState*](#qiskit_addon_aqc_tensor.simulation.TensorNetworkState "qiskit_addon_aqc_tensor.simulation.abstract.TensorNetworkState")
   </Function>
-
-  ###
 
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="apply_circuit_to_state(qc: qiskit.circuit.quantumcircuit.QuantumCircuit, circ0: plum.type.ModuleType[quimb.tensor.Circuit], settings: qiskit_addon_aqc_tensor.simulation.quimb.QuimbSimulator, /, *, out_state: numpy.ndarray | None = None) → quimb.tensor.Circuit">
     **Parameters**
@@ -164,8 +156,6 @@ In each function below, the documentation shows every distinct implementation av
 
   complex dot product value.
 
-  ###
-
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="compute_overlap(mps1: qiskit_addon_aqc_tensor.simulation.aer.state.QiskitAerMPS, mps2: qiskit_addon_aqc_tensor.simulation.aer.state.QiskitAerMPS, /) → complex">
     **Parameters**
 
@@ -176,8 +166,6 @@ In each function below, the documentation shows every distinct implementation av
 
     [complex](https://docs.python.org/3/library/functions.html#complex "(in Python v3.13)")
   </Function>
-
-  ###
 
   <Function github="https://github.com/Qiskit/qiskit-addon-aqc-tensor/tree/stable/0.1/qiskit_addon_aqc_tensor/simulation/abstract.py" signature="compute_overlap(circ1: plum.type.ModuleType[quimb.tensor.Circuit], circ2: plum.type.ModuleType[quimb.tensor.Circuit], /) → complex">
     **Parameters**

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -329,14 +329,16 @@ function prepareFunctionProps(
     };
   }
 
-  if (id) {
-    const name = getLastPartFromFullIdentifier(id);
-    const htag = `h${headerLevel}`;
-    $(
-      `<${htag} data-header-type="method-header">${name}</${htag}>`,
-    ).insertBefore($dl);
-  }
+  // The Function ID could not exist if the function is nested inside another function.
+  // Nested functions could appear for example when using the multiple dispatch paradigm
+  // by using the python `@dispatch` decorator.
+  if (!id) return props;
 
+  const name = getLastPartFromFullIdentifier(id);
+  const htag = `h${headerLevel}`;
+  $(`<${htag} data-header-type="method-header">${name}</${htag}>`).insertBefore(
+    $dl,
+  );
   return props;
 }
 

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -339,6 +339,7 @@ function prepareFunctionProps(
   $(`<${htag} data-header-type="method-header">${name}</${htag}>`).insertBefore(
     $dl,
   );
+
   return props;
 }
 

--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -328,11 +328,14 @@ function prepareFunctionProps(
       isDedicatedPage: true,
     };
   }
-  const name = getLastPartFromFullIdentifier(id);
-  const htag = `h${headerLevel}`;
-  $(`<${htag} data-header-type="method-header">${name}</${htag}>`).insertBefore(
-    $dl,
-  );
+
+  if (id) {
+    const name = getLastPartFromFullIdentifier(id);
+    const htag = `h${headerLevel}`;
+    $(
+      `<${htag} data-header-type="method-header">${name}</${htag}>`,
+    ).insertBefore($dl);
+  }
 
   return props;
 }


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2792

`qiskit-addon-aqc-tensor` is using the "multiple dispatch" paradigm which results in Sphinx nesting functions inside functions. In these cases, the nested functions don't have any ID defined. 

Here is an example of how Sphinx renders the `tensornetwork_from_circuit` function:

<details><summary>Screenshot</summary>
<img width="930" alt="Screenshot 2025-03-27 at 11 26 45" src="https://github.com/user-attachments/assets/e3ea39f9-f812-4cd8-9adb-2bcadea1b3ae" />

</details>

This PR changes the MDX pipeline to stop assuming that every function will have an ID defined. If the ID is not defined the pipeline won't create a new empty heading matching that way the Sphinx output.

<details><summary>Screenshot of the current live docs</summary>
<img width="741" alt="Screenshot 2025-03-27 at 11 33 29" src="https://github.com/user-attachments/assets/42d0c0bd-8a30-42f3-9d4d-5d95a6f7dc3c" />

</details>

<details><summary>Screenshot how the docs will look after this PR</summary>
<img width="758" alt="Screenshot 2025-03-27 at 11 33 04" src="https://github.com/user-attachments/assets/a0ace299-ed30-4c2d-9b48-d2be6ccb3229" />

</details>