### PR TITLE
Update with new limits

### DIFF
--- a/docs/guides/job-limits.mdx
+++ b/docs/guides/job-limits.mdx
@@ -46,10 +46,10 @@ The service permits up to **26.8 million control-system instructions per qubit**
 ## Maximum number of single- and two-qubit gates per circuit
 
 The maximum number of single-qubit gates are as follows:
-- 2.4 million RZ gates
-- 1.6 million SX gates
+- 30 million RZ gates
+- 20 million SX gates
 
-The maximum number of two-qubit gates per circuit is 400,000 for static circuits and 100,000 for dynamic circuits.
+The maximum number of two-qubit gates per circuit is 5 million for static circuits and 100,000 for dynamic circuits.
 This ensures that the job can be manipulated within the memory limits of the low-level software stack.
 
 ## Considerations and limitations for dynamic circuits

--- a/docs/guides/runtime-options-overview.mdx
+++ b/docs/guides/runtime-options-overview.mdx
@@ -155,7 +155,7 @@ Scroll to see the full table.
 
 <span id="experimental-option-note"></span>
 <Admonition type="note">
-Setting `gen3-turbo` enables the next-generation execution path, which provides a great improvement in performance. This option is experimental (subject to change without notice, and stability is not guaranteed) and is only available on `ibm_brisbane`, `ibm_brussels`, `ibm_fez`, `ibm_marrakesh`, `ibm_strasbourg`, and `ibm_torino`.
+Setting `gen3-turbo` enables the next-generation execution path, which provides a great improvement in performance. This option is experimental (subject to change without notice, and stability is not guaranteed).
 </Admonition>
 <span id="options-compatibility-table"></span>
 ### Feature compatibility


### PR DESCRIPTION
Both the gate limits and `gen3-turbo` backend limits have changed. This PR updates them to the new values. 