### PR TITLE
Attempt cross references in C

### DIFF
--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -14,6 +14,7 @@ import { join } from "path/posix";
 
 import { findSeparateReleaseNotesVersions } from "./releaseNotes.js";
 import { determineHistoricalQiskitGithubUrl } from "../qiskitMetapackage.js";
+import { insertCrossRefsVisitor } from "./handleCrossRefs";
 import {
   TocGrouping,
   QISKIT_TOC_GROUPING,
@@ -267,6 +268,11 @@ export class Pkg {
 
   isCApi(): boolean {
     return this.language === "C";
+  }
+
+  crossRefsVisitorFn(): any {
+    if (!this.isCApi()) return null;
+    return insertCrossRefsVisitor(this.name, this.version);
   }
 
   isProblematicLegacyQiskit(): boolean {

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -14,7 +14,7 @@ import { join } from "path/posix";
 
 import { findSeparateReleaseNotesVersions } from "./releaseNotes.js";
 import { determineHistoricalQiskitGithubUrl } from "../qiskitMetapackage.js";
-import { insertCrossRefsVisitor } from "./handleCrossRefs";
+import { TextVisitor, insertCrossRefsVisitor } from "./handleCrossRefs";
 import {
   TocGrouping,
   QISKIT_TOC_GROUPING,
@@ -270,8 +270,8 @@ export class Pkg {
     return this.language === "C";
   }
 
-  crossRefsVisitorFn(): any {
-    if (!this.isCApi()) return null;
+  crossRefsVisitorFn(): TextVisitor | undefined {
+    if (!this.isCApi()) return undefined;
     return insertCrossRefsVisitor(this.name, this.version);
   }
 

--- a/scripts/js/lib/api/conversionPipeline.ts
+++ b/scripts/js/lib/api/conversionPipeline.ts
@@ -34,6 +34,7 @@ import {
   maybeUpdateReleaseNotesFolder,
   handleReleaseNotesFile,
 } from "./releaseNotes.js";
+import { insertCrossRefsVisitor } from "./handleCrossRefs.js";
 
 export async function runConversionPipeline(
   htmlPath: string,
@@ -106,6 +107,7 @@ async function convertFilesToMarkdown(
       html,
       fileName: file,
       determineGithubUrl: pkg.determineGithubUrlFn(),
+      insertCrossReferences: pkg.crossRefsVisitorFn(),
       imageDestination: pkg.outputDir("/images"),
       releaseNotesTitle: pkg.releaseNotesTitle(),
       hasSeparateReleaseNotes: pkg.hasSeparateReleaseNotes(),

--- a/scripts/js/lib/api/handleCrossRefs.test.ts
+++ b/scripts/js/lib/api/handleCrossRefs.test.ts
@@ -1,0 +1,65 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { test, expect } from "@playwright/test";
+
+import { insertCrossReferences } from "./handleCrossRefs";
+import { toMarkdown } from "mdast-util-to-markdown";
+
+function transformString(input: string): string {
+  const ast = insertCrossReferences(
+    { type: "text", value: input },
+    "qiskit-c",
+    "2.0",
+  );
+  return toMarkdown({ type: "root", children: ast }).trim();
+}
+
+test.describe("insertCrossReferences()", () => {
+  test("simple cross ref", async () => {
+    expect(transformString("Ref to [SparseObservable]")).toEqual(
+      "Ref to [QkObs](/api/qiskit-c/2.0/qk-obs#qkobs-1)",
+    );
+  });
+
+  test("many refs in a single sentence", async () => {
+    expect(
+      transformString("Ref to [SparseObservable] and to [CSparseTerm]"),
+    ).toEqual(
+      "Ref to [QkObs](/api/qiskit-c/2.0/qk-obs#qkobs-1) and to [QkObsTerm](/api/qiskit-c/2.0/qk-obs-term#qkobsterm-1)",
+    );
+  });
+
+  test("text after ref", async () => {
+    expect(transformString("Ref to [SparseObservable]!!")).toEqual(
+      "Ref to [QkObs](/api/qiskit-c/2.0/qk-obs#qkobs-1)!!",
+    );
+  });
+
+  test("ref starts sentence", async () => {
+    expect(transformString("[SparseObservable] is a struct")).toEqual(
+      "[QkObs](/api/qiskit-c/2.0/qk-obs#qkobs-1) is a struct",
+    );
+  });
+
+  test("unrecognised ref is escaped", async () => {
+    expect(transformString("This [RefThing] is not a real struct")).toEqual(
+      "This `RefThing` is not a real struct",
+    );
+  });
+
+  test("no refs", async () => {
+    expect(transformString("This string has no refs!")).toEqual(
+      "This string has no refs!",
+    );
+  });
+});

--- a/scripts/js/lib/api/handleCrossRefs.ts
+++ b/scripts/js/lib/api/handleCrossRefs.ts
@@ -92,7 +92,7 @@ function getCrossRef(
   return { type: "link", url, children: [linkTextNode] };
 }
 
-type TextVisitor = (node: Text, index: number, parent: any) => void;
+export type TextVisitor = (node: Text, index: number, parent: any) => void;
 export function insertCrossRefsVisitor(
   packageName: string,
   version: string,

--- a/scripts/js/lib/api/handleCrossRefs.ts
+++ b/scripts/js/lib/api/handleCrossRefs.ts
@@ -1,0 +1,108 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+import { join } from "path";
+import { Text, Link, InlineCode } from "mdast";
+
+interface Ref {
+  name: string;
+  path: string;
+  isAbsolutePath?: boolean;
+}
+type CrossRefsByVersion = {
+  [version: string]: {
+    [objectName: string]: Ref;
+  };
+};
+const CROSS_REFERENCES_BY_VERSION: CrossRefsByVersion = {
+  "2.0": {
+    SparseObservable: {
+      name: "QkObs",
+      path: "/qk-obs#qkobs-1",
+    },
+    CSparseTerm: {
+      name: "QkObsTerm",
+      path: "/qk-obs-term#qkobsterm-1",
+    },
+    BitTerm: {
+      name: "QkBitTerm",
+      path: "/qk-bit-term#qkbitterm-1",
+    },
+    Complex64: {
+      name: "QkComplex64",
+      path: "", // TODO
+    },
+    PySparseObservable: {
+      name: "SparseObservable",
+      path: "/api/qiskit/2.0/qiskit.quantum_info.SparseObservable#sparseobservable",
+      isAbsolutePath: true,
+    },
+  },
+} as const;
+
+type ParsedOutput = Array<Text | Link | InlineCode>;
+export function insertCrossReferences(
+  textNode: Text,
+  packageName: string,
+  version: string,
+): ParsedOutput {
+  const crossRefs = CROSS_REFERENCES_BY_VERSION[version];
+  if (!crossRefs) throw new Error(`Unrecognized C API version: '${version}'`);
+
+  const nodes: ParsedOutput = [];
+  const basePath = "/" + join("api", packageName, version);
+  const regex = /(.*?)\[([A-z]+)\]/gm;
+
+  let match: RegExpExecArray | null;
+  let endOfLastMatch = 0;
+  while ((match = regex.exec(textNode.value)) !== null) {
+    nodes.push({ type: "text", value: match[1] });
+    nodes.push(getCrossRef(match[2], crossRefs, basePath));
+    endOfLastMatch = regex.lastIndex;
+  }
+
+  const remainingText = textNode.value.slice(endOfLastMatch);
+  nodes.push({ type: "text", value: remainingText });
+  return nodes;
+}
+
+function getCrossRef(
+  objectName: string,
+  crossRefs: { [name: string]: Ref },
+  basePath: string,
+): Link | InlineCode {
+  const ref = crossRefs[objectName];
+  if (!ref) {
+    console.error(
+      `Could not find cross reference for '${objectName}' in '${basePath}'.`,
+    );
+    return { type: "inlineCode", value: objectName };
+  }
+  const linkTextNode: Text = { type: "text", value: ref.name };
+  const url = ref.isAbsolutePath ? ref.path : join(basePath, ref.path);
+  return { type: "link", url, children: [linkTextNode] };
+}
+
+type TextVisitor = (node: Text, index: number, parent: any) => void;
+export function insertCrossRefsVisitor(
+  packageName: string,
+  version: string,
+): TextVisitor {
+  return (node: Text, index: number, parent: any): void => {
+    const newNodes = insertCrossReferences(node, packageName, version);
+    parent.children = [
+      ...parent.children.slice(0, index),
+      ...newNodes,
+      ...parent.children.slice(index + 1, parent.children.length),
+    ];
+  };
+}

--- a/scripts/js/lib/api/htmlToMd.ts
+++ b/scripts/js/lib/api/htmlToMd.ts
@@ -29,13 +29,14 @@ import { HtmlToMdResult } from "./HtmlToMdResult.js";
 import { Metadata, ApiTypeName } from "./Metadata.js";
 import { removePrefix, removeSuffix, capitalize } from "../stringUtils.js";
 import { remarkStringifyOptions } from "./commonParserConfig.js";
+import { TextVisitor } from "./handleCrossRefs.js";
 
 export async function sphinxHtmlToMarkdown(options: {
   html: string;
   fileName: string;
   imageDestination: string;
   determineGithubUrl: (fileName: string) => string;
-  insertCrossReferences: ((textNode: Text) => void) | null;
+  insertCrossReferences?: TextVisitor;
   releaseNotesTitle: string;
   hasSeparateReleaseNotes: boolean;
   isCApi: boolean;
@@ -57,7 +58,7 @@ export async function sphinxHtmlToMarkdown(options: {
 async function generateMarkdownFile(
   mainHtml: string,
   meta: Metadata,
-  insertCrossReferences: ((textNode: Text) => void) | null,
+  insertCrossReferences?: TextVisitor,
 ): Promise<string> {
   const noop: any = () => {};
   const handlers = prepareHandlers(meta);


### PR DESCRIPTION
This is an attempt to enable cross references in the C API docs.


## Background

The source docstrings refer to other Rust objects using square brackets. For example:

```rust
/// A [CSparseTerm] contains pointers to the indices and bit terms in the term, which
/// can be used to modify the internal data of the observable. This can leave the observable
```

[Link to source](https://github.com/Qiskit/qiskit/blob/ddb802506a499385caf436522b6fb277b51895c1/crates/cext/src/sparse_observable.rs#L299-L302).

The references link correctly in the developers' editors. The problem is that cbindgen doesn't know to convert these references to their C equivalents. Since Breathe doesn't recognise this syntax the original string ends up on the final web page. (Breathe doesn't even know Rust is involved – it just reads the header file generated by cbindgen).

The mapping of Rust names to C names is specified in Qiskit's `cbindgen.toml`:

```toml
[export.rename]
"SparseObservable" = "QkObs"
"CSparseTerm" = "QkObsTerm"
"BitTerm" = "QkBitTerm"
"Complex64" = "QkComplex64"
```

[Link to source](https://github.com/Qiskit/qiskit/blob/ddb802506a499385caf436522b6fb277b51895c1/crates/cext/cbindgen.toml#L30-L34).


## Propsed solution

I'm not convinced this is the best solution, but it does seem to work for now.

Using the `cbindgen.toml` mapping as a reference, we add the mapping of Rust name -> C name and link to a typescript file in this repo. We then search the C API markdown for possible references and insert the correct names/links ourselves.

The main problem with this is we'd need to manually update the config file. We could potentially grab the mappings automatically from `cbindgen.toml`, but we won't know which pages to link to. We might be able to get the pages from `objects.inv`, but that feels very complicated.


### Other considerations

Creating links to source code will also suffer from similar problems.