### PR TITLE
Skip generating release notes for C API docs

### DIFF
--- a/scripts/js/lib/api/releaseNotes.ts
+++ b/scripts/js/lib/api/releaseNotes.ts
@@ -39,6 +39,12 @@ export async function handleReleaseNotesFile(
     return false;
   }
 
+  // If we're linking to a different to a different package's release notes, we
+  // shouldn't create a new release notes file.
+  if (pkg.releaseNotesConfig.linkToPackage) {
+    return false;
+  }
+
   // When the release notes are a single file, only use them if this is the latest version rather
   // than a historical release.
   if (!pkg.hasSeparateReleaseNotes()) {

--- a/scripts/js/lib/api/saveImages.ts
+++ b/scripts/js/lib/api/saveImages.ts
@@ -31,6 +31,10 @@ function skipReleaseNote(imgFileName: string, pkg: Pkg): boolean {
   // the image files stored.
   if (pkg.isProblematicLegacyQiskit()) return true;
 
+  // If we're linking to another package's release notes, we skip generating the
+  // release notes.
+  if (pkg.releaseNotesConfig.linkToPackage) return true;
+
   if (pkg.hasSeparateReleaseNotes()) {
     // If the pkg has dedicated release notes per release, we should copy its images
     // unless it's the dev version. We don't (yet) support release notes for dev versions:


### PR DESCRIPTION
For the C API, we link to Qiskit's Python API release notes. However, we were still generating the release notes page for the C API, just not using it. This PR skips the release notes generation in the conversion pipeline.
