### PR TITLE
Revert "Use more modern version of changed-files action (#2814)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get all changed docs files
         id: all-changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: docs/**/*.{md,mdx,ipynb}
           separator: "\n"

--- a/.github/workflows/notebook-test-extended.yml
+++ b/.github/workflows/notebook-test-extended.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get relevant changed files
         id: all-changed
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: "{docs/**/*.ipynb,scripts/nb-tester/**/*}"
           separator: "\n"

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get relevant changed files
         id: all-changed
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
+        uses: tj-actions/changed-files@af2816c65436325c50621100d67f6e853cd1b0f1
         with:
           files: "{docs/**/*.ipynb,scripts/nb-tester/**/*}"
           separator: "\n"


### PR DESCRIPTION
The new action is broken for `separator`, which is blocking https://github.com/Qiskit/documentation/pull/2757.

We will find a minimum reproduction & file an issue with their repository.

## Security analysis

We had landed https://github.com/Qiskit/documentation/pull/2757 out of an abundance-of-caution to address https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised#stepsecurity-harden-runner. The security team wanted us to be using the latest version of the action.

However, it was not actually necessary to land https://github.com/Qiskit/documentation/pull/2757 because the prior commit we pinned to was not compromised. There is no known CVE with the old pinned commit.

While it's generally a good idea to use the latest version of deps, it is not strictly necessary and in this case it is blocking us from merging to main.