### PR TITLE
Error when API versions are incomplete

### DIFF
--- a/scripts/js/commands/api/updateApiDocs.ts
+++ b/scripts/js/commands/api/updateApiDocs.ts
@@ -15,7 +15,7 @@ import { hideBin } from "yargs/helpers";
 
 import { Pkg } from "../../lib/api/Pkg.js";
 import { zxMain } from "../../lib/zx.js";
-import { parseMinorVersion } from "../../lib/apiVersions.js";
+import { parseMinorVersion, isValidVersion } from "../../lib/apiVersions.js";
 import { pathExists, rmFilesInFolder } from "../../lib/fs.js";
 import { downloadSphinxArtifact } from "../../lib/api/sphinxArtifacts.js";
 import { runConversionPipeline } from "../../lib/api/conversionPipeline.js";
@@ -46,6 +46,14 @@ const readArgs = (): Arguments => {
       type: "string",
       demandOption: true,
       description: "The full version string of the --package, e.g. 0.44.0",
+      coerce: (version) => {
+        if (!isValidVersion(version)) {
+          throw new Error(
+            "The version must include a major, a minor, and a patch. E.g. `-v 0.46.3`",
+          );
+        }
+        return version;
+      },
     })
     .option("historical", {
       type: "boolean",

--- a/scripts/js/lib/apiVersions.ts
+++ b/scripts/js/lib/apiVersions.ts
@@ -34,3 +34,9 @@ export function parseMinorVersion(version: string): string | null {
   const versionMatch = version.match(/^(\d+\.\d+)/);
   return versionMatch ? versionMatch[0] : null;
 }
+
+export function isValidVersion(versionToCheck: string): boolean {
+  // The version must include a major, a minor, and a patch
+  const fullVersionFormat = new RegExp(/^(\d+\.\d+\.\d+)$/);
+  return !!versionToCheck.match(fullVersionFormat);
+}


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2879

This PR adds a mechanism to catch when a version is incomplete when running `npm run gen-api`