### PR TITLE
Update links that point to removed anchors

### DIFF
--- a/docs/guides/configure-qiskit-local.mdx
+++ b/docs/guides/configure-qiskit-local.mdx
@@ -32,7 +32,7 @@ By default, this file is in `~/.qiskit/settings.conf` but the path can be overri
 - `circuit_mpl_style`: The default style sheet used for the mpl output system for the circuit drawer. Valid values are `default` or `bw`.
 - `circuit_mpl_style_path`: The paths to have the circuit drawer use to look for JSON style sheets when using the mpl output mode.
 - `state_drawer`: This is used to change the default system for the state visualization draw methods. Valid values are `repr`, `text`, `latex`, `latex_source`, `qsphere`, `hinton`, or `bloch`. When the output kwarg is not explicitly set on the [qiskit.quantum_info.DensityMatrix.draw](../api/qiskit/qiskit.quantum_info.DensityMatrix#densitymatrix) method, the specified output method is used.
-- `transpile_optimization_level`: Change the default optimization level for [qiskit.compiler.transpile](../api/qiskit/compiler#circuit-and-pulse-compilation-functions). Specify an integer 0-3.
+- `transpile_optimization_level`: Change the default optimization level for [qiskit.compiler.transpile](../api/qiskit/1.4/compiler#circuit-and-pulse-compilation-functions). Specify an integer 0-3.
 - `parallel`: Whether Python multiprocessing is enabled for operations that support running in parallel.  For example, transpilation of multiple [qiskit.circuit.QuantumCircuit](../api/qiskit/qiskit.circuit.QuantumCircuit#quantumcircuit-class) objects. This setting can be overridden by the `QISKIT_PARALLEL` environment variable. Specify a boolean value.
 - `num_processes`: The maximum number of parallel processes to launch for parallel operations if parallel execution is enabled. This setting can be overridden by the `QISKIT_NUM_PROCS` environment variable. Specify an integer greater than `0`. 
 

--- a/docs/migration-guides/qiskit-1.0-features.mdx
+++ b/docs/migration-guides/qiskit-1.0-features.mdx
@@ -856,7 +856,7 @@ with pulse.build() as only_pulse_scheds:
 
 We recommend writing a minimum pulse program with the builder and attaching it to
 `QuantumCircuit` through the
-[`QuantumCircuit.add_calibration`](/api/qiskit/qiskit.circuit.QuantumCircuit#add_calibration)
+[`QuantumCircuit.add_calibration`](/api/qiskit/1.4/qiskit.circuit.QuantumCircuit#add_calibration)
 method as a microcode of a gate instruction, rather than writing the entire
 program with the pulse model.
 

--- a/docs/migration-guides/qiskit-quantum-instance.mdx
+++ b/docs/migration-guides/qiskit-quantum-instance.mdx
@@ -42,7 +42,7 @@ The following table summarizes the migration alternatives for the [`qiskit.utils
 | --- | --- |
 | [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) | [`qiskit.primitives.Sampler.run`](/api/qiskit/1.4/qiskit.primitives.Sampler#run) or [`qiskit.primitives.Estimator.run`](/api/qiskit/1.4/qiskit.primitives.Estimator#run) |
 | [`qiskit.utils.QuantumInstance.transpile`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#transpile) | [`qiskit.compiler.transpile`](/api/qiskit/compiler#qiskit.compiler.transpile) or [`qiskit.transpiler.pass_manager.PassManager.run`](/api/qiskit/qiskit.transpiler.PassManager#run)|
-| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/compiler#qiskit.compiler.assemble) [Deprecated: no longer part of the workflow]|
+| [`qiskit.utils.QuantumInstance.assemble`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#assemble) | [`qiskit.compiler.assemble`](/api/qiskit/1.4/compiler#qiskit.compiler.assemble) [Deprecated: no longer part of the workflow]|
 
 The remainder of this guide focused on the [`qiskit.utils.QuantumInstance.execute`](/api/qiskit/0.46/qiskit.utils.QuantumInstance#execute) to
 [`qiskit.primitives`](/api/qiskit/primitives) migration path.

--- a/scripts/js/lib/links/ignores.ts
+++ b/scripts/js/lib/links/ignores.ts
@@ -124,6 +124,10 @@ export const ALWAYS_IGNORED_URL_REGEXES: string[] = [
   ..._runtimeObjectsInvRegexes(),
   // TODO(#2761): Move the links to globs to load in `checkInternalLinks.ts` once Qiskit 1.4 becomes historical
   ...QISKIT_REMOVED_PAGES.map((link) => `\/api\/qiskit/1.4\/${link}(|#.*|$)`),
+  "/api/qiskit/1.4/qiskit.circuit.QuantumCircuit#add_calibration",
+  "/api/qiskit/1.4/compiler#qiskit.compiler.assemble",
+  "/api/qiskit/1.4/compiler#circuit-and-pulse-compilation-functions",
+  // End of TODO(#2761)
 ];
 
 // -----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates three links in the migration guides and guides that point to a section that will be removed in Qiskit 2.0. The pages will continue existing, but the sections (and therefore the anchors) will not.

This links were found in https://github.com/Qiskit/documentation/pull/2761#issue-2911555509