### PR TITLE
Pages render: Add instructions for platform specific pages

### DIFF
--- a/scripts/js/commands/checkPagesRender.ts
+++ b/scripts/js/commands/checkPagesRender.ts
@@ -134,7 +134,9 @@ zxMain(async () => {
       `💔 ${failures.length} pages crash when rendering. This is usually due to invalid syntax, such as forgetting ` +
         "the closing component tag, like `</Admonition>`. You can sometimes get a helpful error message " +
         "by previewing the docs locally or in CI. See the README for instructions.\n\n" +
-        failures.join("\n"),
+        failures.join("\n") +
+        "\n\nIf your files are platform specific, you should add them to the `LEGACY_ONLY_PAGES` or `CLOUD_ONLY_PAGES` list " +
+        "at the beginning of `scripts/js/commands/checkPagesRender.ts`",
     );
     process.exit(1);
   }


### PR DESCRIPTION
This PR adds instructions about how to fix `checkPagesRender` errors on platform specific files.