### PR TITLE
Turn off cron job for forks

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -19,6 +19,7 @@ jobs:
   execute:
     name: Execute notebooks
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'Qiskit'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   execute:
     name: Execute notebooks
+    if: github.repository_owner == 'Qiskit'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I didn't realize this has been running on forks: https://github.com/Gyan-max/documentation/pull/2. It shouldn't be, and will result in issues with contributors who merge those PRs to `main`.