### PR TITLE
Remove stale image check warning about closed source

### DIFF
--- a/scripts/js/commands/checkStaleImages.ts
+++ b/scripts/js/commands/checkStaleImages.ts
@@ -43,9 +43,6 @@ zxMain(async () => {
     console.error(
       "\n\n❌ Some images are unused. They should usually be deleted to reduce our repository size.",
     );
-    console.warn(
-      "⚠️ Be careful that some of these images may be used in closed source. Before deleting files, check for their usage there. If they're unused, add it to the allowlist.",
-    );
     process.exit(1);
   }
 });


### PR DESCRIPTION
None of our open source images are used anymore in closed source files. Furthermore, we are almost finished moving all of our closed source content to now live in open source, so there isn't even a concept any more of closed-source images.