### PR TITLE
Add removal notice to pulse page

### DIFF
--- a/docs/guides/pulse.ipynb
+++ b/docs/guides/pulse.ipynb
@@ -35,9 +35,11 @@
    "id": "e315fbd1-f3a6-4eab-bb47-0ee1d52f3d84",
    "metadata": {},
    "source": [
-    "<Admonition type=\"note\">\n",
+    "<Admonition type=\"danger\" title='Removal of Pulse Support'>\n",
     "\n",
-    "With the introduction of [fractional gates](/guides/fractional-gates), pulse-level control on all IBM Quantum&reg; processors has been deprecated and will be removed on 3 February 2025. Additionally, the `qiskit.pulse` module has been deprecated as of the Qiskit SDK v1.3.0 and will be removed in Qiskit SDK v2.0.0. See the [migration guide](../migration-guides/pulse-migration) for more information.\n",
+    "With the introduction of [fractional gates](/guides/fractional-gates), pulse-level control on all IBM Quantum&reg; processors has been removed. \n",
+    "\n",
+    "Additionally, the `qiskit.pulse` module has been **removed** as of the Qiskit SDK v2.0.0 (but is still supported under the Qiskit SDK v1.4 until September of 2025). See the [migration guide](../migration-guides/pulse-migration) for more information.\n",
     "\n",
     "</Admonition>"
    ]


### PR DESCRIPTION
Closes #2432 

Instead of removing the page upon the release of Qiskit 2.0, this adds an admonition warning users that only Qiskit 1.4 supports the `qiskit.pulse` module. We'll plan to remove the page once patch support for Qiskit 1.X has finished in September.