### PR TITLE
Check all notebooks contain `version-info` cells

### DIFF
--- a/scripts/ci/check-for-version-info-cells.py
+++ b/scripts/ci/check-for-version-info-cells.py
@@ -22,25 +22,20 @@ guides_path = Path("./docs/guides")
 for notebook in guides_path.glob("*.ipynb"):
     nb = nbformat.read(notebook, as_version=4)
     num_version_info_cells = len(
-        list(
-            filter(
-                lambda cell: "version-info" in cell.metadata.get("tags", []),
-                nb.cells,
-            )
-        )
+        [cell for cell in nb.cells if "version-info" in cell.metadata.get("tags", [])]
     )
     if num_version_info_cells == 1:
         continue
     if num_version_info_cells == 0:
         print(
-            f"\n\n❌ No version info cell found in {notebook}; add an empty markdown "
-            "cell immediately after the top-level heading and add a "
-            "`version-info` tag. This is so the package versions will be added "
-            "to the notebook next time it's executed.\n\n"
+            f"\n\n❌ No version info cell found in {notebook}. (This allows users to "
+            "see what versions of requirements were used when developing the notebook.)\n\n"
+            "To fix, add a new markdown cell immediately after the top-level heading. Keep its content "
+            "empty. In the `tags` metadata, add 'version-info'.\n\n"
         )
     else:
         print(
-            f"\n\n❌ Found more than one cell with tag `version-info` in {notebook}; "
-            "remove all but one.\n\n"
+            f"\n\n❌ Found more than one cell with tag `version-info` in {notebook}. "
+            "To fix, remove all but one.\n\n"
         )
     sys.exit(1)

--- a/scripts/ci/check-for-version-info-cells.py
+++ b/scripts/ci/check-for-version-info-cells.py
@@ -22,16 +22,19 @@ if __name__ == "__main__":
     guides_path = Path("./docs/guides")
     for notebook in guides_path.glob("*.ipynb"):
         nb = nbformat.read(notebook, as_version=4)
-        num_version_info_cells = len(
-            [
-                cell
-                for cell in nb.cells
-                if "version-info" in cell.metadata.get("tags", [])
-            ]
-        )
-        if num_version_info_cells == 1:
+        version_info_cells = [
+            cell for cell in nb.cells if "version-info" in cell.metadata.get("tags", [])
+        ]
+        if len(version_info_cells) == 1:
+            cell = version_info_cells.pop()
+            if cell.cell_type != "markdown":
+                print(
+                    "\n\n❌ Version info cells must be markdown cells. "
+                    f"Found a {cell.cell_type} cell with tag 'version-info' in "
+                    f"{notebook}.\n\n"
+                )
             continue
-        if num_version_info_cells == 0:
+        if len(version_info_cells) == 0:
             print(
                 f"\n\n❌ No version info cell found in {notebook}. (This allows users to "
                 "see what versions of requirements were used when developing the notebook.)\n\n"

--- a/scripts/ci/check-for-version-info-cells.py
+++ b/scripts/ci/check-for-version-info-cells.py
@@ -18,24 +18,29 @@ from pathlib import Path
 import nbformat
 import sys
 
-guides_path = Path("./docs/guides")
-for notebook in guides_path.glob("*.ipynb"):
-    nb = nbformat.read(notebook, as_version=4)
-    num_version_info_cells = len(
-        [cell for cell in nb.cells if "version-info" in cell.metadata.get("tags", [])]
-    )
-    if num_version_info_cells == 1:
-        continue
-    if num_version_info_cells == 0:
-        print(
-            f"\n\n❌ No version info cell found in {notebook}. (This allows users to "
-            "see what versions of requirements were used when developing the notebook.)\n\n"
-            "To fix, add a new markdown cell immediately after the top-level heading. Keep its content "
-            "empty. In the `tags` metadata, add 'version-info'.\n\n"
+if __name__ == "__main__":
+    guides_path = Path("./docs/guides")
+    for notebook in guides_path.glob("*.ipynb"):
+        nb = nbformat.read(notebook, as_version=4)
+        num_version_info_cells = len(
+            [
+                cell
+                for cell in nb.cells
+                if "version-info" in cell.metadata.get("tags", [])
+            ]
         )
-    else:
-        print(
-            f"\n\n❌ Found more than one cell with tag `version-info` in {notebook}. "
-            "To fix, remove all but one.\n\n"
-        )
-    sys.exit(1)
+        if num_version_info_cells == 1:
+            continue
+        if num_version_info_cells == 0:
+            print(
+                f"\n\n❌ No version info cell found in {notebook}. (This allows users to "
+                "see what versions of requirements were used when developing the notebook.)\n\n"
+                "To fix, add a new markdown cell immediately after the top-level heading. Keep its content "
+                "empty. In the `tags` metadata, add 'version-info'.\n\n"
+            )
+        else:
+            print(
+                f"\n\n❌ Found more than one cell with tag `version-info` in {notebook}. "
+                "To fix, remove all but one.\n\n"
+            )
+        sys.exit(1)

--- a/scripts/ci/check-for-version-info-cells.py
+++ b/scripts/ci/check-for-version-info-cells.py
@@ -1,0 +1,46 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Check all notebooks have exactly one `version-info` cell.
+"""
+
+from pathlib import Path
+import nbformat
+import sys
+
+guides_path = Path("./docs/guides")
+for notebook in guides_path.glob("*.ipynb"):
+    nb = nbformat.read(notebook, as_version=4)
+    num_version_info_cells = len(
+        list(
+            filter(
+                lambda cell: "version-info" in cell.metadata.get("tags", []),
+                nb.cells,
+            )
+        )
+    )
+    if num_version_info_cells == 1:
+        continue
+    if num_version_info_cells == 0:
+        print(
+            f"\n\n❌ No version info cell found in {notebook}; add an empty markdown "
+            "cell immediately after the top-level heading and add a "
+            "`version-info` tag. This is so the package versions will be added "
+            "to the notebook next time it's executed.\n\n"
+        )
+    else:
+        print(
+            f"\n\n❌ Found more than one cell with tag `version-info` in {notebook}; "
+            "remove all but one.\n\n"
+        )
+    sys.exit(1)

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
     lint: ruff check {posargs:docs}
     lint: ruff format --check {posargs:docs}
     lint: squeaky --check --no-advice {posargs:docs}
+    lint: python scripts/ci/check-for-version-info-cells.py
     fix: squeaky {posargs:docs}
     fix: ruff format {posargs:docs}
     fix: ruff check --fix {posargs:docs}


### PR DESCRIPTION
Checks that all notebooks have a markdown cell with tag `version-info`. We add these cells so the notebook tester knows where to insert package version information so users can see which package versions were used to run the notebook.
