### PR TITLE
Fix spellcheck CI

### DIFF
--- a/docs/guides/cloud-account-structure.mdx
+++ b/docs/guides/cloud-account-structure.mdx
@@ -49,7 +49,7 @@ Performing actions often requires a combination of platform management and servi
   </Admonition>
 - Running jobs requires the `writer` service access role and `viewer` platform management role access to the instance.
 
-When creating an access policy (either on an access group or for a user), you can check which actions are part of the role by reviwing the description. For example `quantum-computing.job.create - Create a job to run a program`.
+When creating an access policy (either on an access group or for a user), you can check which actions are part of the role by reviewing the description. For example `quantum-computing.job.create - Create a job to run a program`.
 
 The following table provides examples for some of the platform management actions that users can take within the context of the Qiskit Runtime service.
 

--- a/docs/guides/manage-appid.mdx
+++ b/docs/guides/manage-appid.mdx
@@ -140,7 +140,7 @@ The steps to implement this setup are:
 6. The cloud administrator assigns access by adding users to the access groups that give them access to the projects:
    * Fatima is given access to the `ml` project.
    * Ravi is given access to the `finance` project.
-   * Amyra is given access to the `ml` and `finanace` projects.
+   * Amyra is given access to the `ml` and `finance` projects.
 6. Users can log in through the ID provider URL, create API keys, and work with their projects' service instances.
 
 ## Next steps

--- a/scripts/config/cspell/dictionaries/people.txt
+++ b/scripts/config/cspell/dictionaries/people.txt
@@ -5,6 +5,7 @@ Ahokas
 Almaden
 Alon
 Ambainis
+Amyra
 Bajpe
 Birgitta
 Boeblingen

--- a/scripts/js/commands/checkSpelling.ts
+++ b/scripts/js/commands/checkSpelling.ts
@@ -45,6 +45,7 @@ function readArgs(): Arguments {
 zxMain(async () => {
   const args = readArgs();
   const cspellCmd = ["npx", "cspell", "--no-progress", "--config", args.config];
+  let allGood = true;
 
   try {
     await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx`.pipe(process.stdout);
@@ -53,9 +54,11 @@ zxMain(async () => {
     }
   } catch (p) {
     explainHowToFix("mdx");
+    allGood = false;
   }
 
   await checkAllNotebooks(args.config);
+  if (!allGood) process.exit(1);
 });
 
 function explainHowToFix(format: "mdx" | "jupyter"): void {


### PR DESCRIPTION
Turns out the spellcheck won't block CI if it finds an error in an MDX file, only notebooks.
