### PR TITLE
Refactor checkSpelling.ts

### DIFF
--- a/scripts/js/commands/checkSpelling.ts
+++ b/scripts/js/commands/checkSpelling.ts
@@ -44,53 +44,68 @@ function readArgs(): Arguments {
 
 zxMain(async () => {
   const args = readArgs();
-  const cspellCmd = ["npx", "cspell", "--no-progress", "--config", args.config];
-  let allGood = true;
-
-  try {
-    await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx`.pipe(process.stdout);
-    if (args.apis) {
-      await $`${cspellCmd} docs/api/**/*.mdx`.pipe(process.stdout);
-    }
-  } catch (p) {
-    explainHowToFix("mdx");
-    allGood = false;
-  }
-
-  await checkAllNotebooks(args.config);
-  if (!allGood) process.exit(1);
+  await checkMdx(args.config, args.apis);
+  await checkNotebooks(args.config);
 });
 
 function explainHowToFix(format: "mdx" | "jupyter"): void {
   const dictionary =
-    "2. If you expect this word to appear in other files, add it to a dictionary. " +
+    "Add the word to a dictionary. This means it will be valid in all other files, too. " +
     "Add names to the `scripts/config/cspell/dictionaries/people.txt` file. " +
     "Add scientific or quantum specific-words to the `scripts/config/cspell/dictionaries/qiskit.txt` file. " +
     "If it doesn't fit in either category, add it to the `words` section in `scripts/config/cspell/cSpell.json`. " +
     "The word is not case-sensitive.";
-  const formatFix =
-    format === "mdx"
-      ? "1. Add a comment on a dedicated line near the top of the MDX file, between the page metadata " +
-        "and the H1 heading, such as: {/* cspell:ignore hellllooooo, ayyyyy */}"
-      : "1. Add a comment on a dedicated line to the first markdown cell in the Jupyter notebook.  " +
-        "(This cell should have the page title.) For example, add the " +
-        "following above the H1 heading: {/* cspell:ignore helloooooo */}";
+
+  let hasMultipleFixes: boolean;
+  let fix: string;
+  if (format === "mdx") {
+    hasMultipleFixes = true;
+    fix =
+      "1. Add a comment on a dedicated line near the top of the MDX file, between the page metadata " +
+      "and the H1 heading, such as: {/* cspell:ignore hellllooooo, ayyyyy */}\n\n" +
+      `2. ${dictionary}`;
+  } else if (format === "jupyter") {
+    hasMultipleFixes = true;
+    fix =
+      "1. Add a comment on a dedicated line to the first markdown cell in the Jupyter notebook.  " +
+      "(This cell should have the page title.) For example, add the " +
+      "following above the H1 heading: {/* cspell:ignore helloooooo */}\n\n" +
+      `2. ${dictionary}`;
+  } else {
+    throw new Error(`Unrecognized format: ${format}`);
+  }
+
+  const allowlistInstruction = hasMultipleFixes
+    ? "there are two ways to allowlist it"
+    : "you can allowlist it";
   console.error(
     "\n\n---------------\n\n🙅 There are unrecognized words (see above). If " +
-      `the word is a not a typo, there are two ways to allowlist it:\n\n${formatFix}` +
-      `\n\n${dictionary}`,
+      `the word is a not a typo, ${allowlistInstruction}:\n\n${fix}`,
   );
 }
 
-async function checkAllNotebooks(configPath: string): Promise<void> {
+async function checkMdx(configPath: string, checkApis: boolean): Promise<void> {
+  const cspellCmd = ["npx", "cspell", "--no-progress", "--config", configPath];
+  try {
+    await $`${cspellCmd} docs/**/*.mdx !docs/api/**/*.mdx`.pipe(process.stdout);
+    if (checkApis) {
+      await $`${cspellCmd} docs/api/**/*.mdx`.pipe(process.stdout);
+    }
+  } catch (p) {
+    explainHowToFix("mdx");
+    process.exit(1);
+  }
+}
+
+async function checkNotebooks(configPath: string): Promise<void> {
   const paths = await globby("docs/**/*.ipynb");
   let allGood = true;
   await pMap(paths, async (path) => {
-    const errors = await checkForNotebookMistakes(path, configPath);
-    if (errors.length) {
+    const text = await readMarkdown(path, { includeCodeCellSourceCode: true });
+    const errors = await runCSpell(text, { configPath, fp: path });
+    if (errors.size) {
       allGood = false;
-      const deduplicated = new Set(errors);
-      deduplicated.forEach((mistake) =>
+      errors.forEach((mistake) =>
         console.error(`❌ Unrecognized word in ${path}: ${mistake}`),
       );
     }
@@ -102,25 +117,20 @@ async function checkAllNotebooks(configPath: string): Promise<void> {
   }
 }
 
-/**
- * Returns any spelling mistakes in the notebook's markdown blocks, if any.
- */
-async function checkForNotebookMistakes(
-  fp: string,
-  configPath: string,
-): Promise<string[]> {
-  const text = await readMarkdown(fp, { includeCodeCellSourceCode: true });
-
+async function runCSpell(
+  text: string,
+  options: { configPath: string; fp: string },
+): Promise<Set<string>> {
   const checkOptions = {
-    configFile: configPath,
+    configFile: options.configPath,
   };
   const doc = {
-    uri: fp,
+    uri: options.fp,
     text,
   };
   const result = await spellCheckDocument(doc, checkOptions, {});
 
-  // The line numbers get mangled by `readMarkdown()` and they do not correspond to the original notebook file.
-  // So, we only return the spelling mistake without its context.
-  return result.issues.map((issue) => issue.text);
+  // The line numbers often get mangled. So, we only return the spelling mistake
+  // without its context.
+  return new Set(result.issues.map((issue) => issue.text));
 }


### PR DESCRIPTION
Prework for https://github.com/Qiskit/documentation/issues/2914. This makes the code more generic so that we can add more content types than MDX and Jupyter.