### PR TITLE
Sync C API docs nightly

### DIFF
--- a/scripts/js/commands/api/syncDevDocs.ts
+++ b/scripts/js/commands/api/syncDevDocs.ts
@@ -51,7 +51,10 @@ zxMain(async () => {
   await updateHtmlArtifacts({ qiskitUrl, runtimeUrl });
 
   if (qiskitUrl) {
-    await regenDocs("qiskit", qiskitVersion);
+    await Promise.all([
+      regenDocs("qiskit", qiskitVersion),
+      regenDocs("qiskit-c", qiskitVersion),
+    ]);
   }
   if (runtimeUrl) {
     await regenDocs("qiskit-ibm-runtime", runtimeVersion);
@@ -93,6 +96,7 @@ async function updateHtmlArtifacts(args: {
   const prior = JSON.parse(rawContent);
   if (qiskitUrl) {
     prior["qiskit"]["dev"] = qiskitUrl;
+    prior["qiskit-c"]["dev"] = qiskitUrl;
   }
   if (runtimeUrl) {
     prior["qiskit-ibm-runtime"]["dev"] = runtimeUrl;


### PR DESCRIPTION
Closes #2900

See #2951 for an example of this working, although there's no change to the C API docs (I tested this locally by updating `api-html-artifacts.json` and running `npm run gen-api -- -p qiskit-c -v 2.0.0-dev --dev
`).