### PR TITLE
Unify Python and C API generation

### DIFF
--- a/scripts/config/api-html-artifacts.json
+++ b/scripts/config/api-html-artifacts.json
@@ -31,10 +31,6 @@
     "0.24": "https://ibm.box.com/shared/static/ygdswx8s7fj970kuulkzlh8r2mjuzn3k.zip",
     "0.19": "https://ibm.box.com/shared/static/wjoea4x5tnxd0l4lgo2v3kxnx6btxvvl.zip"
   },
-  "qiskit-c": {
-    "dev": "https://ibm.box.com/shared/static/o7d00zku2c4vaj4zuhg9delb6t1f5aev.zip",
-    "2.0": "https://ibm.box.com/shared/static/r3qdbe7yznpi300y12tvksrts9l0xavw.zip"
-  },
   "qiskit-ibm-runtime": {
     "dev": "https://api.github.com/repos/Qiskit/qiskit-ibm-runtime/actions/artifacts/2866218971/zip",
     "0.37": "https://ibm.box.com/shared/static/8rejvdxww0e99kf7bgu3c178gm6583x6.zip",

--- a/scripts/js/commands/api/syncDevDocs.ts
+++ b/scripts/js/commands/api/syncDevDocs.ts
@@ -52,6 +52,7 @@ zxMain(async () => {
 
   if (qiskitUrl) {
     await regenDocs("qiskit", qiskitVersion);
+    await regenDocs("qiskit-c", qiskitVersion);
   }
   if (runtimeUrl) {
     await regenDocs("qiskit-ibm-runtime", runtimeVersion);

--- a/scripts/js/commands/api/syncDevDocs.ts
+++ b/scripts/js/commands/api/syncDevDocs.ts
@@ -93,7 +93,6 @@ async function updateHtmlArtifacts(args: {
   const prior = JSON.parse(rawContent);
   if (qiskitUrl) {
     prior["qiskit"]["dev"] = qiskitUrl;
-    prior["qiskit-c"]["dev"] = qiskitUrl;
   }
   if (runtimeUrl) {
     prior["qiskit-ibm-runtime"]["dev"] = runtimeUrl;

--- a/scripts/js/commands/api/syncDevDocs.ts
+++ b/scripts/js/commands/api/syncDevDocs.ts
@@ -93,6 +93,7 @@ async function updateHtmlArtifacts(args: {
   const prior = JSON.parse(rawContent);
   if (qiskitUrl) {
     prior["qiskit"]["dev"] = qiskitUrl;
+    prior["qiskit-c"]["dev"] = qiskitUrl;
   }
   if (runtimeUrl) {
     prior["qiskit-ibm-runtime"]["dev"] = runtimeUrl;

--- a/scripts/js/commands/api/updateApiDocs.ts
+++ b/scripts/js/commands/api/updateApiDocs.ts
@@ -92,21 +92,6 @@ export async function generateVersion(
   console.log(`Run pipeline for ${pkg.name}:${pkg.versionWithoutPatch}`);
   await runConversionPipeline(sphinxArtifactFolder, "docs", "public/docs", pkg);
   await generateHistoricalRedirects();
-
-  if (pkg.name === "qiskit") {
-    const majorVersion = Number(pkg.version.split(".").pop());
-    if (majorVersion >= 2) {
-      await generateVersion(
-        await Pkg.fromArgs(
-          "qiskit-c",
-          pkg.version,
-          pkg.versionWithoutPatch,
-          pkg.type,
-        ),
-        args,
-      );
-    }
-  }
 }
 
 export function determineMinorVersion(args: Arguments): string {

--- a/scripts/js/commands/api/updateApiDocs.ts
+++ b/scripts/js/commands/api/updateApiDocs.ts
@@ -92,6 +92,21 @@ export async function generateVersion(
   console.log(`Run pipeline for ${pkg.name}:${pkg.versionWithoutPatch}`);
   await runConversionPipeline(sphinxArtifactFolder, "docs", "public/docs", pkg);
   await generateHistoricalRedirects();
+
+  if (pkg.name === "qiskit") {
+    const majorVersion = Number(pkg.version.split(".").pop());
+    if (majorVersion >= 2) {
+      await generateVersion(
+        await Pkg.fromArgs(
+          "qiskit-c",
+          pkg.version,
+          pkg.versionWithoutPatch,
+          pkg.type,
+        ),
+        args,
+      );
+    }
+  }
 }
 
 export function determineMinorVersion(args: Arguments): string {

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -54,6 +54,7 @@ export class Pkg {
   readonly tocGrouping?: TocGrouping;
   /// Convert URLs like `my_pkg.SomeClass` to `some-class` for better SEO.
   readonly kebabCaseAndShortenUrls: boolean;
+  readonly artifactPackageName: string;
 
   static VALID_NAMES = [
     "qiskit",
@@ -79,6 +80,7 @@ export class Pkg {
     releaseNotesConfig?: ReleaseNotesConfig;
     tocGrouping?: TocGrouping;
     kebabCaseAndShortenUrls: boolean;
+    artifactPackageName?: string;
   }) {
     this.name = kwargs.name;
     this.title = kwargs.title;
@@ -91,6 +93,7 @@ export class Pkg {
       kwargs.releaseNotesConfig ?? new ReleaseNotesConfig({});
     this.tocGrouping = kwargs.tocGrouping;
     this.kebabCaseAndShortenUrls = kwargs.kebabCaseAndShortenUrls;
+    this.artifactPackageName = kwargs.artifactPackageName ?? this.name;
   }
 
   static async fromArgs(
@@ -207,6 +210,7 @@ export class Pkg {
           enabled: true,
           linkToPackage: "qiskit",
         }),
+        artifactPackageName: "qiskit",
       });
     }
 

--- a/scripts/js/lib/api/sphinxArtifacts.ts
+++ b/scripts/js/lib/api/sphinxArtifacts.ts
@@ -52,18 +52,19 @@ export async function downloadSphinxArtifact(pkg: Pkg, artifactFolder: string) {
   );
 
   const artifactName = pkg.isDev() ? "dev" : `${pkg.versionWithoutPatch}`;
-  if (!(`${artifactName}` in artifactJson[`${pkg.name}`])) {
+  if (!(`${artifactName}` in artifactJson[`${pkg.artifactPackageName}`])) {
     throw new Error(
-      `Package ${pkg.name} version ${pkg.versionWithoutPatch} doesn't have an artifact stored. You can add one to https://ibm.ent.box.com/folder/246867452622
+      `Package ${pkg.artifactPackageName} version ${pkg.versionWithoutPatch} doesn't have an artifact stored. You can add one to https://ibm.ent.box.com/folder/246867452622
       following the steps detailed in the \`Generate the API docs\` section on the repo's README. If you are not an IBMer with access to the Box folder,
       you can ask in your pull request for a maintainer to help you. In the meantime, you can use another URL in api-html-artifacts.json, such as GitHub or
       even localhost for a server you start up; the URL needs to result in downloading the zip file.`,
     );
   }
-  const artifactUrl = artifactJson[`${pkg.name}`][`${artifactName}`];
+  const artifactUrl =
+    artifactJson[`${pkg.artifactPackageName}`][`${artifactName}`];
 
   await downloadFromBox(
-    pkg.name,
+    pkg.artifactPackageName,
     artifactUrl,
     `${artifactFolder}/artifact.zip`,
   );


### PR DESCRIPTION
This PR combines the generation of Qiskit's Python and C APIs into a single pipeline. Both these APIs use the same artifact and should be generated at the same time.

***

Closes #2863 and closes #2900.
