### PR TITLE
Add notebook categorization check to `./check`

### DIFF
--- a/check
+++ b/check
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # Note that these are ordered from fastest to slowest.
 CHECKS = {
     "notebook linters": ["tox", "-e", "lint"],
+    "all notebooks are tested": ["python", "scripts/ci/check-all-notebooks-are-tested.py"],
     "patterns index pages": ["npm", "run", "check:patterns-index"],
     "Qiskit bot": ["npm", "run", "check:qiskit-bot"],
     "metadata": ["npm", "run", "check:metadata"],


### PR DESCRIPTION
This is checked in CI but not in the local `./check`
