### PR TITLE
Unpin release candidate from nb-tester

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -1,7 +1,7 @@
 # We pin to exact versions for a more reproducible and
 # stable build.
 
-qiskit[all]==2.0.0rc2
+qiskit[all]==2.0.0
 qiskit-ibm-runtime~=0.37.0
 qiskit-aer~=0.17
 qiskit-serverless~=0.21.0


### PR DESCRIPTION
I noticed that the `requirements.txt` for nb-tester still had the 2.0 release candidate pinned. This PR reverts that change and pins the official release of Qiskit 2.0