### PR TITLE
Fix installation instructions for qiskit-addon-utils package

### DIFF
--- a/docs/guides/qiskit-addons-utils.ipynb
+++ b/docs/guides/qiskit-addons-utils.ipynb
@@ -34,7 +34,7 @@
     "The most straightforward way to install the Qiskit addon utilities package is via PyPI.\n",
     "\n",
     "```bash\n",
-    "pip install 'qiskit-addon-aqc-utils'\n",
+    "pip install 'qiskit-addon-utils'\n",
     "```\n",
     "\n",
     "### Install from source\n",


### PR DESCRIPTION
# Fix installation instructions for qiskit-addon-utils package

Updated the pip install command in the qiskit-addons-utils.ipynb documentation file to use the correct package name `qiskit-addon-utils` instead of the incorrect `qiskit-addon-aqc-utils.`
Fixes #2975