### PR TITLE
[Suggestion]: Reduce frequency of dev docs sync

### DIFF
--- a/.github/workflows/dev-docs-sync.yml
+++ b/.github/workflows/dev-docs-sync.yml
@@ -14,7 +14,7 @@ name: Dev docs sync
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 1 * * *" # Every day at 1 am UTC
+    - cron: "0 1 * * 1,3,5" # At 01:00 on Monday, Wednesday, and Friday.
 
 jobs:
   sync:


### PR DESCRIPTION
The dev docs sync runs every day and we often have a few dev docs PRs open at a time which means many are usually not merged. This PR reduces the frequency to run only three times a week, avoiding weekends.
