### PR TITLE
Fix url in execution modes API

### DIFF
--- a/docs/guides/execution-modes-rest-api.mdx
+++ b/docs/guides/execution-modes-rest-api.mdx
@@ -77,7 +77,7 @@ Output
 import json
 import requests
 
-sessionsUrl = "https://quantum.cloud.ibm.com/api/qiskit-runtime-rest/v1/sessions"
+sessionsUrl = "https://quantum.cloud.ibm.com/api/v1/sessions"
 auth_id = "Bearer <YOUR_BEARER_TOKEN>"
 backend = "<BACKEND_NAME>"
 crn = "<SERVICE-CRN>"
@@ -135,7 +135,7 @@ Session closure response ok?: True
 
 <CloudContent>
 ```python
-closureURL="https://quantum.cloud.ibm.com/api/qiskit-runtime-rest/v1/sessions/"+sessionId+"/close"
+closureURL="https://quantum.cloud.ibm.com/api/v1/sessions/"+sessionId+"/close"
 
 headersList = {
   "Accept": "application/json",
@@ -191,7 +191,7 @@ sessionId = response.json()['id']
 import json
 import requests
 
-sessionsUrl = "https://quantum.cloud.ibm.com/api/qiskit-runtime-rest/sessions"
+sessionsUrl = "https://quantum.cloud.ibm.com/api/v1/sessions"
 
 headersList = {
   "Accept": "application/json",


### PR DESCRIPTION
The url for the execution modes REST API calls in our cloud docs is incorrect. This fixed the typo