### PR TITLE
Do not spellcheck URLs

### DIFF
--- a/scripts/config/cspell/cSpell.json
+++ b/scripts/config/cspell/cSpell.json
@@ -47,6 +47,8 @@
     // Method use, e.g. Class.foo()
     "([a-zA-Z_]\\w*)\\.[a-zA-Z_\\.]*",
     // Words with numbers in them, which are usually code
-    "[a-zA-Z]+\\d+[a-zA-Z\\d]*"
+    "[a-zA-Z]+\\d+[a-zA-Z\\d]*",
+    // TOC URLs
+    "^\\s+\"url\": \".+\""
   ]
 }


### PR DESCRIPTION
#2965 added support to spellcheck TOCs, but this has the side-effect of also checking URLs.

Unfortunately, there are some words that are valid in a URL but shouldn't be added to the dictionary as they're not valid elsewhere. One example of this is `grovers`; usually this should be corrected to `Grover's`, but it _is_ valid in a URL. 

Since we can't add file-level ignores in the `_toc.json`, I think the best approach is to ignore these URLs using a regex.

This is not a problem on `main`, but it's blocking CI in #2978.