### PR TITLE
chore: Remove retired device ibm_kyiv from docs guides

### DIFF
--- a/docs/guides/q-ctrl-optimization-solver.ipynb
+++ b/docs/guides/q-ctrl-optimization-solver.ipynb
@@ -102,7 +102,6 @@
     "- ibm_cleveland\n",
     "- ibm_fez\n",
     "- ibm_kawasaki\n",
-    "- ibm_kyiv\n",
     "- ibm_nazca\n",
     "- ibm_quebec\n",
     "- ibm_rensselaer\n",

--- a/docs/guides/q-ctrl-performance-management.ipynb
+++ b/docs/guides/q-ctrl-performance-management.ipynb
@@ -693,7 +693,6 @@
     "- ibm_cleveland\n",
     "- ibm_fez\n",
     "- ibm_kawasaki\n",
-    "- ibm_kyiv\n",
     "- ibm_nazca\n",
     "- ibm_quebec\n",
     "- ibm_rensselaer\n",


### PR DESCRIPTION
ibm_kyiv has been retired, this PR removes mention of it from documentation guides for the Q-CTRL qiskit functions.