### PR TITLE
Update preview hash

### DIFF
--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:c93a25a2473e180c4fd04d2f520d8745f9ad861ce1ce33389d7038c0b9567eef"
+IMAGE_DIGEST = "sha256:ce0d538c976d0b98248eea8d8bae8963c54f98a4a8adff79fe48a87e227dc92a"
 
 # Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
 # https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7


### PR DESCRIPTION
This is a prework for https://github.com/Qiskit/documentation/pull/2958 and https://github.com/Qiskit/documentation/pull/2973. The new image, removes the `/docs` segment from the links if needed.