### PR TITLE
Add ibm_kyiv to retired QPUs list

### DIFF
--- a/docs/guides/retired-qpus.mdx
+++ b/docs/guides/retired-qpus.mdx
@@ -29,6 +29,7 @@ The following IBM&reg; quantum processing units (QPUs) have been retired. For th
 
 | QPU name       | Qubit count | Retirement date (Year - month - day) |
 | ----------------- | ----------- | --------------- |
+| ibm_kyiv          | **127**     | 2025-04-18      |
 | ibm_nazca         | **127**     | 2024-12-04      |
 | ibm_kyoto         | **127**     | 2024-09-05      |
 | ibm_osaka         | **127**     | 2024-08-13      |


### PR DESCRIPTION
ibm_kyiv, 127-qubit QPU, has been retired as of Friday 18 April 2025.