### PR TITLE
Update run-jobs-batch.mdx to be more explicit about the wording

### DIFF
--- a/docs/guides/run-jobs-batch.mdx
+++ b/docs/guides/run-jobs-batch.mdx
@@ -21,8 +21,8 @@ service = QiskitRuntimeService()
 
 ## Open a batch
 
-You can open a runtime batch by using the context manager `with Batch(...)` or by initializing the `Batch`
-class. When you start a batch,  you must specify a QPU by passing a `backend` object.  The batch starts when its first job begins execution.
+You can open a runtime batch by using the context manager `with <Batch instance>` or by passing a `Batch` instance to the parameter `mode=` of the primitive.
+When you start a batch,  you must specify a QPU by passing a `backend` object.  The batch starts when its first job begins execution.
 
 
 **Batch class**

--- a/docs/guides/run-jobs-batch.mdx
+++ b/docs/guides/run-jobs-batch.mdx
@@ -21,7 +21,7 @@ service = QiskitRuntimeService()
 
 ## Open a batch
 
-You can open a runtime batch by using the context manager `with <Batch instance>` or by passing a `Batch` instance to the parameter `mode=` of the primitive.
+You can open a runtime batch by using the context manager `with <Batch instance>` or by passing a `Batch` instance to the primitive's `mode` parameter.  
 When you start a batch,  you must specify a QPU by passing a `backend` object.  The batch starts when its first job begins execution.
 
 


### PR DESCRIPTION
The expression "initializing the `Batch` class" might refer to the `__init__` call of a class. I think "passing a `Batch` instance to the parameter `mode=` of the primitive" is more correct.