### PR TITLE
Squash `gh-pages` commit history every night

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -13,9 +13,8 @@
 name: PR preview cleanup
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "main"
+  schedule:
+    - cron: "0 0 * * *" # At midnight
 
 jobs:
   preview-cleanup:

--- a/scripts/pr-previews/cleanup.py
+++ b/scripts/pr-previews/cleanup.py
@@ -44,9 +44,10 @@ def main() -> None:
         current_branch = run_subprocess(
             ["git", "branch", "--show-current"]
         ).stdout.strip()
-        assert (
-            current_branch == "gh-pages"
-        ), f"Did not expect to be on branch '{current_branch}'; exiting"
+        if current_branch != "gh-pages":
+            raise AssertionError(
+                f"Did not expect to be on branch '{current_branch}'; exiting"
+            )
 
         # Squash all commits on this branch to save space
         run_subprocess(["git", "reset", "--soft", INITIAL_COMMIT])


### PR DESCRIPTION
Part of #2799.

This PR changes the PR preview cleanup to squash all commits on the branch, and to run at midnight rather than every push to `main`.
