### PR TITLE
Ignore `Untitled*.ipynb` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ poetry.lock
 .mypy_cache/
 /dist/
 /test-results/
+Untitled*.ipynb


### PR DESCRIPTION
Writers sometimes use new notebooks as scratch pads and it can be annoying when they show up in version control. This PR ignores unnamed notebooks (called `Untitled` by default). This is safe as we'll never want to commit an unnamed notebook. I wouldn't recommend adding this as a global ignore rule because I have seen other repos with `Untitled.ipynb` committed.
