### PR TITLE
Sometime "timeout", sometimes "TTL"

### DIFF
--- a/docs/guides/execution-modes-faq.mdx
+++ b/docs/guides/execution-modes-faq.mdx
@@ -57,7 +57,7 @@ No. On-demand calibration is not available.
 
 <details>
   <summary>
-    Is there an interactive timeout (ITTL) with session mode?
+    Is there an interactive timeout (interactive time to live, or Interactive TTL) with session mode?
   </summary>
 
 Yes. This reduces unwanted cost if a user forgets to close their session.
@@ -65,10 +65,10 @@ Yes. This reduces unwanted cost if a user forgets to close their session.
 
 <details>
   <summary>
-    Can I change the interactive timeout (ITTL) or the maximum timeout of a session?
+    Can I change the interactive timeout (interactive time to live, or Interactive TTL) or the maximum timeout (time to live, or TTL) of a session?
   </summary>
 
-You cannot change the interactive timeout value. You can change the maximum timeout value of a session (see [Specify the session length](run-jobs-session#specify-length)), but it must be less than the system-defined maximum. Ask your administrator to contact IBM support if you need a different interactive TTL or system maximum TTL.
+You cannot change the timeout (interactive time to live, or Interactive TTL) value. You can change the maximum TTL value of a session (see [Specify the session length](run-jobs-session#specify-length)), but it must be less than the system-defined maximum. Ask your administrator to contact IBM support if you need a different interactive TTL or system maximum TTL.
 
 </details>
 
@@ -101,7 +101,7 @@ No.  Sessions run in dedicated mode, which means that the user has total access 
     Is compilation time counted as usage in session mode?
   </summary>
 
-Yes.  In session mode, usage is the wall clock time the QPU is **committed to the session**. It starts when the first session job starts and ends when the session goes inactive, is closed, or when the last job completes, whichever happens **last**. Thus, usage continues to accumulate after a session ends if the QPU is still running a job. Additionally, time after a job completes while the QPU waits for another session job (the interactive time to live (ITTL)) counts as usage. This is why you should ensure the session is closed as soon as you are done submitting jobs to it.
+Yes.  In session mode, usage is the wall clock time the QPU is **committed to the session**. It starts when the first session job starts and ends when the session goes inactive, is closed, or when the last job completes, whichever happens **last**. Thus, usage continues to accumulate after a session ends if the QPU is still running a job. Additionally, time after a job completes while the QPU waits for another session job (the interactive time to live) counts as usage. This is why you should ensure the session is closed as soon as you are done submitting jobs to it.
 </details>
 
 ## Batch

--- a/docs/guides/run-jobs-batch.mdx
+++ b/docs/guides/run-jobs-batch.mdx
@@ -69,7 +69,7 @@ Default values:
 | --- | --- | --- |
 | Both Open and Premium Plan | 1 sec | 10 min |
 
-To determine a batch's max TTL or interactive TTL, follow the instructions in [Determine batch details](#batch-details) and look for the `max_time`or `interactive_timeout` value, respectively.
+To determine a batch's maximum TTL or interactive TTL, follow the instructions in [Determine batch details](#batch-details) and look for the `max_time`or `interactive_timeout` value, respectively.
 
 <span id="close"></span>
 ## Close a batch
@@ -108,7 +108,7 @@ batch.close()
 <span id="batch-details"></span>
 ## Determine batch details
 
-For a comprehensive overview of a batch's configuration and status, including its interactive and max TTL, use the  `batch.details() method`.
+For a comprehensive overview of a batch's configuration and status, including its interactive and maximum TTL, use the  `Batch.details` method.
 
 ```python
 from qiskit_ibm_runtime import QiskitRuntimeService, batch, SamplerV2 as Sampler

--- a/docs/guides/run-jobs-session.mdx
+++ b/docs/guides/run-jobs-session.mdx
@@ -113,14 +113,14 @@ Default values:
 </CloudContent>
 *\* Certain Premium Plan instances might be configured to have a different value.*
 
-To determine a session's max TTL or  interactive TTL, follow the instructions in [Determine session details](#session-details) and look for the `max_time`or `interactive_timeout` value, respectively.
+To determine a session's maximum TTL or interactive TTL, follow the instructions in [Determine session details](#session-details) and look for the `max_time`or `interactive_timeout` value, respectively.
 
 <span id="ends"></span>
 ## End a session
 
 A session ends in the following circumstances:
 
-* The maximum timeout (TTL) value is reached, resulting in the cancellation of all queued jobs.
+* The maximum time to live (TTL) value is reached, resulting in the cancellation of all queued jobs.
 * The session is manually canceled, resulting in the cancellation of all queued jobs.
 * The session is manually closed.  The session stops accepting new jobs but continues to run queued jobs with priority.
 * If you use Session as a context manager, that is,  `with Session()`, the session is automatically closed when the context ends (the same behavior as using `session.close()`).
@@ -128,7 +128,7 @@ A session ends in the following circumstances:
 <span id="close"></span>
 ### Close a session
 
-A session automatically closes when it exits the context manager. When the session context manager is exited, the session is put into "In progress, not accepting new jobs" status. This means that the session finishes processing all running or queued jobs until the maximum timeout value is reached. After all jobs are completed, the session is immediately closed. This allows the scheduler to run the next job without waiting for the session interactive timeout, thereby reducing the average job queuing time. You cannot submit jobs to a closed session.
+A session automatically closes when it exits the context manager. When the session context manager is exited, the session is put into "In progress, not accepting new jobs" status. This means that the session finishes processing all running or queued jobs until the maximum timeout (time to live, or TTL) value is reached. After all jobs are completed, the session is immediately closed. This allows the scheduler to run the next job without waiting for the session interactive timeout, thereby reducing the average job queuing time. You cannot submit jobs to a closed session.
 
 <CloudContent>
 <Admonition type="caution">

--- a/docs/guides/run-jobs-session.mdx
+++ b/docs/guides/run-jobs-session.mdx
@@ -82,7 +82,7 @@ with Session(backend=backend):
 <span id="specify-length"></span>
 ## Session length
 
-The maximum session time to live (TTL) determines how long a session can run.  You can set this value with the `max_time` parameter. This should exceed the longest job's execution time.
+The maximum session time to live (TTL) determines how long a session can run before expires.  You can set this value with the `max_time` parameter. This should exceed the longest job's execution time.
 
 This timer starts when the session starts.  When the value is reached, the session is closed.  Any jobs that are running will finish, but jobs still queued are failed.
 


### PR DESCRIPTION
Searching about job expiration, I noticed that the word "expiration" it was not in the docs and made it hard to find it :)

I also noticed that sometimes _timeout_ is used and sometimes _TTL_. I understand that they are related concepts, so I tried to linked them.