### PR TITLE
Fix SQD notebook compatibility with Jupyter Lab (#3052)

### DIFF
--- a/docs/guides/qiskit-addons-sqd-get-started.ipynb
+++ b/docs/guides/qiskit-addons-sqd-get-started.ipynb
@@ -2449,5 +2449,5 @@
   "title": "Getting started with SQD"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Fix SQD notebook compatibility with Jupyter Lab

This PR fixes issue #3052 where the "Getting started with SQD" notebook could not be opened in Jupyter Lab.

The notebook was throwing a validation error in Jupyter Lab with the message:
"ValidationError: 'The notebook is invalid and is missing an expected key: metadata'"

After investigation, I found that while the metadata field was present, the issue was with the notebook format version. The notebook was using `nbformat_minor: 2`, which caused validation issues in Jupyter Lab.

I've updated the `nbformat_minor` from 2 to 5, which allows the notebook to be properly opened in Jupyter Lab while maintaining compatibility with VS Code.

No content changes were made to the notebook - this is purely a format version update.

Fixes #3052