### PR TITLE
Fix mislabeled section of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/courses.yaml
+++ b/.github/ISSUE_TEMPLATE/courses.yaml
@@ -36,7 +36,7 @@ body:
 
   - type: textarea
     attributes:
-      label: URL to the relevant tutorial
+      label: URL to the relevant course
       description: provide a URL and section name/paragraph if reporting a problem with existing content.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/guides.yaml
+++ b/.github/ISSUE_TEMPLATE/guides.yaml
@@ -36,7 +36,7 @@ body:
 
   - type: textarea
     attributes:
-      label: URL to the relevant tutorial
+      label: URL to the relevant guide or resource
       description: provide a URL and section name/paragraph if reporting a problem with existing content.
     validations:
       required: false


### PR DESCRIPTION
"tutorial" is copied in all three types of issue template.