### PR TITLE
Minor fixes to the timing pages

### DIFF
--- a/docs/guides/max-execution-time.mdx
+++ b/docs/guides/max-execution-time.mdx
@@ -35,7 +35,7 @@ The maximum execution time for a job is the smaller of these values:
 - The value set for `max_execution_time`
 - The service-determined job timeout value
 
-The `max_execution_time` value is based on _quantum time_, not wall clock time. Quantum time is the time spent by the QPU complex to process the job. Simulator jobs use wall clock time because they do not have quantum time.
+The `max_execution_time` value is based on _quantum time_, not wall clock time. Quantum time is the amount of time that the QPU is dedicated to processing your job. Simulator jobs use wall clock time because they do not have quantum time.
 
 Set the maximum execution time (in seconds) on the job options, as shown in the following example.  See [Specify options](/docs/guides/specify-runtime-options) for information about setting options.
 
@@ -59,11 +59,11 @@ print(f"Quantum time used by job {job.job_id()} was {job.metrics()['usage']['qua
 ```
 
 <span id="max-QPU"></span>
-### QPU maximum execution time
+### Service-calculated maximum execution time
 
-The QPU calculates an appropriate job timeout value based on the input circuits and options. This QPU-calculated timeout is capped at 3 hours to ensure fair device usage. If a `max_execution_time` is also specified for the job, the lesser of the two values is used.
+The service calculates an appropriate job timeout value based on the input circuits and options. This service-calculated timeout is capped at 3 hours to ensure fair device usage. If a `max_execution_time` is also specified for the job, the lesser of the two values is used.
 
-For example, if you specify `max_execution_time=5000` (approximately 83 minutes), but the QPU determines it should not take more than 5 minutes (300 seconds) to execute the job, then the job is canceled after 5 minutes.
+For example, if you specify `max_execution_time=5000` (approximately 83 minutes), but the service determines it should not take more than 5 minutes (300 seconds) to execute the job, then the job is canceled after 5 minutes.
 
 <span id="batch-max-time"></span>
 ## Batch maximum execution time
@@ -86,11 +86,11 @@ For instructions to work with these values, see [Run jobs in a session.](/docs/g
 ## Other limitations
 <LegacyContent>
 *   Inputs to jobs cannot exceed 64MB in size.
-*   Open Plan users can use up to 10 minutes of QPU execution time per month (resets at 00:00 UTC on the first of each month). QPU execution time is the amount of time that the QPU is dedicated to processing your job. You can track your monthly usage on the [Platform dashboard,](https://quantum.ibm.com/)  [IBM Quantum&reg; Platform Workloads page,](https://quantum.ibm.com/workloads) and [Account](https://quantum.ibm.com/account) page.
+*   Open Plan users can use up to 10 minutes of quantum time per month (resets at 00:00 UTC on the first of each month). Quantum time is the amount of time that the QPU is dedicated to processing your job. You can track your monthly usage on the [Platform dashboard,](https://quantum.ibm.com/)  [IBM Quantum&reg; Platform Workloads page,](https://quantum.ibm.com/workloads) and [Account](https://quantum.ibm.com/account) page.
 </LegacyContent>
 <CloudContent>
-*   Inputs to jobs cannot exceed 64MB in size.
-*   Open Plan users can use up to 10 minutes of QPU execution time per month. QPU execution time is the amount of time that the QPU is dedicated to processing your job. You can view an instance's usage on the [Instances](https://quantum.cloud.ibm.com/instances) page.
+*   Inputs to jobs cannot exceed 50MB in size.
+*   Open Plan users can use up to 10 minutes of quantum time per month. Quantum time is the amount of time that the QPU is dedicated to processing your job. You can view an instance's usage on the [Instances](https://quantum.cloud.ibm.com/instances) page.
 </CloudContent>
 ## Next steps
 

--- a/docs/guides/minimize-time.mdx
+++ b/docs/guides/minimize-time.mdx
@@ -14,7 +14,7 @@ There are several ways you can limit the amount of time spent processing and run
 
 - Use only the necessary settings for error suppression and error mitigation, because higher values can cause your jobs to run longer. See [Introduction to options](./runtime-options-overview), [Configure error suppression](./configure-error-suppression), and [Configure error mitigation](configure-error-mitigation) for details.
 
-- If you are running multiple jobs that contain the same (likely parameterized) circuits and using an error mitigation method that requires noise models, such as PEA and PEC, consider using `NoiseLearner`. This helper program allows you to learn the noise model of a circuit once and reuse the model in subsequent Estimator queries. Note that a noise model becomes stale after certain time, so this is only practical if there is no long delay between jobs (e.g. within a Session). See [Noise learning helper
+- If you are running multiple jobs that contain the same (likely parameterized) circuits and are using an error mitigation method that requires noise models, such as PEA and PEC, consider using `NoiseLearner`. With this helper program, you can learn the noise model of a circuit once and reuse the model in subsequent Estimator queries. Note that a noise model becomes stale after a certain time, so this is only practical if there is no long delay between jobs (for example, within a session). See [Noise learning helper
 ](./noise-learning) for more details.
 
 ## Next steps

--- a/docs/guides/minimize-time.mdx
+++ b/docs/guides/minimize-time.mdx
@@ -6,13 +6,16 @@ description: How to minimize the amount of quantum time spent processing and run
 
 # Minimize job run time
 
-There are several ways you can limit the amount of quantum time spent processing and running a job:
+There are several ways you can limit the amount of time spent processing and running a job:
 
-- Run only as many iterations and shots as you need: The time your workload takes (and therefore, its cost) depends on how many jobs you create in a session and how many shots are run in each job. Therefore, you can manage your cost by running only as many jobs and shots as you need.
+- Run only as many shots as you need: The quantum time a job takes (and therefore, its cost) scales with the number of shots. Therefore, you can manage your cost by running only as many shots as you need. For Estimator jobs, lower precision typically requires more shots and therefore longer execution time.
 
-- Set limits on execution time:  You can limit how long each job or session runs.  For details, see [Maximum execution time for a Qiskit Runtime job or session](max-execution-time).
+- Set limits on execution time:  You can limit how long each job, batch, or session runs.  For details, see [Maximum execution time for Qiskit Runtime workloads](max-execution-time).
 
-- Use only the necessary settings for error suppression, error mitigation, and optimization, because higher values can cause your jobs to run longer. See [Algorithm tuning options](./runtime-options-overview), [Configure runtime compilation](./configure-error-suppression), and [Configure error mitigation](configure-error-mitigation) for details.
+- Use only the necessary settings for error suppression and error mitigation, because higher values can cause your jobs to run longer. See [Introduction to options](./runtime-options-overview), [Configure error suppression](./configure-error-suppression), and [Configure error mitigation](configure-error-mitigation) for details.
+
+- If you are running multiple jobs that contain the same (likely parameterized) circuits and using an error mitigation method that requires noise models, such as PEA and PEC, consider using `NoiseLearner`. This helper program allows you to learn the noise model of a circuit once and reuse the model in subsequent Estimator queries. Note that a noise model becomes stale after certain time, so this is only practical if there is no long delay between jobs (e.g. within a Session). See [Noise learning helper
+](./noise-learning) for more details.
 
 ## Next steps
 

--- a/docs/guides/noise-learning.ipynb
+++ b/docs/guides/noise-learning.ipynb
@@ -93,7 +93,7 @@
    "id": "1859540c-a597-411a-ab98-1b436b284f8a",
    "metadata": {},
    "source": [
-    "The resulting `NoiseLearnerResult.data` is a list of [`LayerError`](../api/qiskit-ibm-runtime/utils-noise-learner-result-layer-error) objects containing the [noise model](https://arxiv.org/abs/2201.09866) for each individual entangling layer that belongs to the target circuit(s). Each `LayerError` stores the layer information, in the form of a circuit and a set of qubit labels, alongside the [`PauliLindBladError`](../api/qiskit-ibm-runtime/utils-noise-learner-result-pauli-lindblad-error) for the noise model that was learned for the given layer."
+    "The resulting `NoiseLearnerResult.data` is a list of [`LayerError`](../api/qiskit-ibm-runtime/utils-noise-learner-result-layer-error) objects containing the [noise model](https://arxiv.org/abs/2201.09866) for each individual entangling layer that belongs to the target circuit(s). Each `LayerError` stores the layer information, in the form of a circuit and a set of qubit labels, alongside the [`PauliLindbladError`](../api/qiskit-ibm-runtime/utils-noise-learner-result-pauli-lindblad-error) for the noise model that was learned for the given layer."
    ]
   },
   {


### PR DESCRIPTION
Some minor fixes to the pages on timing, including

- Use the same wording to describe quantum time
- Change `QPU-calculated max execution time` to `service-calculated`, since QPU is just hardware
- Fix hyperlink text to match the new topic names
- Add wording on minimizing run time for estimator jobs