### PR TITLE
Remove isNew pill from plans overview

### DIFF
--- a/docs/guides/plans-overview.mdx
+++ b/docs/guides/plans-overview.mdx
@@ -1,8 +1,6 @@
 ---
 title: Overview of plans
 description: Overview of the available plans; Standard, Premium, and Open
-isNew: true
-isNewDate: 2025-04-30
 platform: cloud
 ---
 


### PR DESCRIPTION
This PR removes the `isNew` tag from the plan overview metadata.
