### PR TITLE
Update docker digest from start script

### DIFF
--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:d8a00e4db6a9a0e7706ae32f6d3f824eb49d95d2e752d29f741941f85d071a30"
+IMAGE_DIGEST = "sha256:1ba578bfa4e90e5b16eaff1808b19a23c259dbea6bcccc1a02e64dc026602bb7"
 
 # Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
 # https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7


### PR DESCRIPTION
This PR updates the image digest from the `start` script. The new image allows the user to override the dividers from the TOC.