### PR TITLE
AQC = approximate quantum compilation

### DIFF
--- a/docs/guides/qiskit-addons-aqc.mdx
+++ b/docs/guides/qiskit-addons-aqc.mdx
@@ -1,9 +1,9 @@
 ---
-title: Approximate quantum compiler with tensor networks
+title: Approximate quantum compilation with tensor networks
 description: Overview of the addon for approximate quantum compilation using tensor networks
 ---
 
-# Approximate quantum compiler with tensor networks (AQC-Tensor)
+# Approximate quantum compilation with tensor networks (AQC-Tensor)
 
 The Approximate quantum compilation with tensor networks (AQC-Tensor) Qiskit addon enables users to compile the *initial portion* of a circuit into a nearly equivalent approximation of that circuit, but with much fewer layers. This is accomplished using tensor networks using the method described in [[1]](#references). Its primary utility is in circuits which simulate time evolution, but may be applicable to any class of circuits which has access to:
 


### PR DESCRIPTION
This updates it so AQC consistently is expanded as "approximate quantum compilation"

This content was originally added in #2291.