### PR TITLE
Specify rolling plan is for Premium only

### DIFF
--- a/docs/guides/fair-share-scheduler.mdx
+++ b/docs/guides/fair-share-scheduler.mdx
@@ -32,12 +32,12 @@ When you submit a workload to a quantum processing unit (QPU), it enters the sch
 * **Account:** Individuals and organizations use an IBM Cloud account to access IBM Quantum Platform and Qiskit Runtime.
 * **Instance:** The base-level construct to which time is allocated from the overarching account to a set of QPUs, and to which users are directly assigned. Instances are connected to a specific region and [plan](/docs/guides/plans-overview). See the [Instances](/docs/guides/instances) guide for more information.
 </CloudContent>
-*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago.
+*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
 <LegacyContent>
-*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes.
+*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
 </LegacyContent>
 <CloudContent>
-*   **Time used:** For every instance, during the 28-day rolling window, all usage on all the QPUs is accounted for. These include all successful workloads, as well as workloads returning known select error codes.
+*   **Time used:** For every instance, during the 28-day rolling window, all usage on all the QPUs is accounted for. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
 </CloudContent>
 
 ## Allocation and administration

--- a/docs/guides/fair-share-scheduler.mdx
+++ b/docs/guides/fair-share-scheduler.mdx
@@ -32,9 +32,12 @@ When you submit a workload to a quantum processing unit (QPU), it enters the sch
 * **Account:** Individuals and organizations use an IBM Cloud account to access IBM Quantum Platform and Qiskit Runtime.
 * **Instance:** The base-level construct to which time is allocated from the overarching account to a set of QPUs, and to which users are directly assigned. Instances are connected to a specific region and [plan](/docs/guides/plans-overview). See the [Instances](/docs/guides/instances) guide for more information.
 </CloudContent>
-*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
+*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago. 
+<CloudContent>
+(*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
+</CloudContent>
 <LegacyContent>
-*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
+*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes.
 </LegacyContent>
 <CloudContent>
 *   **Time used:** For every instance, during the 28-day rolling window, all usage on all the QPUs is accounted for. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)

--- a/docs/guides/fair-share-scheduler.mdx
+++ b/docs/guides/fair-share-scheduler.mdx
@@ -32,12 +32,12 @@ When you submit a workload to a quantum processing unit (QPU), it enters the sch
 * **Account:** Individuals and organizations use an IBM Cloud account to access IBM Quantum Platform and Qiskit Runtime.
 * **Instance:** The base-level construct to which time is allocated from the overarching account to a set of QPUs, and to which users are directly assigned. Instances are connected to a specific region and [plan](/docs/guides/plans-overview). See the [Instances](/docs/guides/instances) guide for more information.
 </CloudContent>
-*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
+*   **28-day rolling window:** The fair-share scheduler accounts for usage over a rolling time window. Only execution time accumulated within that window is accounted for the purpose of fairness. The length of that window is currently 28 days. When the fair-share scheduler is invoked, it takes into account usage starting 28 days ago. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
 <LegacyContent>
-*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
+*   **Time used:** For every instance, during the 28-day rolling window, we account for all usage on all the QPUs of the IBM Quantum Premium Plan. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
 </LegacyContent>
 <CloudContent>
-*   **Time used:** For every instance, during the 28-day rolling window, all usage on all the QPUs is accounted for. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window applies only to Premium Plan, not to Flex Plan.)
+*   **Time used:** For every instance, during the 28-day rolling window, all usage on all the QPUs is accounted for. These include all successful workloads, as well as workloads returning known select error codes. (*Note:* The rolling time window does not apply to Flex Plan. The fair-share ratio for Flex Plan is total usage versus allocation.)
 </CloudContent>
 
 ## Allocation and administration


### PR DESCRIPTION
Mention on fair-share-scheduler page that the 28-day rolling window only applies to Premium, not Flex Plan.
