### PR TITLE
Update testing env to include `PendingDeprecation` warnings

### DIFF
--- a/docs/guides/circuit-library.ipynb
+++ b/docs/guides/circuit-library.ipynb
@@ -56,7 +56,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "a846a845-7ac5-4c92-b124-d2b90a773ba2",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+        "ignore-warnings"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -97,6 +101,17 @@
     "    \"# Add a controlled-phase gate to the circuit 'qc'\"\n",
     "  ]}\n",
     "/>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff50da63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.simplefilter('default', category=PendingDeprecationWarning)\n"
    ]
   },
   {
@@ -482,7 +497,7 @@
  "metadata": {
   "description": "Read more about out-of-the-box circuits provided by the Qiskit circuit library, including N-local, time-evolution and data-encoding circuits",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "test-pendingDeprecation",
    "language": "python",
    "name": "python3"
   },
@@ -496,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3"
+   "version": "3.11.11"
   },
   "title": "Circuit library"
  },

--- a/docs/guides/circuit-library.ipynb
+++ b/docs/guides/circuit-library.ipynb
@@ -58,7 +58,7 @@
    "id": "a846a845-7ac5-4c92-b124-d2b90a773ba2",
    "metadata": {
     "tags": [
-        "ignore-warnings"
+     "ignore-warnings"
     ]
    },
    "outputs": [
@@ -111,7 +111,8 @@
    "outputs": [],
    "source": [
     "import warnings\n",
-    "warnings.simplefilter('default', category=PendingDeprecationWarning)\n"
+    "\n",
+    "warnings.simplefilter(\"default\", category=PendingDeprecationWarning)"
    ]
   },
   {
@@ -497,7 +498,7 @@
  "metadata": {
   "description": "Read more about out-of-the-box circuits provided by the Qiskit circuit library, including N-local, time-evolution and data-encoding circuits",
   "kernelspec": {
-   "display_name": "test-pendingDeprecation",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -511,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3"
   },
   "title": "Circuit library"
  },

--- a/docs/guides/circuit-library.ipynb
+++ b/docs/guides/circuit-library.ipynb
@@ -104,18 +104,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff50da63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import warnings\n",
-    "\n",
-    "warnings.simplefilter(\"default\", category=PendingDeprecationWarning)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "f1d7c8c9-1b4d-45e1-9cd5-c5d76c2e25ab",
    "metadata": {},

--- a/docs/guides/qiskit-addons-mpf-get-started.ipynb
+++ b/docs/guides/qiskit-addons-mpf-get-started.ipynb
@@ -157,7 +157,11 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "d2f308be-2c13-475c-b9a7-390883a620bc",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+        "ignore-warnings"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/config.py
@@ -76,8 +76,8 @@ def get_notebook_jobs(args: argparse.Namespace) -> Iterator[NotebookJob]:
 
             warning_filter = ""
             if config.check_pending_deprecations:
-                warning_filter = "import warnings as warnings \
-                \nwarnings.simplefilter('default', category=PendingDeprecationWarning)"
+                warning_filter = "import warnings as _warnings \
+                \n_warnings.simplefilter('default', category=PendingDeprecationWarning)"
             pre_execute_code = PRE_EXECUTE_CODE + warning_filter
 
             patch = config.get_patch_for_group(group)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
   -e scripts/nb-tester
   -r scripts/nb-tester/requirements.txt
 setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
-commands = test-docs-notebooks {posargs} --config-path scripts/config/notebook-testing.toml
+commands = test-docs-notebooks {posargs} --check-pending-deprecations --config-path scripts/config/notebook-testing.toml
 
 [testenv:{lint,fix}]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,7 @@ skipsdist = true
 deps =
   -e scripts/nb-tester
   -r scripts/nb-tester/requirements.txt
-setenv = 
-    PYDEVD_DISABLE_FILE_VALIDATION=1
-    PYTHONDEVMODE=1
+setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
 commands = test-docs-notebooks {posargs} --config-path scripts/config/notebook-testing.toml
 
 [testenv:{lint,fix}]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ skipsdist = true
 deps =
   -e scripts/nb-tester
   -r scripts/nb-tester/requirements.txt
-setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
+setenv = 
+    PYDEVD_DISABLE_FILE_VALIDATION=1
+    PYTHONDEVMODE=1
 commands = test-docs-notebooks {posargs} --config-path scripts/config/notebook-testing.toml
 
 [testenv:{lint,fix}]


### PR DESCRIPTION
Closes #2716 

According to the official python docs, `PendingDeprecation` warnings are [ignored by default](https://docs.python.org/3/library/exceptions.html#PendingDeprecationWarning) unless [Python Development Mode](https://docs.python.org/3/library/devmode.html) is enabled (done either through the `-Xdev` or `-Wd` flags when invoking `python` or by setting the environment variable `PYTHONDEVMODE=1`). 

This PR sets the `tox` environment to run using dev mode with the `PYTHONDEVMODE` env var.