### PR TITLE
Fix small error

### DIFF
--- a/docs/guides/hello-world.ipynb
+++ b/docs/guides/hello-world.ipynb
@@ -208,7 +208,7 @@
     "<Admonition type=\"note\" title=\"Operator Notation\">\n",
     "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 1 and Z on qubit 0 together, and obtaining information about the correlation between qubit 1 and qubit 0. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
     "\n",
-    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be different from the measurement of $\\langle I_1 \otimes Z_0 \\rangle \\langle Z_1 \otimes I_0 \\rangle$. For the specific entangled state created by our circuit described above, the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1 and the measurement of $\\langle I_1 \otimes Z_0 \\rangle \\langle Z_1 \otimes I_0 \\rangle$ should be zero.\n",
+    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be different from the measurement of $\\langle I_1 \\otimes Z_0 \\rangle \\langle Z_1 \\otimes I_0 \\rangle$. For the specific entangled state created by our circuit described above, the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1 and the measurement of $\\langle I_1 \\otimes Z_0 \\rangle \\langle Z_1 \\otimes I_0 \\rangle$ should be zero.\n",
     "</Admonition>"
    ]
   },

--- a/docs/guides/hello-world.ipynb
+++ b/docs/guides/hello-world.ipynb
@@ -208,7 +208,7 @@
     "<Admonition type=\"note\" title=\"Operator Notation\">\n",
     "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 1 and Z on qubit 0 together, and obtaining information about the correlation between qubit 1 and qubit 0. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
     "\n",
-    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1.\n",
+    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0\\rangle$ should be different from the measurement of $\\langle I_1\otimes Z_0\\rangle\\langle Z_1\otimes I_0\\rangle$. For the specific entangled state created by our circuit described above, the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1 and the measurement of $\\langle I_1\otimes Z_0\\rangle\\langle Z_1\otimes I_0\\rangle$ should be zero.\n",
     "</Admonition>"
    ]
   },

--- a/docs/guides/hello-world.ipynb
+++ b/docs/guides/hello-world.ipynb
@@ -208,7 +208,7 @@
     "<Admonition type=\"note\" title=\"Operator Notation\">\n",
     "Here, something like the `ZZ` operator is a shorthand for the tensor product $Z\\otimes Z$, which means measuring Z on qubit 1 and Z on qubit 0 together, and obtaining information about the correlation between qubit 1 and qubit 0. Expectation values like this are also typically written as $\\langle Z_1 Z_0 \\rangle$.\n",
     "\n",
-    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0\\rangle$ should be different from the measurement of $\\langle I_1\otimes Z_0\\rangle\\langle Z_1\otimes I_0\\rangle$. For the specific entangled state created by our circuit described above, the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1 and the measurement of $\\langle I_1\otimes Z_0\\rangle\\langle Z_1\otimes I_0\\rangle$ should be zero.\n",
+    "If the state is entangled, then the measurement of $\\langle Z_1 Z_0 \\rangle$ should be different from the measurement of $\\langle I_1 \otimes Z_0 \\rangle \\langle Z_1 \otimes I_0 \\rangle$. For the specific entangled state created by our circuit described above, the measurement of $\\langle Z_1 Z_0 \\rangle$ should be 1 and the measurement of $\\langle I_1 \otimes Z_0 \\rangle \\langle Z_1 \otimes I_0 \\rangle$ should be zero.\n",
     "</Admonition>"
    ]
   },


### PR DESCRIPTION
The Hello World guide seems to have a error (or potentially misleading statement) in its description of an expectation value. While it is true that the referenced expectation value is 1 for the specific entangled state created by the example circuit, that expectation value does not have to be 1 for all entangled states. 