### PR TITLE
Try to fix team tag in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/courses.yaml
+++ b/.github/ISSUE_TEMPLATE/courses.yaml
@@ -5,7 +5,7 @@ assignees:
   - jhwatrous
   - livlanes
   - christopherporter1
-  - Qiskit/docs-content-team
+  - docs-content-team
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/guides.yaml
+++ b/.github/ISSUE_TEMPLATE/guides.yaml
@@ -2,7 +2,7 @@ name: (GUIDES AND ADDITIONAL RESOURCES 📜) Report a bug/typo or request new co
 description: Report typos, bugs, out-of-date content, broken links, etc. or make a request for new content
 labels: ["content 📄", "needs triage 🤔"]
 assignees:
-  - Qiskit/docs-content-team
+  - docs-content-team
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/tutorials.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorials.yaml
@@ -4,7 +4,7 @@ labels: ["content 📄", "tutorial 📒", "needs triage 🤔"]
 assignees:
   - miamico
   - nathanearnestnoble
-  - Qiskit/docs-content-team
+  - docs-content-team
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/tutorials.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorials.yaml
@@ -81,8 +81,8 @@ body:
 
   - type: markdown
     attributes:
-      value: Thank you for your feedback! If you are interested in joining the IBM Quantum Feedback Program, <a href="https://www.ibm.com/quantum/feedback-program">sign up here</a>. 
-  
+      value: Thank you for your feedback! If you are interested in joining the IBM Quantum Feedback Program, <a href="https://www.ibm.com/quantum/feedback-program">sign up here</a>.
+
   - type: markdown
     attributes:
       value: Tagging the [Docs content team](https://github.com/orgs/Qiskit/teams/docs-content-team)

--- a/.github/ISSUE_TEMPLATE/tutorials.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorials.yaml
@@ -81,4 +81,8 @@ body:
 
   - type: markdown
     attributes:
-      value: Thank you for your feedback! If you are interested in joining the IBM Quantum Feedback Program, <a href="https://www.ibm.com/quantum/feedback-program">sign up here</a>.
+      value: Thank you for your feedback! If you are interested in joining the IBM Quantum Feedback Program, <a href="https://www.ibm.com/quantum/feedback-program">sign up here</a>. 
+  
+  - type: markdown
+    attributes:
+      value: Tagging the [Docs content team](https://github.com/orgs/Qiskit/teams/docs-content-team)

--- a/.github/ISSUE_TEMPLATE/ui.yml
+++ b/.github/ISSUE_TEMPLATE/ui.yml
@@ -2,7 +2,7 @@ name: UI issue or feature request 📱
 description: Report a rendering or other visual problem with the user interface, or request a new feature.
 labels: ["UI feedback", "infra 🏗️"]
 assignees:
-  - Qiskit/docs-content-team
+  - docs-content-team
   - javabster
   - Eric-Arellano
 


### PR DESCRIPTION
The issue templates are not recognizing the Qiskit/docs-content-team so I am taking off the `Qiskit/` to see if that solves it.