### PR TITLE
Fix small typo in cbindgen description

### DIFF
--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -50,7 +50,7 @@ This section provides build instructions for UNIX-like systems.
 Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](/docs/guides/install-qiskit-source)
 * A C compiler: for example, GCC on Linux and Clang on MacOS
-* [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to crate the C header, which you can install with `cargo install cbindgen`
+* [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require exporting your `PATH` variable to include `/path/to/.cargo/bin`
 * (GNU) Make: this is optional but is recommended to use automated install processes
 
@@ -114,7 +114,7 @@ Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#installing-qiskit-from-source)
 * A C compiler: for example, MSVC and the native command prompt offering the ``cl`` command
 * A Python installation, with access to both ``python3.lib`` and ``python3.dll``
-* [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to crate the C header, which you can install with `cargo install cbindgen`
+* [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require updating your `PATH` variable to include the cargo path.
 
 ### Build


### PR DESCRIPTION
This commit fixes a small typo in the description of cbindgen in the c api docs guide. It described cbindgen as the "tool to crate" while it should read the "tool to create".