### PR TITLE
Extract notebook image outputs after executing in cron job

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -34,7 +34,7 @@ jobs:
         timeout-minutes: 350
         run: tox -- --write --test-strategy hardware
 
-      - name: Lint and extract images
+      - name: Normalize notebooks
         run: tox -e fix
 
       - name: Detect changed notebooks

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -34,6 +34,9 @@ jobs:
         timeout-minutes: 350
         run: tox -- --write --test-strategy hardware
 
+      - name: Lint and extract images
+        run: tox -e fix
+
       - name: Detect changed notebooks
         id: changed-notebooks
         if: "!cancelled()"


### PR DESCRIPTION
Adds the image extraction step to the notebook cron job.
