### PR TITLE
Prettier should skip learning folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 docs
+learning
 translations
 scripts/js/lib/api/testdata
 .mypy_cache


### PR DESCRIPTION
We don't have Prettier running on files the content writers touch because they found it really annoying.