### PR TITLE
Fix capitalization/missing hyphens in tutorials toc

### DIFF
--- a/docs/tutorials/_toc.json
+++ b/docs/tutorials/_toc.json
@@ -31,7 +31,7 @@
               "platform": "cloud"
             },
             {
-              "title": "Advanced Techniques for QAOA",
+              "title": "Advanced techniques for QAOA",
               "url": "/docs/tutorials/advanced-techniques-for-qaoa",
               "platform": "cloud"
             },
@@ -71,24 +71,24 @@
               "platform": "cloud"
             },
             {
-              "title": "Ground state energy estimation of the Heisenberg chain with VQE",
+              "title": "Ground-state energy estimation of the Heisenberg chain with VQE",
               "url": "/docs/tutorials/spin-chain-vqe",
               "platform": "cloud"
             },
             {
-              "title": "Quantum kernel training ",
+              "title": "Quantum kernel training",
               "url": "/docs/tutorials/quantum-kernel-training",
               "platform": "cloud"
             },
             {
-              "title": "CHSH Inequality",
+              "title": "CHSH inequality",
               "url": "/docs/tutorials/chsh-inequality",
               "platform": "cloud"
             }
           ]
         },
         {
-          "title": "Fault tolerant algorithms",
+          "title": "Fault-tolerant algorithms",
           "children": [
             {
               "title": "Grover's algorithm",
@@ -100,7 +100,7 @@
       ]
     },
     {
-      "title": "Leverage Qiskit Capabilities",
+      "title": "Leverage Qiskit capabilities",
       "collapsible": false,
       "children": [
         {
@@ -112,7 +112,7 @@
               "platform": "cloud"
             },
             {
-              "title": "Transpilation Optimizations with SABRE",
+              "title": "Transpilation optimizations with SABRE",
               "url": "/docs/tutorials/transpilation-optimizations-with-sabre",
               "platform": "cloud"
             },
@@ -159,7 +159,7 @@
           ]
         },
         {
-          "title": "Error mitigation ",
+          "title": "Error mitigation",
           "children": [
             {
               "title": "Utility-scale error mitigation with probabilistic error amplification",
@@ -184,7 +184,7 @@
           ]
         },
         {
-          "title": "Error detection ",
+          "title": "Error detection",
           "children": [
             {
               "title": "Repeat until success",

--- a/docs/tutorials/advanced-techniques-for-qaoa.ipynb
+++ b/docs/tutorials/advanced-techniques-for-qaoa.ipynb
@@ -17,7 +17,7 @@
    "id": "1a869c2d-ae51-47d3-8a41-bfcf5e505f59",
    "metadata": {},
    "source": [
-    "# Advanced Techniques for QAOA\n",
+    "# Advanced techniques for QAOA\n",
     "*Usage estimate: 25 minutes on IBM Sherbrooke (NOTE: This is an estimate only. Your runtime may vary.)*"
    ]
   },

--- a/docs/tutorials/spin-chain-vqe.ipynb
+++ b/docs/tutorials/spin-chain-vqe.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "# Ground state energy estimation of the Heisenberg chain with VQE\n",
+    "# Ground-state energy estimation of the Heisenberg chain with VQE\n",
     "*Usage estimate: 2 minutes on IBM Cusco (NOTE: This is an estimate only. Your runtime may vary.)*"
    ]
   },

--- a/docs/tutorials/transpilation-optimizations-with-sabre.ipynb
+++ b/docs/tutorials/transpilation-optimizations-with-sabre.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "{/* cspell:ignore edgecolor */}\n",
     "\n",
-    "# Transpilation Optimizations with SABRE\n",
+    "# Transpilation optimizations with SABRE\n",
     "*Usage estimate: under 1 minute on IBM Sherbrooke (NOTE: This is an estimate only. Your runtime may vary.)*"
    ]
   },


### PR DESCRIPTION
I noticed some inconsistencies with the style guide