### PR TITLE
Fix typo in notebook config

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -46,7 +46,6 @@ notebooks = [
     "docs/guides/bit-ordering.ipynb",
     "docs/guides/configure-error-mitigation.ipynb",
     "docs/guides/configure-error-suppression.ipynb",
-    "docs/guides/estimate-job-runtime.ipynb",
     "docs/guides/execution-modes-rest-api.ipynb",
     "docs/guides/instances.ipynb",
     "docs/guides/interoperate-qiskit-qasm2.ipynb",


### PR DESCRIPTION
The was left in accidentally and doesn't point to a real notebook. The real notebook is listed correctly in [L159](https://github.com/Qiskit/documentation/pull/3189/files#diff-0eeb1ae761e24b8ec90fd935f7c9a5ab340a645115f863ef8bf58c4fa3ee7801R156-R160).
