### PR TITLE
Add definitions for prob_meas0_prep1, prob_meas1_prep0, and readout_length

### DIFF
--- a/docs/guides/get-qpu-information.ipynb
+++ b/docs/guides/get-qpu-information.ipynb
@@ -345,6 +345,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Additional Qubit Property Definitions\n",
+    "\n",
+    "- **`prob_meas0_prep1`**: Probability of measuring a 0 when a 1 was prepared.\n",
+    "- **`prob_meas1_prep0`**: Probability of measuring a 1 when a 0 was prepared.\n",
+    "- **`readout_length`**: Duration of the measurement pulse used for readout (in seconds).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend = service.backend(\"ibm_fez\")\n",
+    "props = backend.properties().qubit_property(0)\n",
+    "props['prob_meas0_prep1'], props['prob_meas1_prep0'], props['readout_length']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4ba1c604-b4b9-498d-ac29-9cb3a9644e09",
    "metadata": {},
    "source": [

--- a/docs/guides/qpu-information.mdx
+++ b/docs/guides/qpu-information.mdx
@@ -110,6 +110,13 @@ View QPU configuration values by selecting a QPU on the [Quantum processing unit
 View QPU configuration values by selecting a QPU on the [Compute resources](https://quantum.cloud.ibm.com/computers) page. The three tabs in the Calibration data section let you choose how to view the calibration data; the Map view tab is automatically selected.
 </CloudContent>
 
+### Additional Qubit Properties
+
+- `prob_meas0_prep1`: Probability of measuring a 0 when a 1 was prepared. Indicates readout error in detecting excited state.
+- `prob_meas1_prep0`: Probability of measuring a 1 when a 0 was prepared. Indicates readout error in detecting ground state.
+- `readout_length`: Duration of the readout pulse in seconds. Affects circuit duration and timing.
+
+
 ### Expanded card for a sample QPU
 
 ![An expanded card for a sample QPU.](/docs/images/guides/qpu-information/exp-card.avif "Expanded card for a sample QPU")


### PR DESCRIPTION
This should add in definitions for prob_meas0_prep1, prob_meas1_prep0, and readout_length, along with corresponding clusters of code to the documentation.