### PR TITLE
Document Qiskit C API compiler requirements

### DIFF
--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -49,7 +49,7 @@ This section provides build instructions for UNIX-like systems.
 
 Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](/docs/guides/install-qiskit-source)
-* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision) compatible compiler.
+* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision)) compatible compiler.
 * [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require exporting your `PATH` variable to include `/path/to/.cargo/bin`
 * (GNU) Make: this is optional but is recommended to use automated install processes

--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -49,7 +49,7 @@ This section provides build instructions for UNIX-like systems.
 
 Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](/docs/guides/install-qiskit-source)
-* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision)) compatible compiler.
+* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a compiler conforming to the [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision)) standard.
 * [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require exporting your `PATH` variable to include `/path/to/.cargo/bin`
 * (GNU) Make: this is optional but is recommended to use automated install processes

--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -49,7 +49,7 @@ This section provides build instructions for UNIX-like systems.
 
 Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](/docs/guides/install-qiskit-source)
-* A C compiler: for example, GCC on Linux and Clang on MacOS
+* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a `C11 <https://en.wikipedia.org/wiki/C11_(C_standard_revision)>`__ compatible compiler.
 * [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require exporting your `PATH` variable to include `/path/to/.cargo/bin`
 * (GNU) Make: this is optional but is recommended to use automated install processes

--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -49,7 +49,7 @@ This section provides build instructions for UNIX-like systems.
 
 Compilation requires the following tools:
 * A Rust compiler: see for example the [guide on installing Qiskit from source](/docs/guides/install-qiskit-source)
-* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a `C11 <https://en.wikipedia.org/wiki/C11_(C_standard_revision)>`__ compatible compiler.
+* A C compiler: for example, GCC on Linux and Clang on MacOS. Qiskit's C API is compatible with a [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision) compatible compiler.
 * [`cbindgen`](https://github.com/mozilla/cbindgen): a tool to create the C header, which you can install with `cargo install cbindgen`
     Note that running the tool from the command line should be enabled, which might require exporting your `PATH` variable to include `/path/to/.cargo/bin`
 * (GNU) Make: this is optional but is recommended to use automated install processes


### PR DESCRIPTION
Following discussions around Qiskit/qiskit#14138 we decided to document explicitly that Qiskit's C API requires the C11 standard. So you need a C11 compatible C compiler to use the C API. This commit updates the C installation guide to document this requirement.