### PR TITLE
[nb-tester]: Don't write version info if no packages detected

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/post_process.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/post_process.py
@@ -46,7 +46,9 @@ def post_process_notebook(nb: nbformat.NotebookNode) -> nbformat.NotebookNode:
         if "version-info" in cell.metadata.get("tags", []):
             python_code = "\n".join(cell.source for cell in nb.cells if cell.cell_type == 'code')
             requirements_txt = Path("scripts/nb-tester/requirements.txt").read_text()
-            cell.source = VERSION_INFO.format(packages=get_package_versions(python_code, requirements_txt))
+            used_package_versions = get_package_versions(python_code, requirements_txt)
+            if used_package_versions:
+                cell.source = VERSION_INFO.format(packages=used_package_versions)
 
     nb, _ = clean_notebook(nb)
     return nb


### PR DESCRIPTION
Some notebooks don't use any packages. In this case, we shouldn't populate the `version-info` cell. See https://github.com/Qiskit/documentation/pull/3225/commits/025c72feb840c7ba2b90c08e44109ca8129ab1b6 for some examples.
