### PR TITLE
Print first ten results rather than counts in "Get started with primitives"

### DIFF
--- a/docs/guides/get-started-with-primitives.ipynb
+++ b/docs/guides/get-started-with-primitives.ipynb
@@ -423,7 +423,7 @@
     "# Get results for the first (and only) PUB\n",
     "pub_result = result[0]\n",
     "print(\n",
-    "    f\"Counts for the 'meas' output register: {pub_result.data.meas.get_counts()}\"\n",
+    "    f\"First ten results for the 'meas' output register: {pub_result.data.meas.get_memory()[:10]}\"\n",
     ")"
    ]
   },


### PR DESCRIPTION
Printing the full counts dictionary is really noisy, and it also doesn't really make sense since the dictionary is huge and every value is just `1`. I think it makes more sense to just print a handful of results instead.

Draft while I re-run the notebook, I'll have to do this overnight probably due to queue times.