### PR TITLE
Adding references about the Qiskit Code Assistant service is available only through the IBM Quantum Platform classic

### DIFF
--- a/docs/guides/qiskit-code-assistant-jupyterlab.mdx
+++ b/docs/guides/qiskit-code-assistant-jupyterlab.mdx
@@ -57,7 +57,7 @@ Other settings you might want to change:
 
 - Keyboard shortcuts can be changed from Settings > Settings Editor > Keyboard Shortcuts.
 
-- You can change the IBM Quantum API key to use in the JupyterLab command palette. To do that, type `Alt` + `Shift` + `C`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste in your key.
+- You can change the IBM Quantum Classic API token to use in the JupyterLab command palette. To do that, type `Alt` + `Shift` + `C`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste in your key.
 
 - [Advanced] To change the instance of the Qiskit Code Assistant service that the extension should use, edit Qiskit Code Assistant `serviceUrl` setting.
 

--- a/docs/guides/qiskit-code-assistant-vscode.mdx
+++ b/docs/guides/qiskit-code-assistant-vscode.mdx
@@ -18,7 +18,7 @@ This documentation is relevant to the new IBM Quantum&reg; Platform. If you need
 Learn how to install, use, configure and uninstall the official Qiskit Code Assistant extension in Visual Studio Code (VS Code).
 
 <Admonition type="note" title="Notes">
-    - This is an experimental feature available only to IBM Quantum&reg; Premium Plan users registered in the [IBM Quantum Platform Classic](https://quantum.ibm.com/).
+    - This is an experimental feature available only to IBM Quantum&reg; Premium Plan users with[IBM Quantum Platform Classic](https://quantum.ibm.com/) accounts.
     - Qiskit Code Assistant is in preview release status and is subject to change.
     - If you have feedback or want to contact the developer team, use the [Qiskit Slack Workspace channel](https://qiskit.enterprise.slack.com/archives/C07LYA6PL83) or the related public GitHub repositories.
 </Admonition>
@@ -49,7 +49,7 @@ The following settings can be configured:
 
 - To change keyboard shortcuts, open the Keyboard Shortcuts settings (`Cmd/Ctrl`+`Shift`+`P` -> `Preferences: Open Keyboard Shortcuts (JSON)`) and search for `qiskit-vscode`.
 
-- You can change the IBM Quantum API key to use in the VS Code command palette. To do that, type `Cmd/Ctrl`+`Shift`+`P`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste your IBM Quantum Classic API key.
+- You can change the IBM Quantum Classic API token to use in the VS Code command palette. To do that, type `Cmd/Ctrl`+`Shift`+`P`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste your IBM Quantum Classic API token.
 
 - [Advanced] To change the instance of the Qiskit Code Assistant Service that the extension should use, go to File -> Preferences -> Settings.  On the User tab,  search for Qiskit, and edit the `Qiskit Code Assistant: Url`.
 

--- a/docs/guides/qiskit-code-assistant-vscode.mdx
+++ b/docs/guides/qiskit-code-assistant-vscode.mdx
@@ -18,7 +18,7 @@ This documentation is relevant to the new IBM Quantum&reg; Platform. If you need
 Learn how to install, use, configure and uninstall the official Qiskit Code Assistant extension in Visual Studio Code (VS Code).
 
 <Admonition type="note" title="Notes">
-    - This is an experimental feature available only to IBM Quantum&reg; Premium Plan users.
+    - This is an experimental feature available only to IBM Quantum&reg; Premium Plan users registered in the [IBM Quantum Platform Classic](https://quantum.ibm.com/).
     - Qiskit Code Assistant is in preview release status and is subject to change.
     - If you have feedback or want to contact the developer team, use the [Qiskit Slack Workspace channel](https://qiskit.enterprise.slack.com/archives/C07LYA6PL83) or the related public GitHub repositories.
 </Admonition>
@@ -49,7 +49,7 @@ The following settings can be configured:
 
 - To change keyboard shortcuts, open the Keyboard Shortcuts settings (`Cmd/Ctrl`+`Shift`+`P` -> `Preferences: Open Keyboard Shortcuts (JSON)`) and search for `qiskit-vscode`.
 
-- You can change the IBM Quantum API key to use in the VS Code command palette. To do that, type `Cmd/Ctrl`+`Shift`+`P`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste your IBM Quantum API key.
+- You can change the IBM Quantum API key to use in the VS Code command palette. To do that, type `Cmd/Ctrl`+`Shift`+`P`, search for `qiskit`, select the **Qiskit Code Assistant: Set IBM Quantum API token** command, and paste your IBM Quantum Classic API key.
 
 - [Advanced] To change the instance of the Qiskit Code Assistant Service that the extension should use, go to File -> Preferences -> Settings.  On the User tab,  search for Qiskit, and edit the `Qiskit Code Assistant: Url`.
 

--- a/docs/guides/qiskit-code-assistant.mdx
+++ b/docs/guides/qiskit-code-assistant.mdx
@@ -8,7 +8,7 @@ description: Learn how to use Qiskit Code Assistant, a generative AI code assist
 Qiskit Code Assistant aims to make quantum computing more accessible to new Qiskit adopters and to improve the coding experience for current users. It is a generative AI code assistant powered by [watsonx](https://www.ibm.com/products/watsonx-ai). It is trained using millions of text tokens from Qiskit SDK v1.x, years of Qiskit code examples and IBM Quantum&reg; features. Qiskit Code Assistant can help your quantum development workflow by offering LLM-generated suggestions based on [IBM Granite 8B Code,](https://www.ibm.com/products/watsonx-ai/foundation-models) which incorporate the latest features and functionalities from IBM&reg;.
 
 <Admonition type="note" title="Notes">
-    - This is an experimental feature available only to IBM Quantum Premium Plan users.
+    - This is an experimental feature available only to IBM Quantum Premium Plan users registered in the [IBM Quantum Platform Classic](https://quantum.ibm.com/).
     - Qiskit Code Assistant is in preview release status and is subject to change.
     - If you have feedback or want to contact the developer team, use the [Qiskit Slack Workspace channel](https://qiskit.enterprise.slack.com/archives/C07LYA6PL83) or the related public GitHub repositories.
 </Admonition>


### PR DESCRIPTION
Right now the Qiskit Code Assistant is not available through the new IBM Quantum platform. This PR adds references that it's available only for the users registered in the IBM Quantum Platform classic.