### PR TITLE
Fix magick improper header error

### DIFF
--- a/scripts/notebook-normalizer/qiskit_docs_notebook_normalizer/cell_output_data.py
+++ b/scripts/notebook-normalizer/qiskit_docs_notebook_normalizer/cell_output_data.py
@@ -36,7 +36,8 @@ class RasterImage:
         temp_file = NamedTemporaryFile(suffix=self.source_format)
         with temp_file as f:
             f.write(self.data)
-            subprocess.run(["magick", temp_file.name, self.destination_filepath], check=True)
+            f.file.seek(0) # change the File Handle position to the beginning of the file
+            subprocess.run(["magick", f.name, self.destination_filepath], check=True)
 
 
 


### PR DESCRIPTION
This PR aims to fix the following error when running the notebook normalizer:

```
magick: improper image header `/var/folders/d1/z9l0cjmx5jn7nthr53czl1qm0000gn/T/tmpp5co82hx.png' @ error/png.c/ReadPNGImage/3947.
```

Given that the error is with the header, I suspect that magick wasn't able to read it when opening the images. This could be caused because after the `write`, the File Handle is not located at the beginning of the file.

This is an example of some positions printed after the `write` command for some images:

```
  6560
  41510
  55567
  54349
  86080
  104641
  2564
```

This PR changes the File Handle position to the beginning of the file before running the magick command to prevent that