### PR TITLE
Fix `grover_oracle()`

### DIFF
--- a/docs/tutorials/grovers-algorithm.ipynb
+++ b/docs/tutorials/grovers-algorithm.ipynb
@@ -93,9 +93,11 @@
     "        ]\n",
     "        # Add a multi-controlled Z-gate with pre- and post-applied X-gates (open-controls)\n",
     "        # where the target bit-string has a '0' entry\n",
-    "        qc.x(zero_inds)\n",
+    "        if zero_inds:\n",
+    "            qc.x(zero_inds)\n",
     "        qc.compose(MCMTGate(ZGate(), num_qubits - 1, 1), inplace=True)\n",
-    "        qc.x(zero_inds)\n",
+    "        if zero_inds:\n",
+    "            qc.x(zero_inds)\n",
     "    return qc"
    ]
   },


### PR DESCRIPTION
This PR is just a small change in one of the cells of the [Grover's tutorial notebook](https://learning.quantum.ibm.com/tutorial/grovers-algorithm) to consider the edge case where one of the marked states is all 1s.

Before this PR, doing something like this would fail:
```python
grover_oracle("111")
```
After this PR, it works as expected and the circuit contains no X gates in that edge case.

I have limited the change to that cell in the notebook, and I have not rerun the whole notebook to avoid modifying cells metadata and other irrelevant things.

Fixes: #3315