### PR TITLE
fix bug in real-time qubit selection tutorial

### DIFF
--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -461,7 +461,7 @@
    "metadata": {},
    "source": [
     "###  Execute a quantum circuit with default qubit selection\n",
-    "As a reference result of performance, we'll take a look at an example of executing a quantum circuit on a QPU by using the default qubits, that is the qubits selected with the reported backend properties. `optimization_level = 3` setting for the transpiler includes the most advanced transpilation optimizations and the use of target properties (like operation errors) to select best performing qubits for execution.  "
+    "As a reference result of performance, we'll execute a quantum circuit on a QPU by using the default qubits, which are the qubits selected with the requested backend properties. We will use `optimization_level = 3`.  This setting includes the most advanced transpilation optimization, and uses target properties (like operation errors) to select the best performing qubits for execution.  "
    ]
   },
   {

--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -461,12 +461,12 @@
    "metadata": {},
    "source": [
     "###  Execute a quantum circuit with default qubit selection\n",
-    "As a reference result of performance, we'll take a look at an example of executing a quantum circuit on a QPU by using the default qubits, that is the qubits selected with the reported backend properties."
+    "As a reference result of performance, we'll take a look at an example of executing a quantum circuit on a QPU by using the default qubits, that is the qubits selected with the reported backend properties. `optimization_level = 3` setting for the transpiler includes the most advanced transpilation optimizations and the use of target properties (like operation errors) to select best performing qubits for execution.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "5c0d09ad-2e6a-4067-8034-8df92a475ff1",
    "metadata": {},
    "outputs": [],

--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -471,7 +471,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pm = generate_preset_pass_manager(target=backend.target, optimization_level=0)\n",
+    "pm = generate_preset_pass_manager(target=backend.target, optimization_level=3)\n",
     "isa_circuits = pm.run(circuits)\n",
     "initial_qubits = [\n",
     "    [\n",
@@ -598,7 +598,7 @@
     "            )\n",
     "\n",
     "    # transpile circuits to updated target\n",
-    "    pm = generate_preset_pass_manager(target=target, optimization_level=0)\n",
+    "    pm = generate_preset_pass_manager(target=target, optimization_level=3)\n",
     "    isa_circuit_updated = pm.run(circuits)\n",
     "    updated_qubits = [\n",
     "        [\n",

--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -461,7 +461,7 @@
    "metadata": {},
    "source": [
     "###  Execute a quantum circuit with default qubit selection\n",
-    "As a reference result of performance, we'll execute a quantum circuit on a QPU by using the default qubits, which are the qubits selected with the requested backend properties. We will use `optimization_level = 3`.  This setting includes the most advanced transpilation optimization, and uses target properties (like operation errors) to select the best performing qubits for execution.  "
+    "As a reference result of performance, we'll execute a quantum circuit on a QPU by using the default qubits, which are the qubits selected with the requested backend properties. We will use `optimization_level = 3`.  This setting includes the most advanced transpilation optimization, and uses target properties (like operation errors) to select the best performing qubits for execution."
    ]
   },
   {


### PR DESCRIPTION
Closes  #3197 where it was noted that the optimization setting chosen for the transpilation is not noise aware, thus the new calibrations are not used.