### PR TITLE
Add `IBMVideo` component to the preview

### DIFF
--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -100,6 +100,7 @@ To use the component, you only need the video's `id` and a descriptive `title` t
 ```
 
 Ensure that the video is allowed to be embedded on `*.cloud.ibm.com` and `qiskit.github.io`. This is set as metadata in IBM Video Streaming. This should work automatically as long as the video is uploaded to the same group as our other videos.
+
 ## Math
 
 We use [LaTeX](https://www.latex-project.org) to write math, which gets rendered by the library [KaTeX](https://katex.org).

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -91,7 +91,7 @@ You can include a version of the image to be with the dark theme. You only need 
 
 ## IBM Videos
 
-The `IBMVideo` component allows you to add embeded videos from [video.ibm.com](https://video.ibm.com).
+The `IBMVideo` component allows you to add embedded videos from [video.ibm.com](https://video.ibm.com).
 
 To use the component, you only need the video's `id` and a descriptive `title` that will be used for accessibility purposes:
 

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -99,6 +99,7 @@ To use the component, you only need the video's `id` and a descriptive `title` t
 <IBMVideo id="134056207" title="This is an example"/>
 ```
 
+Ensure that the video is allowed to be embedded on `*.cloud.ibm.com` and `qiskit.github.io`. This is set as metadata in IBM Video Streaming. This should work automatically as long as the video is uploaded to the same group as our other videos.
 ## Math
 
 We use [LaTeX](https://www.latex-project.org) to write math, which gets rendered by the library [KaTeX](https://katex.org).

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -95,7 +95,7 @@ The `IBMVideo` component allows you to add embeded videos from [video.ibm.com](h
 
 To use the component, you only need the video's `id` and a descriptive `title` that will be used for accessibility purposes:
 
-```mdx
+```markdown
 <IBMVideo id="134056207" title="This is an example"/>
 ```
 

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -213,6 +213,16 @@ We also have a specialized admonition for Qiskit Code Assistant prompt suggestio
 />
 ```
 
+### IBM Videos
+
+The `IBMVideo` component allows you to add embeded videos from [video.ibm.com](https://video.ibm.com).
+
+To use the component, you only need the video's `id` and a descriptive `title` that will be used for accessibility purposes:
+
+```mdx
+<IBMVideo id="134056207" title="This is an example"/>
+```
+
 ### Definition Tooltip
 
 To use a `DefinitionTooltip`, use the following syntax:

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -89,16 +89,14 @@ To include a caption:
 
 You can include a version of the image to be with the dark theme. You only need to create an image with the same name ending in `@dark`. So for example, if you have a `sampler.png` image, the dark version would be `sampler@dark.png`. This is important for images that have a white background.
 
-## Videos
+## IBM Videos
 
-Videos are stored in the `public/docs/videos` folder. You should use subfolders to organize the files. For example, images for `guides/my-file.mdx` should be stored like `public/docs/videos/guides/my-file/video1.mp4`.
+The `IBMVideo` component allows you to add embeded videos from [video.ibm.com](https://video.ibm.com).
 
-To add a video:
+To use the component, you only need the video's `id` and a descriptive `title` that will be used for accessibility purposes:
 
-```markdown
-<video title="Write a description of the video here as 'alt text' for accessibility." className="max-w-auto h-auto" controls>
-    <source src="/docs/videos/guides/sessions/demo.mp4" type="video/mp4"></source>
-</video>
+```mdx
+<IBMVideo id="134056207" title="This is an example"/>
 ```
 
 ## Math
@@ -211,16 +209,6 @@ We also have a specialized admonition for Qiskit Code Assistant prompt suggestio
     "# Install Qiskit 1.0.2"
   ]}
 />
-```
-
-### IBM Videos
-
-The `IBMVideo` component allows you to add embeded videos from [video.ibm.com](https://video.ibm.com).
-
-To use the component, you only need the video's `id` and a descriptive `title` that will be used for accessibility purposes:
-
-```mdx
-<IBMVideo id="134056207" title="This is an example"/>
 ```
 
 ### Definition Tooltip

--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:cd28a84aa2d1b9c6c4295dc82b83bc9044e95089d7ed53fd0a75d6402fd84687"
+IMAGE_DIGEST = "sha256:30d83c9211f5300cd319d7edf1ef92753a2c4d4c2ddf0d1fe5261b47f2baad32"
 
 # Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
 # https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7


### PR DESCRIPTION
This PR updates the docker image hash to bring the new IBMVideo component to the `start` preview and adds a brief description in the MDX guides.