### PR TITLE
Make announcements links relative to the platform

### DIFF
--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "<Admonition type=\"caution\" title=\"Deprecations to accelerate the new version of dynamic circuits\">\n",
     "\n",
-    "Starting 2 June 2025 and continuing through the year, IBM Quantum&reg; will begin a gradual rollout of new features to dynamic circuits that will enable them at the utility scale. See the [announcement](https://docs.quantum.ibm.com/announcements/product-updates/2025-03-03-new-version-dynamic-circuits) for more details.\n",
+    "Starting 2 June 2025 and continuing through the year, IBM Quantum&reg; will begin a gradual rollout of new features to dynamic circuits that will enable them at the utility scale. See the [announcement](/announcements/product-updates/2025-03-03-new-version-dynamic-circuits) for more details.\n",
     "\n",
     "To accelerate the rollout, the following have been deprecated:\n",
     "\n",

--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -14,7 +14,7 @@ in_page_toc_max_heading_level: 2
 
 Keep up with the latest and greatest from Qiskit and IBM Quantum&reg;!
 
-For all product announcements, visit the [Announcements](https://docs.quantum.ibm.com/announcements/product-updates) page on IBM Quantum Platform Classic.
+For all product announcements, visit the [Announcements](/announcements/product-updates) page on IBM Quantum Platform.
 
 <CloudContent>
 Jump to [IBM Quantum Platform](#latest-platform) | [Qiskit SDK](#latest-qiskit-sdk) | [Qiskit Runtime client](#latest-qiskit-runtime) | [Qiskit Runtime service](#latest-runtime-service) | [Qiskit Transpiler Service](#latest-qiskit-transpiler-service) | [Qiskit Serverless](#latest-qiskit-serverless) | [Qiskit Functions](#latest-qiskit-functions) | [Qiskit Code Assistant](#latest-qca) | [Documentation](#latest-docs)

--- a/docs/guides/transpile-rest-api.mdx
+++ b/docs/guides/transpile-rest-api.mdx
@@ -18,7 +18,7 @@ You have two transpilation options:
 * Use the [Qiskit Transpiler Service Python client](/docs/api/qiskit-ibm-transpiler) or [Qiskit Transpiler Service REST API](/docs/api/qiskit-transpiler-service-rest).
 
 <Admonition type="note">
-    [Transpilation is necessary](https://docs.quantum.ibm.com/announcements/product-updates/2024-02-14-qiskit-runtime-primitives-update) prior to submitting a circuit to IBM&reg; QPUs.
+    [Transpilation is necessary](/announcements/product-updates/2024-02-14-qiskit-runtime-primitives-update) prior to submitting a circuit to IBM&reg; QPUs.
 </Admonition>
 
 The steps in this topic describe how to transpile a given QASM circuit and obtain results using the Cloud Transpiler REST API, and include suggestions on how to submit the transpiled quantum circuit to IBM compute resources.  For an example that uses parameterized input, see [Sampler primitive with REST API and parameterized circuits.](/docs/guides/primitives-rest-api#start-sampler-parms)

--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -32,6 +32,9 @@ const SYNTHETIC_FILES: string[] = [
   "docs/api/runtime/tags/usage.mdx",
   "docs/api/runtime/tags/sessions.mdx",
   "docs/api/qiskit-runtime-rest/tags/instances.mdx",
+  "announcements/product-updates/2024-02-14-qiskit-runtime-primitives-update.mdx",
+  "announcements/product-updates.mdx",
+  "announcements/product-updates/2025-03-03-new-version-dynamic-circuits.mdx",
 ];
 
 interface Arguments {


### PR DESCRIPTION
Until now, announcements were legacy only and we needed to link to them externally. Now, announcements has been incorporated into the cloud app, so we don't need to do so anymore. This PR updates the links to make them relative again.