### PR TITLE
Update the TOC structure of the Learning courses/modules

### DIFF
--- a/learning/courses/basics-of-quantum-information/_toc.json
+++ b/learning/courses/basics-of-quantum-information/_toc.json
@@ -5,88 +5,96 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/basics-of-quantum-information"
+      "url": "/learning/courses/basics-of-quantum-information",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Single systems",
+      "title": "Lessons",
+      "collapsible": false,
       "children": [
         {
-            "title": "Introduction",
-            "url": "/learning/courses/basics-of-quantum-information/single-systems/introduction"
+          "title": "Single systems",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/basics-of-quantum-information/single-systems/introduction"
+            },
+            {
+              "title": "Classical information",
+              "url": "/learning/courses/basics-of-quantum-information/single-systems/classical-information"
+            },
+            {
+              "title": "Quantum information",
+              "url": "/learning/courses/basics-of-quantum-information/single-systems/quantum-information"
+            }
+          ]
         },
         {
-            "title": "Classical information",
-            "url": "/learning/courses/basics-of-quantum-information/single-systems/classical-information"
+          "title": "Multiple systems",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/basics-of-quantum-information/multiple-systems/introduction"
+            },
+            {
+              "title": "Classical information",
+              "url": "/learning/courses/basics-of-quantum-information/multiple-systems/classical-information"
+            },
+            {
+              "title": "Quantum information",
+              "url": "/learning/courses/basics-of-quantum-information/multiple-systems/quantum-information"
+            }
+          ]
         },
         {
-            "title": "Quantum information",
-            "url": "/learning/courses/basics-of-quantum-information/single-systems/quantum-information"
+          "title": "Quantum circuits",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/introduction"
+            },
+            {
+              "title": "Circuits",
+              "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/circuits"
+            },
+            {
+              "title": "Inner products and projections",
+              "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/inner-products-and-projections"
+            },
+            {
+              "title": "Limitations on quantum information",
+              "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/limitations-on-quantum-information"
+            }
+          ]
+        },
+        {
+          "title": "Entanglement in action",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/introduction"
+            },
+            {
+              "title": "Quantum teleportation",
+              "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/quantum-teleportation"
+            },
+            {
+              "title": "Superdense coding",
+              "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/superdense-coding"
+            },
+            {
+              "title": "CHSH game",
+              "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/chsh-game"
+            }
+          ]
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/basics-of-quantum-information/exam",
+          "isExam": true
         }
       ]
-    },
-    {
-      "title": "Multiple systems",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/basics-of-quantum-information/multiple-systems/introduction"
-        },
-        {
-            "title": "Classical information",
-            "url": "/learning/courses/basics-of-quantum-information/multiple-systems/classical-information"
-        },
-        {
-            "title": "Quantum information",
-            "url": "/learning/courses/basics-of-quantum-information/multiple-systems/quantum-information"
-        }
-      ]
-    },
-    {
-      "title": "Quantum circuits",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/introduction"
-        },
-        {
-            "title": "Circuits",
-            "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/circuits"
-        },
-        {
-            "title": "Inner products and projections",
-            "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/inner-products-and-projections"
-        },
-        {
-            "title": "Limitations on quantum information",
-            "url": "/learning/courses/basics-of-quantum-information/quantum-circuits/limitations-on-quantum-information"
-        }
-      ]
-    },
-    {
-      "title": "Entanglement in action",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/introduction"
-        },
-        {
-            "title": "Quantum teleportation",
-            "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/quantum-teleportation"
-        },
-        {
-            "title": "Superdense coding",
-            "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/superdense-coding"
-        },
-        {
-            "title": "CHSH game",
-            "url": "/learning/courses/basics-of-quantum-information/entanglement-in-action/chsh-game"
-        }
-      ]
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/basics-of-quantum-information/exam",
-      "isExam": true
     }
   ]
 }

--- a/learning/courses/foundations-of-quantum-error-correction/_toc.json
+++ b/learning/courses/foundations-of-quantum-error-correction/_toc.json
@@ -5,89 +5,97 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/foundations-of-quantum-error-correction"
+      "url": "/learning/courses/foundations-of-quantum-error-correction",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Correcting quantum errors",
+      "title": "Lessons",
+      "collapsible": false,
       "children": [
         {
-            "title": "Introduction",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/introduction"
+          "title": "Correcting quantum errors",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/introduction"
+            },
+            {
+              "title": "Repetition codes",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/repetition-codes"
+            },
+            {
+              "title": "The 9-qubit Shor code",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/shor-code"
+            },
+            {
+              "title": "Discretization of errors",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/discretization-of-errors"
+            }
+          ]
         },
         {
-            "title": "Repetition codes",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/repetition-codes"
+          "title": "The stabilizer formalism",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/introduction"
+            },
+            {
+              "title": "Pauli operations and observables",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/pauli-operations-and-observables"
+            },
+            {
+              "title": "Repetition code revisited",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/repetition-code-revisited"
+            },
+            {
+              "title": "Stabilizer codes",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/stabilizer-codes"
+            }
+          ]
         },
         {
-            "title": "The 9-qubit Shor code",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/shor-code"
+          "title": "Quantum code constructions",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/introduction"
+            },
+            {
+              "title": "CSS codes",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/css-codes"
+            },
+            {
+              "title": "Toric code",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/toric-code"
+            },
+            {
+              "title": "Other code families",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/other-code-families"
+            }
+          ]
         },
         {
-            "title": "Discretization of errors",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/correcting-quantum-errors/discretization-of-errors"
-        }
-      ]
-    },
-    {
-      "title": "The stabilizer formalism",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/introduction"
-        },
-        {
-            "title": "Pauli operations and observables",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/pauli-operations-and-observables"
-        },
-        {
-            "title": "Repetition code revisited",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/repetition-code-revisited"
-        },
-        {
-            "title": "Stabilizer codes",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/stabilizer-formalism/stabilizer-codes"
-        }
-      ]
-    },
-    {
-      "title": "Quantum code constructions",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/introduction"
-        },
-        {
-            "title": "CSS codes",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/css-codes"
-        },
-        {
-            "title": "Toric code",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/toric-code"
-        },
-        {
-            "title": "Other code families",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/quantum-code-constructions/other-code-families"
-        }
-      ]
-    },
-    {
-      "title": "Fault-tolerant quantum computing",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/introduction"
-        },
-        {
-            "title": "Approach to fault tolerance",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/approach-to-fault-tolerance"
-        },
-        {
-            "title": "Controlling error propagation",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/controlling-error-propagation"
-        },
-        {
-            "title": "The threshold theorem",
-            "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/threshold-theorem"
+          "title": "Fault-tolerant quantum computing",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/introduction"
+            },
+            {
+              "title": "Approach to fault tolerance",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/approach-to-fault-tolerance"
+            },
+            {
+              "title": "Controlling error propagation",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/controlling-error-propagation"
+            },
+            {
+              "title": "The threshold theorem",
+              "url": "/learning/courses/foundations-of-quantum-error-correction/fault-tolerant-quantum-computing/threshold-theorem"
+            }
+          ]
         }
       ]
     }

--- a/learning/courses/fundamentals-of-quantum-algorithms/_toc.json
+++ b/learning/courses/fundamentals-of-quantum-algorithms/_toc.json
@@ -5,108 +5,116 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/fundamentals-of-quantum-algorithms"
+      "url": "/learning/courses/fundamentals-of-quantum-algorithms",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Quantum query algorithms",
+      "title": "Lessons",
+      "collapsible": false,
       "children": [
         {
-            "title": "Introduction",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/introduction"
+          "title": "Quantum query algorithms",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/introduction"
+            },
+            {
+              "title": "The query model of computation",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation"
+            },
+            {
+              "title": "Deutsch's algorithm",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/deutsch-algorithm"
+            },
+            {
+              "title": "The Deutsch\u2013Jozsa algorithm",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/deutsch-jozsa-algorithm"
+            },
+            {
+              "title": "Simon's algorithm",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/simon-algorithm"
+            }
+          ]
         },
         {
-            "title": "The query model of computation",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation"
+          "title": "Quantum algorithmic foundations",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/introduction"
+            },
+            {
+              "title": "Factoring and computing GCDs",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/factoring-and-gcd"
+            },
+            {
+              "title": "Measuring computational cost",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/measuring-computational-cost"
+            },
+            {
+              "title": "Classical computations on quantum computers",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/simulating-classical-computations"
+            }
+          ]
         },
         {
-            "title": "Deutsch's algorithm",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/deutsch-algorithm"
+          "title": "Phase estimation and factoring",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/introduction"
+            },
+            {
+              "title": "Phase estimation problem",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/phase-estimation-problem"
+            },
+            {
+              "title": "Phase estimation procedure",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/phase-estimation-procedure"
+            },
+            {
+              "title": "Shor's algorithm",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/shor-algorithm"
+            }
+          ]
         },
         {
-            "title": "The Deutsch–Jozsa algorithm",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/deutsch-jozsa-algorithm"
+          "title": "Grover's algorithm",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/introduction"
+            },
+            {
+              "title": "Unstructured search",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/unstructured-search"
+            },
+            {
+              "title": "Description of Grover's algorithm",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/grover-algorithm-description"
+            },
+            {
+              "title": "Analysis",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/analysis"
+            },
+            {
+              "title": "Choosing the number of iterations",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/number-of-iterations"
+            },
+            {
+              "title": "Concluding remarks",
+              "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/concluding-remarks"
+            }
+          ]
         },
         {
-            "title": "Simon's algorithm",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/simon-algorithm"
+          "title": "Exam",
+          "url": "/learning/courses/fundamentals-of-quantum-algorithms/exam",
+          "isExam": true
         }
       ]
-    },
-    {
-      "title": "Quantum algorithmic foundations",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/introduction"
-        },
-        {
-            "title": "Factoring and computing GCDs",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/factoring-and-gcd"
-        },
-        {
-            "title": "Measuring computational cost",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/measuring-computational-cost"
-        },
-        {
-            "title": "Classical computations on quantum computers",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/quantum-algorithmic-foundations/simulating-classical-computations"
-        }
-      ]
-    },
-    {
-      "title": "Phase estimation and factoring",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/introduction"
-        },
-        {
-            "title": "Phase estimation problem",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/phase-estimation-problem"
-        },
-        {
-            "title": "Phase estimation procedure",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/phase-estimation-procedure"
-        },
-        {
-            "title": "Shor's algorithm",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/phase-estimation-and-factoring/shor-algorithm"
-        }
-      ]
-    },
-    {
-      "title": "Grover's algorithm",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/introduction"
-        },
-        {
-            "title": "Unstructured search",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/unstructured-search"
-        },
-        {
-            "title": "Description of Grover's algorithm",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/grover-algorithm-description"
-        },
-        {
-            "title": "Analysis",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/analysis"
-        },
-        {
-            "title": "Choosing the number of iterations",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/number-of-iterations"
-        },
-        {
-            "title": "Concluding remarks",
-            "url": "/learning/courses/fundamentals-of-quantum-algorithms/grover-algorithm/concluding-remarks"
-        }
-      ]
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/fundamentals-of-quantum-algorithms/exam",
-      "isExam": true
     }
   ]
 }

--- a/learning/courses/general-formulation-of-quantum-information/_toc.json
+++ b/learning/courses/general-formulation-of-quantum-information/_toc.json
@@ -5,89 +5,97 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/general-formulation-of-quantum-information"
+      "url": "/learning/courses/general-formulation-of-quantum-information",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Density matrices",
+      "title": "Lessons",
+      "collapsible": false,
       "children": [
         {
-            "title": "Introduction",
-            "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/introduction"
+          "title": "Density matrices",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/introduction"
+            },
+            {
+              "title": "Density matrix basics",
+              "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/density-matrix-basics"
+            },
+            {
+              "title": "Convex combinations of density matrices",
+              "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/convex-combinations"
+            },
+            {
+              "title": "Bloch sphere",
+              "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/bloch-sphere"
+            },
+            {
+              "title": "Multiple systems and reduced states",
+              "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/multiple-systems"
+            }
+          ]
         },
         {
-            "title": "Density matrix basics",
-            "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/density-matrix-basics"
+          "title": "Quantum channels",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/introduction"
+            },
+            {
+              "title": "Quantum channel basics",
+              "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/quantum-channel-basics"
+            },
+            {
+              "title": "Channel representations",
+              "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/representations-of-channels"
+            },
+            {
+              "title": "Equivalence of the representations",
+              "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/representation-equivalence"
+            }
+          ]
         },
         {
-            "title": "Convex combinations of density matrices",
-            "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/convex-combinations"
+          "title": "General measurements",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/introduction"
+            },
+            {
+              "title": "Mathematical formulations of measurements",
+              "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/formulations-of-measurements"
+            },
+            {
+              "title": "Naimark's theorem",
+              "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/naimark-theorem"
+            },
+            {
+              "title": "Quantum state discrimination and tomography",
+              "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/discrimination-and-tomography"
+            }
+          ]
         },
         {
-            "title": "Bloch sphere",
-            "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/bloch-sphere"
-        },
-        {
-            "title": "Multiple systems and reduced states",
-            "url": "/learning/courses/general-formulation-of-quantum-information/density-matrices/multiple-systems"
-        }
-      ]
-    },
-    {
-      "title": "Quantum channels",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/introduction"
-        },
-        {
-            "title": "Quantum channel basics",
-            "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/quantum-channel-basics"
-        },
-        {
-            "title": "Channel representations",
-            "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/representations-of-channels"
-        },
-        {
-            "title": "Equivalence of the representations",
-            "url": "/learning/courses/general-formulation-of-quantum-information/quantum-channels/representation-equivalence"
-        }
-      ]
-    },
-    {
-      "title": "General measurements",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/introduction"
-        },
-        {
-            "title": "Mathematical formulations of measurements",
-            "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/formulations-of-measurements"
-        },
-        {
-            "title": "Naimark's theorem",
-            "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/naimark-theorem"
-        },
-        {
-            "title": "Quantum state discrimination and tomography",
-            "url": "/learning/courses/general-formulation-of-quantum-information/general-measurements/discrimination-and-tomography"
-        }
-      ]
-    },
-    {
-      "title": "Purifications and fidelity",
-      "children": [
-        {
-            "title": "Introduction",
-            "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/introduction"
-        },
-        {
-            "title": "Purifications",
-            "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/purifications"
-        },
-        {
-            "title": "Fidelity",
-            "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/fidelity"
+          "title": "Purifications and fidelity",
+          "children": [
+            {
+              "title": "Introduction",
+              "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/introduction"
+            },
+            {
+              "title": "Purifications",
+              "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/purifications"
+            },
+            {
+              "title": "Fidelity",
+              "url": "/learning/courses/general-formulation-of-quantum-information/purifications-and-fidelity/fidelity"
+            }
+          ]
         }
       ]
     }

--- a/learning/courses/quantum-business-foundations/_toc.json
+++ b/learning/courses/quantum-business-foundations/_toc.json
@@ -5,36 +5,44 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/quantum-business-foundations"
+      "url": "/learning/courses/quantum-business-foundations",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Start your quantum journey",
-      "url": "/learning/courses/quantum-business-foundations/start-your-quantum-journey"
-    },
-    {
-      "title": "Introduction to quantum computing",
-      "url": "/learning/courses/quantum-business-foundations/introduction-to-quantum-computing"
-    },
-    {
-      "title": "Quantum computing fundamentals",
-      "url": "/learning/courses/quantum-business-foundations/quantum-computing-fundamentals"
-    },
-    {
-      "title": "Quantum technology",
-      "url": "/learning/courses/quantum-business-foundations/quantum-technology"
-    },
-    {
-      "title": "Business impacts",
-      "url": "/learning/courses/quantum-business-foundations/business-impacts"
-    },
-    {
-      "title": "How to become quantum ready",
-      "url": "/learning/courses/quantum-business-foundations/how-to-become-quantum-ready"
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/quantum-business-foundations/exam",
-      "isExam": true
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Start your quantum journey",
+          "url": "/learning/courses/quantum-business-foundations/start-your-quantum-journey"
+        },
+        {
+          "title": "Introduction to quantum computing",
+          "url": "/learning/courses/quantum-business-foundations/introduction-to-quantum-computing"
+        },
+        {
+          "title": "Quantum computing fundamentals",
+          "url": "/learning/courses/quantum-business-foundations/quantum-computing-fundamentals"
+        },
+        {
+          "title": "Quantum technology",
+          "url": "/learning/courses/quantum-business-foundations/quantum-technology"
+        },
+        {
+          "title": "Business impacts",
+          "url": "/learning/courses/quantum-business-foundations/business-impacts"
+        },
+        {
+          "title": "How to become quantum ready",
+          "url": "/learning/courses/quantum-business-foundations/how-to-become-quantum-ready"
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/quantum-business-foundations/exam",
+          "isExam": true
+        }
+      ]
     }
   ]
 }

--- a/learning/courses/quantum-chem-with-vqe/_toc.json
+++ b/learning/courses/quantum-chem-with-vqe/_toc.json
@@ -5,36 +5,44 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/quantum-chem-with-vqe"
+      "url": "/learning/courses/quantum-chem-with-vqe",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Introduction",
-      "url": "/learning/courses/quantum-chem-with-vqe/introduction"
-    },
-    {
-      "title": "Building a chemical Hamiltonian",
-      "url": "/learning/courses/quantum-chem-with-vqe/hamiltonian-construction"
-    },
-    {
-      "title": "Ansatz",
-      "url": "/learning/courses/quantum-chem-with-vqe/ansatz"
-    },
-    {
-      "title": "Classical optimizers",
-      "url": "/learning/courses/quantum-chem-with-vqe/classical-optimizers2"
-    },
-    {
-      "title": "Ground state energies",
-      "url": "/learning/courses/quantum-chem-with-vqe/ground-state"
-    },
-    {
-      "title": "Molecular geometry",
-      "url": "/learning/courses/quantum-chem-with-vqe/geometry"
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/quantum-chem-with-vqe/exam",
-      "isExam": true
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Introduction",
+          "url": "/learning/courses/quantum-chem-with-vqe/introduction"
+        },
+        {
+          "title": "Building a chemical Hamiltonian",
+          "url": "/learning/courses/quantum-chem-with-vqe/hamiltonian-construction"
+        },
+        {
+          "title": "Ansatz",
+          "url": "/learning/courses/quantum-chem-with-vqe/ansatz"
+        },
+        {
+          "title": "Classical optimizers",
+          "url": "/learning/courses/quantum-chem-with-vqe/classical-optimizers2"
+        },
+        {
+          "title": "Ground state energies",
+          "url": "/learning/courses/quantum-chem-with-vqe/ground-state"
+        },
+        {
+          "title": "Molecular geometry",
+          "url": "/learning/courses/quantum-chem-with-vqe/geometry"
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/quantum-chem-with-vqe/exam",
+          "isExam": true
+        }
+      ]
     }
   ]
 }

--- a/learning/courses/quantum-computing-in-practice/_toc.json
+++ b/learning/courses/quantum-computing-in-practice/_toc.json
@@ -5,27 +5,35 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/quantum-computing-in-practice"
+      "url": "/learning/courses/quantum-computing-in-practice",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Course introduction",
-      "url": "/learning/courses/quantum-computing-in-practice/introduction"
-    },
-    {
-      "title": "Running quantum circuits",
-      "url": "/learning/courses/quantum-computing-in-practice/running-quantum-circuits"
-    },
-    {
-      "title": "Utility-scale QAOA",
-      "url": "/learning/courses/quantum-computing-in-practice/utility-scale-qaoa"
-    },
-    {
-      "title": "Which problems are quantum computers good for?",
-      "url": "/learning/courses/quantum-computing-in-practice/applications-of-qc"
-    },
-    {
-      "title": "Mapping",
-      "url": "/learning/courses/quantum-computing-in-practice/mapping"
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Course introduction",
+          "url": "/learning/courses/quantum-computing-in-practice/introduction"
+        },
+        {
+          "title": "Running quantum circuits",
+          "url": "/learning/courses/quantum-computing-in-practice/running-quantum-circuits"
+        },
+        {
+          "title": "Utility-scale QAOA",
+          "url": "/learning/courses/quantum-computing-in-practice/utility-scale-qaoa"
+        },
+        {
+          "title": "Which problems are quantum computers good for?",
+          "url": "/learning/courses/quantum-computing-in-practice/applications-of-qc"
+        },
+        {
+          "title": "Mapping",
+          "url": "/learning/courses/quantum-computing-in-practice/mapping"
+        }
+      ]
     }
   ]
 }

--- a/learning/courses/quantum-diagonalization-algorithms/_toc.json
+++ b/learning/courses/quantum-diagonalization-algorithms/_toc.json
@@ -5,37 +5,44 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/quantum-diagonalization-algorithms"
+      "url": "/learning/courses/quantum-diagonalization-algorithms",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Introduction",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/introduction"
-    },
-    {
-      "title": "Variational quantum eigensolver",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/vqe"
-    },
-    {
-      "title": "Quantum Krylov methods",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/krylov"
-    },
-    {
-      "title": "Sample-based quantum diagonalization",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/sqd-overview"
-    },
-    {
-      "title": "Implementing SQD",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/sqd-implementation"
-    },
-    {
-      "title": "Sample-based Krylov quantum diagonalization",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/skqd"
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/quantum-diagonalization-algorithms/exam",
-      "isExam": true
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Introduction",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/introduction"
+        },
+        {
+          "title": "Variational quantum eigensolver",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/vqe"
+        },
+        {
+          "title": "Quantum Krylov methods",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/krylov"
+        },
+        {
+          "title": "Sample-based quantum diagonalization",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/sqd-overview"
+        },
+        {
+          "title": "Implementing SQD",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/sqd-implementation"
+        },
+        {
+          "title": "Sample-based Krylov quantum diagonalization",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/skqd"
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/quantum-diagonalization-algorithms/exam",
+          "isExam": true
+        }
+      ]
     }
-    
   ]
 }

--- a/learning/courses/quantum-machine-learning/_toc.json
+++ b/learning/courses/quantum-machine-learning/_toc.json
@@ -5,32 +5,40 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/quantum-machine-learning"
+      "url": "/learning/courses/quantum-machine-learning",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Introduction",
-      "url": "/learning/courses/quantum-machine-learning/introduction"
-    },
-    {
-      "title": "Classical machine learning review",
-      "url": "/learning/courses/quantum-machine-learning/classical-ml-review"
-    },
-    {
-      "title": "Data encoding",
-      "url": "/learning/courses/quantum-machine-learning/data-encoding"
-    },
-    {
-      "title": "Quantum kernels",
-      "url": "/learning/courses/quantum-machine-learning/quantum-kernel-methods"
-    },
-    {
-      "title": "QVCs and QNNs",
-      "url": "/learning/courses/quantum-machine-learning/qvc-qnn"
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/quantum-machine-learning/exam",
-      "isExam": true
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Introduction",
+          "url": "/learning/courses/quantum-machine-learning/introduction"
+        },
+        {
+          "title": "Classical machine learning review",
+          "url": "/learning/courses/quantum-machine-learning/classical-ml-review"
+        },
+        {
+          "title": "Data encoding",
+          "url": "/learning/courses/quantum-machine-learning/data-encoding"
+        },
+        {
+          "title": "Quantum kernels",
+          "url": "/learning/courses/quantum-machine-learning/quantum-kernel-methods"
+        },
+        {
+          "title": "QVCs and QNNs",
+          "url": "/learning/courses/quantum-machine-learning/qvc-qnn"
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/quantum-machine-learning/exam",
+          "isExam": true
+        }
+      ]
     }
   ]
 }

--- a/learning/courses/utility-scale-quantum-computing/_toc.json
+++ b/learning/courses/utility-scale-quantum-computing/_toc.json
@@ -5,63 +5,71 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/utility-scale-quantum-computing"
+      "url": "/learning/courses/utility-scale-quantum-computing",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Introduction",
-      "url": "/learning/courses/utility-scale-quantum-computing/introduction"
-    },
-    {
-      "title": "Bits, gates, and circuits",
-      "url": "/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits"
-    },
-    {
-      "title": "Teleportation",
-      "url": "/learning/courses/utility-scale-quantum-computing/teleportation"
-    },
-    {
-      "title": "Grover's algorithm",
-      "url": "/learning/courses/utility-scale-quantum-computing/grovers-algorithm"
-    },
-    {
-      "title": "Quantum phase estimation",
-      "url": "/learning/courses/utility-scale-quantum-computing/quantum-phase-estimation"
-    },
-    {
-      "title": "Variational quantum algorithms",
-      "url": "/learning/courses/utility-scale-quantum-computing/variational-quantum-algorithms"
-    },
-    {
-      "title": "Quantum simulation",
-      "url": "/learning/courses/utility-scale-quantum-computing/quantum-simulation"
-    },
-    {
-      "title": "Classical simulation",
-      "url": "/learning/courses/utility-scale-quantum-computing/classical-simulation"
-    },
-    {
-      "title": "Hardware",
-      "url": "/learning/courses/utility-scale-quantum-computing/hardware"
-    },
-    {
-      "title": "Quantum circuit optimization",
-      "url": "/learning/courses/utility-scale-quantum-computing/quantum-circuit-optimization"
-    },
-    {
-      "title": "Error mitigation",
-      "url": "/learning/courses/utility-scale-quantum-computing/error-mitigation"
-    },
-    {
-      "title": "Utility I",
-      "url": "/learning/courses/utility-scale-quantum-computing/utility-i"
-    },
-    {
-      "title": "Utility II",
-      "url": "/learning/courses/utility-scale-quantum-computing/utility-ii"
-    },
-    {
-      "title": "Utility III",
-      "url": "/learning/courses/utility-scale-quantum-computing/utility-iii"
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Introduction",
+          "url": "/learning/courses/utility-scale-quantum-computing/introduction"
+        },
+        {
+          "title": "Bits, gates, and circuits",
+          "url": "/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits"
+        },
+        {
+          "title": "Teleportation",
+          "url": "/learning/courses/utility-scale-quantum-computing/teleportation"
+        },
+        {
+          "title": "Grover's algorithm",
+          "url": "/learning/courses/utility-scale-quantum-computing/grovers-algorithm"
+        },
+        {
+          "title": "Quantum phase estimation",
+          "url": "/learning/courses/utility-scale-quantum-computing/quantum-phase-estimation"
+        },
+        {
+          "title": "Variational quantum algorithms",
+          "url": "/learning/courses/utility-scale-quantum-computing/variational-quantum-algorithms"
+        },
+        {
+          "title": "Quantum simulation",
+          "url": "/learning/courses/utility-scale-quantum-computing/quantum-simulation"
+        },
+        {
+          "title": "Classical simulation",
+          "url": "/learning/courses/utility-scale-quantum-computing/classical-simulation"
+        },
+        {
+          "title": "Hardware",
+          "url": "/learning/courses/utility-scale-quantum-computing/hardware"
+        },
+        {
+          "title": "Quantum circuit optimization",
+          "url": "/learning/courses/utility-scale-quantum-computing/quantum-circuit-optimization"
+        },
+        {
+          "title": "Error mitigation",
+          "url": "/learning/courses/utility-scale-quantum-computing/error-mitigation"
+        },
+        {
+          "title": "Utility I",
+          "url": "/learning/courses/utility-scale-quantum-computing/utility-i"
+        },
+        {
+          "title": "Utility II",
+          "url": "/learning/courses/utility-scale-quantum-computing/utility-ii"
+        },
+        {
+          "title": "Utility III",
+          "url": "/learning/courses/utility-scale-quantum-computing/utility-iii"
+        }
+      ]
     }
   ]
 }

--- a/learning/courses/variational-algorithm-design/_toc.json
+++ b/learning/courses/variational-algorithm-design/_toc.json
@@ -5,40 +5,48 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/courses/variational-algorithm-design"
+      "url": "/learning/courses/variational-algorithm-design",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Variational algorithms",
-      "url": "/learning/courses/variational-algorithm-design/variational-algorithms"
-    },
-    {
-      "title": "Reference states",
-      "url": "/learning/courses/variational-algorithm-design/reference-states"
-    },
-    {
-      "title": "Ansaetze and variational forms",
-      "url": "/learning/courses/variational-algorithm-design/ansaetze-and-variational-forms"
-    },
-    {
-      "title": "Cost functions",
-      "url": "/learning/courses/variational-algorithm-design/cost-functions"
-    },
-    {
-      "title": "Optimization loops",
-      "url": "/learning/courses/variational-algorithm-design/optimization-loops"
-    },
-    {
-      "title": "Instances and extensions",
-      "url": "/learning/courses/variational-algorithm-design/instances-and-extensions"
-    },
-    {
-      "title": "Examples and applications",
-      "url": "/learning/courses/variational-algorithm-design/examples-and-applications"
-    },
-    {
-      "title": "Exam",
-      "url": "/learning/courses/variational-algorithm-design/exam",
-      "isExam": true
+      "title": "Lessons",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Variational algorithms",
+          "url": "/learning/courses/variational-algorithm-design/variational-algorithms"
+        },
+        {
+          "title": "Reference states",
+          "url": "/learning/courses/variational-algorithm-design/reference-states"
+        },
+        {
+          "title": "Ansaetze and variational forms",
+          "url": "/learning/courses/variational-algorithm-design/ansaetze-and-variational-forms"
+        },
+        {
+          "title": "Cost functions",
+          "url": "/learning/courses/variational-algorithm-design/cost-functions"
+        },
+        {
+          "title": "Optimization loops",
+          "url": "/learning/courses/variational-algorithm-design/optimization-loops"
+        },
+        {
+          "title": "Instances and extensions",
+          "url": "/learning/courses/variational-algorithm-design/instances-and-extensions"
+        },
+        {
+          "title": "Examples and applications",
+          "url": "/learning/courses/variational-algorithm-design/examples-and-applications"
+        },
+        {
+          "title": "Exam",
+          "url": "/learning/courses/variational-algorithm-design/exam",
+          "isExam": true
+        }
+      ]
     }
   ]
 }

--- a/learning/modules/computer-science/_toc.json
+++ b/learning/modules/computer-science/_toc.json
@@ -5,19 +5,27 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/modules/computer-science"
+      "url": "/learning/modules/computer-science",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "The Deutsch-Jozsa algorithm",
-      "url": "/learning/modules/computer-science/deutsch-jozsa"
-    },
-    {
-      "title": "Quantum key distribution",
-      "url": "/learning/modules/computer-science/quantum-key-distribution"
-    },
-    {
-      "title": "Quantum teleportation",
-      "url": "/learning/modules/computer-science/quantum-teleportation"
+      "title": "Modules",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "The Deutsch-Jozsa algorithm",
+          "url": "/learning/modules/computer-science/deutsch-jozsa"
+        },
+        {
+          "title": "Quantum key distribution",
+          "url": "/learning/modules/computer-science/quantum-key-distribution"
+        },
+        {
+          "title": "Quantum teleportation",
+          "url": "/learning/modules/computer-science/quantum-teleportation"
+        }
+      ]
     }
   ]
 }

--- a/learning/modules/quantum-mechanics/_toc.json
+++ b/learning/modules/quantum-mechanics/_toc.json
@@ -5,23 +5,31 @@
   "children": [
     {
       "title": "Overview",
-      "url": "/learning/modules/quantum-mechanics"
+      "url": "/learning/modules/quantum-mechanics",
+      "useDivider": true,
+      "preventBold": true
     },
     {
-      "title": "Superposition with Qiskit",
-      "url": "/learning/modules/quantum-mechanics/superposition-with-qiskit"
-    },
-    {
-      "title": "Stern-Gerlach measurements with Qiskit",
-      "url": "/learning/modules/quantum-mechanics/stern-gerlach-measurements-with-qiskit"
-    },
-    {
-      "title": "Exploring uncertainty with Qiskit",
-      "url": "/learning/modules/quantum-mechanics/exploring-uncertainty-with-qiskit"
-    },
-    {
-      "title": "Bell's inequality with Qiskit",
-      "url": "/learning/modules/quantum-mechanics/bells-inequality-with-qiskit"
-    }    
+      "title": "Modules",
+      "collapsible": false,
+      "children": [
+        {
+          "title": "Superposition with Qiskit",
+          "url": "/learning/modules/quantum-mechanics/superposition-with-qiskit"
+        },
+        {
+          "title": "Stern-Gerlach measurements with Qiskit",
+          "url": "/learning/modules/quantum-mechanics/stern-gerlach-measurements-with-qiskit"
+        },
+        {
+          "title": "Exploring uncertainty with Qiskit",
+          "url": "/learning/modules/quantum-mechanics/exploring-uncertainty-with-qiskit"
+        },
+        {
+          "title": "Bell's inequality with Qiskit",
+          "url": "/learning/modules/quantum-mechanics/bells-inequality-with-qiskit"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/3287

This PR updates the courses/modules TOC to:

- Add the following additional properties to the Overview page:
  - useDivider
  - preventBold
- Add a top-level subsection called "Lessons" (or "Modules") for all the pages

I used the script provided in the issue (kudos to @frankharkins) together with a small manual change (added some whitespace at the end of the files and fix the two modules subsections as said in the issue).

The only course left is "Practical Introduction to Quantum-Safe Cryptography", which hasn't been merged yet (https://github.com/Qiskit/documentation/pull/3303)