### PR TITLE
Migrate testing to cloud

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -16,13 +16,12 @@ inputs:
   install-linux-deps:
     description: Whether to install extra dependencies
     default: "false"
-  ibm-quantum-token:
-    default: ""
+  ibm-cloud-token:
+    description: "Token for quantum.cloud.ibm.com"
+    required: true
   instance:
-    # We usually only want the same access as an open user, but occasionally we
-    # need higher priority to test notebooks that submit jobs in reasonable
-    # time
-    default: "ibm-q/open/main"
+    description: "CRN for quantum.cloud.ibm.com"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -35,14 +34,13 @@ runs:
       run: pip install tox qiskit-ibm-runtime
 
     - name: Save IBM Quantum account
-      if: ${{ inputs.ibm-quantum-token != '' }}
       shell: python
       run: |
         from qiskit_ibm_runtime import QiskitRuntimeService
         QiskitRuntimeService.save_account(
-            channel="ibm_quantum",
+            channel="ibm_cloud",
             instance="${{ inputs.instance }}",
-            token="${{ inputs.ibm-quantum-token }}",
+            token="${{ inputs.ibm-cloud-token }}",
             set_as_default=True
         )
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,9 @@ jobs:
 
       - name: Setup Python environment
         uses: ./.github/actions/set-up-notebook-testing
+        with:
+          ibm-cloud-token: ${{ secrets.IBM_CLOUD_TEST_TOKEN }}
+          instance: ${{ vars.IBM_CLOUD_TEST_CRN }}
 
       - name: Check all notebooks are listed in the config file
         run: python scripts/ci/check-all-notebooks-are-tested.py

--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/set-up-notebook-testing
         with:
-          ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
-          instance: "client-enablement/documentation/qiskit-documenta"
+          ibm-cloud-token: ${{ secrets.IBM_CLOUD_TEST_TOKEN }}
+          instance: ${{ vars.IBM_CLOUD_TEST_CRN }}
           install-linux-deps: true
 
       - name: Execute notebooks

--- a/.github/workflows/notebook-test-extended.yml
+++ b/.github/workflows/notebook-test-extended.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/set-up-notebook-testing
         with:
-          ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
-          instance: "client-enablement/documentation/qiskit-documenta"
+          ibm-cloud-token: ${{ secrets.IBM_CLOUD_TEST_TOKEN }}
+          instance: ${{ vars.IBM_CLOUD_TEST_CRN }}
           install-linux-deps: true
 
       - name: Execute notebooks

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -65,7 +65,8 @@ jobs:
           # Install Linux deps if the specific guides were changed, or
           # if all files are being tested.
           install-linux-deps: ${{ steps.check-deps.outputs.NEEDS_EXTRA_DEPS }}
-          ibm-quantum-token: ${{ secrets.IBM_QUANTUM_TEST_TOKEN }}
+          ibm-cloud-token: ${{ secrets.IBM_CLOUD_TEST_TOKEN }}
+          instance: ${{ vars.IBM_CLOUD_TEST_CRN }}
 
       - name: Execute notebooks
         env:

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
@@ -28,7 +28,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from .config import NotebookJob, Result
 from .post_process import post_process_notebook
 
-# Keep this in sync with
+# Keep this in sync with `OPEN_BACKENDS` in
 # scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
 OPEN_BACKENDS_TO_INTERNAL = {
     "ibm_brisbane": "alt_brisbane",

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
@@ -28,7 +28,8 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from .config import NotebookJob, Result
 from .post_process import post_process_notebook
 
-
+# Keep this in sync with
+# scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
 OPEN_BACKENDS_TO_INTERNAL = {
     "ibm_brisbane": "alt_brisbane",
     "ibm_torino": "alt_torino",

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
@@ -4,8 +4,13 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 
 QiskitRuntimeService._original_least_busy = QiskitRuntimeService.least_busy
 
+# Backends that we have access to through both internal and open plans
+OPEN_BACKENDS = ["brisbane", "torino"]
+
+def is_open(backend):
+    return any(backend.name.endswith(f"_{name}") for name in OPEN_BACKENDS)
+
 def patched_least_busy(self, *args, **kwargs):
-    open_backends = [b.name for b in self.backends(instance="ibm-q/open/main")]
-    return self._original_least_busy(filters=lambda backend: backend.name in open_backends)
+    return self._original_least_busy(filters=is_open)
 
 QiskitRuntimeService.least_busy = patched_least_busy

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
@@ -5,6 +5,8 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 QiskitRuntimeService._original_least_busy = QiskitRuntimeService.least_busy
 
 # Backends that we have access to through both internal and open plans
+# Keep this in sync with
+# scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
 OPEN_BACKENDS = ["brisbane", "torino"]
 
 def is_open(backend):

--- a/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
@@ -5,7 +5,8 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 QiskitRuntimeService._original_least_busy = QiskitRuntimeService.least_busy
 
 # Backends that we have access to through both internal and open plans
-# Keep this in sync with
+#
+# Keep this in sync with `OPEN_BACKENDS_TO_INTERNAL`
 # scripts/nb-tester/qiskit_docs_notebook_tester/execute.py
 OPEN_BACKENDS = ["brisbane", "torino"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
   -e scripts/nb-tester
   -r scripts/nb-tester/requirements.txt
 setenv = PYDEVD_DISABLE_FILE_VALIDATION=1
-commands = test-docs-notebooks {posargs} --check-pending-deprecations --config-path scripts/config/notebook-testing.toml
+commands = test-docs-notebooks {posargs} --check-pending-deprecations --config-path scripts/config/notebook-testing.toml --map-open-backends-to-internal
 
 [testenv:{lint,fix}]
 deps =


### PR DESCRIPTION
This PR migrates our notebook testing setup to use the IBM Cloud provider rather than the legacy provider.
