### PR TITLE
Bump PR preview polling timeout

### DIFF
--- a/scripts/pr-previews/poll_deployment.py
+++ b/scripts/pr-previews/poll_deployment.py
@@ -24,7 +24,7 @@ from utils import configure_logging
 logger = logging.getLogger(__name__)
 
 INITIAL_DELAY_S = 20
-TIMEOUT_S = 180
+TIMEOUT_S = 220
 RETRY_INTERVAL_S = 10
 
 


### PR DESCRIPTION
Per https://github.com/Qiskit/documentation/issues/3342#issuecomment-2988072602, we are getting timeouts in our polling even when there is no race condition happening. That suggests that our deployment to GH pages is for some reason taking a long time, presumably because we have so many subsites being deployed, each with a lot of content.