### PR TITLE
[nb-tester]: Handle forks better

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -37,12 +37,22 @@ runs:
       shell: python
       run: |
         from qiskit_ibm_runtime import QiskitRuntimeService
-        QiskitRuntimeService.save_account(
-            channel="ibm_cloud",
-            instance="${{ inputs.instance }}",
-            token="${{ inputs.ibm-cloud-token }}",
-            set_as_default=True
-        )
+        from qiskit_ibm_runtime.accounts.exceptions import InvalidAccountError
+
+        try:
+          QiskitRuntimeService.save_account(
+              channel="ibm_cloud",
+              instance="${{ inputs.instance }}",
+              token="${{ inputs.ibm-cloud-token }}",
+              set_as_default=True
+          )
+        except InvalidAccountError as err:
+          print(
+            "There was a problem setting up your account, this can happen if you're "
+            "making a PR from a fork. We will ignore this for now as not all "
+            "notebooks need a valid account to run.\n\nHere is the error:\n"
+          )
+          print(err)
 
     - name: Install Linux dependencies
       if: ${{ inputs.install-linux-deps == 'true' }}

--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -37,22 +37,20 @@ runs:
       shell: python
       run: |
         from qiskit_ibm_runtime import QiskitRuntimeService
-        from qiskit_ibm_runtime.accounts.exceptions import InvalidAccountError
 
-        try:
+        if "${{ inputs.ibm-cloud-token }}" == "":
+          print(
+            "Token is an empty string, this can happen when making a PR from a "
+            "fork. We will continue without setting up the account as not all "
+            "notebooks need a valid account to run."
+          )
+        else:
           QiskitRuntimeService.save_account(
               channel="ibm_cloud",
               instance="${{ inputs.instance }}",
               token="${{ inputs.ibm-cloud-token }}",
               set_as_default=True
           )
-        except InvalidAccountError as err:
-          print(
-            "There was a problem setting up your account, this can happen if you're "
-            "making a PR from a fork. We will ignore this for now as not all "
-            "notebooks need a valid account to run.\n\nHere is the error:\n"
-          )
-          print(err)
 
     - name: Install Linux dependencies
       if: ${{ inputs.install-linux-deps == 'true' }}


### PR DESCRIPTION
Previously, `save_account` would happily accept an empty string for the `token`, but this seems to have changed. Since some notebooks can be tested without a valid account, this PR adds a try/except to continue even if account setup fails. The existing script will give an appropriate error message if any notebooks fail on a fork.