### PR TITLE
Update notebook tester dependencies

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -38,7 +38,6 @@ notebooks = [
     "docs/guides/specify-observables-pauli.ipynb",
     "docs/guides/transpile-with-pass-managers.ipynb",
     "docs/guides/transpiler-plugins.ipynb",
-    "docs/guides/transpiler-stages.ipynb",
     "docs/guides/visualize-circuits.ipynb",
     "docs/guides/qiskit-addons-cutting-wires.ipynb",
     "docs/guides/qiskit-addons-utils.ipynb",
@@ -54,6 +53,7 @@ notebooks = [
     "docs/guides/native-gates.ipynb",
     "docs/guides/primitives-rest-api.ipynb",
     "docs/guides/repetition-rate-execution.ipynb",
+    "docs/guides/save-jobs.ipynb",
     "docs/guides/simulate-with-qiskit-sdk-primitives.ipynb",
     "docs/guides/synthesize-unitary-operators.ipynb",
     "docs/guides/DAG-representation.ipynb",
@@ -138,8 +138,8 @@ notebooks = [
 # Don't ever test the following notebooks
 [groups.exclude]
 notebooks = [
-    # TODO: See if this works again after migrating to cloud
-    "docs/guides/save-jobs.ipynb",
+    # TODO: Fix this (https://github.com/Qiskit/documentation/issues/3413)
+    "docs/guides/transpiler-stages.ipynb",
 
     # This notebook contains undefined variables so can't run at all.
     "docs/guides/function-template-hamiltonian-simulation.ipynb",

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -1,23 +1,23 @@
 # We pin to exact versions for a more reproducible and
 # stable build.
 
-qiskit[all]~=2.0.0
-qiskit-ibm-runtime~=0.37.0
-qiskit-ibm-transpiler[ai-local-mode]~=0.11.0
+qiskit[all]~=2.1.0
+qiskit-ibm-runtime~=0.40.1
+qiskit-ibm-transpiler[ai-local-mode]~=0.12.0
 qiskit-aer~=0.17
-qiskit-serverless~=0.21.0
-qiskit-ibm-catalog~=0.5.0
-qiskit-addon-sqd~=0.10.0
-qiskit-addon-utils~=0.1.0
+qiskit-serverless~=0.24.0
+qiskit-ibm-catalog~=0.8.0
+qiskit-addon-sqd~=0.11.0
+qiskit-addon-utils~=0.1.1
 qiskit-addon-mpf~=0.3.0
 qiskit-addon-aqc-tensor[aer,quimb-jax]~=0.2.0
-qiskit-addon-obp~=0.2.0
+qiskit-addon-obp~=0.3.0
 qiskit-addon-cutting~=0.10.0
 qiskit-experiments~=0.10.0
-scipy~=1.15.2
-scikit-learn~=1.6.1
-pyscf~=2.8.0; sys.platform != 'win32'
+scipy~=1.16.0
+scikit-learn~=1.7.0
+pyscf~=2.9.0; sys.platform != 'win32'
 python-sat~=1.8.dev16
 gem-suite~=0.1.6
-ffsim~=0.0.54; sys.platform != 'win32'
+ffsim~=0.0.57; sys.platform != 'win32'
 sympy~=1.14.0


### PR DESCRIPTION
This PR updates all Python dependencies used for testing to their latest versions.

We were blocked on this by #3363
