### PR TITLE
Remove weird space character

### DIFF
--- a/docs/guides/get-qpu-information.ipynb
+++ b/docs/guides/get-qpu-information.ipynb
@@ -273,9 +273,9 @@
     "\n",
     "- `readout_error`: The readout error quantifies the average probability of incorrectly measuring a qubit's state. It is commonly calculated as the mean of prob_meas0_prep1 and prob_meas1_prep0, providing a single metric for measurement fidelity.\n",
     "\n",
-    "- `prob_meas0_prep1`: This parameter indicates the probability of measuring a qubit in the 0 state when it was intended to be prepared in the $|1\\rangle$ state, denoted as $P(0 | 1)$. It reflects errors in state preparation and measurement (SPAM), particularly measurement errors in superconducting qubits.\n",
+    "- `prob_meas0_prep1`: This parameter indicates the probability of measuring a qubit in the 0 state when it was intended to be prepared in the $|1\\rangle$ state, denoted as $P(0 | 1)$. It reflects errors in state preparation and measurement (SPAM), particularly measurement errors in superconducting qubits.\n",
     "\n",
-    "- `prob_meas1_prep0`: Similarly, this parameter represents the probability of measuring a qubit in the 1 state when it was intended to be prepared in the $|0\\rangle$ state, denoted as $P(1 | 0)$. Like prob_meas0_prep1, it reflects SPAM errors, with measurement errors being the predominant contributor in superconducting qubits.\n",
+    "- `prob_meas1_prep0`: Similarly, this parameter represents the probability of measuring a qubit in the 1 state when it was intended to be prepared in the $|0\\rangle$ state, denoted as $P(1 | 0)$. Like prob_meas0_prep1, it reflects SPAM errors, with measurement errors being the predominant contributor in superconducting qubits.\n",
     "\n",
     "- `readout_length`: The readout_length specifies the duration of the readout operation for a qubit. It measures the time from the initiation of the measurement pulse to the completion of signal digitization, after which the system is ready for the next operation. Understanding this parameter is crucial for optimizing circuit execution, especially when incorporating mid-circuit measurements."
    ]


### PR DESCRIPTION
Replaces "NARROW NO-BREAK SPACE" with regular "SPACE".
