### PR TITLE
Delete stale PR previews

### DIFF
--- a/scripts/pr-previews/cleanup.py
+++ b/scripts/pr-previews/cleanup.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import shutil
+import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,8 @@ from utils import (
 
 INITIAL_COMMIT = "499a5040585d02593cdd8237e19c9ee4a84ae126"
 
+THREE_DAYS_IN_SECONDS = 60 * 60 * 24 *3
+PR_EXPIRATION_TIME = THREE_DAYS_IN_SECONDS
 
 def main() -> None:
     setup_git_account()
@@ -64,14 +67,25 @@ def get_active_pr_folders() -> set[str]:
     # `raw` is JSON string of form: { number: int }[]
     return {f"pr-{obj['number']}" for obj in json.loads(raw)}
 
+def is_stale(folder_name: str) -> bool:
+    # All time measured in seconds, from the unix epoch
+    current_timestamp = time.time()
+    last_modified_timestamp = int(run_subprocess(["git", "log", "-n", "1", "--format=%at", folder_name]).stdout)
+    return (current_timestamp - last_modified_timestamp) > PR_EXPIRATION_TIME
 
 def delete_closed_pr_folders() -> None:
     active_pr_folders = get_active_pr_folders()
-    for folder in Path(".").glob("pr-*"):
-        if folder.name not in active_pr_folders:
-            logger.info(f"Deleting {folder}")
-            shutil.rmtree(folder)
+    is_closed = lambda folder: folder not in active_pr_folders
 
+    for folder in Path(".").glob("pr-*"):
+        if is_closed(folder.name):
+            logger.info(f"Deleting {folder} as PR is closed")
+            shutil.rmtree(folder)
+            continue
+        if is_stale(folder.name):
+            logger.info(f"Would delete {folder} as it is stale")
+            # shutil.rmtree(folder)
+            continue
 
 if __name__ == "__main__":
     configure_logging()


### PR DESCRIPTION

Attempt to improve GitHub pages deployment time by expiring PR previews that have not been updated in a week.

This approach uses Git's last modification date to return the timestamp of the most recent commit that affects each PR folder. This timestamp will correspond to the last time the PR was updated. If a PR preview is deleted, restarting the PR preview job will commit a new folder, starting a new seven day active period. The only downside I can see is that restarting a job that doesn't modify the preview before the preview is cleaned up will have no effect, so writers can't pre-emptively re-trigger a job to keep a preview alive; they can only do this after it's deleted. If that's a problem, we could maybe commit a timestamp file to each preview folder when we create them.

I propose starting by just logging, rather than deleting so we can check it's behaving correctly. I'll then follow up with a PR to start deleting things.

---

Closes #3412
