### PR TITLE
Fix typo in notebook patch

### DIFF
--- a/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
+++ b/scripts/nb-tester/qiskit_docs_notebook_tester/patches/qiskit-ibm-runtime-open
@@ -11,7 +11,7 @@ QiskitRuntimeService._original_least_busy = QiskitRuntimeService.least_busy
 OPEN_BACKENDS = ["brisbane", "torino"]
 
 def is_open(backend):
-    return any(backend.name.endswith(f"_{name}") for name in OPEN_BACKENDS)
+    return any(backend.name.endswith(f"_{{name}}") for name in OPEN_BACKENDS)
 
 def patched_least_busy(self, *args, **kwargs):
     return self._original_least_busy(filters=is_open)


### PR DESCRIPTION
We need to double-escape the curly brackets as there's two interpolations going on.
