### PR TITLE
Stop using the legacy app in previews

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,26 +74,17 @@ jobs:
         run: |
           ./start --apis &
           sleep 1
-      - name: Check that pages render (cloud app)
+      - name: Check that pages render
         if: steps.all-changed-files.outputs.any_changed == 'true'
         run: |
           npm run check:pages-render -- --from-file .github/outputs/all_changed_files.txt
-      - name: Check that Katex expressions render (cloud app)
+      - name: Check that Katex expressions render
         if: steps.all-changed-files.outputs.any_changed == 'true'
         run: |
           npm run check:katex-render -- --from-file .github/outputs/all_changed_files.txt
-      - name: Stop Docker preview (cloud app)
+      - name: Stop Docker preview
         if: steps.all-changed-files.outputs.any_changed == 'true'
         run: docker ps -q | xargs docker stop
-      - name: Start local Docker preview (legacy app)
-        if: steps.all-changed-files.outputs.any_changed == 'true'
-        run: |
-          ./start --legacy &
-          sleep 1
-      - name: Check that non-API pages render (legacy app)
-        if: steps.all-changed-files.outputs.any_changed == 'true'
-        run: |
-          npm run check:pages-render -- --legacy --from-file .github/outputs/all_changed_files.txt
 
       - name: Setup Python environment
         uses: ./.github/actions/set-up-notebook-testing

--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -28,11 +28,11 @@ jobs:
           node-version: 18
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Start local Docker preview (cloud app)
+      - name: Start local Docker preview
         run: |
           ./start --apis &
           sleep 20
-      - name: Check all pages render (cloud app)
+      - name: Check all pages render
         run: >
           npm run check:pages-render --
           --non-api
@@ -40,15 +40,8 @@ jobs:
           --current-apis
           --dev-apis
           --historical-apis
-      - name: Stop Docker preview (cloud app)
+      - name: Stop Docker preview
         run: docker ps -q | xargs docker stop
-      - name: Start local Docker preview (legacy app)
-        run: |
-          ./start --legacy &
-          sleep 20
-      - name: Check all non-API pages render (legacy app)
-        run: >
-          npm run check:pages-render -- --legacy
 
   external-link-checker:
     runs-on: ubuntu-latest

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -157,24 +157,6 @@ use `&trade;` to get &trade; for nonregistered trademarks.
 
 ⚠️ **Note**: Do not include trademarks in headings. The code will display rather than the symbol.
 
-## Platform-specific pages
-
-You can restrict pages to only appear on a specific platform (IQP Cloud or IQP Classic).
-
-1. Add `"platform": "cloud"` or `"platform": "legacy"` to the pages' entry in `_toc.json`. This will stop the page from appearing in the left table of contents in the other platform.
-
-   ```json
-   {
-     "title": "Connecting to IBM Cloud",
-     "url": "/cloud/connect-to-ibm-cloud",
-     "platform": "cloud"
-   }
-   ```
-
-   **Note:** If every page in a section is platform-specific, you must also add the `"platform"` attribute to the section too. Otherwise, users will see an empty section on the other platform.
-
-2. Add `platform: cloud` to the page's metadata. This will make the page 404 if a user tries to access that page's URL. See [Page metadata](#page-metadata) for how to set this.
-
 ## Custom components
 
 These are components that we expose through MDX. You can use them in both

--- a/start
+++ b/start
@@ -37,8 +37,6 @@ def main() -> None:
         subprocess.run(["docker", "pull", IMAGE], check=True)
         sys.exit(0)
 
-    platform = "legacy" if "--legacy" in sys.argv else "cloud"
-
     # Keep this aligned with the Dockerfile at the root of the repository.
     cmd = [
         "docker",
@@ -52,8 +50,6 @@ def main() -> None:
         f"{PWD}/public:/home/node/app/packages/preview/public",
         "-p",
         "3000:3000",
-        "-e",
-        f"DOCS_PLATFORM={platform}",
         # Needed for ctrl-c to shut down the container.
         "--init",
         "--rm",


### PR DESCRIPTION
This PR deletes the `platform` option from the `start` script. This is because we are removing the legacy app in inner source and from the preview app. It also simplifies the render checker to only verify cloud pages.

This change will be accompanied by a follow-up that finishes removing missing parts once we don't use any platform specific tag in the content.