### PR TITLE
Fixed typo in QDA lesson 4.1

### DIFF
--- a/learning/courses/quantum-diagonalization-algorithms/sqd-implementation.ipynb
+++ b/learning/courses/quantum-diagonalization-algorithms/sqd-implementation.ipynb
@@ -612,7 +612,7 @@
     "\n",
     "$$\n",
     "\\begin{align}\\nonumber\n",
-    "    \\text{Batch0: } \\vert \\psi \\rangle &= 0.8 \\times \\vert 1001 \\rangle + 0.6 \\times \\vert 0101 \\rangle \\\\ \\nonumber\n",
+    "    \\text{Batch0: } \\vert \\psi \\rangle &= 0.8 \\times \\vert 1001 \\rangle + 0.6 \\times \\vert 0110 \\rangle \\\\ \\nonumber\n",
     "    \\text{Batch1: } \\vert \\psi \\rangle &= \\frac{1}{\\sqrt{3}} \\left( \\vert 1001 \\rangle + \\vert 0101 \\rangle + \\vert 0110 \\rangle \\right) \\nonumber\n",
     "\\end{align}\n",
     "$$\n",


### PR DESCRIPTION
Fixed a typo in the Batch0 line of lesson 4.1 in QDA
Fixes issue: Configuration recovery bitstring typo
Fixes #3488