### PR TITLE
Always run notebook normalization in cron job

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -35,6 +35,7 @@ jobs:
         run: tox -- --write --test-strategy hardware
 
       - name: Normalize notebooks
+        if: "!cancelled()"
         run: tox -e fix
 
       - name: Detect changed notebooks


### PR DESCRIPTION
This step was not running because the "Execute notebooks" step almost always fails. It should always be safe to run the normalization.
