### PR TITLE
Fix anchors detection for headings with single/double quotes

### DIFF
--- a/scripts/js/lib/links/extractLinks.test.ts
+++ b/scripts/js/lib/links/extractLinks.test.ts
@@ -52,6 +52,12 @@ test("parseAnchors()", () => {
   <Class>
       ### Header inside a component
   </Class>
+
+  ### Click Run on (QPU name)
+
+  ### Click "Run on (QPU name)"
+
+  ### Click 'Run on (QPU name)'
   `);
   expect(result).toEqual(
     new Set([
@@ -69,6 +75,9 @@ test("parseAnchors()", () => {
       "#repeated",
       "#repeated-1",
       "#repeated-2",
+      "#click-run-on-qpu-name",
+      "#click-run-on-qpu-name-1",
+      "#click-run-on-qpu-name-2",
     ]),
   );
 });

--- a/scripts/js/lib/links/extractLinks.ts
+++ b/scripts/js/lib/links/extractLinks.ts
@@ -34,6 +34,7 @@ export type ParsedFile = {
   externalLinks: Set<string>;
 };
 
+// Keep in sync with the function `getHeadingAnchorId` in closed source"
 export function parseAnchors(markdown: string): Set<string> {
   const lines = markdown.split("\n");
   const anchors = new Set<string>();
@@ -44,7 +45,7 @@ export function parseAnchors(markdown: string): Set<string> {
         .toLowerCase()
         .trim()
         .replaceAll(" ", "-")
-        .replaceAll(/[\.,;:!?`\\\(\)]/g, "");
+        .replaceAll(/[\.,;:!?`\\\(\)"']/g, "");
       let deduplicated = normalized;
       let i = 1;
       while (anchors.has(`#${deduplicated}`)) {


### PR DESCRIPTION
Our code wasn't accounting for headings that contain double and single quotes. I found this issue while working in translations. To find the behavior of the anchors with this type of titles, you can go to https://quantum.cloud.ibm.com/docs/en/guides/composer#click-run-on-qpu-name to see how the double quotes are removed.