### PR TITLE
Use new Docker image to fix preview link issue

### DIFF
--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:cebc0063663e738496500325a7f0e52b556f9a0666162471c19d617ea8bb0f8e"
+IMAGE_DIGEST = "sha256:3f0ce2e317aa90b2a20deb14210d7b2ac5fba6f7a41b1dcef50d985925054bc7"
 
 # Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
 # https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7


### PR DESCRIPTION
Fixes a bug where relative links like `./other-file` weren't working.