### PR TITLE
Remove extra line in stretch example

### DIFF
--- a/docs/guides/stretch.mdx
+++ b/docs/guides/stretch.mdx
@@ -195,7 +195,6 @@ Support for `stretch` in Qiskit Runtime is currently experimental and has the fo
     <Tabs>
          <TabItem value="Invalid" label="Invalid">
         ```python
-        delay[a  - 40.0] $0; #if "a" resolves to a value <= 40.0
         from qiskit.circuit import Duration
 
         circuit.barrier((q0, q1))


### PR DESCRIPTION
Looks like we forgot to delete the QASM3 line in the stretch example, when converting to circuits. 