### PR TITLE
Add limits on DC support for QASM3

### DIFF
--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -398,7 +398,7 @@
     "\n",
     "- Having `reset` or measurements inside conditionals is not supported.\n",
     "- Arithmetic operations are not supported.\n",
-    "- See the [OpenQASM 3 feature table](/docs/guides/qasm-feature-table) to determine which OpenQASM 3 features are supported on Qiskit and Qiskit Runtime."
+    "- See the [OpenQASM 3 feature table](/docs/guides/qasm-feature-table) to determine which OpenQASM 3 features are supported on Qiskit and Qiskit Runtime.\n",
     "- When OpenQASM 3 (instead of `QuantumCircuit`) is used as the input format to pass circuits to Qiskit Runtime primitives, only instructions that can be loaded into Qiskit are supported. Classical operations, for example, are not supported because they cannot be loaded into Qiskit. See [Import an OpenQASM 3 program into Qiskit](/docs/guides/interoperate-qiskit-qasm3#import-an-openqasm-3-program-into-qiskit) for more information on loading an OpenQASM 3 program into Qiskit."
    ]
   },


### PR DESCRIPTION
This PR adds another limit to dynamic circuits support when QASM3 is used as the input format for circuits. 