### PR TITLE
Report file when encountering parsing problem

### DIFF
--- a/scripts/js/lib/links/extractLinks.ts
+++ b/scripts/js/lib/links/extractLinks.ts
@@ -129,6 +129,10 @@ export async function parseFile(filePath: string): Promise<ParsedFile> {
     };
 
   const markdown = await readMarkdown(filePath);
-  const [internalLinks, externalLinks] = await parseLinks(markdown);
-  return { anchors: parseAnchors(markdown), internalLinks, externalLinks };
+  try {
+    const [internalLinks, externalLinks] = await parseLinks(markdown);
+    return { anchors: parseAnchors(markdown), internalLinks, externalLinks };
+  } catch (err) {
+    throw new Error(`Problem parsing '${filePath}':\n` + err.message);
+  }
 }


### PR DESCRIPTION
When the link checker fails to parse a file, it doesn't tell us which file it failed to parse. This makes it harder to work out where the problem is.

This PR reports the file name if the parse step fails.
