### PR TITLE
Fix code example in the C API installation guide

### DIFF
--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -13,10 +13,10 @@ The following example builds an observable with C:
 ```c
 // file: example.c
 #include <stdio.h>
-#include <complex.h>
+#include <stdint.h>
 #include <qiskit.h>
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // build a 100-qubit empty observable
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_zero(num_qubits);

--- a/docs/guides/install-c-api.mdx
+++ b/docs/guides/install-c-api.mdx
@@ -13,17 +13,16 @@ The following example builds an observable with C:
 ```c
 // file: example.c
 #include <stdio.h>
-#include <stdint.h>
 #include <complex.h>
 #include <qiskit.h>
 
 int main(int argc, char* argv[]) {
     // build a 100-qubit empty observable
-    u_int32_t num_qubits = 100;
+    uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_zero(num_qubits);
 
     // add the term 2 * (X0 Y1 Z2) to the observable
-    complex double coeff = 2;  // on MSVC use: _Dcomplex coeff = {2, 0}
+    QkComplex64 coeff = {2, 0};
     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};  // bit terms: X Y Z
     uint32_t indices[3] = {0, 1, 2};  // indices: 0 1 2
     QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};


### PR DESCRIPTION
This PR fixes a compilation error in the code example of the C API installation guide. 

Fixes #3689 