### PR TITLE
Clarify service init behavior

### DIFF
--- a/docs/guides/cloud-setup-invited.mdx
+++ b/docs/guides/cloud-setup-invited.mdx
@@ -66,7 +66,7 @@ When an instance CRN or name is passed in, only backends and jobs from that inst
 
 
       ```python
-        from qiskit_ibm_runtime import QiskitRuntimeService
+    from qiskit_ibm_runtime import QiskitRuntimeService
 
     # If you named your credentials, optionally specify the name here, as follows:
     # QiskitRuntimeService(name='account-name')
@@ -76,6 +76,7 @@ When an instance CRN or name is passed in, only backends and jobs from that inst
       * If you are saving multiple accounts, consider using the `name` parameter to differentiate them.
       * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
       * If you don't save your credentials, you must specify them every time you start a new session.
+      * If you specify your credentials, a saved account will not be used.
 
     <Admonition type="note" title="Notes">
       * Follow [these instructions](/docs/guides/cloud-setup-untrusted) to authenticate to IBM Cloud if you are not using a trusted environment. For example, if you are using a public comptuer.

--- a/docs/guides/cloud-setup-untrusted.mdx
+++ b/docs/guides/cloud-setup-untrusted.mdx
@@ -24,6 +24,7 @@ To initialize the service in this situation, use code like the following:
 
     ```python
     from qiskit_ibm_runtime import QiskitRuntimeService
+
     # Saved accounts are not used when a token is passed in. The service is initialized with credentials that are not saved.
     service = QiskitRuntimeService(
       # Delete your key on the API keys page after entering this code:

--- a/docs/guides/cloud-setup-untrusted.mdx
+++ b/docs/guides/cloud-setup-untrusted.mdx
@@ -24,7 +24,7 @@ To initialize the service in this situation, use code like the following:
 
     ```python
     from qiskit_ibm_runtime import QiskitRuntimeService
-
+    # Saved accounts are not used when a token is passed in. The service is initialized with credentials that are not saved.
     service = QiskitRuntimeService(
       # Delete your key on the API keys page after entering this code:
       token="<IBM Cloud API key>",

--- a/docs/guides/cloud-setup.mdx
+++ b/docs/guides/cloud-setup.mdx
@@ -101,7 +101,7 @@ When an instance CRN or name is passed in, only backends and jobs from that inst
 
 
       ```python
-        from qiskit_ibm_runtime import QiskitRuntimeService
+    from qiskit_ibm_runtime import QiskitRuntimeService
 
     # If you named your credentials, optionally specify the name here, as follows:
     # QiskitRuntimeService(name='account-name')
@@ -111,6 +111,7 @@ When an instance CRN or name is passed in, only backends and jobs from that inst
       * If you are saving multiple accounts, consider using the `name` parameter to differentiate them.
       * Credentials are saved to `$HOME/.qiskit/qiskit-ibm.json`.  Do not manually edit this file.
       * If you don't save your credentials, you must specify them every time you start a new session.
+      * If you specify your credentials, a saved account will not be used.
 
     <Admonition type="note" title="Notes">
       * Follow [these instructions](/docs/guides/cloud-setup-untrusted) to authenticate to IBM Cloud if you are not using a trusted environment. For example, if you are using a public comptuer.


### PR DESCRIPTION
A user saved their account with a default instance but then initialized the `QiskitRuntimeService` with a token so the saved account was not used. This confusion caused them to mistakenly use a premium instance, thinking they were using the open instance. 

```python
QiskitRuntimeService.save_account(
    token=token,
    channel="ibm_quantum_platform",
    instance=CRN
)

# This initializes a new account with the token and channel, it does not use the saved account. 
service = QiskitRuntimeService(channel="ibm_quantum_platform", token=token)
```