### PR TITLE
Update qiskit-ibm-runtime install from source instructions

### DIFF
--- a/docs/guides/install-qiskit-source.mdx
+++ b/docs/guides/install-qiskit-source.mdx
@@ -121,13 +121,7 @@ git clone https://github.com/Qiskit/qiskit-ibm-runtime.git
 cd qiskit-ibm-runtime
 ```
 
-3. (Optional) If you want to run tests or linting checks, install the developer requirements. We recommend using a [virtual environment](https://docs.python.org/3/library/venv.html) to avoid polluting your global Python installation.
-
-```bash
-pip install -r requirements-dev.txt
-```
-
-4. Install `qiskit-runtime`. We recommend using a [virtual environment](https://docs.python.org/3/library/venv.html) to avoid polluting your global Python installation.
+3. Install `qiskit-runtime`. We recommend using a [virtual environment](https://docs.python.org/3/library/venv.html) to avoid polluting your global Python installation.
 
   * **Standard install**:
 
@@ -142,6 +136,12 @@ pip install -r requirements-dev.txt
     ```
 
     In editable mode, the compiled extensions are built in _debug mode_ without optimizations.
+
+4. (Optional) If you want to run tests or linting checks, install the developer requirements. We recommend using a [virtual environment](https://docs.python.org/3/library/venv.html) to avoid polluting your global Python installation.
+
+```bash
+pip install -e ".[dev]"
+```
 
 
 ## Next steps


### PR DESCRIPTION
`pip install -r requirements-dev.txt` does not work for qiskit-ibm-runtime because we removed the requirements text files in https://github.com/Qiskit/qiskit-ibm-runtime/pull/2053