### PR TITLE
updates to Custom roles: view analytics only section

### DIFF
--- a/docs/guides/custom-roles.mdx
+++ b/docs/guides/custom-roles.mdx
@@ -44,7 +44,8 @@ This custom role grants quantum-specific roles to users.
 
 6. In the Service dropdown menu, choose Qiskit Runtime. A table appears that contains all the actions that you can map to the role.
 
-7. For this example, look for any actions that pertain to analytics, such as "Read usage filters for analytics" and "Read usage for analytics". To add the actions to your custom role, click Add at the end of the action's row.
+7. For this example, look for any actions that pertain to analytics, such as "Read usage filters for analytics" and "Read usage for analytics". Also include the "Read account configuration" action.
+To add the actions to your custom role, click Add at the end of the action's row.
 
 8. Once you have added all the actions you want mapped to the role, click Create.
 

--- a/docs/guides/custom-roles.mdx
+++ b/docs/guides/custom-roles.mdx
@@ -23,10 +23,8 @@ This custom role grants quantum-specific roles to users.
     * quantum-computing.job.cancel
     * quantum-computing.job.create
     * quantum-computing.job.read
-    * quantum-computing.program.create
     * quantum-computing.program.delete
     * quantum-computing.program.read
-    * quantum-computing.program.update
     * quantum-computing.user.logout
     * Select quantum-computing.job.delete if you want to allow users to delete jobs.
 


### PR DESCRIPTION
Add missing info, and remove the unused actions on the Custom roles page. (See internal issue.)