### PR TITLE
Reorder cells in "Real-time benchmarking for qubit selection" tutorial

### DIFF
--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -100,6 +100,42 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64c25da9-a728-4ae4-a377-3078a1dc618d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Image src=\"/docs/images/tutorials/real-time-benchmarking-for-qubit-selection/extracted-outputs/95571eca-02ba-4452-816a-c04822675be8-0.avif\" alt=\"Output of the previous code cell\" />"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from qiskit import QuantumCircuit\n",
+    "\n",
+    "ideal_dist = {\"00\": 0.5, \"11\": 0.5}\n",
+    "\n",
+    "num_qubits_list = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 127]\n",
+    "circuits = []\n",
+    "for num_qubits in num_qubits_list:\n",
+    "    circuit = QuantumCircuit(num_qubits, 2)\n",
+    "    circuit.h(0)\n",
+    "    for i in range(num_qubits - 1):\n",
+    "        circuit.cx(i, i + 1)\n",
+    "    circuit.barrier()\n",
+    "    circuit.measure(0, 0)\n",
+    "    circuit.measure(num_qubits - 1, 1)\n",
+    "    circuits.append(circuit)\n",
+    "\n",
+    "circuits[-1].draw(output=\"mpl\", style=\"clifford\", fold=-1)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "16948f21-a39b-4444-bf02-5f81331825c4",
    "metadata": {},
@@ -399,43 +435,6 @@
    "metadata": {},
    "source": [
     "You can see that over several days some of the qubit properties can change considerably. This highlights the importance of having fresh information of the QPU status, to be able to select the best performing qubits for an experiment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "95571eca-02ba-4452-816a-c04822675be8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Image src=\"/docs/images/tutorials/real-time-benchmarking-for-qubit-selection/extracted-outputs/95571eca-02ba-4452-816a-c04822675be8-0.avif\" alt=\"Output of the previous code cell\" />"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from qiskit import QuantumCircuit\n",
-    "\n",
-    "ideal_dist = {\"00\": 0.5, \"11\": 0.5}\n",
-    "\n",
-    "num_qubits_list = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 127]\n",
-    "circuits = []\n",
-    "for num_qubits in num_qubits_list:\n",
-    "    circuit = QuantumCircuit(num_qubits, 2)\n",
-    "    circuit.h(0)\n",
-    "    for i in range(num_qubits - 1):\n",
-    "        circuit.cx(i, i + 1)\n",
-    "    circuit.barrier()\n",
-    "    circuit.measure(0, 0)\n",
-    "    circuit.measure(num_qubits - 1, 1)\n",
-    "    circuits.append(circuit)\n",
-    "\n",
-    "circuits[-1].draw(output=\"mpl\", style=\"clifford\", fold=-1)"
    ]
   },
   {


### PR DESCRIPTION
The code cell corresponding to the sentence
>To benchmark the difference in performance, we consider a circuit that prepares a Bell state across a linear chain of varying length. The fidelity of the Bell state at the ends of the chain is measured.

is placed in a later location, seemingly out of place. This PR moves the code cell to be immediately after the sentence.