### PR TITLE
Add imagemagick to notebook testing environment

### DIFF
--- a/.github/actions/set-up-notebook-testing/action.yml
+++ b/.github/actions/set-up-notebook-testing/action.yml
@@ -57,7 +57,8 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install texlive-pictures texlive-latex-extra poppler-utils graphviz
+        sudo apt-get install texlive-pictures texlive-latex-extra poppler-utils graphviz imagemagick
+        sudo ln -s /usr/bin/convert /usr/bin/magick
 
     - name: Set ulimit
       # https://github.com/Qiskit/documentation/issues/2387#issuecomment-2523753374


### PR DESCRIPTION
Our cron job was not running `tox -e fix` correctly when generating new notebook outputs. This was because imagemagick wasn't included in the CI environment. This PR fixes that bug.