### PR TITLE
Fixed typo in metadata title

### DIFF
--- a/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/simon-algorithm.ipynb
+++ b/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/simon-algorithm.ipynb
@@ -328,7 +328,7 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
-  "title": "Sinon's algorithm"
+  "title": "Simon's algorithm"
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
The title in metadata of "Simon's algorithm" read "Sinon's algorithm".