### PR TITLE
Re-added video to replace gif in QPE lesson.

### DIFF
--- a/learning/courses/utility-scale-quantum-computing/quantum-phase-estimation.ipynb
+++ b/learning/courses/utility-scale-quantum-computing/quantum-phase-estimation.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "The quantum Fourier transform (QFT) transforms between two bases, the computational (Z) basis, and the Fourier basis. But what does the Fourier basis mean in this context? You likely recall that the Fourier transform $F(\\omega)$ of a function $f(x)$ describes the convolution of $f(x)$ onto a sinusoidal function with frequency $\\omega$. In Layman's terms: the Fourier transform is a function describing how much of each frequency $\\omega$ we would need to build up a function $f(x)$ out of sine functions (or cosine functions). To get a better sense for what the QFT means in this context, consider the stepped images below which show a number encoded in binary, using four qubits:\n",
     "\n",
-    "IFRAME\n",
+    "<IBMVideo id=\"134399598\" title=\"This short video shows how four qubits precessing at different rates can be used to encode digits.\"/>\n",
     "\n",
     "In the computational basis, we store numbers in binary using the states $|0\\rangle$ and $|1\\rangle$.\n",
     "\n",


### PR DESCRIPTION
Closes #3786 
A gif of fourier counting should have been replaced with a video component during migration. Fixing it now.