### PR TITLE
Fixed mispelling, changed errer to error

### DIFF
--- a/learning/courses/quantum-diagonalization-algorithms/krylov.ipynb
+++ b/learning/courses/quantum-diagonalization-algorithms/krylov.ipynb
@@ -799,7 +799,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Choose the absolute error you can tolerate, and make a list for tracking the Krylov subspace size at which that errer is achieved.\n",
+    "# Choose the absolute error you can tolerate, and make a list for tracking the Krylov subspace size at which that error is achieved.\n",
     "abserr = 0.05\n",
     "accept_subspace_size = []\n",
     "\n",


### PR DESCRIPTION
In a comment in the course, the word "error" was mispelled as "errer". I fixed it.