### PR TITLE
docs: add v1->v2 migration guide to the index

### DIFF
--- a/docs/migration-guides/index.mdx
+++ b/docs/migration-guides/index.mdx
@@ -8,6 +8,9 @@ description: Migrate to using the newest from Qiskit and Qiskit Runtime
 
 These migration guides help you more effectively use Qiskit and Qiskit Runtime:
 
+* Migrate to Qiskit 2.0
+   * [Qiskit v2.0 migration guide](/docs/migration-guides/qiskit-2.0)
+   * [Migrate from BackendV1 to BackendV2](/docs/migration-guides/qiskit-backendv1-to-v2)
 * Migrate to the new version of IBM Quantum&reg; Platform
    * [Migrate to the upgraded IBM Quantum Platform](/docs/migration-guides/classic-iqp-to-cloud-iqp)
    * [Migrate from using the Qiskit Runtime REST API on IBM Quantum Platform Classic to using the new Qiskit Runtime REST API](/docs/migration-guides/migrate-classic-rest-api#from-classic)


### PR DESCRIPTION
In the index for the migration guides the new guide vor v2 was missing. I added the context as stated in the menu file [`_toc.json`](https://github.com/Qiskit/documentation/blob/main/docs/migration-guides/_toc.json)