### PR TITLE
fix: Dirac notation for Pauli-Y

### DIFF
--- a/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb
+++ b/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb
@@ -541,7 +541,7 @@
     "0 & -i \\\\\n",
     "i & 0 \\\\\n",
     "\\end{pmatrix}\n",
-    "= -1|0\\rangle \\langle 1|+i|1\\rangle \\langle 0|\n",
+    "= -i|0\\rangle \\langle 1|+i|1\\rangle \\langle 0|\n",
     "$$\n",
     "\n",
     "$$\n",


### PR DESCRIPTION
In "Utility-scale quantum computing", chapter "Quantum bits, gates, and circuits" (https://github.com/Qiskit/documentation/blob/main/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb), section "3.2 Single-qubit quantum state and unitary evolution", paragraph 3, the Pauli-Y gate (using Dirac notation) is given as `-1 |0><1| + i |1><0|`.

Shouldn't it be `-i |0><1| + i |1><0|`?