### PR TITLE
fix: S gate

### DIFF
--- a/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb
+++ b/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb
@@ -615,7 +615,7 @@
     "\\end{bmatrix},\\quad\n",
     "S = \\begin{bmatrix}\n",
     "1 & 0 \\\\\n",
-    "0 & -i \\\\\n",
+    "0 & i \\\\\n",
     "\\end{bmatrix}, \\quad\n",
     "T = \\begin{bmatrix}\n",
     "1 & 0 \\\\\n",


### PR DESCRIPTION


In "Utility-scale quantum computing", chapter "Quantum bits, gates, and circuits" (https://github.com/Qiskit/documentation/blob/main/learning/courses/utility-scale-quantum-computing/bits-gates-and-circuits.ipynb), section "3.2 Single-qubit quantum state and unitary evolution", paragraph 5, we have S = [1 0; 0 -i].

I think S should be [1 0; 0 i], instead.  See https://en.wikipedia.org/wiki/Quantum_logic_gate (section "Notable examples", subsection "Phase shift gates", paragraph 2), or https://github.com/Qiskit/documentation/blob/main/learning/courses/basics-of-quantum-information/single-systems/quantum-information.ipynb (section "Unitary operations", subsection "Examples of unitary operations on qubits", paragraph 1, item 3).
