### PR TITLE
Fix real-time benchmarking tutorial warnings

### DIFF
--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -501,7 +501,7 @@
     "In this section, we'll investigate the importance of having updated information on qubit properties of the QPU for optimal results. First, we'll carry out a full suite of QPU characterization experiments ($T_1$, $T_2$, SPAM, single-qubit RB and two-qubit RB), which we can then use to update the backend properties. This allows the pass manager to select qubits for the execution based on fresh information about the QPU, possibly improving execution performances. Second, we execute the Bell pair circuit and we compare the fidelity obtained after selecting the qubits with update QPU properties to the fidelity we obtained before when we use the default reported properties for qubit selection.\n",
     "\n",
     "<Admonition type=\"caution\">\n",
-    "Note that some of the characterization experiments may fail when the fitting routine cannot fit a curve to the measured data. If you see warnings coming from these experiments, inspect them to understand which characterization failed on which qubits, and try adjusting the parameters of the experiment (like the times for $T_1$, $T_2$, or the number lengths of RB experiments).\n",
+    "Note that some of the characterization experiments might fail when the fitting routine cannot fit a curve to the measured data. If you see warnings coming from these experiments, inspect them to understand which characterization failed on which qubits, and try adjusting the parameters of the experiment (like the times for $T_1$, $T_2$, or the number lengths of RB experiments).\n",
     "</Admonition>"
    ]
   },


### PR DESCRIPTION
Add text to explain the possibility of warnings arising in the execution of qubit characterization experiments