### PR TITLE
Update qiskit-addons-cutting.mdx

### DIFF
--- a/docs/guides/qiskit-addons-cutting.mdx
+++ b/docs/guides/qiskit-addons-cutting.mdx
@@ -112,7 +112,7 @@ As a basic explicit example, consider the decomposition of a cut RZZGate (detail
 For some chosen $\theta$ parameter for the RZZGate, the six subexperiments are as follows:
 1. With coefficient $a_1 = \cos^2(\theta/2)$, do nothing ($I\otimes I$)
 1. With coefficient $a_2 = \sin^2(\theta/2)$, perform a ZGate on each qubit ($Z\otimes Z$)
-1. With coefficient $a_3 = -\sin(\theta)/2$, perform a projective measurement in the $Z$ basis on the first qubit and an $S$ on the second ($M_z\otimes S^\dagger$). If the result of the measurement is $1$, flip the sign of that outcome's contribution during reconstruction.
+1. With coefficient $a_3 = -\sin(\theta)/2$, perform a projective measurement in the $Z$ basis on the first qubit and an $S$ on the second ($M_z\otimes S$). If the result of the measurement is $1$, flip the sign of that outcome's contribution during reconstruction.
 1. With coefficient $a_4 = \sin(\theta)/2$, perform a projective measurement in the $Z$ basis on the first qubit and an $S^\dagger$ on the second ($M_z\otimes S^\dagger$). If the result of the measurement is 1, flip the sign of that outcome's contribution during reconstruction.
 1. Same as 3. ($a_5=a_3$), but swap the qubits (perform $S\otimes M_z$ instead).
 1. Same as 4. ($a_6=a_4$), but swap the qubits (perform $S^\dagger\otimes M_z$ instead).


### PR DESCRIPTION
### Description of the issue

In the documentation at “A short example: cutting a RZZGate”, subsection 3rd subexperiment, the text currently reads:

“... perform a projective measurement in the $Z$ basis on the first qubit and an $S$ on the second $(M_z \otimes S^\dagger)$”

I believe this may be a mistake. Since the description says “apply an $S$ on the second qubit,” the expression should likely be:

$(M_z \otimes S)$ instead of $(M_z \otimes S^\dagger)$.

### Proposed correction

Replace $(M_z \otimes S^\dagger)$ with $(M_z \otimes S)$

<img width="913" height="615" alt="Image" src="https://github.com/user-attachments/assets/c588089a-cb39-4e89-9436-36fb510b447f" />