### PR TITLE
Update slack link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Trouble with your code? 😕
-    url: https://ibm.co/joinqiskitslack
+    url: http://qisk.it/join-slack
     about: Ask for debugging help on the Qiskit community Slack when you run into problems with your code.
   - name: Overall impressions and feedback 📝
     url: https://ibmxm.iad1.qualtrics.com/jfe/form/SV_7Uq9FCMjZPyTsFM?Q_PopulateResponse={%22QID20%22:%223%22}


### PR DESCRIPTION
New slack url is [qisk.it/join-slack](http://qisk.it/join-slack)

Thank you @abdonrd for flagging!