### PR TITLE
[on hold till Qiskit 2.3] Document macOS x86_64 downgraded to tier 2

### DIFF
--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -227,7 +227,6 @@ In the Qiskit v2.x release series, the supported platforms are:
   Tier 1 operating systems:
 
   - Linux x86_64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification).
-  - macOS x86_64 (10.12 or later)
   - macOS ARM64 (11.0 or newer)
   - Windows 64-bit (Windows 10 and later supported)
   - Linux AArch64 (distributions compatible with the [manylinux 2014](https://www.python.org/dev/peps/pep-0599/) packaging specification)
@@ -237,7 +236,13 @@ In the Qiskit v2.x release series, the supported platforms are:
   <summary>
     Tier 2
   </summary>
-  *There are no Tier 2 operating systems in the Qiskit v2.x release series.* Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
+
+  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
+
+  Tier 2 operating systems:
+
+  - macOS x86_64 (10.12 or later)
+
 </details>
 
 <details>


### PR DESCRIPTION
In Qiskit 2.3 the macOS x86_64 platform will be downgraded from tier 1 to tier 2 (see Qiskit/Qiskit#15041 for more details). This is due to lack of support from apple and limited resources available on Github for the platform. This commit updates the documentation page for platform support to reflect this change. This should not be merged until Qiskit 2.3.0 as this change only takes effect in 2.3.0 and 2.2.x still has tier 1 support for the platform.