### PR TITLE
Fix typo in primitive-input-output.ipynb

### DIFF
--- a/docs/guides/primitive-input-output.ipynb
+++ b/docs/guides/primitive-input-output.ipynb
@@ -254,8 +254,8 @@
     "        [SparsePauliOp([\"IZI\"])],\n",
     "        [SparsePauliOp([\"IIZ\"])],\n",
     "    ],\n",
-    "]\n",
-    "# >> pub result has shape (2, 3, 1)"
+    "]  # shape (2, 3, 1)\n",
+    "# >> pub result has shape (2, 3, 6)"
    ]
   },
   {


### PR DESCRIPTION
Fixed a typo in primitive-input-output.ipynb