### PR TITLE
Fix release notes TOC entries

### DIFF
--- a/docs/api/qiskit/0.46/_toc.json
+++ b/docs/api/qiskit/0.46/_toc.json
@@ -3494,7 +3494,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/1.0/_toc.json
+++ b/docs/api/qiskit/1.0/_toc.json
@@ -2219,7 +2219,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/1.1/_toc.json
+++ b/docs/api/qiskit/1.1/_toc.json
@@ -2183,7 +2183,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/1.2/_toc.json
+++ b/docs/api/qiskit/1.2/_toc.json
@@ -2199,7 +2199,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/1.3/_toc.json
+++ b/docs/api/qiskit/1.3/_toc.json
@@ -2435,7 +2435,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/1.4/_toc.json
+++ b/docs/api/qiskit/1.4/_toc.json
@@ -2447,7 +2447,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/2.0/_toc.json
+++ b/docs/api/qiskit/2.0/_toc.json
@@ -2025,7 +2025,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/docs/api/qiskit/2.1/_toc.json
+++ b/docs/api/qiskit/2.1/_toc.json
@@ -2097,7 +2097,7 @@
       "children": [
         {
           "title": "2.2",
-          "url": "/api/qiskit/release-notes/2.2"
+          "url": "/docs/api/qiskit/release-notes/2.2"
         },
         {
           "title": "2.1",

--- a/scripts/js/lib/api/releaseNotes.ts
+++ b/scripts/js/lib/api/releaseNotes.ts
@@ -12,7 +12,7 @@
 
 import { parse } from "path";
 import { readFile, writeFile, readdir } from "fs/promises";
-
+import { groupBy } from "lodash-es";
 import { $ } from "zx";
 import transformLinks from "transform-markdown-links";
 
@@ -22,8 +22,6 @@ import type { HtmlToMdResultWithUrl } from "./HtmlToMdResult.js";
 import { C_API_BASE_PATH, DOCS_BASE_PATH } from "./conversionPipeline.js";
 import { kebabCaseAndShortenPage } from "./normalizeResultUrls.js";
 import { removePrefix } from "../stringUtils.js";
-
-import { groupBy } from "lodash-es";
 
 // ---------------------------------------------------------------------------
 // Generic release notes handling
@@ -221,7 +219,7 @@ function addNewReleaseNoteToc(releaseNotesNode: any, newVersion: string) {
   if (releaseNotesNode.children[0].title != newVersion) {
     releaseNotesNode.children.unshift({
       title: newVersion,
-      url: `/api/qiskit/release-notes/${newVersion}`,
+      url: `${DOCS_BASE_PATH}/api/qiskit/release-notes/${newVersion}`,
     });
   }
 }


### PR DESCRIPTION
This PR fixes the link to the Qiskit 2.2 release note entry in all the historical version TOCs.