### PR TITLE
Refactor how we determine release note page versions

### DIFF
--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -12,7 +12,7 @@
 
 import { join } from "path/posix";
 
-import { findSeparateReleaseNotesVersions } from "./releaseNotes.js";
+import { determineReleaseNotesSeparetePagesVersions } from "./releaseNotes.js";
 import { determineHistoricalQiskitGithubUrl } from "../qiskitMetapackage.js";
 import {
   TocGrouping,
@@ -22,6 +22,7 @@ import {
 
 export class ReleaseNotesConfig {
   readonly enabled: boolean;
+  /** A list of the release note versions in descending order. */
   readonly separatePagesVersions: string[];
   readonly linkToPackage?: string;
 
@@ -110,7 +111,11 @@ export class Pkg {
     };
 
     if (name === "qiskit") {
-      const releaseNoteEntries = await findSeparateReleaseNotesVersions(name);
+      const releaseNoteEntries =
+        await determineReleaseNotesSeparetePagesVersions(
+          name,
+          versionWithoutPatch,
+        );
       return new Pkg({
         ...args,
         title: "Qiskit SDK",


### PR DESCRIPTION
Prework for part 2 of https://github.com/Qiskit/documentation/issues/2904. 

This PR removes a confusing part of our release note code: `ReleaseNotesConfig.separatePagesVersions` was not guaranteed to have every version it needed! Now, the expectation is that when creating `ReleaseNotesConfig`, you already have all the versions populated.

This doesn't fully unblock https://github.com/Qiskit/documentation/issues/2904, but it makes the code less confusing.