### PR TITLE
Refactor release notes handling for historical API docs when new version

### DIFF
--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -229,7 +229,7 @@ function generateOverviewPage(tocModules: TocEntry[]): void {
   }
 }
 
-function generateReleaseNotesEntry(pkg: Pkg): TocEntry | undefined {
+export function generateReleaseNotesEntry(pkg: Pkg): TocEntry | undefined {
   if (!pkg.releaseNotesConfig.enabled) return;
   const releaseNotesUrl = `${DOCS_BASE_PATH}/api/${pkg.releaseNotesPackageName()}/release-notes`;
   const releaseNotesEntry: TocEntry = {


### PR DESCRIPTION
This implements part 2 of https://github.com/Qiskit/documentation/issues/2904. 

Before, our code was very brittle for when we have a brand new version of Qiskit and need to add its release note to the _toc.json for all historical versions. It was going to break with https://github.com/Qiskit/documentation/pull/3979.

Now, the new code should be more resilient. The new code generates in-memory the canonical "Release notes" section one-time, as it should be the same for all versions of Qiskit. Then, we simply overwrite the `_toc.json` for every version with this canonical `TocEntry`. When combined with https://github.com/Qiskit/documentation/pull/3984, we should now always handle release notes correctly.