### PR TITLE
Replace a broken link from the runtime release notes

### DIFF
--- a/docs/api/qiskit-ibm-runtime/release-notes.mdx
+++ b/docs/api/qiskit-ibm-runtime/release-notes.mdx
@@ -348,7 +348,7 @@ The qiskit-ibm-runtime `v0.41.0` release focuses on the removal of IBM Quantum P
 ### Upgrade Notes
 
 *   Python 3.8 reached end-of-life on Oct 7th, 2024. Qiskit SDK dropped support for 3.8 in `qiskit 1.3`. In the same vein, `qiskit-ibm-runtime` does not support Python 3.8 anymore. ([2097](https://github.com/Qiskit/qiskit-ibm-runtime/pull/2097))
-*   Support for `backend.run()` has been removed. Refer to the [migration guide](/docs/migration-guides/qiskit-runtime) for instructions to migrate any existing code that uses `backend.run()` to the new V2 primitives interface. ([1962](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1962))
+*   Support for `backend.run()` has been removed. Refer to the [migration guide](https://github.com/Qiskit/documentation/blob/2d2c2fcad47dd9e7ac1cc6807527dfccd796ea24/docs/migration-guides/qiskit-runtime.mdx) for instructions to migrate any existing code that uses `backend.run()` to the new V2 primitives interface. ([1962](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1962))
 *   Parameter expressions with RZZ gates will be checked against the values assigned to them in the PUB. An `IBMInputValueError` will be raised if parameter values specified in the PUB make a parameter expression evaluate to an invalid angle (negative, or greater than `pi/2`). ([2093](https://github.com/Qiskit/qiskit-ibm-runtime/pull/2093))
 *   When there is a maintenance outage, an appropriate error message will be raised when trying to initialize the `QiskitRuntimeService`. ([2100](https://github.com/Qiskit/qiskit-ibm-runtime/pull/2100))
 

--- a/docs/api/qiskit-ibm-runtime/release-notes.mdx
+++ b/docs/api/qiskit-ibm-runtime/release-notes.mdx
@@ -814,7 +814,7 @@ The qiskit-ibm-runtime `v0.41.0` release focuses on the removal of IBM Quantum P
 
 ### Deprecation Notes
 
-*   [backend.run()](/docs/api/qiskit-ibm-runtime/ibm-backend#run) has been deprecated. Please use the primitives instead. More details can be found in the [migration guide](/docs/migration-guides/qiskit-runtime) . ([1561](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561))
+*   [backend.run()](/docs/api/qiskit-ibm-runtime/ibm-backend#run) has been deprecated. Please use the primitives instead. More details can be found in the [migration guide](https://github.com/Qiskit/documentation/blob/2d2c2fcad47dd9e7ac1cc6807527dfccd796ea24/docs/migration-guides/qiskit-runtime.mdx) . ([1561](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1561))
 *   In a future release, the `service` parameter in [from\_id()](/docs/api/qiskit-ibm-runtime/session#from_id) will be required. ([1311](https://github.com/Qiskit/qiskit-ibm-runtime/pull/1311))
 
 <span id="id88" />


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/3787

This PR replaces a link in the qiskit-ibm-runtime release notes that was pointing to one of the archived migration guides.