### PR TITLE
Remove bad space character

### DIFF
--- a/learning/courses/quantum-machine-learning/data-encoding.ipynb
+++ b/learning/courses/quantum-machine-learning/data-encoding.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "These bit strings are assigned to three sets of four qubits, so the overall 12-qubit basis state is:\n",
     "$$\n",
-    "∣0101 0111 0000⟩\n",
+    "∣0101 0111 0000⟩\n",
     "$$\n",
     "\n",
     "Here, the first four qubits represent the first feature, the next four qubits the second feature, and the last four qubits the third feature. The code below converts the data vector (5,7,0) to a quantum state, and is generalized to do so for other single-digit features."


### PR DESCRIPTION
Replaces "NARROW NO-BREAK SPACE" with regular "SPACE". This type of space produces a warning when building our application. We had a similar instance months ago in https://github.com/Qiskit/documentation/pull/3426