### PR TITLE
Fix Learning overview titles

### DIFF
--- a/learning/courses/basics-of-quantum-information/index.mdx
+++ b/learning/courses/basics-of-quantum-information/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: overview
+title: Overview
 description: Learn about quantum states, projective measurements, and unitary operations; quantum circuits; how entanglement enables quantum teleportation, and more.
 ---
 

--- a/learning/courses/foundations-of-quantum-error-correction/index.mdx
+++ b/learning/courses/foundations-of-quantum-error-correction/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: overview
+title: Overview
 description: Learn about quantum error correction, quantum error correcting codes, and fault-tolerant quantum computation.
 ---
 

--- a/learning/courses/fundamentals-of-quantum-algorithms/index.mdx
+++ b/learning/courses/fundamentals-of-quantum-algorithms/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: overview
+title: Overview
 description: Learn how quantum computers can efficiently solve problems, including searching and factoring, faster than classical computers.
 ---
 


### PR DESCRIPTION
The overview title in the courses metadata should have the first `O` in upper-case. Thanks to @abdonrd for finding it!