### PR TITLE
Add new addons to Qiskit addons overview page

### DIFF
--- a/docs/guides/addons.mdx
+++ b/docs/guides/addons.mdx
@@ -30,7 +30,8 @@ Multi-product formulas (MPF) reduce the Trotter error of Hamiltonian dynamics th
 
 The Optimization Mapper addon contains functionality to model optimization problems by formulating them in abstract models and then converting into representations that a quantum computer can understand.
 
-- Visit the [documentation](https://qiskit.github.io/qiskit-addon-opt-mapper/) for how-to guides and API references.
+- Read the [documentation](https://qiskit.github.io/qiskit-addon-opt-mapper/) for how-to guides and API references.
+- Visit the [GitHub](https://github.com/qiskit/qiskit-addon-opt-mapper) repository.
 
 
 ## Addons for optimizing
@@ -65,6 +66,7 @@ Sample-based quantum diagonalization (SQD) classically post-processes noisy quan
 This addon is an HPC-ready implementation of the SQD addon. It is written in modern C++17 standards and is designed to create a single compiled binary for use with MPI.
 
 - Visit the [API reference](https://qiskit.github.io/qiskit-addon-sqd-hpc/) documentation.
+- View the [GitHub](https://github.com/qiskit/qiskit-addon-sqd-hpc) repository.
 
 ## Addons for error mitigation
 


### PR DESCRIPTION
Add upcoming addons to Overview page and link out to their public repos. Closes #4031. Do we need to wait for more docs to be be available in the public repos before publishing here?

Tagging @caleb-johnson @jyu00 @mrossinek, per @kaelynj 