### PR TITLE
add Katie and reclassify from courses to learning in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/courses.yaml
+++ b/.github/ISSUE_TEMPLATE/courses.yaml
@@ -1,8 +1,8 @@
-name: (COURSES 🎓) Report a bug/typo or request new content
+name: (LEARNING 🎓) Report a bug/typo or request new content
 description: Report typos, bugs, out-of-date content, broken links, etc. or make a request for new content
 labels: ["content 📄", "course 🎓", "needs triage 🤔"]
 assignees:
-  - livlanes
+  - kcmccormibm
   - christopherporter1
   - docs-content-team
 
@@ -13,7 +13,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ⚠️ Note that this issue template is only for course content; verify that /learning/ is in the URL.
+        ⚠️ Note that this issue template is only for learning content; verify that /learning/ is in the URL.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/guides.yaml
+++ b/.github/ISSUE_TEMPLATE/guides.yaml
@@ -16,7 +16,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * If your issue concerns courses (with /learning/ in the URL), use the [Courses issue template](https://github.com/Qiskit/documentation/issues/new?template=courses.yaml) instead.
+        * If your issue concerns learning (with /learning/ in the URL), use the [Learning issue template](https://github.com/Qiskit/documentation/issues/new?template=courses.yaml) instead.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/tutorials.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorials.yaml
@@ -16,7 +16,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * If your issue concerns courses (with /learning/ in the URL), use the [Courses issue template](https://github.com/Qiskit/documentation/issues/new?template=courses.yaml) instead.
+        * If your issue concerns learning (with /learning/ in the URL), use the [Learning issue template](https://github.com/Qiskit/documentation/issues/new?template=courses.yaml) instead.
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
FYI @kcmccormibm ! 

Revamping the course issue template to encompass both courses and modules - renaming it to the Learning issue template.

Adding @kcmccormibm to be assigned whenever one of these issues is raised.

