### PR TITLE
Qunova HI-VQE Qiskit Function Tutorial Fix

### DIFF
--- a/docs/tutorials/qunova-hivqe.ipynb
+++ b/docs/tutorials/qunova-hivqe.ipynb
@@ -53,11 +53,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install qiskit-ibm-catalog\n",
-    "!pip install qiskit_ibm_runtime\n",
-    "!pip install pyscf\n",
-    "!pip install numpy\n",
-    "!pip install matplotlib"
+    "!pip install --upgrade pip\n",
+    "!pip install -U qiskit-ibm-catalog \"qiskit_ibm_runtime<0.42.0\" pyscf numpy matplotlib typing_extensions"
    ]
   },
   {
@@ -79,12 +76,10 @@
    "outputs": [],
    "source": [
     "from qiskit_ibm_catalog import QiskitFunctionsCatalog\n",
-    "from qiskit_ibm_runtime import QiskitRuntimeService\n",
     "from pyscf import gto, scf, mcscf\n",
     "import matplotlib.pyplot as plt\n",
     "import pprint\n",
     "\n",
-    "service = QiskitRuntimeService()\n",
     "catalog = QiskitFunctionsCatalog(\n",
     "    channel=\"ibm_quantum_platform\",\n",
     "    instance=\"INSTANCE_CRN\",\n",


### PR DESCRIPTION
This pull request removes an unused import and restricts the `qiskit_ibm_runtime` package version to avoid v0.42.0 which causes an import error on loading.