### PR TITLE
Fix typo in PEA tutorial =+ should be +

### DIFF
--- a/docs/tutorials/probabilistic-error-amplification.ipynb
+++ b/docs/tutorials/probabilistic-error-amplification.ipynb
@@ -47,7 +47,7 @@
     "It assumes expectation values scale with noise by a known function\n",
     "\n",
     "$$\n",
-    "\\langle A(\\lambda) \\rangle = \\langle A(0) \\rangle =+ \\sum_{k=0}^{m} a_k \\lambda^k + R\n",
+    "\\langle A(\\lambda) \\rangle = \\langle A(0) \\rangle + \\sum_{k=0}^{m} a_k \\lambda^k + R\n",
     "$$\n",
     "where $\\lambda$ parameterizes the noise strength and can be amplified."
    ]


### PR DESCRIPTION
There is an erroneous extra `=` in an equation.

This PR removes it.

For the correct expression, see, for example Eq (1) in [this paper](https://arxiv.org/pdf/1805.04492)  ([abstract for same paper](https://arxiv.org/abs/1805.04492))