### PR TITLE
Refactor models information for qkca

### DIFF
--- a/docs/guides/qiskit-code-assistant-local.mdx
+++ b/docs/guides/qiskit-code-assistant-local.mdx
@@ -48,14 +48,16 @@ GGUF format models are optimized for local use and require fewer computational r
 
 #### Qiskit versions used for training
 
-| Model | Trained on Qiskit version | Release date |
-|---|---|---|
-| **mistral-small-3.2-24b-qiskit** | **2.1** | **October 2025** |
-| qwen2.5-coder-14b-qiskit | 2.0 | June 2025 |
-| granite-3.3-8b-qiskit | 2.0 | June 2025 |
-| granite-3.2-8b-qiskit | 2.0 | June 2025 |
-| granite-8b-qiskit-rc-0.10 | 1.3 | February 2025 |
-| granite-8b-qiskit | 1.2 | November 2024 |
+| **Model** |  | **Benchmark Metrics** |  | **Release date** | **Trained on Qiskit version** |
+|---|---|---|---|---|---|
+|  | **QiskitHumanEval** | **QiskitHumanEval-Hard** | **HumanEval** |  |  |
+| **mistral-small-3.2-24b-qiskit** | 20.53 | 40.39 | 77.49 | **October 2025** | **2.1** |
+| qwen2.5-coder-14b-qiskit | 25.16 | 49.01 | 91.46 | June 2025 | 2.0 |
+| granite-3.3-8b-qiskit | 14.56 | 27.15 | 62.80 | June 2025 | 2.0 |
+| granite-3.2-8b-qiskit | 9.93 | 24.50 | 57.31 | June 2025 | 2.0 |
+| granite-8b-qiskit-rc-0.10 | 15.89 | 38.41 | 59.76 | February 2025 | 1.3 |
+| granite-8b-qiskit | 17.88 | 44.37 | 53.66 | November 2024 | 1.2 |
+
 
 #### Deprecated models
 


### PR DESCRIPTION
Updating information for models available to use in the Qiskit Code Assistant. As well as the table indicating the version to which each model was trained for.