### PR TITLE
fix: refactor notebook to adapt to current version of the iskay solver qiskit-function

### DIFF
--- a/docs/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer.ipynb
+++ b/docs/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer.ipynb
@@ -100,7 +100,7 @@
     "* Qiskit Functions (`pip install qiskit-ibm-catalog`)\n",
     "* NumPy (`pip install numpy`)\n",
     "* Requests (`pip install requests`)\n",
-    "* Opt Mapper Qiskit Addon (`pip install qiskit-addon-opt-mapper`)\n",
+    "* Opt Mapper Qiskit addon (`pip install qiskit-addon-opt-mapper`)\n",
     "\n",
     "You will also need to get access to the [Iskay Quantum Optimizer function](https://quantum.cloud.ibm.com/functions?id=kipu-quantum-iskay-quantum-optimizer) from the Qiskit Functions Catalog."
    ]
@@ -236,24 +236,24 @@
     "\n",
     "## From constraints to QUBO: the mathematical transformation\n",
     "\n",
-    "The power of quantum optimization lies in transforming constrained problems into unconstrained quadratic forms [4]. For the Market Split problem, we convert the equality constraints\n",
+    "The power of quantum optimization lies in transforming constrained problems into unconstrained quadratic forms [\\[4\\]](#references). For the Market Split problem, we convert the equality constraints\n",
     "\n",
     "$$ Ax = b $$\n",
     "\n",
     "where $x ∈ \\{0,1\\}^n$, into a QUBO by penalizing constraint violations.\n",
     "\n",
-    "**The Penalty Method:**\n",
+    "**The penalty method:**\n",
     "Since we need $Ax = b$ to hold exactly, we minimize the squared violation:\n",
     "$$f(x) = ||Ax - b||^2$$\n",
     "\n",
     "This equals zero precisely when all constraints are satisfied. Expanding algebraically:\n",
     "$$f(x) = (Ax - b)^T(Ax - b) = x^T A^T A x - 2b^T A x + b^T b$$\n",
     "\n",
-    "**QUBO Objective:**\n",
+    "**QUBO objective:**\n",
     "Since $b^T b$ is constant, our optimization becomes:\n",
     "$$\\text{minimize} \\quad Q(x) = x^T(A^T A)x - 2(A^T b)^T x$$\n",
     "\n",
-    "**Key Insight:** This transformation is exact, not approximate. Equality constraints naturally square into quadratic form without requiring auxiliary variables or penalty parameters—making this formulation mathematically elegant and computationally efficient for quantum solvers [4]. We'll use the `OptimizationProblem` class to define our constrained problem, then convert it to QUBO format using `OptimizationProblemToQubo`, both from the **qiskit_addon_opt_mapper** package. This automatically handles the penalty-based transformation."
+    "**Key insight:** This transformation is exact, not approximate. Equality constraints naturally square into quadratic form without requiring auxiliary variables or penalty parameters - making this formulation mathematically elegant and computationally efficient for quantum solvers [\\[4\\]](#references). We'll use the `OptimizationProblem` class to define our constrained problem, then convert it to QUBO format using `OptimizationProblemToQubo`, both from the **qiskit_addon_opt_mapper** package. This automatically handles the penalty-based transformation."
    ]
   },
   {
@@ -437,7 +437,7 @@
    "source": [
     "### Convert QUBO to Iskay format\n",
     "\n",
-    "Now we need to convert the QUBO object into the dictionary format required by Kipu Quantum's Iskay optimizer.\n",
+    "Now we need to convert the QUBO object into the dictionary format required by Kipu Quantum's Iskay Optimizer.\n",
     "\n",
     "The `problem` and `problem_type` arguments encode an optimization problem of the form\n",
     "\n",
@@ -468,7 +468,7 @@
     "\\end{align}\n",
     "$$\n",
     "\n",
-    "Please note that the keys of the dictionary must be strings containing a valid tuple of non-repeating integers. For binary problems, we know that:\n",
+    "Note that the keys of the dictionary must be strings containing a valid tuple of non-repeating integers. For binary problems, we know that:\n",
     "\n",
     "$$\n",
     "x_i^2 = x_i\n",


### PR DESCRIPTION
# Changes

  - Removed classical comparison section: Eliminated the comprehensive benchmark against classical optimization algorithms (simulated annealing, random search, brute force) due to dependency on QPU time retrieval functionality.
  - Updated QUBO-to-Iskay conversion: Refactored the conversion logic to properly handle diagonal quadratic terms b combining them with linear coefficients, ensuring binary variable property ($x_i^2 = x_i$) is correctly applied.
  - Enhanced documentation: Added detailed mathematical explanation of the penalty method and QUBO formulation including proper handling of diagonal quadratic terms.
  - Added dependency: Included qiskit-addon-opt-mapper as a required package, which is now available via `pip`.
  - Updated configuration: Modified Iskay optimizer configuration to remove token/instance parameters from input dictionary.
  - Cleaned up outputs: Removed QPU time display from results section as this metric is only available in the latest (unreleased) version of the qiskit-function.

 # Why?

  The latest version of the qiskit-function includes the ability to retrieve QPU time from results, which was used for performance comparisons with classical algorithms. However, since this version hasn't been promoted to production yet (because some problems after the upgrade of qiskit-serverless, which are being currently investigated) the tutorial has been adapted to work with the currently available production version by removing sections dependent on this feature.

# Testing

  - Notebook executes successfully with current production qiskit-function
  - QUBO conversion produces correct Iskay format
  - Solution validation works as expected
  - All code cells produce expected outputs