### PR TITLE
Fix typo on basis set

### DIFF
--- a/docs/tutorials/sample-based-quantum-diagonalization.ipynb
+++ b/docs/tutorials/sample-based-quantum-diagonalization.ipynb
@@ -182,7 +182,7 @@
    "source": [
     "## Step 1: Map classical inputs to a quantum problem\n",
     "\n",
-    "In this tutorial, we will find an approximation to the ground state of the molecule at equilibrium in the 6-31G basis set. First, we specify the molecule and its properties."
+    "In this tutorial, we will find an approximation to the ground state of the molecule at equilibrium in the cc-pVDZ basis set. First, we specify the molecule and its properties."
    ]
   },
   {


### PR DESCRIPTION
The tutorial writes to use the 6-31G basis set, whereas the code uses the cc-pVDZ basis set.

Closes issue #4222 