### PR TITLE
use least busy backend in m3 tutorial

### DIFF
--- a/docs/tutorials/readout-error-mitigation-sampler.ipynb
+++ b/docs/tutorials/readout-error-mitigation-sampler.ipynb
@@ -1385,7 +1385,7 @@
  "metadata": {
   "description": "Use the M3 readout mitigation addon with the Sampler primitive",
   "kernelspec": {
-   "display_name": "documentation",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1399,7 +1399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3"
   },
   "title": "Readout error mitigation for the Sampler primitive using M3",
   "toc": {


### PR DESCRIPTION
switch from hardcoded backend to least_busy()