### PR TITLE
Switched to using least busy backend for Long Range Entanglement tutorial. 

### DIFF
--- a/docs/tutorials/long-range-entanglement.ipynb
+++ b/docs/tutorials/long-range-entanglement.ipynb
@@ -681,8 +681,9 @@
     "from qiskit.circuit import IfElseOp\n",
     "\n",
     "service = QiskitRuntimeService()\n",
-    "backend_name = \"ibm_kingston\"\n",
-    "backend = service.backend(backend_name)"
+    "backend = service.least_busy(\n",
+    "    operational=True, simulator=False, min_num_qubits=156\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the issue of a hard coded backend for the tutorial, and also requires that the `min_num_qubits` be to least 156 to match a heron v2 device, as this tutorial does use the function `_heron_coords_r2`.