### PR TITLE
Improve ImageMagick install time in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
         run: npm ci
       - name: Install ImageMagick
         run: |
-          sudo apt-get update
           sudo apt-get install -y imagemagick
           sudo ln -s /usr/bin/convert /usr/bin/magick
       - name: Install Playwright


### PR DESCRIPTION
ImageMagick installation now takes ~10s ([see logs](https://github.com/Qiskit/documentation/actions/runs/19461097878/job/55685245098#step:7:1)) and seems to still work as the normalizer tests pass ([logs](https://github.com/Qiskit/documentation/actions/runs/19461097878/job/55685245098#step:27:26)).