### PR TITLE
Add more information to external link checker logs

### DIFF
--- a/scripts/js/lib/links/ExternalLink.test.ts
+++ b/scripts/js/lib/links/ExternalLink.test.ts
@@ -55,26 +55,6 @@ test.describe("ExternalLink.check()", () => {
     );
   });
 
-  test("temporary redirect", async () => {
-    global.fetch = () => Promise.resolve(new Response("", { status: 302 }));
-    let link = new ExternalLink("https://bad-link.com", ["/testorigin.mdx"]);
-    const result = await link.check();
-    expect(result).toBeUndefined();
-  });
-
-  test("permanent redirect", async () => {
-    global.fetch = () =>
-      Promise.resolve(
-        new Response("", {
-          status: 308,
-          headers: { location: "https://good-link.com" },
-        }),
-      );
-    let link = new ExternalLink("https://bad-link.com", ["/testorigin.mdx"]);
-    const result = await link.check();
-    expect(result).toBeUndefined();
-  });
-
   test("other problem", async () => {
     global.fetch = () => Promise.resolve(new Response("", { status: 502 }));
     let link = new ExternalLink("https://bad-link.com", ["/testorigin.mdx"]);

--- a/scripts/js/lib/links/ExternalLink.ts
+++ b/scripts/js/lib/links/ExternalLink.ts
@@ -73,9 +73,6 @@ function responseToErrorMessage(
   const isOk = httpCode >= 100 && httpCode < 300;
   if (isOk) return undefined;
 
-  const isRedirectLike = httpCode >= 300 && httpCode < 399;
-  if (isRedirectLike) return undefined;
-
   if (httpCode === 404) return `Could not find link '${link}' (${httpCode})`;
   if (httpCode === 410) return `Link '${link}' has been removed (${httpCode})`;
   if (httpCode === 418) return `Link '${link}' is a teapot (${httpCode})`;


### PR DESCRIPTION
It's helpful to be able to glance at the logs and determine why a link failed.

For example: A 502 status code is most likely a temporary flake, which we can ignore. Whereas a 410 status code means the link is definitely broken.

This PR adds the status code to the logs and reports if the fetch failed for some other reason.