### PR TITLE
Use Python script for status check path filtering in CI

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -13,17 +13,31 @@
 name: Test notebooks
 on:
   pull_request:
-    paths:
-      - ".github/workflows/notebook-test.yml"
-      - "docs/**/*.ipynb"
-      - "learning/**/*.ipynb"
-      - "!docs/api/**/*"
-      - "scripts/nb-tester/**/*"
   workflow_dispatch:
 jobs:
+  check_paths:
+    name: Decide whether to run
+    if: github.repository_owner == 'Qiskit'
+    runs-on: ubuntu-latest
+    outputs:
+      SHOULD_RUN_NOTEBOOK_TESTER: ${{ steps.filter.outputs.SHOULD_RUN_NOTEBOOK_TESTER }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/ci/pr-path-filter.py
+      - name: Check paths
+        id: filter
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CHANGED_FILES=$(gh pr diff ${{ github.event.number }} --name-only)
+          echo $CHANGED_FILES | python scripts/ci/pr-path-filter.py
+          cat $GITHUB_OUTPUT
   execute:
     name: Execute notebooks
-    if: github.repository_owner == 'Qiskit'
+    needs: [check_paths]
+    if: needs.check_paths.outputs.SHOULD_RUN_NOTEBOOK_TESTER == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/ci/pr-path-filter.py
+++ b/scripts/ci/pr-path-filter.py
@@ -1,0 +1,101 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import os
+import sys
+from typing import TypedDict
+
+
+class Config(TypedDict):
+    SHOULD_RUN_NOTEBOOK_TESTER: str
+
+
+def filter_paths(changed_files: list[str]) -> Config:
+    contains_script_file = any(
+        path == ".github/workflows/notebook-test.yml"
+        or path.startswith("scripts/nb-tester")
+        for path in changed_files
+    )
+    if contains_script_file:
+        return {"SHOULD_RUN_NOTEBOOK_TESTER": "true"}
+
+    def is_content_notebook(path: str) -> bool:
+        return path.endswith(".ipynb") and (
+            path.startswith("learning/")
+            or (path.startswith("docs/") and not path.startswith("docs/api/"))
+        )
+
+    content_notebooks = list(filter(is_content_notebook, changed_files))
+    if content_notebooks == []:
+        return {"SHOULD_RUN_NOTEBOOK_TESTER": "false"}
+    return {"SHOULD_RUN_NOTEBOOK_TESTER": "true"}
+
+
+if __name__ == "__main__":
+    all_changed_files = sys.stdin.read().strip().split(" ")
+    print(repr(all_changed_files))
+    print(
+        "Changed files:\n *",
+        "\n * ".join(all_changed_files)
+    )
+    config = filter_paths(all_changed_files)
+    print(config)
+
+    github_output = os.getenv("GITHUB_OUTPUT")
+    with open(github_output, "a") as output:
+        for key, value in config.items():
+            output.write(f"{key}={value}")
+
+
+# =====
+# TESTS
+# =====
+
+
+def test_should_not_run_changed_mdx_config():
+    files = ["docs/guides/thing.mdx"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "false"
+
+
+def test_should_not_run_changed_ts_script():
+    files = ["scripts/js/lib/thing.ts"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "false"
+
+
+def test_should_not_run_changed_api_notebook():
+    files = ["docs/api/thing.ipynb"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "false"
+
+
+def test_should_run_changed_docs_notebook():
+    files = ["docs/other/page.ipynb"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "true"
+
+
+def test_should_run_changed_learning_notebook():
+    files = ["learning/courses/my-course/page.ipynb"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "true"
+
+
+def test_should_run_changed_workflow_file():
+    files = [".github/workflows/notebook-test.yml"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "true"
+
+
+def test_should_run_changed_source_file():
+    files = ["scripts/nb-tester/requirements.txt"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "true"
+
+
+def test_should_run_if_some_files_do_not_match():
+    files = ["docs/other/page.ipynb", "docs/api/thing.ipynb"]
+    assert filter_paths(files)["SHOULD_RUN_NOTEBOOK_TESTER"] == "true"

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,6 @@ deps =
   -e scripts/image-tester
   -e scripts/notebook-normalizer
   pytest
-commands = pytest
+commands =
+  pytest
+  pytest scripts/ci/pr-path-filter.py


### PR DESCRIPTION
Work towards #1970

This PR has changed since I first opened it and I have force-pushed to clean up the commits.

We can't use GitHub's path filtering to have status checks be required for some files but not for others. If a check is required but does not run due to path filtering, then CI can never pass (see https://github.com/orgs/community/discussions/44490#discussion-4761945).

This PR adds a workaround for the notebook test job: We use a separate job to decide if the check should run and use conditionals to skip the main job if the check isn't required.