### PR TITLE
Update Kipu optimization guide with new preprocessing, transpilation, and postprocessing levels

### DIFF
--- a/docs/guides/kipu-optimization.ipynb
+++ b/docs/guides/kipu-optimization.ipynb
@@ -201,9 +201,9 @@
     "\n",
     "**Preprocessing Levels (0-3)**: Specially important for larger problems that cannot currently fit on the coherence times of the hardware. Higher preprocessing levels achieve shallower circuit depths by approximations in the problem transpilation:\n",
     "- **Level 0**: Exact, longer circuits\n",
-    "- **Level 1**: Good balance between accuracy and approximation, cutting out only the gates with angles in the lowest 10 percentile\n",
-    "- **Level 2**: Slightly higher approximation, cutting out the gates with angles in the lowest 20 percentile and using `approximation_degree=0.95` in the transpilation\n",
-    "- **Level 3**: Maximum approximation level, cutting out the gates in the lowest 30 percentile and using `approximation_degree=0.90` in the transpilation\n",
+    "- **Level 1**: Good balance between accuracy and approximation, cutting out only the gates with angles in the lowest 10th percentile\n",
+    "- **Level 2**: Slightly higher approximation, cutting out the gates with angles in the lowest 20th percentile and using `approximation_degree=0.95` in the transpilation\n",
+    "- **Level 3**: Maximum approximation level, cutting out the gates in the lowest 30th percentile and using `approximation_degree=0.90` in the transpilation\n",
     "\n",
     "**Transpilation Levels (0-5)**: Control the advanced transpiler optimization trials for quantum circuit compilation. This can lead to an increase in classical overhead, and for some cases it might not change the circuit depth. The default value `2` in general leads to the smallest circuit and is relatively fast.\n",
     "- **Level 0**: Optimization of the decomposed DCQO circuit (layout, routing, scheduling)\n",
@@ -248,7 +248,7 @@
    "source": [
     "**Seed optimization**: Note that `seed_transpiler` is set to `None` by default. This enables the transpiler's automatic optimization process. When `None`, the system will start a trial with multiple seeds and select the one that produces the best circuit depth, leveraging the full power of the `max_trials` parameter for each transpilation level.\n",
     "\n",
-    "**Transpilation level performance**: Increasing the number of `max_trials` with higher values for `transpilation_level` will unavoidably increase the transpilation time, but it may not always change the final circuit - this depends heavily on the specific circuit structure and complexity. For some circuits/problems, however, the difference between 10 trials (level 1) and 50 trials (level 5) can be dramatic, so exploring these parameter might be the key to successfully finding a solution."
+    "**Transpilation level performance**: Increasing the number of `max_trials` with higher values for `transpilation_level` will unavoidably increase the transpilation time, but it might not always change the final circuit - this depends heavily on the specific circuit structure and complexity. For some circuits/problems, however, the difference between 10 trials (level 1) and 50 trials (level 5) can be dramatic, so exploring these parameters might be the key to successfully finding a solution."
    ]
   },
   {
@@ -329,7 +329,7 @@
     "\n",
     "In this documentation, we will go through the steps of using the Iskay Quantum Optimizer. In the process we will quickly show how to load the function from the catalog and how to convert your problem to a valid input, all while showing how you can experiment with different optional parameters.\n",
     "\n",
-    "For a more detailed example, please check out the tutorial [Solve the Market Split problem with Kipu Quantum's Iskay Quantum Optimizer](https://quantum.cloud.ibm.com/docs/en/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer), where we work through the whole process of tackling a particular use case with Iskay Solver, the Market Split problem, which represents a real-world resource allocation challenge where markets must be partitioned into balanced sales regions to meet exact demand targets.\n",
+    "For a more detailed example, please check out the tutorial [Solve the Market Split problem with Kipu Quantum's Iskay Quantum Optimizer](/docs/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer), where we work through the whole process of using Iskay Solver to address the Market Split problem, which represents a real-world resource allocation challenge where markets must be partitioned into balanced sales regions to meet exact demand targets.\n",
     "\n",
     "Authenticate using your API key, found on the [IBM Quantum Platform dashboard](http://quantum.cloud.ibm.com/), and select the Qiskit Function as follows:"
    ]
@@ -745,7 +745,7 @@
     "* Protein folding (HUBO): [scientific publication](https://doi.org/10.1103/PhysRevApplied.20.014024)\n",
     "* Logistics scheduling (QUBO): [scientific publication](https://doi.org/10.1103/PhysRevApplied.22.064068)\n",
     "* Network optimization: [webinar](https://www.youtube.com/watch?v=w5SrCIK88No)\n",
-    "* Market split (QUBO): [tutorial](https://quantum.cloud.ibm.com/docs/en/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer)\n",
+    "* Market split (QUBO): [tutorial](/docs/tutorials/solve-market-split-problem-with-iskay-quantum-optimizer)\n",
     "\n",
     "If you are interested in tackling a specific use case and develop a dedicated mapping, we can assist you. [Contact us.](https://share-eu1.hsforms.com/2Ff8cgWvTR9ukT_fPoaNhDw2dqpz5)"
    ]


### PR DESCRIPTION
## Description
Updates the Kipu Iskay Quantum optimizer documentation to reflect new features added in recent updates, including enhanced transpilation system and optimization levels.

Fixes #4120

## Done 
- Add documentation for:
    - new transpilation levels (0-5) with max_trials specifications
    - new postprocessing levels (0-2) for classical optimization
    - new transpile-only mode feature
- Add notes on seed_transpiler default behavior and optimization strategy

## To do:
- Add performance impact section with circuit depth and two-qubit gate reduction benchmarks
- Add business value explanation for different optimization levels
- Update benchmark table 

The things that are still in the to-do list will be included once I have the new benchmark table. We are thinking of including a market split instance there so it makes sense to add one example, and then the circuit depth and number of two-qubit gates benchmark and comment on the business value after that.


