### PR TITLE
Fix notebook cron job

### DIFF
--- a/.github/workflows/notebook-test-cron.yml
+++ b/.github/workflows/notebook-test-cron.yml
@@ -93,7 +93,7 @@ jobs:
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Weekly notebook test failed",
+              title: "Fortnightly notebook test failed",
               body: message,
               labels: ["needs triage 🤔"],
             })


### PR DESCRIPTION
This job executes notebooks and makes a PR with the new outputs.

We were using `git commit -a` to commit the executed notebooks. This is fine _most_ of the time, but if a new image is added by the execution, it won't be added to the commit, because `-a` does not add new files. This PR fixes that by doing `git add .` first before committing.

I also fixed the failure issue title – something I've noticed for a while but kept forgetting to fix – and added myself as a review to the PRs.
