### PR TITLE
Update Python dependencies

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -3,7 +3,7 @@
 
 qiskit[all]~=2.2.3
 qiskit-ibm-runtime~=0.43.1
-qiskit-ibm-transpiler[ai-local-mode]~=0.14.5
+qiskit-ibm-transpiler[ai-local-mode]~=0.15.0
 qiskit-aer~=0.17
 qiskit-serverless~=0.27.1
 qiskit-ibm-catalog~=0.11.0
@@ -20,5 +20,5 @@ pyscf~=2.11.0; sys.platform != 'win32'
 python-sat~=1.8.dev24
 plotly~=6.5.0
 gem-suite~=0.1.6
-ffsim~=0.0.62; sys.platform != 'win32'
+ffsim~=0.0.63; sys.platform != 'win32'
 sympy~=1.14.0


### PR DESCRIPTION
This combines a couple of dependabot PRs, although we can't update `qiskit-ibm-catalog` or `qiskit-serverless` until `qiskit-ibm-transpiler` upgrades to the latest serverless version.
