### PR TITLE
Add preview for main branch

### DIFF
--- a/.github/workflows/main-branch-preview.yml
+++ b/.github/workflows/main-branch-preview.yml
@@ -13,7 +13,6 @@
 name: Main branch preview
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
This PR copies our PR preview action, adapting it to run on pushes to `main`, publishing to https://qiskit.github.io/documentation/main
