### PR TITLE
Update 2025 line for dynamic circuit limits

### DIFF
--- a/docs/guides/classical-feedforward-and-control-flow.ipynb
+++ b/docs/guides/classical-feedforward-and-control-flow.ipynb
@@ -346,7 +346,7 @@
    "source": [
     "## Qiskit Runtime limitations\n",
     "\n",
-    "Be aware of the following constraints when running dynamic circuits in Qiskit Runtime.  Note that as new features and improvements are added throughout 2025, some of these limitations will be lifted.\n",
+    "Be aware of the following constraints when running dynamic circuits in Qiskit Runtime.\n",
     "\n",
     "- Due to the limited physical memory on control electronics, there is also a limit on the number of `if` statements and size of their operands. This limit is a function of the number of broadcasts and the number of broadcasted bits in a job (not a circuit).\n",
     "\n",


### PR DESCRIPTION
We are not going to lift the remaining limits this year, so we should remove the 2025 line. 
