### PR TITLE
switching left and right

### DIFF
--- a/learning/courses/basics-of-quantum-information/multiple-systems/qiskit-implementation.ipynb
+++ b/learning/courses/basics-of-quantum-information/multiple-systems/qiskit-implementation.ipynb
@@ -96,12 +96,12 @@
    "id": "60007f43-c890-4f03-8d38-37f8e08923fa",
    "metadata": {},
    "source": [
-    "Other allowed labels include \"+\" and \"-\" for the plus and minus states, as well as \"r\" and \"l\" (short for \"right\" and \"left\") for the states\n",
+    "Other allowed labels include \"+\" and \"-\" for the plus and minus states, as well as \"l\" and \"r\" (short for \"left\" and \"right\") for the states\n",
     "\n",
     "$$\n",
-    "\\vert {+i} \\rangle = \\frac{1}{\\sqrt{2}} \\vert 0 \\rangle + \\frac{i}{\\sqrt{2}} \\vert 1 \\rangle\n",
-    "\\qquad\\text{and}\\qquad\n",
     "\\vert {-i} \\rangle = \\frac{1}{\\sqrt{2}} \\vert 0 \\rangle - \\frac{i}{\\sqrt{2}} \\vert 1 \\rangle.\n",
+    "\\qquad\\text{and}\\qquad\n",
+    "\\vert {+i} \\rangle = \\frac{1}{\\sqrt{2}} \\vert 0 \\rangle + \\frac{i}{\\sqrt{2}} \\vert 1 \\rangle\n",
     "$$\n",
     "\n",
     "Here's an example of the tensor product of $\\vert {+} \\rangle$ and $\\vert {-i} \\rangle.$"


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/4414.


The text says:

> Other allowed labels include "+" and "-" for the plus and minus states, as well as "r" and "l" (short for "right" and "left") for the states:

And then proceeds defining the "r" state on the left, and the "l" state on the right, which might be confusing. I suggest to write the "l" state on the left and the "r" state on the right.
