### PR TITLE
Specify renderer in Visualize circuit timing

### DIFF
--- a/docs/guides/visualize-circuit-timing.ipynb
+++ b/docs/guides/visualize-circuit-timing.ipynb
@@ -151,9 +151,7 @@
    "execution_count": null,
    "id": "ab8c6c23",
    "metadata": {},
-   "outputs": [
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2\n",
     "\n",
@@ -2645,7 +2643,7 @@
     ")\n",
     "\n",
     "# Display the figure\n",
-    "fig.show()\n",
+    "fig.show(renderer=\"notebook\")\n",
     "\n",
     "# Save to a file\n",
     "# fig.write_html(\"scheduler_timing.html\")"


### PR DESCRIPTION
Closes #4190.

It seems to be clearest to simply use `fig.show(renderer="notebook")` instead of `fig.show()` - unless there is a situation for some people where specifying the renderer wouldn't work, while only `fig.show()` would?... cc: @jyu00 

Also removing warnings in a couple outputs.