### PR TITLE
Re-hide cell from users

### DIFF
--- a/docs/guides/qedma-qesem.ipynb
+++ b/docs/guides/qedma-qesem.ipynb
@@ -142,7 +142,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2fb4efc4",
-   "metadata": {},
+   "metadata": {
+     "tags": [
+       "remove-cell"
+     ]
+   },
    "outputs": [],
    "source": [
     "# This cell is hidden from users\n",


### PR DESCRIPTION
Looks like this `remove-cell` tag was accidentally removed, so the cell appears on the website. Thank @abbycross for spotting.
