### PR TITLE
Add no-answer option in default position, in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/courses.yaml
+++ b/.github/ISSUE_TEMPLATE/courses.yaml
@@ -71,6 +71,7 @@ body:
       description:
       multiple: false
       options:
+        - (No answer)
         - I will write (or already have written) a draft of the proposed content
         - I can help the team by providing enough information or by referring them to a specific Subject Matter Expert to write the material
         - I only want to review the material when it's finished

--- a/.github/ISSUE_TEMPLATE/guides.yaml
+++ b/.github/ISSUE_TEMPLATE/guides.yaml
@@ -66,6 +66,7 @@ body:
       description:
       multiple: false
       options:
+        - (No answer)
         - I will write (or already have written) a draft of the proposed content
         - I can help the team by providing enough information or by referring them to a specific Subject Matter Expert to write the material
         - I only want to review the material when it's finished

--- a/.github/ISSUE_TEMPLATE/tutorials.yaml
+++ b/.github/ISSUE_TEMPLATE/tutorials.yaml
@@ -70,6 +70,7 @@ body:
       description:
       multiple: false
       options:
+        - (No answer)
         - I will write (or already have written) a draft of the proposed content
         - I can help the team by providing enough information or by referring them to a specific Subject Matter Expert to write the material
         - I only want to review the material when it's finished


### PR DESCRIPTION
To help clarify whether someone chooses a response or skips the last questions altogether, adding a (no answer) option that will become the default if it is skipped (otherwise it is unclear whether the person who opened the issue wants to work on it themselves)