### PR TITLE
Fixed definition of Max-Cut problem in QAOA tutorial.ipynb

### DIFF
--- a/docs/tutorials/quantum-approximate-optimization-algorithm.ipynb
+++ b/docs/tutorials/quantum-approximate-optimization-algorithm.ipynb
@@ -30,7 +30,7 @@
     "This tutorial demonstrates how to implement the **Quantum Approximate Optimization Algorithm (QAOA)** – a hybrid (quantum-classical) iterative method – within the context of Qiskit patterns. You will first solve the **Maximum-Cut** (or **Max-Cut**) problem for a small graph and then learn how to execute it at utility scale. All the hardware executions in the tutorial should run within the time limit for the freely-accessible Open Plan.\n",
     "\n",
     "\n",
-    "The Max-Cut problem is an optimization problem that is hard to solve (more specifically, it is an *NP-hard* problem) with a number of different applications in clustering, network science, and statistical physics. This tutorial considers a graph of nodes connected by edges, and aims to partition it into separate graphs such that they are both as large as possible. Put another way, the goal of this problem is to partition the nodes of a graph into two sets such that the number of edges traversed by this cut is maximized.\n",
+    "The Max-Cut problem is an optimization problem that is hard to solve (more specifically, it is an *NP-hard* problem) with a number of different applications in clustering, network science, and statistical physics. This tutorial considers a graph of nodes connected by edges, and aims to partition the nodes into two sets such that the number of edges traversed by this cut is maximized.\n",
     "\n",
     "![Illustration of a max-cut problem](/docs/images/tutorials/quantum-approximate-optimization-algorithm/maxcut-illustration.avif)"
    ]


### PR DESCRIPTION
Fixed the definition of the Max-Cut problem as discussed in https://github.com/Qiskit/documentation/issues/4358. The fix consists in the elimination of the incorrect statement "This tutorial considers a graph of nodes connected by edges, and aims to partition it into separate graphs such that they are both as large as possible." The definition is in section _Background_ of the __Quantum approximate optimization algorithm_ tutorial at https://quantum.cloud.ibm.com/docs/en/tutorials/quantum-approximate-optimization-algorithm