### PR TITLE
chore: Update `tutorials/` to fix translation problems in documentation 

### DIFF
--- a/docs/tutorials/depth-reduction-with-circuit-cutting.ipynb
+++ b/docs/tutorials/depth-reduction-with-circuit-cutting.ipynb
@@ -173,7 +173,7 @@
    "id": "babfbd0f",
    "metadata": {},
    "source": [
-    "*Find and cut the distant gates:* We will replace the distant gates (gates connecting non-local qubits, 0 and 3) with `TwoQubitQPDGate`s by specifying their indices. `cut_gates` will replace the gates in the specified indices with `TwoQubitQPDGate`s and also return a list of `QPDBasis` instances -- one for each gate decomposition. The `QPDBasis` object contains information about how to decompose the cut gates into single-qubit operations."
+    "*Find and cut the distant gates:* We will replace the distant gates (gates connecting non-local qubits, 0 and 3) with `TwoQubitQPDGate` objects by specifying their indices. `cut_gates` will replace the gates in the specified indices with `TwoQubitQPDGate` objects and also return a list of `QPDBasis` instances -- one for each gate decomposition. The `QPDBasis` object contains information about how to decompose the cut gates into single-qubit operations."
    ]
   },
   {

--- a/docs/tutorials/readout-error-mitigation-sampler.ipynb
+++ b/docs/tutorials/readout-error-mitigation-sampler.ipynb
@@ -915,7 +915,7 @@
    "metadata": {},
    "source": [
     "Now we apply the readout correction learned by M3 to the counts.\n",
-    "The function `apply_corrections` returns a quasi-probability distribution. This is a list of `float`s that sum to $1$. But some values might be negative."
+    "The function `apply_corrections` returns a quasi-probability distribution. This is a list of `float` objects that sum to $1$. But some values might be negative."
    ]
   },
   {


### PR DESCRIPTION
In the documentation, multiple objects of a class were sometimes referred to using the style "MyClasss".
This PR updates these references to "MyClass objects" to fix translation problems in documentation.

This addresses the part of #2067  for `/tutorials`.