### PR TITLE
Demote Intel macOS to Tier 2 support in Qiskit SDK

### DIFF
--- a/docs/guides/install-qiskit.mdx
+++ b/docs/guides/install-qiskit.mdx
@@ -225,7 +225,7 @@ In the Qiskit v2.x release series, the supported platforms are:
   <summary>
     Tier 2
   </summary>
-  Tier 2 operating systems are not tested as part of development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process and these packages can be expected to be installed with only a functioning Python environment.
+  Tier 2 operating systems are not tested as part of the development process. However, pre-compiled binaries are built, tested, and published to PyPI as part of the release process, and these packages can be expected to be installed with only a functioning Python environment.
   There might be a delay in releasing packages for these systems, since test failures might not be detected until much later, and failures during publishing will not block the publication of the package for Tier 1 systems.
 
   Tier 2 operating systems:


### PR DESCRIPTION
This change is being publicised as part of the Qiskit 2.3 release, but since that also marks 2.2 as no longer supported at all, the effect is that the whole 2.x series _now_ has Intel macOS at Tier 2.

We had to make this change due to Apple sunsetting the platform, CI runners slowing withdrawing support for it, and the Qiskit development team no longer having access to the hardware.