### PR TITLE
Updating qiskit-mcp-servers docs

### DIFF
--- a/docs/guides/qiskit-mcp-servers.mdx
+++ b/docs/guides/qiskit-mcp-servers.mdx
@@ -51,7 +51,7 @@ Provides AI-powered circuit optimization through the [AI-powered transpiler pass
 To use Qiskit MCP Servers, you need:
 
 - Python 3.10 or later (3.11+ recommended)
-- An IBM Quantum account and API token (see [Set up your IBM Cloud account](/docs/guides/cloud-setup) for instructions.)
+- An IBM Quantum account and API token (see [Set up your IBM Cloud&reg; account](/docs/guides/cloud-setup) for instructions)
 
 Install all the available Qiskit MCP servers by running the following command from a terminal:
 


### PR DESCRIPTION
Fixes #4485 


This PR adds docs for two new MCP servers available as part of the https://github.com/Qiskit/mcp-servers project `qiskit-mcp-server` and `qiskit-ibm-transpiler-mcp-server` 