### PR TITLE
Add junye for functions releated notifications

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -649,7 +649,7 @@ notifications:
     - "@abbycross"
     - "@pandasa123"
     - "@HuangJunye"
-    - "Henri-ColibrITD"
+    - "@Henri-ColibrITD"
   "docs/tutorials/chsh-inequality":
     - "@miamico"
   "docs/tutorials/multi-product-formula":


### PR DESCRIPTION
As requested by @Eric-Arellano, I added myself to Qiskit functions related notifications.

- [x] Replaced Johannes handle with mine
- [x] Added my handle to new function tutorials
- [x] Fix a missing `@` for Henri in colibritd tutorial.

The new function tutorials only have the original authors listed. Should we also add @abbycross and @pandasa123 like the functions guides?