### PR TITLE
Fixed typo (Added “be” and removed “,”)  in the QML course page #4541

### DIFF
--- a/learning/courses/quantum-machine-learning/introduction.ipynb
+++ b/learning/courses/quantum-machine-learning/introduction.ipynb
@@ -131,7 +131,7 @@
     "\n",
     "__Answer:__\n",
     "\n",
-    "A lot. Notably: complex coefficients, and superposition with a single copy. There are many other differences that will discussed in future lessons, including entanglement, and interference.\n",
+    "A lot. Notably: complex coefficients, and superposition with a single copy. There are many other differences that will be discussed in future lessons, including entanglement and interference.\n",
     "\n",
     "True or False? Highly entangled quantum states enable us to solve most machine learning problems more efficiently on a quantum computer.\n",
     "\n",


### PR DESCRIPTION
This PR Fixes typo in the QML course page. 

Closes #4541 