### PR TITLE
Add JSON files to the PR preview changed files regex

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -79,14 +79,14 @@ jobs:
           # If changing these regexes, test them on https://regex101.com/ with the
           # following paths (you can paste the block in and uncomment it):
           # Add new tests if necessary
-          CONTENT_FILE_REGEX: (docs|learning)(?!\/api)\/.*\.(mdx|ipynb)
+          CONTENT_FILE_REGEX: (docs|learning)(?!\/api)\/.*\.(mdx|ipynb|json)
           #  -- Should match:
           #  docs/guides/thing.ipynb
           #  docs/guides/thing.mdx
           #  learning/courses/my-course/introduction.ipynb
+          #  docs/guides/_toc.json
           #
           #  -- Should not match:
-          #  docs/guides/_toc.json
           #  docs/api/qiskit/index.mdx
           #  scripts/nb-tester/example-notebook.ipynb
         id: changed-content-files


### PR DESCRIPTION
After https://github.com/Qiskit/documentation/pull/4405 we are only building changed files in our PR previews. However, we were not including JSON files which are used to define our TOC.

Without this, PRs that only change `_toc.json` files fail to build. Example -> https://github.com/Qiskit/documentation/pull/4568