### PR TITLE
Upgrade the `mdx-link-extract` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@qiskit/mdx-link-extract": "^1.0.0",
+        "@qiskit/mdx-link-extract": "^1.1.0",
         "cheerio": "^1.0.0-rc.12",
         "cspell": "^8.12.1",
         "fast-levenshtein": "^3.0.0",
@@ -927,24 +927,24 @@
       }
     },
     "node_modules/@qiskit/mdx-link-extract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract/-/mdx-link-extract-1.0.0.tgz",
-      "integrity": "sha512-kVn/cO5cwtwpyw2u/ONkc8QbUM9AsayoZiyc3naXc/b2c+q6F9aKB5JniHdYMECTQIjTd/RqDNeOuwz0kcl/8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract/-/mdx-link-extract-1.1.0.tgz",
+      "integrity": "sha512-pCYIF+zAhEr6qv1eG8y1hL8jTQ9OpMoanscuWPOTYCk0yt66fy9njN6INUxbAwCzuiYuqG+rqG2mgslG0wd3pw==",
       "license": "Apache 2.0",
       "engines": {
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "@qiskit/mdx-link-extract-darwin-arm64": "1.0.0",
-        "@qiskit/mdx-link-extract-darwin-x64": "1.0.0",
-        "@qiskit/mdx-link-extract-linux-x64-gnu": "1.0.0",
-        "@qiskit/mdx-link-extract-win32-x64-msvc": "1.0.0"
+        "@qiskit/mdx-link-extract-darwin-arm64": "1.1.0",
+        "@qiskit/mdx-link-extract-darwin-x64": "1.1.0",
+        "@qiskit/mdx-link-extract-linux-x64-gnu": "1.1.0",
+        "@qiskit/mdx-link-extract-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@qiskit/mdx-link-extract-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-darwin-arm64/-/mdx-link-extract-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-tN1LaBpToiJCJ8clOQRDEO3KVHr3eW7y9bXoXWiBnoTlV3WIE+B5rMeTwEZWT+z7uoXKiufINDpuqsF6r9cyLg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-darwin-arm64/-/mdx-link-extract-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-XWTICl3uQlSBbeSgnODoQoJ88/QgbH+m+Kh2nSFjsswUAqfaCSSJ3pk6k1UySg2XROXjI21DMVWN1eHo8CXO1Q==",
       "cpu": [
         "arm64"
       ],
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@qiskit/mdx-link-extract-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-darwin-x64/-/mdx-link-extract-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-HyUaGAvYqu85NY/aBsmA7kLFkffiJ5VQsdNqbCOqaX9+uBGAdfGBb9vjjSXtuk2msx09XJzWdiU9+S/BY+OByg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-darwin-x64/-/mdx-link-extract-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-NILOrvp42aZ2RrlU15ZvqP5BlFAD93ad3Liy4UVf0TlJ4xjAHZ7NSPD20wtEr6L39FEPwQZ+JLVOY2JSkDkbDw==",
       "cpu": [
         "x64"
       ],
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@qiskit/mdx-link-extract-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-linux-x64-gnu/-/mdx-link-extract-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-8laci5qBQrQS8styxh6czd4oM8Sm6paH8WuqzE1nVRQrMMZ2c0Mk/P6oPUkpejgAiryc92b1uq81CXO6x6X4bQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-linux-x64-gnu/-/mdx-link-extract-linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-Qq53U6HUkvbL0hc8R7JthhLf2tk9Iv9KIZZsZcqm3sjJ1wA+o6eccmHVzUKJ2ed9oPHOYTgZiWHeDXN1mNc0eQ==",
       "cpu": [
         "x64"
       ],
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/@qiskit/mdx-link-extract-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-win32-x64-msvc/-/mdx-link-extract-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-j8+emuqrXgSw92X5P77RvLhNGeu5GtGP0o7ovgMERicuMpIHFU3kL3UTaQSonhcbSmS/iJiS9GesEVqSW9NB8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qiskit/mdx-link-extract-win32-x64-msvc/-/mdx-link-extract-win32-x64-msvc-1.1.0.tgz",
+      "integrity": "sha512-CZ+gf8HgRC18qk/GVBPgbvB0uKh+C3vA3hj2mEgWppRoW0CdjvTqxSodUBMNQc5M9hq8Gb3eZk0vZG33xN8WQQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "save-internal-links": "tsx scripts/js/commands/saveInternalLinks.ts"
   },
   "dependencies": {
-    "@qiskit/mdx-link-extract": "^1.0.0",
+    "@qiskit/mdx-link-extract": "^1.1.0",
     "cheerio": "^1.0.0-rc.12",
     "cspell": "^8.12.1",
     "fast-levenshtein": "^3.0.0",


### PR DESCRIPTION
This PR upgrades the `mdx-link-extract` package to v1.1.0 to bring a fix to how we generate anchors from headings that contain links on them.

I ran the link checker to every content file, and I didn't find any new broken links:

```
No links appear broken ✅
```