### PR TITLE
Remove material, reorganize cells in reptition code tutorial 

### DIFF
--- a/docs/tutorials/repetition-codes.ipynb
+++ b/docs/tutorials/repetition-codes.ipynb
@@ -74,6 +74,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b588703a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose the least busy backend that supports `measure_2`.\n",
+    "\n",
+    "backend = service.least_busy(\n",
+    "    filters=lambda b: \"measure_2\" in b.supported_instructions,\n",
+    "    operational=True,\n",
+    "    simulator=False,\n",
+    "    dynamic_circuits=True,\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "4d01e8d3",
    "metadata": {},
@@ -89,23 +106,6 @@
     "### Build a bit-flip stabilizer circuit\n",
     "\n",
     "The bit-flip code protects the state against a single bit-flip (X) error on any of the encoding qubits. Consider the action of bit-flip error $X$, which maps $|0\\rangle \\rightarrow |1\\rangle$ and $|1\\rangle \\rightarrow |0\\rangle$ on any of our qubits, then we have $\\epsilon = \\{E_0, E_1, E_2 \\} = \\{IIX, IXI, XII\\}$. The code requires five qubits: three are used to encode the protected state, and the remaining two are used as stabilizer measurement ancillas."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b588703a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Choose the least busy backend that supports `measure_2`.\n",
-    "\n",
-    "backend = service.least_busy(\n",
-    "    filters=lambda b: \"measure_2\" in b.supported_instructions,\n",
-    "    operational=True,\n",
-    "    simulator=False,\n",
-    "    dynamic_circuits=True,\n",
-    ")"
    ]
   },
   {


### PR DESCRIPTION
Two editing changes to tighten up the "Repetition codes" tutorial
* Omit the discussion of stabilizers, which is more advanced than this tutorial. For example, the paper linked in the tutorial does not mention stabilizers until after a thorough discussion of background topics as well as the 3-qubit bit-flip code and the 9-qubit code. The same is true in Gottesman's [recent book](https://www.cs.umd.edu/class/spring2024/cmsc858G/QECCbook-2024-ch1-15.pdf). I did retain the link to more information about QEC, which does discuss stabilizer codes.

* Move the cell that gets a backend from "Step 1" to "Setup". It seems clear that it belongs in setup. I doubt the current organization is intentional.

### Note
This  https://github.com/Qiskit/documentation/issues/4287#issuecomment-3577475265 proposes changing too many things at once. I think it will be easier to review this way. The present PR does not address the question of variable names, which is the topic of #4287. I'll do that in a separate PR. @matteo-piccolini 