### PR TITLE
Only run PR preview cleanup every two weeks

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -14,7 +14,7 @@ name: PR preview cleanup
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # At midnight
+    - cron: "0 0 1,15 * *" # At 00:00 on day-of-month 1 and 15
 
 jobs:
   preview-cleanup:


### PR DESCRIPTION
The PR preview cleanup recently caused some unintuitive behaviour: Kaeyln triggered the job to regenerate the preview, but it got cleaned up the same evening because deployments don't count as "PR activity".

This PR changes the cleanup cron job to only run once every two weeks. This means a regenerated preview will last longer. It does also mean that some PR previews will hang around for a maximum of four weeks. I think this is an OK tradeoff.
