### PR TITLE
corrected function output types to list[tuple[str, list[int], float]]:

### DIFF
--- a/docs/tutorials/quantum-approximate-optimization-algorithm.ipynb
+++ b/docs/tutorials/quantum-approximate-optimization-algorithm.ipynb
@@ -295,7 +295,9 @@
     }
    ],
    "source": [
-    "def build_max_cut_paulis(graph: rx.PyGraph) -> list[tuple[str, list[int], float]]:\n",
+    "def build_max_cut_paulis(\n",
+    "    graph: rx.PyGraph,\n",
+    ") -> list[tuple[str, list[int], float]]:\n",
     "    \"\"\"Convert the graph to Pauli list.\n",
     "\n",
     "    This function does the inverse of `build_max_cut_graph`\n",


### PR DESCRIPTION
Fixes #4632 