### PR TITLE
Fix typo of classical and quantum bounds in chsh-inequality.ipynb

### DIFF
--- a/docs/tutorials/chsh-inequality.ipynb
+++ b/docs/tutorials/chsh-inequality.ipynb
@@ -449,7 +449,7 @@
    "id": "63e63853",
    "metadata": {},
    "source": [
-    "In the figure, the lines and gray areas delimit the bounds; the outer-most (dash-dotted) lines delimit the quantum-bounds ($\\pm 2$), whereas the inner (dashed) lines delimit the classical bounds ($\\pm 2\\sqrt{2}$). You can see that there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
+    "In the figure, the lines and gray areas delimit the bounds; the outer-most (dash-dotted) lines delimit the quantum-bounds ($\\pm 2\\sqrt{2}$), whereas the inner (dashed) lines delimit the classical bounds ($\\pm 2$). You can see that there are regions where the CHSH witness quantities exceeds the classical bounds. Congratulations! You have successfully demonstrated the violation of CHSH inequality in a real quantum system!"
    ]
   },
   {


### PR DESCRIPTION
Quantum bounds are 2*sqrt(2) and classical bounds are 2.