### PR TITLE
Fix confusion between stdlib random and np.random

### DIFF
--- a/learning/courses/basics-of-quantum-information/entanglement-in-action/qiskit-implementation.ipynb
+++ b/learning/courses/basics-of-quantum-information/entanglement-in-action/qiskit-implementation.ipynb
@@ -56,7 +56,8 @@
     "from qiskit.visualization import plot_histogram, array_to_latex\n",
     "from qiskit.result import marginal_distribution\n",
     "from qiskit.circuit.library import UGate\n",
-    "from math import pi, random"
+    "from math import pi\n",
+    "import random"
    ]
   },
   {


### PR DESCRIPTION
The existing code that generates

https://quantum.cloud.ibm.com/learning/en/courses/basics-of-quantum-information/entanglement-in-action/qiskit-implementation

imports both `pi` and `random` from numpy.  The notebook uses nothing else from numpy. These two objects are used only in a scalar context. In some cases, using numpy can degrade performance. In qiskit there has been an effort, reflected in PRs, to avoid using numpy habitually, when not necessary. This is done even in non-performance critical code.

This PR changes the code to import `pi` from `math`. And it imports `random` from the stdlib.  When producing single samples, standard library `random.randint` is about 5 times faster than `numpy.random.randint`.

Furthermore, the existing code calls numpy's `random.randint(0, 1)`, which always returns zero. This was mistakenly introduced. Since this PR uses `randint` from the standard library, the range is 0 to 1, inclusive.  So it may return either 0 or 1. My best understanding is that this is the original intent of the code.

The following issues and PRs are on exactly the same code touched here
* #4438
* #4439
* #4474 
* #4643 

Closes #4643 
