### PR TITLE
Add admonition about verifying rep delay value

### DIFF
--- a/docs/guides/repetition-rate-execution.ipynb
+++ b/docs/guides/repetition-rate-execution.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "When a circuit is executed on an IBM&reg; quantum processing unit (QPU), an implicit reset is typically inserted at the beginning of the circuit to ensure the qubits are initialized to zero. This is controlled by the `init_qubits` flag, set as a [primitive execution option](/docs/api/qiskit-ibm-runtime/options-execution-options-v2).\n",
     "\n",
-    "However, the reset process is not perfect and can create state preparation errors. To alleviate the error, the QPU also inserts repetition delay time (or `rep_delay`) between circuits. Each backend has a different default `rep_delay`, but it's usually set to balance reset fidelity against total execution time. Run `backend.default_rep_delay` to find the default `rep_delay` for a specific QPU.\n",
+    "However, imperfections in the reset process can introduce state-preparation errors. To alleviate the error, the QPU also inserts repetition delay time (or `rep_delay`) between circuits. Each backend has a different default `rep_delay`, but it's usually set to balance reset fidelity against total execution time. Run `backend.default_rep_delay` to find the default `rep_delay` for a specific QPU.\n",
     "\n",
     "Because all IBM QPUs use dynamic repetition rate execution, you can change the `rep_delay` for each job. Circuits you submit in a primitive job are batched together for execution on the QPU. These circuits are executed by iterating over the circuits for each shot requested; the execution is column-wise over a matrix of circuits and shots, as illustrated in the following figure.\n",
     "\n",


### PR DESCRIPTION
Add clarification that rep_delay can vary across QPUs, and to always verify it, as it has impact on execution time/capacity consumption. 