### PR TITLE
Fix-4660/Update gdq/qpo documentation quide

### DIFF
--- a/docs/guides/global-data-quantum-optimizer.ipynb
+++ b/docs/guides/global-data-quantum-optimizer.ipynb
@@ -122,7 +122,7 @@
    "metadata": {},
    "source": [
     "<Admonition type=\"caution\" title=\"Warning\">\n",
-    "Loading data from previous sessions (to resume an optimization) can take up to one hour of classical computational time and does not consume quantum runtime resources.\n",
+    "Loading data from previous sessions (to resume an optimization) can take up to one hour of classical computational time. This does not consume quantum runtime resources.\n",
     "</Admonition>"
    ]
   },


### PR DESCRIPTION
Fixes #4660:

Changed:
```<Admonition type="caution" title="Warning">
Loading data for previous sessions (for resuming an optimization) can take up to one hour.
</Admonition>
```
by:
```
<Admonition type="caution" title="Warning">
Loading data from previous sessions (to resume an optimization) can take up to one hour of classical computational time and does not consume quantum runtime resources.
</Admonition>
```