### PR TITLE
Fix grammatical error in classical-information.ipynb

### DIFF
--- a/learning/courses/basics-of-quantum-information/single-systems/classical-information.ipynb
+++ b/learning/courses/basics-of-quantum-information/single-systems/classical-information.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "The archetypal example, which we will come back to repeatedly, is that of a *bit*, which is a system whose classical states are $0$ and $1.$\n",
     "Other examples include a standard six-sided die, whose classical states are $1,$ $2,$ $3,$ $4,$ $5,$ and $6$ (represented by the corresponding number of dots on whatever face is on top); a nucleobase in a strand of DNA, whose classical states are *A*, *C*, *G*, and *T;* and a switch on an electric fan, whose classical states are (commonly) *high*, *medium*, *low*, and *off*.\n",
-    "In mathematical terms, the specification of the classical states of a system are, in fact, the starting point: we *define* a bit to be a system that has classical states $0$ and $1,$ and likewise for systems having different classical state sets.\n",
+    "In mathematical terms, the specification of the classical states of a system is, in fact, the starting point: we *define* a bit to be a system that has classical states $0$ and $1,$ and likewise for systems having different classical state sets.\n",
     "\n",
     "For the sake of this discussion, let us give the name $\\mathsf{X}$ to the system being considered, and let us use the symbol $\\Sigma$ to refer to the set of classical states of $\\mathsf{X}.$\n",
     "In addition to the assumption that $\\Sigma$ is finite, which was already mentioned, we naturally assume that $\\Sigma$ is *nonempty* — for it is nonsensical for a physical system to have no states at all.\n",


### PR DESCRIPTION
The verb should be "is," because the subject is single form.