### PR TITLE
Add support for the new tables and accordions on local previews

### DIFF
--- a/start
+++ b/start
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 # Get the latest digest by running `docker pull icr.io/qc-open-source-docs-public/preview:latest`.
-IMAGE_DIGEST = "sha256:38f95d1f85636ae5729ff8dfd81fe8620159740072dbc5b3fecf3bd2bf93c8b2"
+IMAGE_DIGEST = "sha256:f49013e3e0ec74a48a4ffb92846dcb1053f2d9cb2a8137deb0fdd02a78f72520"
 
 # Docker on Windows uses `/` rather than `\`, so we need to call `.as_posix()`:
 # https://medium.com/@kale.miller96/how-to-mount-your-current-working-directory-to-your-docker-container-in-windows-74e47fa104d7


### PR DESCRIPTION
This PR updates the `start` script digest to add support for the new tables design