### PR TITLE
Ajc/fix admonitions

### DIFF
--- a/docs/guides/q-ctrl-optimization-solver.ipynb
+++ b/docs/guides/q-ctrl-optimization-solver.ipynb
@@ -22,7 +22,7 @@
     "# Optimization Solver: A Qiskit Function by Q-CTRL Fire Opal\n",
     "\n",
     "<Admonition type=\"note\">\n",
-    "Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
+    "   Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
     "</Admonition>"
    ]
   },
@@ -367,7 +367,7 @@
     "Retrieve the optimal cut value from the results dictionary.\n",
     "\n",
     "<Admonition type=\"note\">\n",
-    "The mapping of the variables to the bitstring may have changed. The output dictionary contains a `variables_to_bitstring_index_map` sub-dictionary, which helps to verify the ordering.\n",
+    "   The mapping of the variables to the bitstring may have changed. The output dictionary contains a `variables_to_bitstring_index_map` sub-dictionary, which helps to verify the ordering.\n",
     "</Admonition>"
    ]
   },

--- a/docs/guides/q-ctrl-performance-management.ipynb
+++ b/docs/guides/q-ctrl-performance-management.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "\n",
     "<Admonition type=\"note\" title=\"Note\">\n",
-    "Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
+    "   Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
     "</Admonition>"
    ]
   },
@@ -372,7 +372,7 @@
    "source": [
     "### Estimator inputs\n",
     "<Admonition type=\"caution\">\n",
-    "Fire Opal Performance Management accepts abstract circuits, in contrast to the native Qiskit Runtime primitives, which only accept circuits that are written in the target backend’s Instruction Set Architecture (ISA). For best results, do not transpile circuits before submitting via the Performance Management function.\n",
+    "   Fire Opal Performance Management accepts abstract circuits, in contrast to the native Qiskit Runtime primitives, which only accept circuits that are written in the target backend's Instruction Set Architecture (ISA). For best results, do not transpile circuits before submitting via the Performance Management function.\n",
     "</Admonition>\n",
     "\n",
     "| Name  | Type  | Description | Required | Default  | Example |\n",
@@ -688,7 +688,7 @@
    "source": [
     "### Sampler inputs\n",
     "<Admonition type=\"caution\">\n",
-    "Fire Opal Performance Management accepts abstract circuits, in contrast to the native Qiskit Runtime primitives, which only accept circuits that are written in the target backend’s Instruction Set Architecture (ISA). For best results, do not transpile circuits before submitting via the Performance Management function.\n",
+    "   Fire Opal Performance Management accepts abstract circuits, in contrast to the native Qiskit Runtime primitives, which only accept circuits that are written in the target backend's Instruction Set Architecture (ISA). For best results, do not transpile circuits before submitting via the Performance Management function.\n",
     "</Admonition>\n",
     "\n",
     "\n",

--- a/docs/guides/qedma-qesem.ipynb
+++ b/docs/guides/qedma-qesem.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "<Admonition type=\"note\" title=\"Note\">\n",
-    "Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
+    "   Qiskit Functions are an experimental feature available only to IBM Quantum&reg; Premium Plan, Flex Plan, and On-Prem (via IBM Quantum Platform API) Plan users. They are in preview release status and subject to change.\n",
     "</Admonition>\n",
     "\n",
     "## Overview\n",
@@ -264,11 +264,11 @@
     "\n",
     "\n",
     "<Admonition type=\"caution\">\n",
-    "The QPU time estimation changes from one backend to another. Therefore, when executing the QESEM function, make sure to run it on the same backend that was selected when obtaining the QPU time estimation.\n",
+    "   The QPU time estimation changes from one backend to another. Therefore, when executing the QESEM function, make sure to run it on the same backend that was selected when obtaining the QPU time estimation.\n",
     "</Admonition>\n",
     "\n",
     "<Admonition type=\"note\">\n",
-    "QESEM will end its run when it reaches the target precision or when it reaches `max_execution_time`, whichever comes first.\n",
+    "   QESEM will end its run when it reaches the target precision or when it reaches `max_execution_time`, whichever comes first.\n",
     "</Admonition>\n",
     "\n",
     "- `estimate_time_only` - This flag enables users to obtain an estimate for the QPU time required to execute the circuit with QESEM.\n",
@@ -291,7 +291,7 @@
     "\n",
     "\n",
     "<Admonition type=\"note\">\n",
-    "Barrier operations are typically used to specify the layers of two-qubit gates in quantum circuits. In level 0, QESEM preserves the layers specified by the barriers. In level 1, the layers specified by the barriers are considered as one transpilation alternative when minimizing QPU time.\n",
+    "   Barrier operations are typically used to specify the layers of two-qubit gates in quantum circuits. In level 0, QESEM preserves the layers specified by the barriers. In level 1, the layers specified by the barriers are considered as one transpilation alternative when minimizing QPU time.\n",
     "</Admonition>"
    ]
   },

--- a/docs/guides/qiskit-code-assistant-local.mdx
+++ b/docs/guides/qiskit-code-assistant-local.mdx
@@ -148,7 +148,7 @@ The Ollama application provides a simple solution to run the LLMs locally. It is
 1. Launch the installed Ollama application
 
     <Admonition type="info">
-    The application is running successfully when the Ollama icon appears in the desktop menu bar. You can also verify the service is running by going to `http://localhost:11434/`.
+        The application is running successfully when the Ollama icon appears in the desktop menu bar. You can also verify the service is running by going to `http://localhost:11434/`.
     </Admonition>
 
 1. Try Ollama in your terminal and start running models. For example:
@@ -208,7 +208,7 @@ If you have manually downloaded a GGUF model such as https://huggingface.co/Qisk
     ```
 
     <Admonition type="note">
-    This process may take some time for Ollama to read the model file, initialize the model instance, and configure it according to the specifications provided.
+        This process may take some time for Ollama to read the model file, initialize the model instance, and configure it according to the specifications provided.
     </Admonition>
 
 

--- a/mdx-guide.md
+++ b/mdx-guide.md
@@ -168,7 +168,7 @@ To use an `Admonition`, use the following syntax
 
 ```mdx
 <Admonition type="note">
-This is an example of a note.
+  This is an example of a note.
 </Admonition>
 ```
 


### PR DESCRIPTION
Closes #4696. Add carriage return both after <Admonition> and before </Admonition> so that the right spacing renders in the published page.