### PR TITLE
Fix imagemagick install in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         run: npm ci
       - name: Install ImageMagick
         run: |
-          sudo apt update
+          sudo apt-get update
           sudo apt-get install -y imagemagick
           sudo ln -s /usr/bin/convert /usr/bin/magick
       - name: Install Playwright


### PR DESCRIPTION
We removed this to speed up CI time in https://github.com/Qiskit/documentation/pull/4271, but CI broke recently and this seems to fix it (thanks @arnaucasau for the solution). Not sure why this used to take three minutes, but it only adds a few extra seconds now.