### PR TITLE
Remove stale PR preview cleanup

### DIFF
--- a/scripts/pr-previews/builder.py
+++ b/scripts/pr-previews/builder.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Iterator
 
-from utils import configure_logging, run_subprocess, write_timestamp
+from utils import configure_logging, run_subprocess
 
 # You can change this to `iqp-channel-docs-preview-builder` when running locally, if
 # you're able to create a local copy of the builder image through the closed source repo.
@@ -67,7 +67,6 @@ def main() -> None:
     with setup_dir(changed_content_files) as dir:
         yarn_build(dir, args.basepath)
         save_output(dir, args.dest)
-    write_timestamp(args.dest)
 
 
 def write_proof_of_concept(dest: Path) -> None:

--- a/scripts/pr-previews/cleanup.py
+++ b/scripts/pr-previews/cleanup.py
@@ -15,7 +15,6 @@
 import json
 import logging
 import shutil
-import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -26,13 +25,10 @@ from utils import (
     setup_git_account,
     switch_branch,
     changed_files,
-    get_timestamp,
 )
 
 INITIAL_COMMIT = "499a5040585d02593cdd8237e19c9ee4a84ae126"
 
-SEVEN_DAYS_IN_SECONDS = 60 * 60 * 24 * 7
-PR_EXPIRATION_TIME_SECONDS = SEVEN_DAYS_IN_SECONDS
 
 def main() -> None:
     setup_git_account()
@@ -61,35 +57,21 @@ def main() -> None:
         logger.info("Cleaned up closed PR previews")
 
 
-def get_active_pr_folders() -> set[str]:
+def get_active_pr_folders() -> 'set[str]':
     raw = run_subprocess(
         ["gh", "pr", "list", "--state", "open", "--json", "number", "--limit", "1000"]
     ).stdout
     # `raw` is JSON string of form: { number: int }[]
     return {f"pr-{obj['number']}" for obj in json.loads(raw)}
 
-def is_stale(folder_name: str) -> bool:
-    # All time measured in seconds, from the unix epoch
-    current_timestamp = time.time()
-    last_modified_timestamp = get_timestamp(Path(folder_name))
-    if last_modified_timestamp is None:
-        return False
-    return (current_timestamp - last_modified_timestamp) > PR_EXPIRATION_TIME_SECONDS
-
 def delete_closed_pr_folders() -> None:
     active_pr_folders = get_active_pr_folders()
-
     for folder in Path(".").glob("pr-*"):
         is_closed = folder.name not in active_pr_folders
         if is_closed:
             logger.info(f"Deleting {folder} as PR is closed")
             shutil.rmtree(folder)
-            continue
-        if is_stale(folder.name):
-            logger.info(f"Would delete {folder} as it is stale")
-            # TODO (#3433) Change the log message and uncomment the following line
-            # shutil.rmtree(folder)
-            continue
+
 
 if __name__ == "__main__":
     configure_logging()

--- a/scripts/pr-previews/utils.py
+++ b/scripts/pr-previews/utils.py
@@ -14,26 +14,12 @@ from __future__ import annotations
 
 import logging
 import subprocess
-import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
 
 logger = logging.getLogger(__name__)
-
-
-def get_timestamp(dest: Path) -> int | None:
-    try:
-        return int(Path(dest / "last_modified.txt").read_text())
-    except (FileNotFoundError, ValueError):
-        return None
-
-
-def write_timestamp(dest: Path) -> None:
-    now = time.time()
-    Path(dest).mkdir(parents=True, exist_ok=True)
-    Path(dest / "last_modified.txt").write_text(str(int(now)))
 
 
 def configure_logging() -> None:


### PR DESCRIPTION
This reverts the stale PR preview cleanup. This feature removed previews for open PRs that have been inactive for over two weeks.

We decided to remove it for the following reasons:

1. We originally introduced this to improve the reliability and speed of preview deployments. However, we're not sure it makes a noticeable difference; there are usually only one or two stale previews at any one point in time (vs ~20-30 previews in total).

2. Even with the small number of stale previews, the expiration has inconvenienced writers who needed to share previews with stakeholders.

3. The final straw is that the tests are broken in a really nasty way: They fail on the GitHub actions MacOS runner but pass on our local MacOS machines. When I deleted the failing test to debug things, the Windows runner started showing even more crazy errors. I have no idea what's causing it but it's related to the `datetime` library and I think it's going to take a lot of time to fix. I also think there's a real risk the code is actually broken and it's not just a test problem. With points 1 & 2, we decided to just remove the feature.
