### PR TITLE
Move composer to getting started section

### DIFF
--- a/docs/guides/_toc.json
+++ b/docs/guides/_toc.json
@@ -14,6 +14,10 @@
           "url": "/docs/guides/quick-start"
         },
         {
+          "title": "IBM Quantum Composer",
+          "url": "/docs/guides/composer"
+        },
+        {
           "title": "Latest updates",
           "url": "/docs/guides/latest-updates"
         }
@@ -914,10 +918,6 @@
           ]
         }
       ]
-    },
-    {
-      "title": "IBM Quantum Composer",
-      "url": "/docs/guides/composer"
     }
   ]
 }


### PR DESCRIPTION
I've gotten feedback stating that the composer is a helpful "getting started" tool and I would like us to prioritize its placement for better visibility to new users. This PR moves the `IBM Quantum Composer` documentation to the getting started section.