### PR TITLE
Remove period from a learning math expression

### DIFF
--- a/learning/courses/basics-of-quantum-information/single-systems/classical-information.ipynb
+++ b/learning/courses/basics-of-quantum-information/single-systems/classical-information.ipynb
@@ -67,7 +67,7 @@
     "One way to represent our knowledge of the classical state of a system $\\mathsf{X}$ is to associate *probabilities* with its different possible classical states, resulting in what we shall call a *probabilistic state*.\n",
     "\n",
     "For example, suppose $\\mathsf{X}$ is a bit.\n",
-    "Based on what we know or expect about what has happened to $\\mathsf{X}$ in the past, we might perhaps believe that $\\mathsf{X}$ is in the classical state $0$ with probability $3/4$ and in the state $1$ with probability $1/4.$\n",
+    "Based on what we know or expect about what has happened to $\\mathsf{X}$ in the past, we might perhaps believe that $\\mathsf{X}$ is in the classical state $0$ with probability $3/4$ and in the state $1$ with probability $1/4$.\n",
     "We may represent these beliefs by writing this:\n",
     "\n",
     "$$\n",


### PR DESCRIPTION
This PR removes a period that shouldn't be part of the math expression. This was affecting our translations.