### PR TITLE
API generation script: Support Sphinx 9 properties

### DIFF
--- a/scripts/js/lib/api/generateApiComponents.ts
+++ b/scripts/js/lib/api/generateApiComponents.ts
@@ -250,23 +250,27 @@ function prepareAttributeOrPropertyProps(
   id: string,
   headerLevel: number,
 ): ComponentProps {
-  // Properties/attributes have multiple `em.property` values to set:
+  // Properties/attributes have multiple `span.property` values to set:
   //
   //  - the modifiers, like `property` or `abstract property`
   //  - the type hint
   //  - the default value
   //
-  // We need to remove the modifiers `em.property` to not mess up creating the heading, although
+  // We need to remove the modifiers `span.property` to not mess up creating the heading, although
   // we must first extract any modifiers. Attributes will not have modifiers, whereas
   // properties will have `field` (Pydantic), `property` or possibly `abstract property`. If the modifier is simply
   // `property`, then we do not save its value because there is no practical difference for end-users
   // between an attribute and property. However, we preserve the full string if it's `abstract property` or `field`.
   //
-  // Meanwhile, we preserve the non-modifier `em.property` elements to be processed below.
-  const rawModifiers = $child.find("em.property").filter((i, el) => {
-    const text = $(el).text();
-    return text.includes("property") || text.includes("field");
-  });
+  // Meanwhile, we preserve the non-modifier `span.property` elements to be processed below.
+  //
+  // Notice that we also search for `em.property` for compatibility with Sphinx 8
+  const rawModifiers = $child
+    .find("em.property, span.property")
+    .filter((i, el) => {
+      const text = $(el).text();
+      return text.includes("property") || text.includes("field");
+    });
   const modifiersText = rawModifiers.text().trim();
   const filteredModifiers =
     modifiersText === "property" ? undefined : modifiersText;
@@ -449,7 +453,8 @@ function getAndRemoveModifiers($child: Cheerio<any>): string {
   $child.find("em.autodoc_pydantic_validator_arrow").remove();
   $child.find("em.xref").remove();
 
-  const rawModifiers = $child.find("em.property");
+  // Sphinx 8 uses `em.property` while Sphinx 9 uses `span.property`
+  const rawModifiers = $child.find("em.property, span.property");
   const modifiers = rawModifiers.text().trim();
   rawModifiers.remove();
   return modifiers;


### PR DESCRIPTION
When testing the new Qiskit sphinx docs artifact in https://github.com/Qiskit/documentation/pull/4605 I noticed that Sphinx 9.1.0 started using `span` instead of `em` for the properties.

For the proof-of-concept PR I work around it by doing [this](https://github.com/Qiskit/documentation/pull/4605/changes/d14acd6a38e5bd89ce366b15fb9d946bc3e711dc), but I think this PRs approach is much cleaner. We should merge this before Qiskit updates their Sphinx version to avoid having bad docs in the next "Update dev docs" PR.

I tested this changes against the same artifact from https://github.com/Qiskit/documentation/pull/4605 to validate everything was working and I also ran `npm run regen-apis` to ensure we are not adding any regression.