### PR TITLE
Update code block in Q-CTRL performance management doc

### DIFF
--- a/docs/guides/q-ctrl-performance-management.ipynb
+++ b/docs/guides/q-ctrl-performance-management.ipynb
@@ -398,13 +398,13 @@
     "- A nested list of Pauli strings: `[[\"XY\", \"YZ\"], [\"ZX\", \"XX\"]]`\n",
     "- A nested list of Pauli strings with coefficients: `[[(\"XY\", 0.1), (\"YZ\", 0.2)], [(\"ZX\", 0.3), (\"XX\", 0.4)]]`\n",
     "\n",
-    "**Supported backends:**\n",
-    "The following list of backends are currently supported. If your device is not listed, [reach out to Q-CTRL](https://form.typeform.com/to/iuujEAEI?typeform-source=q-ctrl.com) to add support."
+    "**Backends you can access:**\n",
+    "Run the following code to see the list of backends that you have access to. If your device is not listed, [reach out to Q-CTRL](https://form.typeform.com/to/iuujEAEI?typeform-source=q-ctrl.com) to add support."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "4351fb76",
    "metadata": {},
    "outputs": [
@@ -426,6 +426,12 @@
     }
    ],
    "source": [
+    "# The output list of backends is an example for the purpose\n",
+    "# of this guide only, and might not match the list you see\n",
+    "# when you run the following code.\n",
+    "from qiskit_ibm_runtime import QiskitRuntimeService\n",
+    "\n",
+    "service = QiskitRuntimeService()\n",
     "service.backends()"
    ]
   },
@@ -704,8 +710,8 @@
     "- (Optional) A collection of parameter values to bind the circuit against.\n",
     "- (Optional) An integer representing the shot count, or a dictionary of runtime options containing the shot count. For example: `(circ, None, 123)` or `(circ, None, {\"shots\": 123})`.\n",
     "\n",
-    "**Supported backends:**\n",
-    "Run the following code to see the list of backends that are currently supported. If your device is not listed, [reach out to Q-CTRL](https://form.typeform.com/to/iuujEAEI?typeform-source=q-ctrl.com) to add support."
+    "**Backends you can access:**\n",
+    "Run the following code to see the list of backends that you have access to. If your device is not listed, [reach out to Q-CTRL](https://form.typeform.com/to/iuujEAEI?typeform-source=q-ctrl.com) to add support."
    ]
   },
   {
@@ -732,6 +738,9 @@
     }
    ],
    "source": [
+    "# The output list of backends is an example for the purpose\n",
+    "# of this guide only, and might not match the list you see\n",
+    "# when you run the following code.\n",
     "from qiskit_ibm_runtime import QiskitRuntimeService\n",
     "\n",
     "service = QiskitRuntimeService()\n",


### PR DESCRIPTION
Closes #4046. Adds the following to the code block that currently says only 

> `service.backends()`

to instead say

```
from qiskit_ibm_runtime import QiskitRuntimeService
 
service = QiskitRuntimeService()
service.backends()
```

FYI @acastellane 