### PR TITLE
docs: Add the new qiskit-docs-mcp-server to the MCP docs

### DIFF
--- a/docs/guides/qiskit-mcp-servers.mdx
+++ b/docs/guides/qiskit-mcp-servers.mdx
@@ -17,6 +17,7 @@ Qiskit MCP Servers is a collection of [Model Context Protocol (MCP)](https://mod
 Qiskit MCP Servers allow AI assistants to help you with quantum computing tasks, such as the following:
 
 - Creating, manipulating, and transpiling quantum circuits
+- Retrieving and searching Qiskit documentation, guides, and API references
 - Answering quantum computing questions directly from reliable sources
 - Generating quantum code with contextual awareness
 - Optimizing circuits using AI-powered transpilation
@@ -41,6 +42,10 @@ As with any other feature from Qiskit Code Assistant, this MCP server only works
 ### Qiskit Runtime MCP Server
 
 Provides access to IBM Quantum cloud services through Qiskit Runtime. This enables AI assistants to interact with quantum backends, submit jobs, and retrieve results.
+
+### Qiskit Docs MCP Server
+
+Provides AI assistants with access to the complete Qiskit documentation ecosystem, including SDK module documentation, implementation guides, and best practices. This server enables intelligent retrieval and search across the Qiskit documentation without requiring authentication.
 
 ### Qiskit IBM Transpiler MCP Server
 
@@ -73,6 +78,7 @@ You can also install individual MCP servers:
 pip install qiskit-mcp-server
 pip install qiskit-code-assistant-mcp-server
 pip install qiskit-ibm-runtime-mcp-server
+pip install qiskit-docs-mcp-server
 pip install qiskit-ibm-transpiler-mcp-server
 pip install qiskit-gym-mcp-server
 ```
@@ -81,7 +87,7 @@ pip install qiskit-gym-mcp-server
 
 ### Set environment variables
 
-Set up the required environment variables for authentication. The Qiskit MCP Server does not require authentication for local use.
+Set up the required environment variables for authentication. The Qiskit MCP Server and Qiskit Docs MCP Server do not require authentication.
 
 For the Qiskit Runtime, Qiskit Code Assistant, or Qiskit IBM Transpiler MCP Servers:
 
@@ -106,6 +112,9 @@ You can configure an MCP-compatible client (such as Claude Desktop, Cursor, or o
     },
     "qiskit-code-assistant": {
       "command": "qiskit-code-assistant-mcp-server"
+    },
+    "qiskit-docs": {
+      "command": "qiskit-docs-mcp-server"
     },
     "qiskit-ibm-transpiler": {
       "command": "qiskit-ibm-transpiler-mcp-server"
@@ -132,6 +141,9 @@ npx @modelcontextprotocol/inspector qiskit-ibm-runtime-mcp-server
 
 # Test the Qiskit Code Assistant MCP Server
 npx @modelcontextprotocol/inspector qiskit-code-assistant-mcp-server
+
+# Test the Qiskit Docs MCP Server
+npx @modelcontextprotocol/inspector qiskit-docs-mcp-server
 
 # Test the Qiskit IBM Transpiler MCP Server
 npx @modelcontextprotocol/inspector qiskit-ibm-transpiler-mcp-server


### PR DESCRIPTION
This PR adds the new `qiskit-docs-mcp-server` to the MCP servers docs page.

Fixes #4791 