### PR TITLE
Add `qiskit.capi` to the TOC grouping

### DIFF
--- a/scripts/js/lib/api/TocGrouping.ts
+++ b/scripts/js/lib/api/TocGrouping.ts
@@ -152,6 +152,7 @@ function qiskitModuleToSection(module: string): string | undefined {
   if (
     hasPrefix(module, [
       "qiskit.assembler",
+      "qiskit.capi",
       "qiskit.compiler",
       "qiskit.exceptions",
       "qiskit.qobj",


### PR DESCRIPTION
This new module was added in https://github.com/Qiskit/qiskit/pull/15711
