### PR TITLE
fix: remove license preamble for GitHub license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,3 @@
-This repository is dual-licensed to distinguish between code and content.
-   - Code (including scripts, source files, and code snippets in documentation
-      examples) is licensed under the Apache License 2.0.
-   - Content (including guides, tutorials, courses, media, and other non-code 
-      assets) is licensed under the Creative Commons Attribution-ShareAlike 4.0 
-      International (CC BY-SA 4.0).
-   
-   
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE-DOCS
+++ b/LICENSE-DOCS
@@ -1,11 +1,3 @@
-This repository is dual-licensed to distinguish between code and content.
-    - Code (including scripts, source files, and code snippets in documentation
-      examples) is licensed under the Apache License 2.0.
-    - Content (including guides, tutorials, courses, media, and other non-code 
-      assets) is licensed under the Creative Commons Attribution-ShareAlike 4.0 
-      International (CC BY-SA 4.0).
-
-
 Attribution-ShareAlike 4.0 International
 
 =======================================================================


### PR DESCRIPTION
## Summary
- current LICENSE + LICENSE-DOCS cause GitHub to display "Other" instead of "Apache-2.0" in the repository sidebar, which may confuse potential contributors and downstream users about the licensing terms.
- Remove the dual-license preamble (8 lines) from `LICENSE` and `LICENSE-DOCS` so GitHub can auto-detect the license type
- No content changes — only removing the redundant header text that's already documented in the README

## Problem

GitHub's license detection requires the standard license text to begin at line 1. Both `LICENSE` and `LICENSE-DOCS` currently start with a dual-license explanation block:

```
This repository is dual-licensed to distinguish between code and content.
   - Code (including scripts, source files, and code snippets in documentation
      examples) is licensed under the Apache License 2.0.
   - Content (including guides, tutorials, courses, media, and other non-code
      assets) is licensed under the Creative Commons Attribution-ShareAlike 4.0
      International (CC BY-SA 4.0).
```

This causes GitHub to display **"Other"** instead of **"Apache-2.0"** in the repository sidebar, which may confuse potential contributors and downstream users about the licensing terms.

## Why this is safe

The dual-license explanation is already clearly documented in the [README](https://github.com/Qiskit/documentation#readme), and having two separate files (`LICENSE` for code, `LICENSE-DOCS` for content) is self-documenting. Removing the preamble from the license files eliminates redundancy and enables proper GitHub detection.

## Test plan
- [ ] After merge, verify the repo sidebar shows "Apache-2.0" instead of "Other"