### PR TITLE
Link checker: Qiskit loads every Qiskit C API page

### DIFF
--- a/scripts/js/commands/checkInternalLinks.ts
+++ b/scripts/js/commands/checkInternalLinks.ts
@@ -260,8 +260,15 @@ async function determineCurrentDocsFileBatch(
 }
 
 async function determineDevFileBatches(): Promise<FileBatch[]> {
+  const qiskitDevGlobsToLoad = [
+    ...QISKIT_GLOBS_TO_LOAD,
+    // Qiskit sometimes links to the C API, so we load every
+    // qiskit-c dev version page.
+    "docs/api/qiskit-c/dev/*",
+  ];
+
   const projects: [string, string[]][] = [
-    ["qiskit", QISKIT_GLOBS_TO_LOAD],
+    ["qiskit", qiskitDevGlobsToLoad],
     ["qiskit-ibm-runtime", RUNTIME_GLOBS_TO_LOAD],
   ];
 


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/4498

This PR replaces every qiskit-c file in the `QISKIT_GLOBS_TO_LOAD` array for a general glob that loads all of the latest version files. In addition, we also load the necessary historical/dev ones for each qiskit historical/dev version.

This will avoid new checker errors when the Python API links another C API page.