### PR TITLE
Fix import paths

### DIFF
--- a/scripts/js/commands/checkInternalLinksFromOtherRepo.ts
+++ b/scripts/js/commands/checkInternalLinksFromOtherRepo.ts
@@ -18,15 +18,13 @@
  * and public/, the other repositories use a snapshot.
  */
 
-import { readFile } from "fs/promises";
-
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { globby } from "globby";
 
 import { File } from "../lib/links/InternalLink.js";
 import { FileBatch } from "../lib/links/FileBatch.js";
-import { readJsonFile } from "../lib/fs";
+import { readJsonFile } from "../lib/fs.js";
 
 interface Arguments {
   [x: string]: unknown;

--- a/scripts/js/commands/checkKatexRender.ts
+++ b/scripts/js/commands/checkKatexRender.ts
@@ -16,8 +16,8 @@ import { hideBin } from "yargs/helpers";
 import { firefox, Page } from "playwright";
 import fs from "fs/promises";
 
-import { readMarkdown } from "../lib/markdownReader";
-import { hasInlineMath, removeFileExtension } from "../lib/katexRenderUtils";
+import { readMarkdown } from "../lib/markdownReader.js";
+import { hasInlineMath, removeFileExtension } from "../lib/katexRenderUtils.js";
 
 // This list contains files with inline math expressions that should be
 // fixed to avoid any possible overflow.

--- a/scripts/js/commands/checkMarkdown.ts
+++ b/scripts/js/commands/checkMarkdown.ts
@@ -17,7 +17,7 @@ import { hideBin } from "yargs/helpers";
 import { collectInvalidImageErrors } from "../lib/markdownImages.js";
 import { readMarkdownAndMetadata } from "../lib/markdownReader.js";
 import { collectHeadingTitleMismatch } from "../lib/markdownTitles.js";
-import { parseMarkdown } from "../lib/markdownUtils";
+import { parseMarkdown } from "../lib/markdownUtils.js";
 import { checkMetadata } from "../lib/metadataChecker.js";
 import {
   METADATA_ALLOWLIST,

--- a/scripts/js/commands/checkNewPills.ts
+++ b/scripts/js/commands/checkNewPills.ts
@@ -12,8 +12,8 @@
 
 import { globby } from "globby";
 
-import { readJsonFile } from "../lib/fs";
-import { collectNewPills, NewPillEntry } from "../lib/newPills";
+import { readJsonFile } from "../lib/fs.js";
+import { collectNewPills, NewPillEntry } from "../lib/newPills.js";
 
 const TODAY = new Date();
 

--- a/scripts/js/commands/checkOrphanPages.ts
+++ b/scripts/js/commands/checkOrphanPages.ts
@@ -18,7 +18,7 @@ import { hideBin } from "yargs/helpers";
 import { flatten } from "lodash-es";
 
 import { TocEntry } from "../lib/api/generateToc.js";
-import { readJsonFile } from "../lib/fs";
+import { readJsonFile } from "../lib/fs.js";
 
 interface Arguments {
   [x: string]: unknown;

--- a/scripts/js/commands/checkQiskitApiVersions.ts
+++ b/scripts/js/commands/checkQiskitApiVersions.ts
@@ -1,7 +1,7 @@
 import { isEqual } from "lodash-es";
 import { diff } from "jest-diff";
 
-import { getDevVersion, getReleasedVersions } from "../lib/apiVersions";
+import { getDevVersion, getReleasedVersions } from "../lib/apiVersions.js";
 
 async function main() {
   const [qiskitHistoricalVersions, qiskitCurrentVersion] =

--- a/scripts/js/lib/api/objectsInv.ts
+++ b/scripts/js/lib/api/objectsInv.ts
@@ -17,7 +17,7 @@ import { mkdirp } from "mkdirp";
 
 import { removePrefix, removeSuffix } from "../stringUtils.js";
 import { C_API_BASE_PATH } from "./conversionPipeline.js";
-import { PackageLanguage } from "./Pkg";
+import { PackageLanguage } from "./Pkg.js";
 
 /**
  * Some pages exist in the sphinx docs but not in our docs

--- a/scripts/js/lib/api/releaseNotes.test.ts
+++ b/scripts/js/lib/api/releaseNotes.test.ts
@@ -10,12 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { groupByMajorVersion } from "./releaseNotes";
-import { generateReleaseNotesIndex } from "./releaseNotes";
-
 import { expect, test } from "@playwright/test";
 
 import { Pkg } from "./Pkg.js";
+import { groupByMajorVersion } from "./releaseNotes.js";
+import { generateReleaseNotesIndex } from "./releaseNotes.js";
 
 test("groupByMajorVersion()", () => {
   const input = ["2.1", "2.0", "1.5", "1.2", "3.0", "3.2", "3.1", "4.0", "4.3"];

--- a/scripts/js/lib/api/updateLinks.test.ts
+++ b/scripts/js/lib/api/updateLinks.test.ts
@@ -11,8 +11,8 @@
 // that they have been altered from the originals.
 
 import { expect, test } from "@playwright/test";
-import { ObjectsInv } from "./objectsInv";
 
+import { ObjectsInv } from "./objectsInv.js";
 import { updateLinks, normalizeUrl, relativizeLink } from "./updateLinks.js";
 import { HtmlToMdResultWithUrl } from "./HtmlToMdResult.js";
 

--- a/scripts/js/lib/apiVersions.ts
+++ b/scripts/js/lib/apiVersions.ts
@@ -12,7 +12,7 @@
 
 import { readdir } from "fs/promises";
 
-import { pathExists, readJsonFile } from "./fs";
+import { pathExists, readJsonFile } from "./fs.js";
 
 export async function readApiFullVersion(
   versionFolder: string,

--- a/scripts/js/lib/katexRenderUtils.test.ts
+++ b/scripts/js/lib/katexRenderUtils.test.ts
@@ -12,7 +12,7 @@
 
 import { expect, test } from "@playwright/test";
 
-import { hasInlineMath, removeFileExtension } from "./katexRenderUtils";
+import { hasInlineMath, removeFileExtension } from "./katexRenderUtils.js";
 
 test("hasInlineMath()", () => {
   const baselineMd = `

--- a/scripts/js/lib/katexRenderUtils.ts
+++ b/scripts/js/lib/katexRenderUtils.ts
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-import { removeSuffix } from "./stringUtils";
+import { removeSuffix } from "./stringUtils.js";
 
 export function hasInlineMath(markdown: string): boolean {
   return !!markdown.match(/(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)/);

--- a/scripts/js/lib/markdownImages.test.ts
+++ b/scripts/js/lib/markdownImages.test.ts
@@ -12,7 +12,7 @@
 
 import { expect, test } from "@playwright/test";
 
-import { parseMarkdown } from "./markdownUtils";
+import { parseMarkdown } from "./markdownUtils.js";
 import { collectInvalidImageErrors } from "./markdownImages.js";
 
 test("Test the finding of invalid images", async () => {

--- a/scripts/js/lib/markdownReader.ts
+++ b/scripts/js/lib/markdownReader.ts
@@ -12,8 +12,10 @@
 
 import path from "node:path";
 import { readFile } from "fs/promises";
-import { readJsonFile } from "./fs";
+
 import grayMatter from "gray-matter";
+
+import { readJsonFile } from "./fs.js";
 
 export async function readMarkdown(
   filePath: string,

--- a/scripts/js/lib/markdownTitles.test.ts
+++ b/scripts/js/lib/markdownTitles.test.ts
@@ -11,9 +11,9 @@
 // that they have been altered from the originals.
 
 import { expect, test } from "@playwright/test";
-import { parseMarkdown } from "./markdownUtils";
 
-import { collectHeadingTitleMismatch } from "./markdownTitles";
+import { parseMarkdown } from "./markdownUtils.js";
+import { collectHeadingTitleMismatch } from "./markdownTitles.js";
 
 const assert = async (
   markdown: string,

--- a/scripts/js/lib/markdownTitles.ts
+++ b/scripts/js/lib/markdownTitles.ts
@@ -13,7 +13,7 @@
 import { visit, EXIT } from "unist-util-visit";
 import { Root } from "mdast";
 
-import { extractHeadingText } from "./markdownUtils";
+import { extractHeadingText } from "./markdownUtils.js";
 
 export function collectHeadingTitleMismatch(
   tree: Root,

--- a/scripts/js/lib/metadataChecker.test.ts
+++ b/scripts/js/lib/metadataChecker.test.ts
@@ -12,7 +12,7 @@
 
 import { expect, test } from "@playwright/test";
 
-import { checkMetadata } from "./metadataChecker";
+import { checkMetadata } from "./metadataChecker.js";
 
 test.describe("checkMarkdown", () => {
   test("should return no errors for valid metadata", () => {

--- a/scripts/js/lib/newPills.test.ts
+++ b/scripts/js/lib/newPills.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { collectNewPills } from "./newPills";
-import { TocEntry } from "./api/generateToc.js";
+
+import { collectNewPills } from "./newPills.js";
+import { type TocEntry } from "./api/generateToc.js";
+
 test("collectNewPills()", () => {
   const input: TocEntry[] = [
     {


### PR DESCRIPTION
Using Qiskit/documentation as a VCS requirement will fail for our function templates if any imports don't end in `.js`.

I couldn't find a good way to enforce this rule. TypeScript lets you set `moduleResolution: esnext`, but it resulted in other errors. ESLint has a mechanism, but we don't use ESLint. We will catch future issues when updating `functions-template` and trying to run `./check` and `./fix`.