### PR TITLE
Rewrite Qiskit C API extension-module guide

### DIFF
--- a/docs/guides/c-extension-for-python.mdx
+++ b/docs/guides/c-extension-for-python.mdx
@@ -196,7 +196,7 @@ class AddSpectatorMeasures(TransformationPass):
 ```
 
 The exact details of this pass are unimportant for this guide.  If you are interested, you can
-consult [the API documentation of `AddSpectatorMeasures` in
+consult the [`AddSpectatorMeasures` API documentation in
 `qiskit-addon-utils`][AddSpectatorMeasures-api].  This guide produces a simple port of that pass,
 without support for control-flow operations.
 


### PR DESCRIPTION
The previous "Extend Qiskit from C" guide was very out of date, but more importantly, suggested several code patterns that are highly non-standard and require significant care and understanding to use safely.

As of Qiskit 2.4, the C API is now safely packaged up in a way that allows writing Python extension modules _correctly_ and safely.  This new form of the guide walks through the construction of a complete extension module, using the minimal amount of non-standard tooling.