### PR TITLE
Re-order local checks

### DIFF
--- a/check
+++ b/check
@@ -25,14 +25,14 @@ logger = logging.getLogger(__name__)
 
 # Note that these are ordered from fastest to slowest.
 CHECKS = {
+    "spelling": ["npm", "run", "check:spelling"],
+    "internal links": ["npm", "run", "check:internal-links"],
     "notebook linters": ["tox", "-e", "lint"],
     "all notebooks are tested": ["python3", "scripts/ci/check-all-notebooks-are-tested.py"],
     "Qiskit bot": ["npm", "run", "check:qiskit-bot"],
     "tutorials index page": ["python3", "scripts/ci/check-tutorials-index.py"],
     "markdown": ["npm", "run", "check:markdown"],
     "orphan pages": ["npm", "run", "check:orphan-pages"],
-    "spelling": ["npm", "run", "check:spelling"],
-    "internal links": ["npm", "run", "check:internal-links"],
 }
 
 


### PR DESCRIPTION
Becky's local `./check` takes quite a long time to run comnpared to the rest of us. She mentioned that spelling and link checking are the most common failures, so this PR moves those checks to run first. That way, she can get useful feedback faster.
