### PR TITLE
Fix typo in options-zne-options.mdx

### DIFF
--- a/docs/api/qiskit-ibm-runtime/options-zne-options.mdx
+++ b/docs/api/qiskit-ibm-runtime/options-zne-options.mdx
@@ -69,7 +69,7 @@ python_api_name: qiskit_ibm_runtime.options.ZneOptions
   <Attribute id="qiskit_ibm_runtime.options.ZneOptions.extrapolated_noise_factors" attributeTypeHint="UnsetType | Sequence[float]" attributeValue="Unset">
     Noise factors to evaluate the fit extrapolation models at.
 
-    If unset, this will default to `[0, *noise_factors]`. This option does not affect execution or model fitting in any way, it only determines the points at which the `extrapolator`\s are evaluated to be returned in the data fields called `evs_extrapolated` and `stds_extrapolated`.
+    If unset, this will default to `[0, *noise_factors]`. This option does not affect execution or model fitting in any way, it only determines the points at which the `extrapolator`s are evaluated to be returned in the data fields called `evs_extrapolated` and `stds_extrapolated`.
   </Attribute>
 
   ### extrapolator


### PR DESCRIPTION
Fix typo in options-zne-options.mdx.

`extrapolator`\s   ->   `extrapolator`s