### PR TITLE
Keep Functions API toc open

### DIFF
--- a/docs/api/functions/_toc.json
+++ b/docs/api/functions/_toc.json
@@ -67,5 +67,6 @@
                 }
             ]
         }
-    ]
+    ],
+  "collapsible": false
 }


### PR DESCRIPTION
Table of contents for the Qiskit Functions API ref docs should always display all Functions.