### PR TITLE
Functions toc sections open by default

### DIFF
--- a/docs/api/functions/_toc.json
+++ b/docs/api/functions/_toc.json
@@ -29,7 +29,8 @@
                   "url": "/docs/api/functions/qedma-qesem",
                   "untranslatable": true
                 }
-            ]
+            ],
+            "collapsible": false
         },
         {
             "title": "Application functions",
@@ -65,8 +66,8 @@
                   "url": "/docs/api/functions/qunova-chemistry",
                   "untranslatable": true
                 }
-            ]
+            ],
+            "collapsible": false
         }
-    ],
-  "collapsible": false
+    ]
 }


### PR DESCRIPTION
This looks good in local preview, but can't be checked in the PR preview because we don't include API refs in PR previews.