### PR TITLE
SQD tutorial: fix bond distance description

### DIFF
--- a/docs/tutorials/sample-based-quantum-diagonalization.ipynb
+++ b/docs/tutorials/sample-based-quantum-diagonalization.ipynb
@@ -144,7 +144,7 @@
    "source": [
     "## Small-scale simulator example\n",
     "\n",
-    "In this tutorial, we will find an approximation to the ground state of a nitrogen molecule at equilibrium. We first use a small STO-6G basis set so that we can simulate the experiment and make sure it's working."
+    "In this tutorial, we will find an approximation to the ground state of a nitrogen molecule near its equilibrium bond distance. We first use a small STO-6G basis set so that we can simulate the experiment and make sure it's working."
    ]
   },
   {


### PR DESCRIPTION
We're using 1.0 angstroms which is not exactly the equilibrium bond length but close.