### PR TITLE
Fix dependency requirements

### DIFF
--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -56,9 +56,7 @@ notebooks = [
 test-strategies.ci = { patch = "qiskit-fake-provider", num_qubits = 6 }
 test-strategies.extended = { patch = "qiskit-fake-provider", num_qubits = 6 }
 test-strategies.hardware = { patch = "qiskit-ibm-runtime-open" }
-notebooks = [
-  "docs/guides/visualize-results.ipynb",
-]
+notebooks = ["docs/guides/visualize-results.ipynb"]
 
 # Mock the following notebooks in our extended checks using IBM Quantum's
 # test-eagle device, which returns nonsense results. Use this to test notebooks
@@ -75,7 +73,6 @@ notebooks = [
   "docs/guides/debug-qiskit-runtime-jobs.ipynb",
   "docs/guides/fractional-gates.ipynb",
   "docs/guides/functions.ipynb",
-  "docs/guides/get-started-with-primitives.ipynb",
   "docs/guides/ibm-circuit-function.ipynb",
   "docs/guides/sampler-examples.ipynb",
   "docs/guides/estimator-examples.ipynb",
@@ -169,7 +166,7 @@ notebooks = [
   "docs/guides/qiskit-transpiler-service.ipynb",
 
   # We never run tutorials notebooks
-#  "docs/tutorials/implicit-solvent-calculations.ipynb",
+  #  "docs/tutorials/implicit-solvent-calculations.ipynb",
   "docs/tutorials/simulate-kicked-ising-tem.ipynb",
   "docs/tutorials/implicit-solvent-calculations.ipynb",
   "docs/tutorials/dc-hex-ising.ipynb",
@@ -361,5 +358,5 @@ notebooks = [
   "learning/courses/use-a-qc-today/quantum-mechanics-basics.ipynb",
   "learning/courses/use-a-qc-today/your-first-quantum-experiment.ipynb",
   "learning/courses/use-a-qc-today/quantum-computing-context.ipynb",
-  "learning/courses/use-a-qc-today/continue-your-learning-journey.ipynb"
+  "learning/courses/use-a-qc-today/continue-your-learning-journey.ipynb",
 ]

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -2,11 +2,11 @@
 # stable build.
 
 qiskit[all]~=2.4.0
-qiskit-ibm-runtime~=0.45.1
-qiskit-ibm-transpiler[ai-local-mode]~=0.18.0
+qiskit-ibm-runtime~=0.46.1
+#qiskit-ibm-transpiler[ai-local-mode]~=0.18.0
 qiskit-aer~=0.17
-qiskit-serverless~=0.30.1
-qiskit-ibm-catalog~=0.14.0
+qiskit-serverless~=0.31.0
+qiskit-ibm-catalog~=0.15.0
 qiskit-addon-sqd~=0.12.0
 qiskit-addon-utils~=0.3.1
 qiskit-addon-mpf~=0.3.0


### PR DESCRIPTION
A dependency chain conflict is preventing us from using the most recent version of runtime. This PR will temporarily remove the `qiskit-ibm-transpiler` requirement from the notebook tester so that we can continue checking the majority of our notebooks against `qiskit-ibm-runtime==0.46.1`