### PR TITLE
Update _toc.json to remove duplication

### DIFF
--- a/docs/guides/_toc.json
+++ b/docs/guides/_toc.json
@@ -641,10 +641,6 @@
               "url": "/docs/guides/qpu-information"
             },
             {
-              "title": "Get backend information with Qiskit",
-              "url": "/docs/guides/get-qpu-information"
-            },
-            {
               "title": "Monitoring, calibrations, and benchmarking",
               "url": "/docs/guides/calibration-jobs"
             },


### PR DESCRIPTION
Fixes #5096 

An entry in the toc was inadvertently added back in #4640.  Removing it 