### PR TITLE
Functions APIs: update page titles with names

### DIFF
--- a/docs/api/functions/colibritd-pde.mdx
+++ b/docs/api/functions/colibritd-pde.mdx
@@ -1,9 +1,9 @@
 ---
-title: QUICK-PDE API reference
+title: ColibriTD QUICK-PDE API reference
 description: API reference for QUICK-PDE, A Qiskit Function by ColibriTD
 ---
 
-# QUICK-PDE API reference
+# ColibriTD QUICK-PDE API reference
 
 <CardGroup>
     <Card

--- a/docs/api/functions/kipu-optimization.mdx
+++ b/docs/api/functions/kipu-optimization.mdx
@@ -1,9 +1,9 @@
 ---
-title: Iskay Quantum Optimizer API reference
+title: Kipu Quantum Iskay Quantum Optimizer API reference
 description: API reference for Iskay Quantum Optimizer, a Qiskit Function by Kipu Quantum
 ---
 
-# Iskay Quantum Optimizer API reference
+# Kipu Quantum Iskay Quantum Optimizer API reference
 
 <CardGroup>
     <Card

--- a/docs/api/functions/multiverse-computing-singularity.mdx
+++ b/docs/api/functions/multiverse-computing-singularity.mdx
@@ -1,11 +1,11 @@
 ---
-title: Singularity Machine Learning API reference
+title: Multiverse Singularity Machine Learning API reference
 description: API reference for Singularity Machine Learning, a Qiskit Function by Multiverse Computing
 ---
 
 {/* cspell:ignore sparsify, sparsification */}
 
-# Singularity Machine Learning API reference
+# Multiverse Singularity Machine Learning API reference
 
 <CardGroup>
     <Card

--- a/docs/api/functions/q-ctrl-optimization-solver.mdx
+++ b/docs/api/functions/q-ctrl-optimization-solver.mdx
@@ -1,8 +1,8 @@
 ---
-title: Q-CTRL Optimization Solver API reference
+title: Q-CTRL Optimization Solver by Global Data Quantum API reference
 description: API reference for Optimization Solver, A Qiskit Function by Q-CTRL Fire Opal
 ---
-# Q-CTRL Optimization Solver API reference
+# Q-CTRL Optimization Solver by Global Data Quantum API reference
 
 <CardGroup>
     <Card

--- a/docs/api/functions/qunova-chemistry.mdx
+++ b/docs/api/functions/qunova-chemistry.mdx
@@ -1,8 +1,8 @@
 ---
-title: HI-VQE Chemistry API reference
+title: Qunova HI-VQE Chemistry API reference
 description: API reference for HI-VQE Chemistry, a Qiskit Function by Qunova Computing
 ---
-# HI-VQE Chemistry API reference
+# Qunova HI-VQE Chemistry API reference
 
 <CardGroup>
     <Card


### PR DESCRIPTION
The search does not associate table of contents titles with their relevant files, and so searching for a name like Kipu in our API references returns no hits, even though it appears in the left nav. Updating page titles and metadata to include names so that they can be found in the search.

Fixes #5077 