### PR TITLE
change W to X in stinespring rep

### DIFF
--- a/learning/courses/general-formulation-of-quantum-information/quantum-channels/representation-equivalence.ipynb
+++ b/learning/courses/general-formulation-of-quantum-information/quantum-channels/representation-equivalence.ipynb
@@ -356,7 +356,7 @@
     "\n",
     "$$\n",
     "U(\\vert 0\\rangle\\langle 0 \\vert \\otimes \\rho)U^{\\dagger}\n",
-    "= U(\\vert 0\\rangle\\otimes\\mathbb{I}_{\\mathsf{W}}) \\rho (\\langle 0\\vert \\otimes \\mathbb{I}_{\\mathsf{W}}) U^{\\dagger},\n",
+    "= U(\\vert 0\\rangle\\otimes\\mathbb{I}_{\\mathsf{X}}) \\rho (\\langle 0\\vert \\otimes \\mathbb{I}_{\\mathsf{X}}) U^{\\dagger},\n",
     "$$\n",
     "\n",
     "and we see from our choice of $U$ that\n",


### PR DESCRIPTION
missed a "W->X" correction when we fixed the stinespring representation last time. fixes #5172 