### PR TITLE
Ajc/qca sunset

### DIFF
--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -28,6 +28,10 @@ Jump to [IBM Quantum Platform](#latest-platform) | [Qiskit SDK](#latest-qiskit-s
 
 This section summarizes the recent enhancements and new features for the new [IBM Quantum Platform](https://quantum.cloud.ibm.com/).
 
+### May 2026
+
+- **New Classroom Accounts**: Professors can now request a [Classroom Account](/docs/guides/classroom-accounts) to manage and facilitate access for their students. With Classroom Accounts, students can use Open Plan resources without needing to provide personal credit card information.
+
 ### April 2026
 - **New export options now available in IBM Quantum**: Introducing new export capabilities that make it easier for account administrators to analyze, share, and work with their data.
 

--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -10,7 +10,7 @@ in_page_toc_max_heading_level: 2
 
 # Changelog
 
-*Last updated 29 May 2026*
+*Last updated 8 April 2026*
 
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
@@ -27,10 +27,6 @@ Jump to [IBM Quantum Platform](#latest-platform) | [Qiskit SDK](#latest-qiskit-s
 ## IBM Quantum Platform
 
 This section summarizes the recent enhancements and new features for the new [IBM Quantum Platform](https://quantum.cloud.ibm.com/).
-
-### May 2026
-
-- **New Classroom Accounts**: Professors can now request a [Classroom Account](/docs/guides/classroom-accounts) to manage and facilitate access for their students. With Classroom Accounts, students can use Open Plan resources without needing to provide personal credit card information.
 
 ### April 2026
 - **New export options now available in IBM Quantum**: Introducing new export capabilities that make it easier for account administrators to analyze, share, and work with their data.
@@ -439,16 +435,6 @@ To get started, explore the [Qiskit Functions documentation](/docs/guides/functi
 <span id="latest-qca"></span>
 ## Qiskit Code Assistant
 
-### 29 May 2026
-- **Qiskit Code Assistant service discontinued** - The preview service has been discontinued and the Visual Studio Code and JupyterLab extensions have been archived.
-
-  Based on feedback and usage patterns, more users are running Qiskit Code Assistant models locally and working in editor integrations that are already part of their development workflow.
-
-  Qiskit Code Assistant models remain available for local use. See the [Qiskit Code Assistant](/docs/guides/qiskit-code-assistant) documentation for more information.
-
-<Accordion>
-<AccordionItem title="**Previous updates**">
-
 ### 28 October 2025
 - We have updated the model available in the service to the newer `mistral-small-3.2-24b-qiskit` model
 
@@ -458,6 +444,3 @@ To get started, explore the [Qiskit Functions documentation](/docs/guides/functi
     - [Qiskit/mistral-small-3.2-24b-qiskit-GGUF](https://huggingface.co/Qiskit/mistral-small-3.2-24b-qiskit-GGUF)
 
 For more details on Qiskit Code Assistant, see the [documentation](/docs/guides/qiskit-code-assistant).
-
-</AccordionItem>
-</Accordion>

--- a/docs/guides/latest-updates.mdx
+++ b/docs/guides/latest-updates.mdx
@@ -10,7 +10,7 @@ in_page_toc_max_heading_level: 2
 
 # Changelog
 
-*Last updated 8 April 2026*
+*Last updated 1 June 2026*
 
 {/* remember to update the date in the previous line each time this page is updated!!! */}
 
@@ -435,6 +435,15 @@ To get started, explore the [Qiskit Functions documentation](/docs/guides/functi
 <span id="latest-qca"></span>
 ## Qiskit Code Assistant
 
+### 29 May 2026
+- **Qiskit Code Assistant service discontinued** - The preview service has been discontinued and the Visual Studio Code and JupyterLab extensions have been archived.
+
+  Based on feedback and usage patterns, more users are running Qiskit Code Assistant models locally and working in editor integrations that are already part of their development workflow.
+
+  Qiskit Code Assistant models remain available for local use. See the [Qiskit Code Assistant](/docs/guides/qiskit-code-assistant) documentation for more information.
+
+<Accordion>
+<AccordionItem title="**Previous updates**">
 ### 28 October 2025
 - We have updated the model available in the service to the newer `mistral-small-3.2-24b-qiskit` model
 
@@ -444,3 +453,6 @@ To get started, explore the [Qiskit Functions documentation](/docs/guides/functi
     - [Qiskit/mistral-small-3.2-24b-qiskit-GGUF](https://huggingface.co/Qiskit/mistral-small-3.2-24b-qiskit-GGUF)
 
 For more details on Qiskit Code Assistant, see the [documentation](/docs/guides/qiskit-code-assistant).
+
+</AccordionItem>
+</Accordion>


### PR DESCRIPTION
When QCA is officially decommissioned, add to changelog. Anticipating early in the week of 1 June 2026.