### PR TITLE
docs: fix query model wording typo

### DIFF
--- a/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation.ipynb
+++ b/learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "![Illustration of a standard computation.](/learning/images/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/standard-computation.svg)\n",
     "\n",
-    "While it is true that the computers we use today continuously receive input and produce output, essentially interacting with both us and with other computers in a way not reflected by the figure, the intention is not to represent the ongoing operation of computers.\n",
+    "While it is true that the computers we use today continuously receive input and produce output, essentially interacting both with us and with other computers in a way not reflected by the figure, the intention is not to represent the ongoing operation of computers.\n",
     "Rather, it is to create a simple abstraction of computation, focusing on isolated computational tasks.\n",
     "For example, the input might encode a number, a vector, a matrix, a graph, a description of a molecule, or something more complicated, while the output encodes a solution to the computational task we have in mind.\n",
     "\n",


### PR DESCRIPTION
## Summary
- fix a typo in the query model of computation course text
- change "interacting with both us and with other computers" to "interacting both with us and with other computers"

Fixes #5229.

## Testing
- `git diff --check`
- parsed `learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation.ipynb` as JSON
- `rg -n "interacting with both us|interacting both with us" learning/courses/fundamentals-of-quantum-algorithms/quantum-query-algorithms/query-model-of-computation.ipynb`

AI disclosure: I used OpenAI Codex to help prepare this change.