### PR TITLE
Fix toc entry for sunset transpiler service

### DIFF
--- a/docs/guides/_toc.json
+++ b/docs/guides/_toc.json
@@ -210,6 +210,10 @@
                 {
                   "title": "Work with DAGs in transpiler passes",
                   "url": "/docs/guides/DAG-representation"
+                },
+                {
+                  "title": "AI-powered transpiler passes",
+                  "url": "/docs/guides/ai-transpiler-passes"
                 }
               ]
             }
@@ -251,8 +255,8 @@
                   "url": "/docs/guides/simulate-with-qiskit-aer"
                 },
                 {
-              "title": "Exact simulation with Qiskit SDK primitives",
-              "url": "/docs/guides/simulate-with-qiskit-sdk-primitives"
+                  "title": "Exact simulation with Qiskit SDK primitives",
+                  "url": "/docs/guides/simulate-with-qiskit-sdk-primitives"
                 },
                 {
                   "title": "Build noise models",
@@ -261,7 +265,8 @@
                 {
                   "title": "Efficient simulation of stabilizer circuits with Qiskit Aer primitives",
                   "url": "/docs/guides/simulate-stabilizer-circuits"
-                }              ]
+                }
+              ]
             },
             {
               "title": "Visualization",
@@ -317,7 +322,7 @@
         },
         {
           "title": "Qiskit Code Assistant",
-            "url": "/docs/guides/qiskit-code-assistant"
+          "url": "/docs/guides/qiskit-code-assistant"
         }
       ],
       "collapsible": false
@@ -329,17 +334,17 @@
           "title": "Introduction to IBM Quantum services",
           "url": "/docs/guides/compute-services"
         },
-            {
+        {
           "title": "Install",
           "children": [
             {
               "title": "Install the Qiskit Runtime client",
               "url": "/docs/guides/install-qiskit-runtime"
             },
-                    {
+            {
               "title": "Install the Qiskit Runtime client from source",
               "url": "/docs/guides/install-qiskit-runtime-source"
-        }
+            }
           ]
         },
         {
@@ -476,151 +481,152 @@
             }
           ]
         },
-                {
-                    "title": "Execute with primitives",
-                    "children": [
-                        {
-                            "title": "Introduction to primitives",
-                            "url": "/docs/guides/qiskit-runtime-primitives"
-                        }, 
-                        {
-                            "title": "Directed execution model (beta)",
-                            "url": "/docs/guides/directed-execution-model"
-                        },
-                       {
-                            "title": "Introduction to options",
-                            "url": "/docs/guides/runtime-options-overview"
-                        },
-                    {
-                    "title": "Estimator",
-                    "children": [
-                            {
-                            "title": "Get started",
-                            "url": "/docs/guides/get-started-with-estimator"
-                            },
-                            {
-                            "title": "Inputs and outputs",
-                            "url": "/docs/guides/estimator-input-output"
-                            },
-                            {
-                            "title": "Options",
-                            "url": "/docs/guides/estimator-options"
-                            },
-                            {
-                            "title": "Configure noise management",
-                            "url": "/docs/guides/estimator-noise-management"
-                            },
-                            {
-                            "title": "Examples",
-                            "url": "/docs/guides/estimator-examples"
-                            },
-                            {
-                            "title": "REST API",
-                            "url": "/docs/guides/estimator-rest-api"
-                            }
-                        ]
-                    },
-                    {
-                    "title": "Sampler",
-                    "children": [
-                            {
-                            "title": "Get started",
-                            "url": "/docs/guides/get-started-with-sampler"
-                            },
-                            {
-                            "title": "Inputs and outputs",
-                            "url": "/docs/guides/sampler-input-output"
-                            },
-                            {
-                            "title": "Options",
-                            "url": "/docs/guides/sampler-options"
-                            },
-                            {
-                            "title": "Configure noise management",
-                            "url": "/docs/guides/sampler-noise-management"
-                            },
-                            {
-                            "title": "Examples",
-                            "url": "/docs/guides/sampler-examples"
-                            },
-                            {
-                            "title": "REST API",
-                            "url": "/docs/guides/sampler-rest-api"
-                            }
-                        ]
-                    },
-                    {
-                    "title": "Executor",
-                    "children": [
-                            {
-                            "title": "Get started",
-                            "url": "/docs/guides/get-started-with-executor"
-                            },
-                            {
-                            "title": "Inputs and outputs",
-                            "url": "/docs/guides/executor-input-output"
-                            },
-                            {
-                            "title": "Broadcasting",
-                            "url": "/docs/guides/executor-broadcasting"
-                            },
-                            {
-                            "title": "Options",
-                            "url": "/docs/guides/executor-options"
-                            },
-                            {
-                            "title": "Examples",
-                            "url": "/docs/guides/executor-examples"
-                            }                        ]
-                    },
-                   {
-                    "title": "Manage noise",
-                   "children": [
-                     {
-                       "title": "Overview of noise management techniques",
-                       "url": "/docs/guides/error-mitigation-overview"
-                      },
-                      {
-                        "title": "Error mitigation and suppression",
-                        "url": "/docs/guides/error-mitigation-and-suppression-techniques"
-                      },
-                      {
-                        "title": "Noise learning",
-                        "url": "/docs/guides/noise-learning"
-                      },
-                      {
-                        "title": "Use postselection in workloads",
-                        "url": "/docs/guides/post-selection"
-                      }
-                     ]
-                    },
-                        {
-                             "title": "Debug Qiskit Runtime jobs",
-                            "url": "/docs/guides/debug-qiskit-runtime-jobs"
-                         },
-                        {
-                            "title": "Qiskit Runtime local testing mode",
-                            "url": "/docs/guides/local-testing-mode"
-                        }
-                    ]
-                },
-              {
-                "title": "Advanced execution features",
+        {
+          "title": "Execute with primitives",
+          "children": [
+            {
+              "title": "Introduction to primitives",
+              "url": "/docs/guides/qiskit-runtime-primitives"
+            },
+            {
+              "title": "Directed execution model (beta)",
+              "url": "/docs/guides/directed-execution-model"
+            },
+            {
+              "title": "Introduction to options",
+              "url": "/docs/guides/runtime-options-overview"
+            },
+            {
+              "title": "Estimator",
               "children": [
                 {
-                  "title": "Fractional gates",
-                  "url": "/docs/guides/fractional-gates"
+                  "title": "Get started",
+                  "url": "/docs/guides/get-started-with-estimator"
                 },
                 {
-              "title": "Execute dynamic circuits",
-              "url": "/docs/guides/execute-dynamic-circuits"
+                  "title": "Inputs and outputs",
+                  "url": "/docs/guides/estimator-input-output"
                 },
                 {
-                  "title": "Visualize circuit timing",
-                  "url": "/docs/guides/qiskit-runtime-circuit-timing"
+                  "title": "Options",
+                  "url": "/docs/guides/estimator-options"
+                },
+                {
+                  "title": "Configure noise management",
+                  "url": "/docs/guides/estimator-noise-management"
+                },
+                {
+                  "title": "Examples",
+                  "url": "/docs/guides/estimator-examples"
+                },
+                {
+                  "title": "REST API",
+                  "url": "/docs/guides/estimator-rest-api"
                 }
               ]
             },
+            {
+              "title": "Sampler",
+              "children": [
+                {
+                  "title": "Get started",
+                  "url": "/docs/guides/get-started-with-sampler"
+                },
+                {
+                  "title": "Inputs and outputs",
+                  "url": "/docs/guides/sampler-input-output"
+                },
+                {
+                  "title": "Options",
+                  "url": "/docs/guides/sampler-options"
+                },
+                {
+                  "title": "Configure noise management",
+                  "url": "/docs/guides/sampler-noise-management"
+                },
+                {
+                  "title": "Examples",
+                  "url": "/docs/guides/sampler-examples"
+                },
+                {
+                  "title": "REST API",
+                  "url": "/docs/guides/sampler-rest-api"
+                }
+              ]
+            },
+            {
+              "title": "Executor",
+              "children": [
+                {
+                  "title": "Get started",
+                  "url": "/docs/guides/get-started-with-executor"
+                },
+                {
+                  "title": "Inputs and outputs",
+                  "url": "/docs/guides/executor-input-output"
+                },
+                {
+                  "title": "Broadcasting",
+                  "url": "/docs/guides/executor-broadcasting"
+                },
+                {
+                  "title": "Options",
+                  "url": "/docs/guides/executor-options"
+                },
+                {
+                  "title": "Examples",
+                  "url": "/docs/guides/executor-examples"
+                }
+              ]
+            },
+            {
+              "title": "Manage noise",
+              "children": [
+                {
+                  "title": "Overview of noise management techniques",
+                  "url": "/docs/guides/error-mitigation-overview"
+                },
+                {
+                  "title": "Error mitigation and suppression",
+                  "url": "/docs/guides/error-mitigation-and-suppression-techniques"
+                },
+                {
+                  "title": "Noise learning",
+                  "url": "/docs/guides/noise-learning"
+                },
+                {
+                  "title": "Use postselection in workloads",
+                  "url": "/docs/guides/post-selection"
+                }
+              ]
+            },
+            {
+              "title": "Debug Qiskit Runtime jobs",
+              "url": "/docs/guides/debug-qiskit-runtime-jobs"
+            },
+            {
+              "title": "Qiskit Runtime local testing mode",
+              "url": "/docs/guides/local-testing-mode"
+            }
+          ]
+        },
+        {
+          "title": "Advanced execution features",
+          "children": [
+            {
+              "title": "Fractional gates",
+              "url": "/docs/guides/fractional-gates"
+            },
+            {
+              "title": "Execute dynamic circuits",
+              "url": "/docs/guides/execute-dynamic-circuits"
+            },
+            {
+              "title": "Visualize circuit timing",
+              "url": "/docs/guides/qiskit-runtime-circuit-timing"
+            }
+          ]
+        },
         {
           "title": "IBM quantum computers",
           "children": [
@@ -738,19 +744,6 @@
             {
               "title": "Port code to Qiskit Serverless",
               "url": "/docs/guides/serverless-port-code"
-            }
-          ]
-        },
-        {
-          "title": "Qiskit Transpiler Service",
-          "children": [
-            {
-              "title": "Transpile circuits remotely with the Qiskit Transpiler Service",
-              "url": "/docs/guides/qiskit-transpiler-service"
-            },
-            {
-              "title": "AI-powered transpiler passes",
-              "url": "/docs/guides/ai-transpiler-passes"
             }
           ]
         }

--- a/scripts/config/notebook-testing.toml
+++ b/scripts/config/notebook-testing.toml
@@ -164,9 +164,6 @@ notebooks = [
   "docs/guides/estimate-job-run-time.ipynb",
   "docs/guides/serverless-port-code.ipynb",
 
-  # This is temporarily broken while the transpiler service migrates to cloud
-  "docs/guides/qiskit-transpiler-service.ipynb",
-
   # We never run tutorials notebooks
   "docs/tutorials/implicit-solvent-calculations.ipynb",
   "docs/tutorials/simulate-kicked-ising-tem.ipynb",


### PR DESCRIPTION
In #5149 I forgot to remove the Transpiler service entry in the toc (which somehow didn't get caught by our link checker :thinking:). This PR removes the entry and moves the local AI-transpiler page to the advanced transpilation resources section.