### PR TITLE
Update wording on usage for cancelled jobs

### DIFF
--- a/docs/guides/estimate-job-run-time.ipynb
+++ b/docs/guides/estimate-job-run-time.ipynb
@@ -44,7 +44,7 @@
     "## Usage for failed and canceled jobs\n",
     "When a job is failed or canceled, the reported usage is as follows:\n",
     "\n",
-    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point, including the overhead incurred from setup tasks.\n",
+    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point, including the overhead incurred to prepare the system to run the job.\n",
     "\n",
     "* Session mode: The reported usage is the wall-clock time the session is active, regardless of the number of jobs that fail or are canceled.\n",
     "\n",

--- a/docs/guides/estimate-job-run-time.ipynb
+++ b/docs/guides/estimate-job-run-time.ipynb
@@ -44,7 +44,7 @@
     "## Usage for failed and canceled jobs\n",
     "When a job is failed or canceled, the reported usage is as follows:\n",
     "\n",
-    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point, including the overhead incurred to prepare the system to run the job.\n",
+    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point, including the overhead incurred to prepare the QPU to run the job.\n",
     "\n",
     "* Session mode: The reported usage is the wall-clock time the session is active, regardless of the number of jobs that fail or are canceled.\n",
     "\n",

--- a/docs/guides/estimate-job-run-time.ipynb
+++ b/docs/guides/estimate-job-run-time.ipynb
@@ -44,7 +44,7 @@
     "## Usage for failed and canceled jobs\n",
     "When a job is failed or canceled, the reported usage is as follows:\n",
     "\n",
-    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point.\n",
+    "* Job or batch mode: If the failure or cancellation occurred because of a system error, the reported usage is zero. For jobs that failed due to user error or when a user canceled a job, the reported usage is any consumption that has occurred up to that point, including the overhead incurred from setup tasks.\n",
     "\n",
     "* Session mode: The reported usage is the wall-clock time the session is active, regardless of the number of jobs that fail or are canceled.\n",
     "\n",


### PR DESCRIPTION
We got a question about why the usage for a user cancelled job was higher than its total runtime. This PR updates the wording to point out the usage charged includes overheard incurred to prepare the system to run the job. 