### PR TITLE
Address broken links in virtual-private-endpoints.mdx

### DIFF
--- a/docs/guides/virtual-private-endpoints.mdx
+++ b/docs/guides/virtual-private-endpoints.mdx
@@ -19,9 +19,9 @@ Connecting to IBM Quantum Platform through the public endpoints transmits all re
 Before you target a VPE for IBM Quantum Platform, complete the following steps:
 
 * [Create a Virtual Private Cloud](https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started).
-* [Plan for the network topology](https://cloud.ibm.com/docs/vpc?topic=vpc-planning-considerations) to connect to VPEs.
+* [Plan for the network topology](https://cloud.ibm.com/docs/vpc?topic=vpc-vpe-planning-considerations) to connect to VPEs.
 * [Set access controls](https://cloud.ibm.com/docs/vpc?topic=vpc-configure-acls-sgs-endpoint-gateways) for your VPE.
-* Understand the [limitations](https://cloud.ibm.com/docs/vpc?topic=vpc-limitations-vpe) of having a VPE.
+* Understand the [service restrictions](https://cloud.ibm.com/docs/vpc?topic=vpc-limitations).
 * Understand how to [view VPE details](https://cloud.ibm.com/docs/vpc?topic=vpc-vpe-viewing-details-of-an-endpoint-gateway).
 
 ## Set up a VPE for IBM Quantum Platform


### PR DESCRIPTION
Closes #5346 

@Eric-Arellano I don't see a good replacement for the broken "VPE limitations" link. Is my substitute acceptable, or is there a better one (also we can just remove the bullet point if needed)?