### PR TITLE
Prefactor: generalize observability page generation

### DIFF
--- a/.github/workflows/rest-api-sync.yml
+++ b/.github/workflows/rest-api-sync.yml
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-name: Generate Observability Docs
+name: Generate REST API Guides
 on:
   workflow_dispatch:
   schedule:
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run observability script
-        run: npx tsx scripts/js/commands/generateObservabilityPage.ts
+      - name: Run REST API guides script
+        run: npx tsx scripts/js/commands/generateRestApiGuides.ts
 
       - name: Get all changed docs files
         id: changed-docs-files
@@ -48,13 +48,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git switch -c actions/cron-${{ github.run_id }}
           git add .
-          git commit -m "Update observability page"
+          git commit -m "Update REST API guides"
           git push origin actions/cron-${{ github.run_id }}
           gh pr create \
            -B main \
            -H actions/cron-${{ github.run_id }} \
-           --title "Update observability page" \
-           --body "An action recently updated the observability page.
+           --title "Update REST API guides" \
+           --body "An action recently updated the REST API guides.
             > [!NOTE]
             > This pull request was created by a GitHub action." \
            --reviewer arnaucasau \

--- a/scripts/js/commands/generateRestApiGuides.ts
+++ b/scripts/js/commands/generateRestApiGuides.ts
@@ -12,10 +12,7 @@
 
 import { writeFile } from "fs/promises";
 
-import {
-  generateObservabilityTable,
-  extractEndpoints,
-} from "../lib/observabilityPage";
+import { generateTable, extractEndpoints } from "../lib/restApiGuides.js";
 
 export const RUNTIME_API_TITLE = "Qiskit Runtime";
 export const QUANTUM_SYSTEM_API_TITLE = "the IBM Quantum System service";
@@ -50,8 +47,8 @@ async function writeObservabilityFile(
 ) {
   const response = await fetch(PACKAGE_TO_URL[pkgTitle]);
   const jsonstr = await response.text();
-  const endpoints = extractEndpoints(jsonstr);
-  const table = generateObservabilityTable(endpoints);
+  const endpoints = extractEndpoints(jsonstr, "x-ibm-events", "events");
+  const table = generateTable(endpoints, "Action", "Triggered by");
   const mdx = `${getProse(pkgTitle)}\n${table}`;
   await writeFile(destPath, mdx, "utf8");
   console.log(`✅ Wrote ${destPath}`);

--- a/scripts/js/lib/restApiGuides.test.ts
+++ b/scripts/js/lib/restApiGuides.test.ts
@@ -12,10 +12,7 @@
 
 import { expect, test } from "@playwright/test";
 
-import {
-  extractEndpoints,
-  generateObservabilityTable,
-} from "./observabilityPage";
+import { extractEndpoints, generateTable } from "./restApiGuides.js";
 
 test("extract end points", () => {
   const sampleJson1 = JSON.stringify({
@@ -51,10 +48,39 @@ test("extract end points", () => {
 
   const expected2: Array<[string, string]> = [];
 
-  const actual1 = extractEndpoints(sampleJson1);
-  const actual2 = extractEndpoints(sampleJson2);
+  const actual1 = extractEndpoints(sampleJson1, "x-ibm-events", "events");
+  const actual2 = extractEndpoints(sampleJson2, "x-ibm-events", "events");
   expect(expected1).toEqual(actual1);
   expect(expected2).toEqual(actual2);
+});
+
+test("extract end points for permissions", () => {
+  const sampleJson = JSON.stringify({
+    paths: {
+      "/v1/jobs": {
+        get: {
+          summary: "List jobs",
+          "x-ibm-permissions": {
+            actions: [{ name: "quantum-computing.job.read" }],
+          },
+        },
+        post: {
+          summary: "Run a job",
+          "x-ibm-permissions": {
+            actions: [{ name: "quantum-computing.job.create" }],
+          },
+        },
+      },
+    },
+  });
+
+  const expected = [
+    ["quantum-computing.job.create", "Run a job (`POST /v1/jobs`)"],
+    ["quantum-computing.job.read", "List jobs (`GET /v1/jobs`)"],
+  ];
+
+  const actual = extractEndpoints(sampleJson, "x-ibm-permissions", "actions");
+  expect(expected).toEqual(actual);
 });
 
 test("generate observability table", () => {
@@ -68,7 +94,7 @@ test("generate observability table", () => {
       "List job results (`GET /v1/jobs/{id}/results`)",
     ],
   ];
-  const actual = generateObservabilityTable(input);
+  const actual = generateTable(input, "Action", "Triggered by");
 
   const expectedOutput =
     "| Action | Triggered by |\n" +
@@ -78,6 +104,22 @@ test("generate observability table", () => {
     "| `quantum-computing.job.read` | List job details (`GET /v1/jobs/{id}`) |\n" +
     "| `quantum-computing.job.delete` | Delete a job (`DELETE /v1/jobs/{id}`) |\n" +
     "| `quantum-computing.job.read` | List job results (`GET /v1/jobs/{id}/results`) |\n";
+
+  expect(actual).toBe(expectedOutput);
+});
+
+test("generate permissions table", () => {
+  const input: Array<[string, string]> = [
+    ["quantum-computing.job.read", "List jobs (`GET /v1/jobs`)"],
+    ["quantum-computing.job.create", "Run a job (`POST /v1/jobs`)"],
+  ];
+  const actual = generateTable(input, "Permission", "Required by");
+
+  const expectedOutput =
+    "| Permission | Required by |\n" +
+    "| -- | -- |\n" +
+    "| `quantum-computing.job.read` | List jobs (`GET /v1/jobs`) |\n" +
+    "| `quantum-computing.job.create` | Run a job (`POST /v1/jobs`) |\n";
 
   expect(actual).toBe(expectedOutput);
 });

--- a/scripts/js/lib/restApiGuides.ts
+++ b/scripts/js/lib/restApiGuides.ts
@@ -12,7 +12,13 @@
 
 const validMethods = ["get", "post", "delete", "patch"];
 
-export function extractEndpoints(json: string): Array<[string, string]> {
+// Extracts named items from an OpenAPI extension on each endpoint, such as
+// `x-ibm-events.events[].name` or `x-ibm-permissions.actions[].name`.
+export function extractEndpoints(
+  json: string,
+  extensionKey: string,
+  itemsKey: string,
+): Array<[string, string]> {
   const result: Array<[string, string]> = [];
   const data = JSON.parse(json);
   const paths = data.paths || "";
@@ -30,14 +36,14 @@ export function extractEndpoints(json: string): Array<[string, string]> {
         throw new Error(`Missing summary for endpoint: ${summaryText}`);
       }
 
-      const ibmXEvents = operationObject["x-ibm-events"]?.events || [];
-      for (const event of ibmXEvents) {
-        const eventName = event.name;
-        if (!eventName) {
-          throw new Error(`Missing event name for endpoint: ${summaryText}`);
+      const items = operationObject[extensionKey]?.[itemsKey] || [];
+      for (const item of items) {
+        const name = item.name;
+        if (!name) {
+          throw new Error(`Missing name for endpoint: ${summaryText}`);
         }
 
-        result.push([eventName, summaryText]);
+        result.push([name, summaryText]);
       }
     }
   }
@@ -46,12 +52,14 @@ export function extractEndpoints(json: string): Array<[string, string]> {
   return result;
 }
 
-export function generateObservabilityTable(
+export function generateTable(
   input: Array<[string, string]>,
+  leftHeader: string,
+  rightHeader: string,
 ): string {
-  let markdown = `| Action | Triggered by |\n| -- | -- |\n`;
-  for (const [action, description] of input) {
-    markdown += `| \`${action}\` | ${description} |\n`;
+  let markdown = `| ${leftHeader} | ${rightHeader} |\n| -- | -- |\n`;
+  for (const [name, description] of input) {
+    markdown += `| \`${name}\` | ${description} |\n`;
   }
   return markdown;
 }


### PR DESCRIPTION
For General Availability, we will add a new page called `docs/guides/authorization-roles`. This PR generalizes our script to generate the two observability pages so that it's easy for us to add the new guide later. 

`npx tsx scripts/js/commands/generateRestApiGuides.ts` generates the same two guides as before. This is only a refactor.