### PR TITLE
Correcting number of quiz questions

### DIFF
--- a/learning/courses/quantum-safe-cryptography/exam.mdx
+++ b/learning/courses/quantum-safe-cryptography/exam.mdx
@@ -15,7 +15,7 @@ Congratulations on completing this course! Please take a moment to help us impro
 
 After completing the reading and activities in this course, click the button below to navigate to IBM&reg; Training, where you can take the badging exam for Quantum-safe cryptography.
 
-The exam consists of 20 questions, and you must answer at least 16 correctly to pass. Upon receiving a passing score, your badge will automatically be sent to the email you used to register with IBM&reg; Training.
+The exam consists of 25 questions, and you must answer at least 20 correctly to pass. Upon receiving a passing score, your badge will automatically be sent to the email you used to register with IBM&reg; Training.
 
 Make sure you're ready to take the exam. If you don't receive a passing score in two attempts, the exam becomes temporarily locked.
 


### PR DESCRIPTION
The number of exam questions was not consistent across the IBM Training site and the course page. Updating the course page to match the exam.