### PR TITLE
docs: link to implicit solvent tutorial from chemistry function templ…

### DIFF
--- a/docs/guides/function-template-chemistry-workflow.ipynb
+++ b/docs/guides/function-template-chemistry-workflow.ipynb
@@ -33,6 +33,8 @@
    "source": [
     "This template, developed in collaboration with the Cleveland Clinic, consists of a workflow to calculate the ground state energy and solvation free energy of a molecule in an implicit solvent [[1]](#references). These simulations are based on the sample-based quantum diagonalization (SQD) method [[2-6]](#references) and the integral equation formalism polarizable continuum model (IEF-PCM) of solvent [[7]](#references).\n",
     "\n",
+    "For a step-by-step walkthrough of this same workflow with a worked example, see the [Implicit solvent calculations using Qiskit Serverless](/docs/tutorials/implicit-solvent-calculations) tutorial.\n",
+    "\n",
     "This guide utilizes the template with a methanol molecule as the solute, the electronic structure of which is simulated explicitly, and water as the solvent, approximated as a continuous dielectric medium. To account for the [electron correlation effects](https://onlinelibrary.wiley.com/doi/epdf/10.1002/ijch.202100111) in methanol, while maintaining the balance between the computational cost and accuracy, we only include the $\\sigma$, $\\sigma^{*}$, and lone pair orbitals in the active space simulated with SQD IEF-PCM. This orbital selection is done with [atomic valence active space (AVAS) method](https://github.com/pyscf/pyscf.github.io/blob/master/examples/mcscf/43-avas.py) using the C[2s,2p], O[2s,2p], and H[1s] atomic orbital components, which results in the active space of 14 electrons and 12 orbitals (14e,12o). The reference orbitals are calculated with closed-shell Hartree Fock using the cc-pvdz basis set."
    ]
   },
@@ -714,6 +716,7 @@
     "\n",
     "<Admonition type=\"info\" title=\"Recommendations\">\n",
     "\n",
+    "- Follow the [Implicit solvent calculations using Qiskit Serverless](/docs/tutorials/implicit-solvent-calculations) tutorial for a worked example of this same workflow\n",
     "- Review the guide on building a function template for [Hamiltonian simulation](/docs/guides/function-template-hamiltonian-simulation)\n",
     "- Check out the source files for this template on [GitHub](https://github.com/qiskit-community/qiskit-function-templates/tree/main/chemistry/sqd_pcm)\n",
     "\n",


### PR DESCRIPTION
Closes #5326

Adds a link from the chemistry function template guide to the
Implicit solvent calculations tutorial, in the preamble and in
Next steps. The reverse link (tutorial -> guide) already existed.