### PR TITLE
Update FG and DC compatibility

### DIFF
--- a/docs/guides/fractional-gates.ipynb
+++ b/docs/guides/fractional-gates.ipynb
@@ -378,7 +378,6 @@
     "Additionally, the Qiskit transpiler has limited capability to use $R_{ZZ}(\\theta)$ in its optimization passes. This requires you to take more care in crafting and optimizing circuits that contain these instructions.\n",
     "\n",
     "Lastly, using fractional gates is not supported for:\n",
-    "- [Dynamic circuits](/docs/guides/classical-feedforward-and-control-flow)\n",
     "- [Pauli twirling](/docs/guides/error-mitigation-and-suppression-techniques#pauli-twirling) - however, [measurement twirling with TREX](/docs/guides/error-mitigation-and-suppression-techniques#twirled-readout-error-extinction-trex) *is* supported.\n",
     "- [Probabilistic error cancellation](/docs/guides/error-mitigation-and-suppression-techniques#probabilistic-error-cancellation-pec)\n",
     "- [Zero-noise extrapolation (using probabilistic error amplification)](/docs/guides/error-mitigation-and-suppression-techniques#probabilistic-error-amplification-pea)\n",


### PR DESCRIPTION
Related to #4098.

When we did #4098 we missed the fractional gate page, which still says it's not compatible with dynamic circuits. 