### PR TITLE
Add details about QPU Contention

### DIFF
--- a/docs/guides/monitor-job.ipynb
+++ b/docs/guides/monitor-job.ipynb
@@ -41,7 +41,7 @@
     "<span id=\"retrieve-later\"></span>\n",
     "## Retrieve job results at a later time\n",
     "\n",
-    "Call `service.job(\\<job\\_id>)` to retrieve a job you previously submitted. If you don't have the job ID, or if you want to retrieve multiple jobs at once; including jobs from retired QPUs (quantum processing units), call `service.jobs()` with optional filters instead. See [QiskitRuntimeService.jobs](../api/qiskit-ibm-runtime/qiskit-runtime-service#jobs).\n",
+    "Call `service.job(<job_id>)` to retrieve a job you previously submitted. If you don't have the job ID, or if you want to retrieve multiple jobs at once; including jobs from retired QPUs (quantum processing units), call `service.jobs()` with optional filters instead. See [QiskitRuntimeService.jobs](../api/qiskit-ibm-runtime/qiskit-runtime-service#jobs).\n",
     "\n",
     "<Admonition type=\"note\" title=\"Deprecated provider packages\">\n",
     "  `service.jobs()` also returns jobs run from the deprecated `qiskit-ibm-provider` package. Jobs submitted by the older (also deprecated) `qiskit-ibmq-provider` package are no longer available.\n",
@@ -217,7 +217,15 @@
     "\n",
     "You can cancel a job from the IBM Quantum Platform dashboard either on the Workloads page or the details page for a specific workload. On the Workloads page, click the overflow menu at the end of the row for that workload, and select Cancel. If you are on the details page for a specific workload, use the Actions dropdown at the top of the page, and select Cancel.\n",
     "\n",
-    "In Qiskit, use `job.cancel()` to cancel a job."
+    "In Qiskit, use `job.cancel()` to cancel a job.\n",
+    "\n",
+    "<Admonition type=\"note\" title=\"QPU Contention\">\n",
+    "You may notice that jobs which estimate only a few seconds of runtime spend a much longer time in the \"In Progress\" state. This is completely expected.\n",
+    "All jobs must go through a classical pre-processing phase before being run on the QPU. Jobs transition to \"In Progress\" status as soon as the classical processing begins, and many jobs can be in this state at once.\n",
+    "However, only one job can run on the QPU at a time. If many jobs are ready to be run on the QPU, this causes QPU contention and jobs may be seem like they are stuck in the \"In Progress\" state.\n",
+    "\n",
+    "Both the estimated usage and maximum execution time are based on the amount of time that the job reserves the QPU. Therefore, the time on your plan will not be spent while waiting for your job to use the QPU. Consider this before cancelling your jobs.\n",
+    "</Admonition>\n"
    ]
   },
   {

--- a/docs/guides/monitor-job.ipynb
+++ b/docs/guides/monitor-job.ipynb
@@ -225,7 +225,7 @@
     "However, only one job can run on the QPU at a time. If many jobs are ready to be run on the QPU, this causes QPU contention and jobs may be seem like they are stuck in the \"In Progress\" state.\n",
     "\n",
     "Both the estimated usage and maximum execution time are based on the amount of time that the job reserves the QPU. Therefore, the time on your plan will not be spent while waiting for your job to use the QPU. Consider this before cancelling your jobs.\n",
-    "</Admonition>\n"
+    "</Admonition>"
    ]
   },
   {


### PR DESCRIPTION
Fixes #5336
Adds an admonition in the "Cancel Jobs" section of the "Monitor or cancel a jobs" page explaining why jobs can seem to get stuck as "In Progress".

An admonition felt correct rather than a whole new page / section since this comment supports the idea of why or why not users should cancel jobs. 