### PR TITLE
Add documentation for new `qiskit_ibm_catalog` surfaces

### DIFF
--- a/docs/guides/functions-get-started.ipynb
+++ b/docs/guides/functions-get-started.ipynb
@@ -105,11 +105,15 @@
     "\n",
     "         <CodeCellPlaceholder tag=\"id-catalog\" />\n",
     "\n",
+    "      `backends()` accepts the same filters as Qiskit Runtime's [`QiskitRuntimeService.backends()`](/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#backends). For example, list only the backends with at least 127 qubits, or pass a `filters` function for finer control:\n",
+    "\n",
+    "         <CodeCellPlaceholder tag=\"id-backends-filter\" />\n",
+    "\n",
     "      Look up a single backend and confirm access:\n",
     "\n",
     "         <CodeCellPlaceholder tag=\"id-backend\" />\n",
     "\n",
-    "      You can also get the backend with the fewest pending jobs:\n",
+    "      You can also get the backend with the fewest pending jobs. `least_busy()` takes the same filters as Qiskit Runtime's [`QiskitRuntimeService.least_busy()`](/docs/api/qiskit-ibm-runtime/qiskit-runtime-service#least_busy):\n",
     "\n",
     "         <CodeCellPlaceholder tag=\"id-least-busy\" />\n",
     "\n",
@@ -154,7 +158,7 @@
     "         - **`RUNNING: WAITING_FOR_QPU`**: The function has submitted a job to Qiskit Runtime, and is waiting in the queue.\n",
     "         - **`RUNNING: EXECUTING_QPU`**: The function has an active Qiskit Runtime job.\n",
     "         - **`RUNNING: POST_PROCESSING`**: The function is post-processing results, which can include error mitigation, mapping quantum results to classical, and so forth.\n",
-    "      - **`DONE`**: The program is complete, and you can retrieve result data with `job.results()`.\n",
+    "      - **`DONE`**: The program is complete, and you can retrieve result data with `job.result()`.\n",
     "      - **`ERROR`**: The program stopped running because of a problem. Use `job.result()` to get the error message.\n",
     "      - **`CANCELED`**: The program was canceled by a user, the service, or the server.\n",
     "\n",
@@ -163,7 +167,7 @@
     "\n",
     "   <span id=\"retrieve-results\"></span>\n",
     "## Retrieve results\n",
-    "      After a program is `DONE`, you can use `job.results()` to fetch the result. This output format varies with each function, so be sure to follow the specific documentation:\n",
+    "      After a program is `DONE`, you can use `job.result()` to fetch the result. This output format varies with each function, so be sure to follow the specific documentation:\n",
     "\n",
     "         <CodeCellPlaceholder tag=\"id-retrieve\" />\n",
     "\n",
@@ -172,13 +176,41 @@
     "        <CodeCellPlaceholder tag=\"id-cancel\" />\n",
     "\n",
     "\n",
+    "## Access the associated Qiskit Runtime jobs\n",
+    "\n",
+    "      A Qiskit Function can submit one or more Qiskit Runtime jobs to a QPU while it runs. To retrieve the IDs of those runtime jobs, use `job.runtime_jobs()`. You can use these IDs to fetch the runtime job objects from a `QiskitRuntimeService` instance, or to find the workloads on the IBM Quantum&reg; Platform dashboard.\n",
+    "\n",
+    "      <CodeCellPlaceholder tag=\"id-runtime-jobs\" />\n",
+    "\n",
+    "      If a function groups its runtime jobs into sessions or batches, use `job.runtime_sessions()` to list the session IDs. Pass one session ID to `job.runtime_jobs()` to return only the runtime jobs in that session:\n",
+    "\n",
+    "      <CodeCellPlaceholder tag=\"id-runtime-sessions\" />\n",
+    "\n",
+    "      <Admonition type=\"note\">\n",
+    "      The returned list can be empty. A function reports its runtime jobs only when it submits them through the runtime service that the function receives at run time, and some functions do not submit runtime jobs directly.\n",
+    "      </Admonition>\n",
+    "\n",
+    "## View job logs\n",
+    "\n",
+    "      Use `job.logs()` to retrieve the log output that a function produces while it runs. Logs are useful for tracking progress and for debugging a job that ends in an `ERROR` state.\n",
+    "\n",
+    "      <CodeCellPlaceholder tag=\"id-logs\" />\n",
+    "\n",
+    "      For a long-running job that produces many log lines, use `job.filtered_logs()` to return only the lines you want. Pass a regular expression to `include` to keep matching lines, or to `exclude` to drop matching lines:\n",
+    "\n",
+    "      <CodeCellPlaceholder tag=\"id-filtered-logs\" />\n",
+    "\n",
     "## List previously run Qiskit Functions jobs\n",
     "\n",
     "      You can use `jobs()` to list all jobs submitted to Qiskit Functions:\n",
     "\n",
     "            <CodeCellPlaceholder tag=\"id-all-jobs\" />\n",
     "\n",
-    "      If you already have the job ID for a certain job, you can retrieve the job with `catalog.get_job_by_id()`:\n",
+    "      To narrow the results, pass filters. Filter by function with `function`, by status with `status`, and by submission date with `created_after`. Page through results with `limit` and `offset`:\n",
+    "\n",
+    "      <CodeCellPlaceholder tag=\"id-filter-jobs\" />\n",
+    "\n",
+    "      If you already have the job ID for a certain job, you can retrieve the job with `catalog.job()`:\n",
     "\n",
     "            <CodeCellPlaceholder tag=\"id-by-id\" />\n",
     "\n",
@@ -283,6 +315,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f6252b70-c063-4f81-c273-6e5f8a02c145",
+   "metadata": {
+    "tags": [
+     "id-backends-filter"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "catalog.backends(min_num_qubits=127)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "fec85827-af64-40db-a4a8-1173d6378e52",
    "metadata": {
     "tags": [
@@ -305,7 +351,7 @@
    },
    "outputs": [],
    "source": [
-    "catalog.least_busy()"
+    "catalog.least_busy(min_num_qubits=127)"
    ]
   },
   {
@@ -472,7 +518,66 @@
     }
    ],
    "source": [
-    "job.stop()"
+    "job.cancel()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1f0c2d4-7b1e-4a3c-9d2e-1f0a3b5c7d90",
+   "metadata": {
+    "tags": [
+     "id-runtime-jobs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "runtime_job_ids = job.runtime_jobs()\n",
+    "runtime_job_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2e1d3c5-8c2f-4b4d-8e3f-2a1b4c6d8e01",
+   "metadata": {
+    "tags": [
+     "id-runtime-sessions"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "sessions = job.runtime_sessions()\n",
+    "session_runtime_jobs = job.runtime_jobs(runtime_session=sessions[0])\n",
+    "session_runtime_jobs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3f2e4d6-9d30-4c5e-9f40-3b2c5d7e9f12",
+   "metadata": {
+    "tags": [
+     "id-logs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(job.logs())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4030f5e-ae41-4d6f-a051-4c3d6e80af23",
+   "metadata": {
+    "tags": [
+     "id-filtered-logs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(job.filtered_logs(include=\"iteration\"))"
    ]
   },
   {
@@ -512,6 +617,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "e5141a6f-bf52-4e70-b162-5d4e7f91b034",
+   "metadata": {
+    "tags": [
+     "id-filter-jobs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "recent_errors = catalog.jobs(\n",
+    "    function=ibm_cf,\n",
+    "    status=\"ERROR\",\n",
+    "    created_after=\"2024-01-01T00:00:00Z\",\n",
+    "    limit=5,\n",
+    ")\n",
+    "recent_errors"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 18,
    "id": "18d87f07-8a8e-4b93-80d0-7c07e49272e2",
    "metadata": {
@@ -532,8 +657,8 @@
     "# First, get the most recent job that has been executed.\n",
     "latest_job = old_jobs[0]\n",
     "\n",
-    "# We can also get that same job with get_job_by_id\n",
-    "job_by_id = catalog.get_job_by_id(latest_job.job_id)\n",
+    "# We can also get that same job with `catalog.job`\n",
+    "job_by_id = catalog.job(latest_job.job_id)\n",
     "\n",
     "# Verify that the job is the same using both retrieval methods.\n",
     "assert job_by_id.job_id == latest_job.job_id\n",

--- a/docs/guides/functions-get-started.ipynb
+++ b/docs/guides/functions-get-started.ipynb
@@ -563,7 +563,7 @@
    },
    "outputs": [],
    "source": [
-    "print(job.logs())"
+    "print(job.logs().splitlines())"
    ]
   },
   {


### PR DESCRIPTION
Extends the Qiskit Functions get-started page with previously undocumented `qiskit_ibm_catalog` client surfaces: 

- Retrieving associated Qiskit Runtime jobs (`runtime_jobs`/`runtime_sessions`)
- Viewing and filtering logs (`logs`/`filtered_logs`), and filtering the jobs list.
- Adds filtering examples for `backends()`/`least_busy()` with links to the Qiskit Runtime API reference. 
- Replaces the deprecated `job.stop()` and `catalog.get_job_by_id()` calls with `job.cancel()` and `catalog.job()`, and fixes a `job.results()` typo. 