### PR TITLE
Fix Pauli-basis expansion normalization (#5107)

### DIFF
--- a/docs/guides/specify-observables-pauli.ipynb
+++ b/docs/guides/specify-observables-pauli.ipynb
@@ -147,10 +147,13 @@
     "We expand the observable $O$ as\n",
     "\n",
     "$$\n",
-    "O = \\sum_{P \\in \\{I, X, Y, Z\\}^{\\otimes n}} \\mathrm{Tr}(O P) P,\n",
+    "O =\n",
+    "\\frac{1}{2^n}\n",
+    "\\sum_{P \\in \\{I, X, Y, Z\\}^{\\otimes n}}\n",
+    "\\mathrm{Tr}(O P) P,\n",
     "$$\n",
     "\n",
-    "where the sum runs over all possible $n$-qubit Pauli terms and $\\mathrm{Tr}(\\cdot)$ is the trace of a matrix, which acts as inner product.\n",
+    "where the sum runs over all possible $n$-qubit Pauli terms and $\\mathrm{Tr}(\\cdot)$ is the trace of a matrix, which acts as an inner product. The factor $1/2^n$ accounts for the Hilbert--Schmidt normalization of $n$-qubit Pauli strings.\n",
     "You can implement this decomposition  from a matrix to Pauli terms using the `SparsePauliOp.from_operator` method, like so:"
    ]
   },


### PR DESCRIPTION


## What changed

This corrects the Pauli-basis expansion formula in `docs/guides/specify-observables-pauli.ipynb` by adding the missing `1/2^n` Hilbert--Schmidt normalization factor.

## Why

For standard n-qubit Pauli strings,

```latex
\mathrm{Tr}(P_i P_j) = 2^n \delta_{ij},
```

so the coefficient of a Pauli string `P` in the expansion of an observable `O` is

```latex
\alpha_P = \frac{1}{2^n}\mathrm{Tr}(O P).
```

This also matches the coefficients printed by the example immediately below the formula.

## Risk

Documentation-only change. No code or API behavior is changed.

## Tested

Checked the formula against the 2-qubit matrix example in the same guide:
`Tr(O IZ) = -4`, `Tr(O XI) = 2`, and `Tr(O YY) = 4`, which become `-1`, `0.5`, and `1` after division by `2^2 = 4`.