### PR TITLE
Correct link in hamiltonian-construction.ipynb

### DIFF
--- a/learning/courses/quantum-chem-with-vqe/hamiltonian-construction.ipynb
+++ b/learning/courses/quantum-chem-with-vqe/hamiltonian-construction.ipynb
@@ -31,7 +31,7 @@
     "* [A Comparison of the Bravyi–Kitaev and Jordan–Wigner Transformations for the Quantum Simulation of Quantum Chemistry, Tranter, et al.](https://pubs.acs.org/doi/full/10.1021/acs.jctc.8b00450)\n",
     "* [Quantum Chemistry in the Age of Quantum Computing, Cao, et al.](https://arxiv.org/pdf/1812.09976.pdf)\n",
     "* [Quantum computational chemistry, McArdle, et al.](https://arxiv.org/pdf/1808.10402.pdf)\n",
-    "* [The Bravyi-Kitaev transformation for quantum computation of electronic structure, Seeley, et al., McArdle, et al.](https://arxiv.org/pdf/1812.09976.pdf)\n",
+    "* [The Bravyi-Kitaev transformation for quantum computation of electronic structure, Seeley, et al.](https://arxiv.org/pdf/1208.5986.pdf)\n",
     "\n",
     "## Preparing Hamiltonians for Quantum Chemistry\n",
     "\n",


### PR DESCRIPTION
# Problem
In the [Building a chemical Hamiltonian](https://quantum.cloud.ibm.com/learning/en/courses/quantum-chem-with-vqe/hamiltonian-construction) page of the Quantum Chemistry with VQE course, the link for the reference "The Bravyi-Kitaev transformation for quantum computation of electronic structure, Seeley, et al., McArdle, et al." is incorrect. The link should point to https://arxiv.org/pdf/1208.5986. 

Additionally, the reference should not list "McArdle, et al.". Rather, the reference should be the following:
"The Bravyi-Kitaev transformation for quantum computation of electronic structure, Seeley, et al."

# Solution
The change proposed here fixes the link and removes "McArdle, et al." from the reference.

This change resolves issue #5490 . 