### PR TITLE
Update twirling default in Sampler options

### DIFF
--- a/docs/guides/sampler-options.ipynb
+++ b/docs/guides/sampler-options.ipynb
@@ -139,7 +139,7 @@
     "\n",
     "1. If the PUB specifies shots, use that value.\n",
     "2. If the `shots` keyword argument is specified in `run`, use that value.\n",
-    "4. If `twirling` is enabled  (True by default), then the product of `num_randomizations` and `shots_per_randomization`, as specified as  [`twirling` options](/docs/api/qiskit-ibm-runtime/options-twirling-options), is used.\n",
+    "4. If `twirling` is enabled, then the product of `num_randomizations` and `shots_per_randomization`, as specified as  [`twirling` options](/docs/api/qiskit-ibm-runtime/options-twirling-options), is used.\n",
     "5. If `sampler.options.default_shots` is specified, use that value.\n",
     "\n",
     "Thus, if shots are specified in all possible places, the one with highest precedence (shots specified in the PUB) is used.\n",


### PR DESCRIPTION
I noticed it says twirling is enabled by default for Sampler - this is incorrect. It's only enabled by default for Estimator. 