### PR TITLE
Add that you can find the least-busy backend that supports fractional gates

### DIFF
--- a/docs/guides/fractional-gates.ipynb
+++ b/docs/guides/fractional-gates.ipynb
@@ -392,7 +392,7 @@
    "source": [
     "## Which backends support fractional gates?\n",
     "\n",
-    "Not all backends support fractional gates. Run `service.backends(use_fractional_gates=True)` to find those that do. A fake backend supports fractional gates only if the related \"real\" backend supports them.\n",
+    "Not all backends support fractional gates. Run `service.backends(use_fractional_gates=True)` to find those that do. With the release of `qiskit-ibm-runtime` v0.48, you can also run `service.least_busy(fractional_gates=True)` to find the least-busy backend that supports fractional gates. A fake backend supports fractional gates only if the related \"real\" backend supports them.\n",
     "\n",
     "Note that fake backends don't support fractional gates by default, since fractional gates are disabled by default. To enable fractional gates on a fake backend that supports them, refresh its configuration.\n",
     "\n",


### PR DESCRIPTION
Closes #5305.