### PR TITLE
Fix DD documentation inconsistency for reset qubits

### DIFF
--- a/docs/guides/error-mitigation-and-suppression-techniques.ipynb
+++ b/docs/guides/error-mitigation-and-suppression-techniques.ipynb
@@ -115,7 +115,8 @@
    "source": [
     "estimator = Estimator(mode=backend)\n",
     "estimator.options.dynamical_decoupling.enable = True\n",
-    "estimator.options.dynamical_decoupling.sequence_type = \"XpXm\""
+    "estimator.options.dynamical_decoupling.sequence_type = \"XpXm\"",
+    "estimator.options.dynamical_decoupling.skip_reset_qubits = True"
    ]
   },
   {


### PR DESCRIPTION
The DD option and the figure shown below are inconsistent.

Because `dynamical_decoupling.skip_reset_qubits` defaults to False, the XX sequence is also applied to q2.
To match the figure, `dynamical_decoupling.skip_reset_qubits=True` should be specified.

In general, setting `dynamical_decoupling.skip_reset_qubits=True` provides better accuracy because it avoids applying DD sequences to reset (clean) qubits, as illustrated in the figure. However, the default value remains False for backward compatibility.

Reference: https://quantum.cloud.ibm.com/docs/en/guides/estimator-options#available-options

<img width="3992" height="1663" alt="image" src="https://github.com/user-attachments/assets/16a0e9e3-4229-422a-8e8b-6cbea07cf37b" />
