### PR TITLE
fix(guides): correct Content-Type typo in REST API setup page

### DIFF
--- a/docs/guides/cloud-setup-rest-api.mdx
+++ b/docs/guides/cloud-setup-rest-api.mdx
@@ -3,7 +3,7 @@ title: Set up to use IBM Quantum Platform with REST API
 description: Setup instructions to use the REST API to submit IBM Quantum Compute Service jobs
 ---
 
-{/* cspell:ignore urlendcoded, WQVY */}
+{/* cspell:ignore WQVY */}
 
 # Set up to use IBM Quantum Platform with REST API
 
@@ -43,7 +43,7 @@ You can access quantum processors with REST APIs, enabling you to work with QPUs
    url = 'https://iam.cloud.ibm.com/identity/token'
    api_key = 'MY_APIKEY'
    headers = {
-    'Content-Type': 'application/x-www-form-urlendcoded',
+    'Content-Type': 'application/x-www-form-urlencoded',
    }
    data = f'grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={api_key}'
    response = requests.post(url, headers=headers, data=data)


### PR DESCRIPTION
### What's broken

The Python sample in [Set up to use IBM Quantum Platform with REST API](https://quantum.cloud.ibm.com/docs/en/guides/cloud-setup-rest-api) (step 1) sets the request header to `application/x-www-form-urlendcoded` — note the extra `d` — instead of `application/x-www-form-urlencoded`.

### The fix

- Corrected the header value in the Python tab to `application/x-www-form-urlencoded`, matching the Curl tab on the same page.
- Removed the now-unneeded `urlendcoded` entry from the page's `cspell:ignore` directive (it existed only to silence the spell checker on the misspelling).

### Verification

`npm run check:spelling` → 0 issues; `npx prettier --check` on the changed file → clean.

Closes #5493