### PR TITLE
remove broken back links

### DIFF
--- a/docs/api/qiskit-addon-aqc-tensor/_toc.json
+++ b/docs/api/qiskit-addon-aqc-tensor/_toc.json
@@ -102,7 +102,5 @@
     }
   ],
   "collapsed": true,
-  "untranslatable": true,
-  "parentUrl": "/docs/addons/qiskit-addon-aqc-tensor",
-  "parentLabel": "Approximate quantum compilation (AQC-Tensor)"
+  "untranslatable": true
 }

--- a/docs/api/qiskit-addon-utils/_toc.json
+++ b/docs/api/qiskit-addon-utils/_toc.json
@@ -127,7 +127,5 @@
     }
   ],
   "collapsed": true,
-  "untranslatable": true,
-  "parentUrl": "/docs/addons/qiskit-addon-utils",
-  "parentLabel": "Qiskit addon utilities"
+  "untranslatable": true
 }

--- a/scripts/js/lib/api/Pkg.ts
+++ b/scripts/js/lib/api/Pkg.ts
@@ -57,6 +57,8 @@ export class Pkg {
   readonly kebabCaseAndShortenUrls: boolean;
   readonly artifactPackageName: string;
   readonly hasRootNamespaceFile: boolean;
+  /** Whether this addon has a dedicated docs page at /docs/addons/{name}. */
+  readonly hasAddonDocs: boolean;
   /** Slugs of docs/tutorials/ notebooks to surface under this addon's tutorials route. */
 
   static ADDON_NAMES = [
@@ -93,6 +95,7 @@ export class Pkg {
     kebabCaseAndShortenUrls: boolean;
     artifactPackageName?: string;
     hasRootNamespaceFile?: boolean;
+    hasAddonDocs?: boolean;
   }) {
     this.name = kwargs.name;
     this.title = kwargs.title;
@@ -107,6 +110,7 @@ export class Pkg {
     this.kebabCaseAndShortenUrls = kwargs.kebabCaseAndShortenUrls;
     this.artifactPackageName = kwargs.artifactPackageName ?? this.name;
     this.hasRootNamespaceFile = kwargs.hasRootNamespaceFile ?? false;
+    this.hasAddonDocs = kwargs.hasAddonDocs ?? false;
   }
 
   static async fromArgs(
@@ -180,6 +184,7 @@ export class Pkg {
         githubSlug: "Qiskit/qiskit-addon-obp",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "qiskit-addon-mpf") {
@@ -199,6 +204,7 @@ export class Pkg {
         githubSlug: "Qiskit/qiskit-addon-sqd",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "qiskit-addon-cutting") {
@@ -217,6 +223,7 @@ export class Pkg {
         githubSlug: "Qiskit/qiskit-addon-paulice",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "qiskit-addon-pna") {
@@ -226,6 +233,7 @@ export class Pkg {
         githubSlug: "Qiskit/qiskit-addon-pna",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "pauli-prop") {
@@ -235,6 +243,7 @@ export class Pkg {
         githubSlug: "Qiskit/pauli-prop",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "qiskit-addon-slc") {
@@ -244,6 +253,7 @@ export class Pkg {
         githubSlug: "Qiskit/qiskit-addon-slc",
         kebabCaseAndShortenUrls: true,
         language: "Python",
+        hasAddonDocs: true,
       });
     }
     if (name === "qiskit-addon-utils") {

--- a/scripts/js/lib/api/generateToc.ts
+++ b/scripts/js/lib/api/generateToc.ts
@@ -73,7 +73,7 @@ export function generateToc(pkg: Pkg, results: HtmlToMdResultWithUrl[]): Toc {
     children: orderedEntries,
     collapsed: true,
     untranslatable: true,
-    ...(pkg.isAddon() && {
+    ...(pkg.hasAddonDocs && {
       parentUrl: `/docs/addons/${pkg.name}`,
       parentLabel: pkg.title,
     }),


### PR DESCRIPTION
Some of our qiskit addon apis had back buttons to view the addon prose docs, but they don't exist, leading to a 404. This adds a flag to disable the back links when no addon docs exist for the api. 