### PR TITLE
Update nbtester deps

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -31,3 +31,4 @@ qiskit-basis-constructor~=0.1.0
 qiskit_addon_slc~=0.1.0
 mthree~=2.8.1
 qctrl-visualizer~=11.0.0
+imbalanced-learn~=0.12.3

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -9,10 +9,11 @@ qiskit-serverless~=0.34.0
 qiskit-ibm-catalog~=0.18.0
 qiskit-addon-sqd~=0.13.1
 qiskit-addon-utils~=0.4.0
-qiskit-addon-mpf~=0.3.0
+qiskit-addon-mpf[tenpy]~=0.3.0
 qiskit-addon-aqc-tensor[aer,quimb-jax]~=0.3.1; sys.platform != 'darwin'
 qiskit-addon-obp~=0.3.0
 qiskit-addon-cutting~=0.10.0
+qiskit-addon-pna~=0.2.0
 qiskit-experiments~=0.14.1
 samplomatic~=0.20.0
 scipy~=1.17.1
@@ -23,3 +24,9 @@ plotly~=6.9.0
 gem-suite~=0.1.6
 ffsim~=0.0.83; sys.platform != 'win32'
 sympy~=1.14.0
+qiskit-addon-opt-mapper~=0.1.0
+qiskit-paulice~=0.2.1
+category_encoders~=2.10.0
+qiskit-basis-constructor~=0.1.0
+qiskit_addon_slc~=0.1.0
+mthree~=2.8.1

--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -30,3 +30,4 @@ category_encoders~=2.10.0
 qiskit-basis-constructor~=0.1.0
 qiskit_addon_slc~=0.1.0
 mthree~=2.8.1
+qctrl-visualizer~=11.0.0


### PR DESCRIPTION
nb-tester dependencies do not include dependencies required by tutorials. This PR attempts to sync dependencies to ensure they are up-to-date.

~There are two dependencies missing from requirements.txt file that need to be added eventually:~
* ~qctrl-visualizer~
* ~imblearn~

^Update: It turns out both dependencies had different import names and pip install targets, so the imports are actually valid.

These dependencies require additional fixes applied to tutorial notebooks, so I am saving them for a follow-up PR.