### PR TITLE
Update rustworkx attributes for version used in qiskit~=2.5.2

### DIFF
--- a/docs/tutorials/advanced-techniques-for-qaoa.ipynb
+++ b/docs/tutorials/advanced-techniques-for-qaoa.ipynb
@@ -408,7 +408,7 @@
     "\n",
     "    def find_initial_mappings(\n",
     "        self,\n",
-    "        program_graph: rx.Graph,\n",
+    "        program_graph: rx.PyGraph,\n",
     "        swap_strategy: SwapStrategy,\n",
     "        min_layers: int | None = None,\n",
     "        max_layers: int | None = None,\n",
@@ -419,7 +419,7 @@
     "        a SAT problem.\n",
     "\n",
     "        Args:\n",
-    "            program_graph (rx.Graph): The program graph with commuting gates, where\n",
+    "            program_graph (rx.PyGraph): The program graph with commuting gates, where\n",
     "                                        each edge represents a two-qubit gate.\n",
     "            swap_strategy (SwapStrategy): The swap strategy to use to find the\n",
     "                                        initial mapping.\n",
@@ -539,7 +539,7 @@
     "        return binary_search_results\n",
     "\n",
     "    def remap_graph_with_sat(\n",
-    "        self, graph: rx.Graph, swap_strategy, max_layers\n",
+    "        self, graph: rx.PyGraph, swap_strategy, max_layers\n",
     "    ):\n",
     "        \"\"\"Applies the SAT mapping.\n",
     "\n",
@@ -1422,6 +1422,7 @@
   }
  ],
  "metadata": {
+  "hours": 1.5,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1439,7 +1440,6 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
-  "hours": 1.5,
   "qpuSeconds": 180
  },
  "nbformat": 4,


### PR DESCRIPTION
qiskit~=2.5.2 is pinned [here](https://github.com/Qiskit/documentation/blob/51d4c0bc421fe3b2eecc5b4a4420c38991e2eaff/scripts/nb-tester/requirements.txt#L4), which correlates to rustworkx 0.18.1. Rustworkx types and function calls were modified such that `rx.Graph` -> `rx.PyGraph`. This PR updates advanced-techniques-for-qaoa to match that format.