### PR TITLE
Fix unmatched fstrings in tutorials

### DIFF
--- a/docs/tutorials/dc-hex-ising.ipynb
+++ b/docs/tutorials/dc-hex-ising.ipynb
@@ -1196,7 +1196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "de870864",
    "metadata": {},
    "outputs": [
@@ -1212,11 +1212,11 @@
    "source": [
     "print(\n",
     "    f'Mid-circuit measurement `measure_2` duration: '\n",
-    "    f'{backend.instruction_durations.get('measure_2',0) * backend.dt * 1e9/1e3} μs'\n",
+    "    f\"{backend.instruction_durations.get('measure_2',0) * backend.dt * 1e9/1e3} μs\"\n",
     ")\n",
     "print(\n",
     "    f'Terminal measurement `measure` duration: '\n",
-    "    f'{backend.instruction_durations.get('measure',0) * backend.dt *1e9/1e3} μs'\n",
+    "    f\"{backend.instruction_durations.get('measure',0) * backend.dt *1e9/1e3} μs\"\n",
     ")"
    ]
   },
@@ -1947,6 +1947,7 @@
   }
  ],
  "metadata": {
+  "hours": 1,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1964,7 +1965,6 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
-  "hours": 1,
   "qpuSeconds": 450
  },
  "nbformat": 4,

--- a/docs/tutorials/solve-higher-order-binary-optimization-problems-with-q-ctrls-optimization-solver.ipynb
+++ b/docs/tutorials/solve-higher-order-binary-optimization-problems-with-q-ctrls-optimization-solver.ipynb
@@ -682,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "f6f6e93a",
    "metadata": {},
    "outputs": [
@@ -696,7 +696,7 @@
    ],
    "source": [
     "# Get the solution ground state energy\n",
-    "print(f\"Minimum ground state energy: {result[\"solution_bitstring_cost\"]}\")"
+    "print(f\"Minimum ground state energy: {result['solution_bitstring_cost']}\")"
    ]
   },
   {
@@ -841,6 +841,7 @@
   }
  ],
  "metadata": {
+  "hours": 1,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -858,7 +859,6 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
-  "hours": 1,
   "qpuSeconds": 1440
  },
  "nbformat": 4,


### PR DESCRIPTION
Revises quotes within fstring to be different than surrounding quotes within two tutorials.

Original:
```
var = {"a": 1}
f"{var["a"]}" # inner quotes conflict with outer quotes
```

Fix:
```
var = {"a": 1}
f"{var['a']}" # inner quotes use '', outer quotes use ""
```