### PR TITLE
Update var type in tutorial

### DIFF
--- a/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
+++ b/docs/tutorials/real-time-benchmarking-for-qubit-selection.ipynb
@@ -549,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a8266467-9d60-411f-89dd-8cad6558f588",
    "metadata": {},
    "outputs": [],
@@ -557,7 +557,7 @@
     "# Prepare characterization experiments\n",
     "batches = [t1_exp, t2_exp, readout_exp, singleq_rb_exp, twoq_rb_exp_batched]\n",
     "batches_exp = BatchExperiment(batches, backend)  # , analysis=None)\n",
-    "run_options = {\"shots\": 1e3, \"dynamic\": False}\n",
+    "run_options = {\"shots\": int(1e3), \"dynamic\": False}\n",
     "\n",
     "with Session(backend=backend) as session:\n",
     "    sampler = SamplerV2(mode=session)\n",
@@ -809,6 +809,7 @@
   }
  ],
  "metadata": {
+  "hours": 2.5,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -826,13 +827,12 @@
    "pygments_lexer": "ipython3",
    "version": "3"
   },
+  "qpuSeconds": 240,
   "vscode": {
    "interpreter": {
     "hash": "72460b19b35c51a2148375679c8e282bc3cd3c5550c209f0a38b7d09cded82d9"
    }
-  },
-  "hours": 2.5,
-  "qpuSeconds": 240
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
Change type of 'shots' from float to int in real-time-benchmarking tutorial. This was previously causing the tutorial to crash with `TypeError: shots must be an integer` because of `shots = 1000.0` (Python `1e3` is evaluated to float `1000.0`, not `1000`).