### PR TITLE
Add qiskit-device-benchmarking to requirements.txt

### DIFF
--- a/scripts/nb-tester/requirements.txt
+++ b/scripts/nb-tester/requirements.txt
@@ -32,3 +32,4 @@ qiskit_addon_slc~=0.1.0
 mthree~=3.0.0
 qctrl-visualizer~=11.0.0
 imbalanced-learn~=0.14.2
+qiskit-device-benchmarking @ git+https://github.com/qiskit-community/qiskit-device-benchmarking.git@aff6064fe5079df572b807b1ee5c9e06ea74fa13


### PR DESCRIPTION
The refresh-backend-properties-with-real-time-benchmarking tutorial requires qiskit-device-benchmarking as a dependency ([link](https://quantum.cloud.ibm.com/docs/en/tutorials/refresh-backend-properties-with-real-time-benchmarking#requirements)). This PR adds that dependency to requirements.txt.

[aff6064fe5079df572b807b1ee5c9e06ea74fa13](https://github.com/qiskit-community/qiskit-device-benchmarking/commit/aff6064fe5079df572b807b1ee5c9e06ea74fa13) is the latest commit from the repo on the `main` branch as of this PR.