### PR TITLE
Link to instance-based Qiskit Functions access configuration

### DIFF
--- a/docs/guides/functions-get-started.ipynb
+++ b/docs/guides/functions-get-started.ipynb
@@ -84,6 +84,8 @@
     "\n",
     "   <span id=\"save-account\"></span>**If you are working in a trusted Python environment (such as on a personal laptop or workstation),** use the `save_account()` method to save your credentials locally. ([Skip to the next step](#functions-untrusted) if you are not using a trusted environment, such as a shared or public computer, to authenticate to IBM Quantum Platform.)\n",
     "\n",
+    "   The instance you authenticate with must have Qiskit Functions access enabled. To configure it on an existing instance, see [Configure Qiskit Functions access on an instance](/docs/guides/access-instances-platform-apis#configure-qiskit-functions-access-on-an-instance).\n",
+    "\n",
     "   To use `save_account()`, run `python` in your shell, then enter the following:\n",
     "\n",
     "   ```python\n",


### PR DESCRIPTION
Add a link on the "Get started with Qiskit Functions" page to the instructions for configuring Qiskit Functions access on an instance.

The get-started flow walks users through saving credentials with an instance CRN but does not point them to the steps for enabling Qiskit Functions access on that instance. The link points to the existing [Configure Qiskit Functions access on an instance](/docs/guides/access-instances-platform-apis#configure-qiskit-functions-access-on-an-instance) section