### PR TITLE
Issue 5226: Fix typo in create-a-provider#providing-access-to-backends

### DIFF
--- a/docs/guides/create-a-provider.mdx
+++ b/docs/guides/create-a-provider.mdx
@@ -19,7 +19,7 @@ An example implementation may look something like:
 
 ```python
 from qiskit.transpiler import Target
-from qsikit.providers import BackendV2
+from qiskit.providers import BackendV2
 
 class ProviderService:
     """ Class for interacting with a provider's service"""
@@ -31,11 +31,11 @@ class ProviderService:
         """ Initiate a connection with the provider service, given some method 
                 of authentication """
 
-    def return_target(name: Str) -> Target:
+    def return_target(name: str) -> Target:
         """ Interact with the service and return a Target object """
         return target
 
-    def return_backend(name: Str) -> BackendV2:
+    def return_backend(name: str) -> BackendV2:
         """ Interact with the service and return a BackendV2 object """
         return backend
 


### PR DESCRIPTION
Fixes two typos ("qsikit" --> "qiskit"  AND "Str" --> "str") in "Providing access to backends" in "Integrate external resources with Qiskit" (https://quantum.cloud.ibm.com/docs/en/guides/create-a-provider).

Fixes #5226 (https://github.com/Qiskit/documentation/issues/5226)

I did NOT triage or address the separate error in the same issue about running code under "Providing an interface for execution" with the error NameError: na,me 'Iterable' is not defined:

In my view, the content describing the error when running the code should be copied into a new Issue with its own Issue number. A debug error and a typo error require different types of triage. I would feel more comfortable if someone else addressed the debug error content.

