### PR TITLE
Fix incorrect Activity Tracker link in responsibilities doc

### DIFF
--- a/docs/guides/responsibilities.mdx
+++ b/docs/guides/responsibilities.mdx
@@ -35,7 +35,7 @@ Identity and access management includes tasks such as authentication, authorizat
 | --- | --- | --- |
 | Identity and access control | Provide the ability to manage and restrict access to resources through IBM Cloud. | Grant, revoke, and manage access to resources through [Cloud Identity and Access Management](/docs/guides/access-groups) (IAM). |
 | Service authentication | Ensure that only authenticated users have access to your IBM Quantum Compute Service and resources. | <ul><li>[Safeguard your API key](/docs/guides/cloud-setup-untrusted#initialize-the-service-in-an-untrusted-environment) from unauthorized access.</li><li>Rotate and update your [API keys](https://cloud.ibm.com/iam/apikeys) according to your security policy requirements.</li></ul> |
-| Observability | Allow integration of IBM Cloud Activity Tracker Event Routing to audit user actions. | Set up [IBM Cloud Activity Tracker Event Routing](https://cloud.ibm.com/docs/vmware-service?topic=vmware-service-at_events) or other functions to track user activity. |
+| Observability | Allow integration of IBM Cloud Activity Tracker Event Routing to audit user actions. | Set up [IBM Cloud Activity Tracker Event Routing](https://cloud.ibm.com/docs/atracker?topic=atracker-getting-started&locale=en) or other functions to track user activity. |
 
 ## Security and regulation compliance
 


### PR DESCRIPTION
Fixes #5613

Updated the Activity Tracker Event Routing link to point to the correct getting-started documentation in IBM Cloud docs.